### PR TITLE
Add auto-add workflow for electinfo/tasks project

### DIFF
--- a/.github/workflows/project-auto-add.yml
+++ b/.github/workflows/project-auto-add.yml
@@ -1,0 +1,14 @@
+name: Auto-add issues to electinfo/tasks project
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1
+        with:
+          project-url: https://github.com/orgs/electinfo/projects/1
+          github-token: ${{ secrets.ELECTINFO_PROJECT_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a GitHub Action that auto-adds new issues to the `electinfo/tasks` umbrella project (https://github.com/orgs/electinfo/projects/1)
- Uses `actions/add-to-project@v1` with `ELECTINFO_PROJECT_TOKEN` secret (already configured)
- Triggers on `issues.opened` events

## Why
siege_utilities is in a different org than the project (`siege-analytics` vs `electinfo`), so GitHub's built-in project auto-add rules can't reach it. This Action bridges the gap.

## Test plan
- [ ] Merge to main
- [ ] Create a test issue on siege_utilities
- [ ] Verify it appears in https://github.com/orgs/electinfo/projects/1