### PR TITLE
Add Databricks spatial fallback planning helpers

### DIFF
--- a/siege_utilities/geo/__init__.py
+++ b/siege_utilities/geo/__init__.py
@@ -174,6 +174,13 @@ from .choropleth import (
     BIVARIATE_COLOR_SCHEMES,
 )
 
+from .databricks_fallback import (
+    SpatialLoaderPlan,
+    select_spatial_loader,
+    build_census_table_name,
+    build_census_ingest_targets,
+)
+
 __all__ = [
     # Core spatial data classes
     'CensusDirectoryDiscovery',
@@ -304,6 +311,12 @@ __all__ = [
     'BivariateAnalysisResult',
     'save_map',
     'BIVARIATE_COLOR_SCHEMES',
+
+    # Databricks fallback planning
+    'SpatialLoaderPlan',
+    'select_spatial_loader',
+    'build_census_table_name',
+    'build_census_ingest_targets',
 
     # PL 94-171 redistricting files
     'PLFileDownloader',

--- a/siege_utilities/geo/databricks_fallback.py
+++ b/siege_utilities/geo/databricks_fallback.py
@@ -1,0 +1,74 @@
+"""Databricks-oriented fallback planning for spatial ingestion workflows."""
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from siege_utilities.config.census_constants import resolve_geographic_level
+
+
+@dataclass(frozen=True)
+class SpatialLoaderPlan:
+    """Chosen loader with deterministic fallback ordering."""
+
+    primary_loader: str
+    loader_order: List[str]
+    reason: str
+
+
+def select_spatial_loader(
+    ogr2ogr_available: bool,
+    sedona_available: bool,
+) -> SpatialLoaderPlan:
+    """
+    Select a spatial loader strategy for Databricks-style environments.
+
+    Loader order:
+    1. ogr2ogr
+    2. sedona
+    3. python
+    """
+    if ogr2ogr_available:
+        return SpatialLoaderPlan(
+            primary_loader="ogr2ogr",
+            loader_order=["ogr2ogr", "sedona", "python"],
+            reason="ogr2ogr available",
+        )
+    if sedona_available:
+        return SpatialLoaderPlan(
+            primary_loader="sedona",
+            loader_order=["sedona", "python"],
+            reason="ogr2ogr unavailable, sedona available",
+        )
+    return SpatialLoaderPlan(
+        primary_loader="python",
+        loader_order=["python"],
+        reason="ogr2ogr and sedona unavailable",
+    )
+
+
+def build_census_table_name(
+    year: int,
+    geography_level: str,
+    prefix: str = "census",
+) -> str:
+    """Build a normalized census table name like `census_2024_block_group`."""
+    canonical = resolve_geographic_level(geography_level)
+    safe_level = canonical.replace("-", "_")
+    return f"{prefix}_{int(year)}_{safe_level}"
+
+
+def build_census_ingest_targets(
+    year: int,
+    geography_levels: Iterable[str],
+    prefix: str = "census",
+) -> List[str]:
+    """Build de-duplicated target table names for ingest planning."""
+    seen = set()
+    targets: List[str] = []
+    for level in geography_levels:
+        name = build_census_table_name(year=year, geography_level=level, prefix=prefix)
+        if name in seen:
+            continue
+        seen.add(name)
+        targets.append(name)
+    return targets

--- a/tests/test_databricks_fallback.py
+++ b/tests/test_databricks_fallback.py
@@ -1,0 +1,34 @@
+"""Tests for Databricks spatial fallback planning helpers."""
+
+from siege_utilities.geo.databricks_fallback import (
+    build_census_ingest_targets,
+    build_census_table_name,
+    select_spatial_loader,
+)
+
+
+def test_select_spatial_loader_prefers_ogr2ogr() -> None:
+    plan = select_spatial_loader(ogr2ogr_available=True, sedona_available=True)
+    assert plan.primary_loader == "ogr2ogr"
+    assert plan.loader_order == ["ogr2ogr", "sedona", "python"]
+
+
+def test_select_spatial_loader_falls_back_to_sedona() -> None:
+    plan = select_spatial_loader(ogr2ogr_available=False, sedona_available=True)
+    assert plan.primary_loader == "sedona"
+    assert plan.loader_order == ["sedona", "python"]
+
+
+def test_select_spatial_loader_falls_back_to_python() -> None:
+    plan = select_spatial_loader(ogr2ogr_available=False, sedona_available=False)
+    assert plan.primary_loader == "python"
+    assert plan.loader_order == ["python"]
+
+
+def test_build_census_table_name_normalizes_alias() -> None:
+    assert build_census_table_name(2024, "bg") == "census_2024_block_group"
+
+
+def test_build_census_ingest_targets_dedupes_by_canonical_level() -> None:
+    targets = build_census_ingest_targets(2024, ["bg", "block_group", "tract"])
+    assert targets == ["census_2024_block_group", "census_2024_tract"]


### PR DESCRIPTION
## Summary
- add `siege_utilities.geo.databricks_fallback` module focused on Databricks spatial loader selection
- add deterministic fallback selector: `select_spatial_loader(ogr2ogr_available, sedona_available)`
- add canonical table naming helpers for Census ingest targets:
  - `build_census_table_name`
  - `build_census_ingest_targets`
- export new fallback helpers in `siege_utilities.geo`
- add unit tests for fallback selection and canonicalized target naming

## Why
Suzy/DataPod needs reliable spatial ingestion behavior when `ogr2ogr` and/or Sedona are unavailable in Databricks runtimes. This PR codifies a deterministic fallback strategy and target naming conventions to support Python-native ingestion paths.

## Validation
- `uv run --python 3.11 pytest -c /dev/null tests/test_databricks_fallback.py -q` (5 passed)
