### PR TITLE
Add general Databricks auth/session/secrets and dataframe bridge helpers

### DIFF
--- a/siege_utilities/__init__.py
+++ b/siege_utilities/__init__.py
@@ -402,6 +402,68 @@ __author__ = "Siege Analytics"
 __description__ = "Comprehensive utilities for data engineering, analytics, and distributed computing"
 
 # Package discovery and dependency checking - NOW WITH DYNAMIC DISCOVERY!
+try:
+    from .databricks import (
+        build_databricks_run_url,
+        build_foreign_table_sql,
+        build_jdbc_url,
+        build_lakebase_psql_command,
+        build_pgpass_entry,
+        build_schema_and_table_sync_sql,
+        ensure_secret_scope,
+        geopandas_to_spark,
+        get_active_spark_session,
+        get_dbutils,
+        get_runtime_secret,
+        get_workspace_client,
+        pandas_to_spark,
+        parse_conninfo,
+        put_secret,
+        runtime_secret_exists,
+        spark_to_geopandas,
+        spark_to_pandas,
+    )
+except ImportError as e:
+    logger.warning(f"Could not import Databricks utilities: {e}")
+
+    build_databricks_run_url = _create_dependency_wrapper(
+        "build_databricks_run_url", ["databricks-sdk"]
+    )
+    build_foreign_table_sql = _create_dependency_wrapper(
+        "build_foreign_table_sql", ["databricks-sdk"]
+    )
+    build_jdbc_url = _create_dependency_wrapper("build_jdbc_url", ["databricks-sdk"])
+    build_lakebase_psql_command = _create_dependency_wrapper(
+        "build_lakebase_psql_command", ["databricks-sdk"]
+    )
+    build_pgpass_entry = _create_dependency_wrapper("build_pgpass_entry", ["databricks-sdk"])
+    build_schema_and_table_sync_sql = _create_dependency_wrapper(
+        "build_schema_and_table_sync_sql", ["databricks-sdk"]
+    )
+    ensure_secret_scope = _create_dependency_wrapper("ensure_secret_scope", ["databricks-sdk"])
+    geopandas_to_spark = _create_dependency_wrapper(
+        "geopandas_to_spark", ["pyspark", "geopandas"]
+    )
+    get_active_spark_session = _create_dependency_wrapper(
+        "get_active_spark_session", ["pyspark"]
+    )
+    get_dbutils = _create_dependency_wrapper("get_dbutils", ["pyspark"])
+    get_runtime_secret = _create_dependency_wrapper("get_runtime_secret", ["pyspark"])
+    get_workspace_client = _create_dependency_wrapper(
+        "get_workspace_client", ["databricks-sdk"]
+    )
+    pandas_to_spark = _create_dependency_wrapper("pandas_to_spark", ["pyspark", "pandas"])
+    parse_conninfo = _create_dependency_wrapper("parse_conninfo", ["databricks-sdk"])
+    put_secret = _create_dependency_wrapper("put_secret", ["databricks-sdk"])
+    runtime_secret_exists = _create_dependency_wrapper(
+        "runtime_secret_exists", ["pyspark"]
+    )
+    spark_to_geopandas = _create_dependency_wrapper(
+        "spark_to_geopandas", ["pyspark", "geopandas", "shapely"]
+    )
+    spark_to_pandas = _create_dependency_wrapper("spark_to_pandas", ["pyspark", "pandas"])
+
+
 def get_package_info() -> Dict[str, Any]:
     """
     Get comprehensive information about the siege_utilities package.
@@ -435,6 +497,7 @@ def get_package_info() -> Dict[str, Any]:
             'data': [],
             'analytics': [],
             'reporting': [],
+            'databricks': [],
             'git': [],
             'development': []
         }
@@ -547,6 +610,26 @@ def get_package_info() -> Dict[str, Any]:
         'get_snowflake_connector': 'analytics', 'upload_to_snowflake': 'analytics',
         'download_from_snowflake': 'analytics', 'execute_snowflake_query': 'analytics',
         'connect': 'analytics', 'disconnect': 'analytics', 'list_tables': 'analytics', 'get_table_schema': 'analytics',
+
+        # Databricks functions
+        'build_databricks_run_url': 'databricks',
+        'build_foreign_table_sql': 'databricks',
+        'build_jdbc_url': 'databricks',
+        'build_lakebase_psql_command': 'databricks',
+        'build_pgpass_entry': 'databricks',
+        'build_schema_and_table_sync_sql': 'databricks',
+        'ensure_secret_scope': 'databricks',
+        'geopandas_to_spark': 'databricks',
+        'get_active_spark_session': 'databricks',
+        'get_dbutils': 'databricks',
+        'get_runtime_secret': 'databricks',
+        'get_workspace_client': 'databricks',
+        'pandas_to_spark': 'databricks',
+        'parse_conninfo': 'databricks',
+        'put_secret': 'databricks',
+        'runtime_secret_exists': 'databricks',
+        'spark_to_geopandas': 'databricks',
+        'spark_to_pandas': 'databricks',
         
         # Reporting functions  
         'BaseReportTemplate': 'reporting', 'ReportGenerator': 'reporting', 'ChartGenerator': 'reporting',

--- a/siege_utilities/databricks/__init__.py
+++ b/siege_utilities/databricks/__init__.py
@@ -1,0 +1,47 @@
+"""
+Databricks and LakeBase utilities for siege_utilities.
+"""
+
+from .artifacts import build_databricks_run_url
+from .auth import get_workspace_client
+from .dataframe_bridge import (
+    geopandas_to_spark,
+    pandas_to_spark,
+    spark_to_geopandas,
+    spark_to_pandas,
+)
+from .lakebase import (
+    build_jdbc_url,
+    build_lakebase_psql_command,
+    build_pgpass_entry,
+    parse_conninfo,
+)
+from .secrets import (
+    ensure_secret_scope,
+    get_runtime_secret,
+    put_secret,
+    runtime_secret_exists,
+)
+from .session import get_active_spark_session, get_dbutils
+from .unity_catalog import build_foreign_table_sql, build_schema_and_table_sync_sql
+
+__all__ = [
+    "build_databricks_run_url",
+    "build_foreign_table_sql",
+    "build_jdbc_url",
+    "build_lakebase_psql_command",
+    "build_pgpass_entry",
+    "build_schema_and_table_sync_sql",
+    "ensure_secret_scope",
+    "geopandas_to_spark",
+    "get_active_spark_session",
+    "get_dbutils",
+    "get_runtime_secret",
+    "get_workspace_client",
+    "pandas_to_spark",
+    "parse_conninfo",
+    "put_secret",
+    "runtime_secret_exists",
+    "spark_to_geopandas",
+    "spark_to_pandas",
+]

--- a/siege_utilities/databricks/artifacts.py
+++ b/siege_utilities/databricks/artifacts.py
@@ -1,0 +1,7 @@
+"""Databricks artifact helpers."""
+
+
+def build_databricks_run_url(host: str, workspace_id: str, run_id: str) -> str:
+    """Build a direct Databricks run URL."""
+    clean_host = host.rstrip("/")
+    return f"{clean_host}/jobs/runs/{run_id}?o={workspace_id}"

--- a/siege_utilities/databricks/auth.py
+++ b/siege_utilities/databricks/auth.py
@@ -1,0 +1,67 @@
+"""Databricks authentication helpers."""
+
+from typing import Any, Dict, Optional
+
+
+def _validate_azure_sp_inputs(
+    azure_client_id: Optional[str],
+    azure_client_secret: Optional[str],
+    azure_tenant_id: Optional[str],
+) -> None:
+    """Validate Azure service principal inputs."""
+    provided = [azure_client_id, azure_client_secret, azure_tenant_id]
+    if any(provided) and not all(provided):
+        raise ValueError(
+            "Azure service principal authentication requires "
+            "azure_client_id, azure_client_secret, and azure_tenant_id."
+        )
+
+
+def get_workspace_client(
+    profile: Optional[str] = None,
+    host: Optional[str] = None,
+    token: Optional[str] = None,
+    azure_client_id: Optional[str] = None,
+    azure_client_secret: Optional[str] = None,
+    azure_tenant_id: Optional[str] = None,
+    **kwargs: Any,
+) -> Any:
+    """
+    Build a Databricks WorkspaceClient for PAT, profile, or Azure SP auth.
+
+    Args:
+        profile: Databricks CLI profile name.
+        host: Databricks workspace host URL.
+        token: Databricks PAT.
+        azure_client_id: Azure service principal client ID.
+        azure_client_secret: Azure service principal client secret.
+        azure_tenant_id: Azure tenant ID.
+        **kwargs: Additional WorkspaceClient arguments.
+    """
+    try:
+        from databricks.sdk import WorkspaceClient
+    except ImportError as exc:
+        raise ImportError(
+            "Databricks SDK not available. Install with: pip install databricks-sdk"
+        ) from exc
+
+    _validate_azure_sp_inputs(
+        azure_client_id=azure_client_id,
+        azure_client_secret=azure_client_secret,
+        azure_tenant_id=azure_tenant_id,
+    )
+
+    client_kwargs: Dict[str, Any] = dict(kwargs)
+    if profile:
+        client_kwargs["profile"] = profile
+    if host:
+        client_kwargs["host"] = host
+    if token:
+        client_kwargs["token"] = token
+
+    if azure_client_id and azure_client_secret and azure_tenant_id:
+        client_kwargs["azure_client_id"] = azure_client_id
+        client_kwargs["azure_client_secret"] = azure_client_secret
+        client_kwargs["azure_tenant_id"] = azure_tenant_id
+
+    return WorkspaceClient(**client_kwargs)

--- a/siege_utilities/databricks/dataframe_bridge.py
+++ b/siege_utilities/databricks/dataframe_bridge.py
@@ -1,0 +1,105 @@
+"""Bridges for Pandas/GeoPandas and Spark DataFrames."""
+
+from typing import Any, Optional
+
+import pandas as pd
+
+from .session import get_active_spark_session
+
+
+def pandas_to_spark(dataframe: pd.DataFrame, spark: Optional[Any] = None) -> Any:
+    """Convert a Pandas DataFrame to a Spark DataFrame."""
+    if spark is None:
+        spark = get_active_spark_session(create_if_missing=True)
+    return spark.createDataFrame(dataframe)
+
+
+def spark_to_pandas(dataframe: Any, limit: Optional[int] = None) -> pd.DataFrame:
+    """Convert a Spark DataFrame to a Pandas DataFrame, with optional limit."""
+    if limit is not None:
+        dataframe = dataframe.limit(int(limit))
+    return dataframe.toPandas()
+
+
+def _validate_geometry_format(geometry_format: str) -> str:
+    """Validate supported geometry format names."""
+    clean_format = geometry_format.lower().strip()
+    if clean_format not in {"wkt", "wkb_hex"}:
+        raise ValueError("geometry_format must be one of: wkt, wkb_hex")
+    return clean_format
+
+
+def geopandas_to_spark(
+    dataframe: Any,
+    spark: Optional[Any] = None,
+    geometry_column: str = "geometry",
+    geometry_format: str = "wkt",
+    crs_column: str = "geometry_crs",
+) -> Any:
+    """
+    Convert a GeoPandas DataFrame to Spark using a serializable geometry column.
+
+    Geometry is serialized as WKT or WKB hex to avoid runtime-specific geospatial
+    library requirements on Spark clusters.
+    """
+    try:
+        import geopandas as gpd
+    except ImportError as exc:
+        raise ImportError("GeoPandas not available. Install with: pip install geopandas") from exc
+
+    geom_format = _validate_geometry_format(geometry_format)
+    if not isinstance(dataframe, gpd.GeoDataFrame):
+        raise TypeError("dataframe must be a GeoPandas GeoDataFrame")
+    if geometry_column not in dataframe.columns:
+        raise ValueError(f"geometry column not found: {geometry_column}")
+
+    pdf = pd.DataFrame(dataframe.copy())
+
+    if geom_format == "wkt":
+        pdf[geometry_column] = dataframe[geometry_column].apply(
+            lambda geom: None if geom is None else geom.wkt
+        )
+    else:
+        pdf[geometry_column] = dataframe[geometry_column].apply(
+            lambda geom: None if geom is None else geom.wkb_hex
+        )
+
+    pdf[crs_column] = str(dataframe.crs) if dataframe.crs else None
+    return pandas_to_spark(pdf, spark=spark)
+
+
+def spark_to_geopandas(
+    dataframe: Any,
+    geometry_column: str = "geometry",
+    geometry_format: str = "wkt",
+    crs: Optional[str] = None,
+) -> Any:
+    """
+    Convert Spark DataFrame with serialized geometry into GeoPandas DataFrame.
+
+    Supports WKT and WKB hex serialization formats.
+    """
+    try:
+        import geopandas as gpd
+        from shapely import wkb, wkt
+    except ImportError as exc:
+        raise ImportError(
+            "GeoPandas and Shapely are required. Install with: pip install geopandas shapely"
+        ) from exc
+
+    geom_format = _validate_geometry_format(geometry_format)
+    pdf = spark_to_pandas(dataframe)
+
+    if geometry_column not in pdf.columns:
+        raise ValueError(f"geometry column not found: {geometry_column}")
+
+    if geom_format == "wkt":
+        pdf[geometry_column] = pdf[geometry_column].apply(
+            lambda value: None if value is None else wkt.loads(value)
+        )
+    else:
+        pdf[geometry_column] = pdf[geometry_column].apply(
+            lambda value: None if value is None else wkb.loads(bytes.fromhex(value))
+        )
+
+    return gpd.GeoDataFrame(pdf, geometry=geometry_column, crs=crs)

--- a/siege_utilities/databricks/lakebase.py
+++ b/siege_utilities/databricks/lakebase.py
@@ -1,0 +1,51 @@
+"""LakeBase/Postgres connection helpers for Databricks workflows."""
+
+import shlex
+from typing import Dict
+
+
+def parse_conninfo(conninfo: str) -> Dict[str, str]:
+    """
+    Parse a PostgreSQL-style conninfo string into key/value pairs.
+
+    Example:
+        host=example.com user=alice dbname=mydb port=5432 sslmode=require
+    """
+    parts = shlex.split(conninfo)
+    parsed: Dict[str, str] = {}
+    for part in parts:
+        if "=" not in part:
+            continue
+        key, value = part.split("=", 1)
+        parsed[key.strip()] = value.strip()
+    return parsed
+
+
+def build_lakebase_psql_command(
+    host: str,
+    user: str,
+    dbname: str,
+    port: int = 5432,
+    sslmode: str = "require",
+) -> str:
+    """Build a psql command line for LakeBase/Postgres."""
+    conninfo = (
+        f"host={host} user={user} dbname={dbname} port={int(port)} sslmode={sslmode}"
+    )
+    return f'psql "{conninfo}"'
+
+
+def build_pgpass_entry(
+    host: str,
+    port: int,
+    dbname: str,
+    user: str,
+    password: str,
+) -> str:
+    """Build a single .pgpass line."""
+    return f"{host}:{int(port)}:{dbname}:{user}:{password}"
+
+
+def build_jdbc_url(host: str, dbname: str, port: int = 5432) -> str:
+    """Build a PostgreSQL JDBC URL."""
+    return f"jdbc:postgresql://{host}:{int(port)}/{dbname}"

--- a/siege_utilities/databricks/secrets.py
+++ b/siege_utilities/databricks/secrets.py
@@ -1,0 +1,46 @@
+"""Databricks secret management helpers."""
+
+from typing import Any, Optional
+
+from .session import get_dbutils
+
+
+def get_runtime_secret(scope: str, key: str, dbutils: Optional[Any] = None) -> str:
+    """Read a secret from Databricks runtime dbutils."""
+    dbutils = dbutils or get_dbutils()
+    return dbutils.secrets.get(scope=scope, key=key)
+
+
+def runtime_secret_exists(scope: str, key: str, dbutils: Optional[Any] = None) -> bool:
+    """Check whether a runtime secret key exists in a scope."""
+    dbutils = dbutils or get_dbutils()
+    try:
+        keys = dbutils.secrets.list(scope=scope)
+    except Exception:
+        return False
+    return any(getattr(item, "key", None) == key for item in keys)
+
+
+def ensure_secret_scope(scope: str, workspace_client: Any) -> bool:
+    """
+    Ensure a secret scope exists using Databricks workspace APIs.
+
+    Returns True when scope exists or is created.
+    """
+    existing = workspace_client.secrets.list_scopes()
+    if any(getattr(item, "name", None) == scope for item in existing):
+        return True
+
+    workspace_client.secrets.create_scope(scope=scope)
+    return True
+
+
+def put_secret(
+    scope: str,
+    key: str,
+    value: str,
+    workspace_client: Any,
+) -> bool:
+    """Create or update a secret key using Databricks workspace APIs."""
+    workspace_client.secrets.put_secret(scope=scope, key=key, string_value=value)
+    return True

--- a/siege_utilities/databricks/session.py
+++ b/siege_utilities/databricks/session.py
@@ -1,0 +1,56 @@
+"""Databricks runtime session helpers."""
+
+from typing import Any, Optional
+
+
+def get_active_spark_session(create_if_missing: bool = False, app_name: str = "siege_utilities_databricks") -> Any:
+    """
+    Get active Spark session from Databricks or PySpark runtime.
+
+    Args:
+        create_if_missing: If True, create a Spark session when none is active.
+        app_name: App name used when creating a new session.
+    """
+    try:
+        from pyspark.sql import SparkSession
+    except ImportError as exc:
+        raise ImportError("PySpark not available. Install with: pip install pyspark") from exc
+
+    spark = SparkSession.getActiveSession()
+    if spark is not None:
+        return spark
+
+    if not create_if_missing:
+        raise RuntimeError(
+            "No active Spark session found. Set create_if_missing=True to build one."
+        )
+
+    return SparkSession.builder.appName(app_name).getOrCreate()
+
+
+def get_dbutils(spark: Optional[Any] = None) -> Any:
+    """
+    Get a Databricks DBUtils handle.
+
+    Tries pyspark DBUtils first, then notebook global namespace fallback.
+    """
+    if spark is None:
+        spark = get_active_spark_session(create_if_missing=True)
+
+    try:
+        from pyspark.dbutils import DBUtils
+
+        return DBUtils(spark)
+    except Exception:
+        pass
+
+    try:
+        from IPython import get_ipython
+
+        ipython = get_ipython()
+        if ipython and "dbutils" in ipython.user_ns:
+            return ipython.user_ns["dbutils"]
+    except Exception:
+        pass
+
+    raise RuntimeError("Could not resolve dbutils from Spark or notebook runtime.")

--- a/siege_utilities/databricks/unity_catalog.py
+++ b/siege_utilities/databricks/unity_catalog.py
@@ -1,0 +1,61 @@
+"""Unity Catalog SQL helpers for foreign table registration."""
+
+from typing import Iterable, List
+
+
+def quote_ident(value: str) -> str:
+    """Quote an identifier with backticks for Databricks SQL."""
+    return "`" + value.replace("`", "``") + "`"
+
+
+def build_foreign_table_sql(
+    catalog: str,
+    schema: str,
+    table: str,
+    connection_name: str,
+    source_schema: str,
+    source_table: str | None = None,
+) -> str:
+    """
+    Build SQL for creating a Unity Catalog foreign table from a LakeBase source table.
+
+    Note: syntax can vary by workspace/feature flag. Keep this as a composable
+    helper and validate generated SQL in the target Databricks environment.
+    """
+    resolved_source = source_table or table
+    fq_table = ".".join([quote_ident(catalog), quote_ident(schema), quote_ident(table)])
+    source_ref = f"{source_schema}.{resolved_source}"
+    return (
+        f"CREATE FOREIGN TABLE IF NOT EXISTS {fq_table}\n"
+        f"USING CONNECTION {quote_ident(connection_name)}\n"
+        f"OPTIONS (table '{source_ref}');"
+    )
+
+
+def build_schema_and_table_sync_sql(
+    catalog: str,
+    schema: str,
+    connection_name: str,
+    source_schema: str,
+    tables: Iterable[str],
+) -> List[str]:
+    """Build CREATE SCHEMA + CREATE FOREIGN TABLE statements for multiple tables."""
+    statements: List[str] = [
+        (
+            "CREATE SCHEMA IF NOT EXISTS "
+            + ".".join([quote_ident(catalog), quote_ident(schema)])
+            + ";"
+        )
+    ]
+    for table in tables:
+        statements.append(
+            build_foreign_table_sql(
+                catalog=catalog,
+                schema=schema,
+                table=table,
+                connection_name=connection_name,
+                source_schema=source_schema,
+                source_table=table,
+            )
+        )
+    return statements

--- a/tests/test_databricks_auth_session_secrets.py
+++ b/tests/test_databricks_auth_session_secrets.py
@@ -1,0 +1,162 @@
+"""Tests for Databricks auth/session/secrets helpers."""
+
+import sys
+import types
+
+import pytest
+
+from siege_utilities.databricks.auth import get_workspace_client
+from siege_utilities.databricks.secrets import (
+    ensure_secret_scope,
+    get_runtime_secret,
+    put_secret,
+    runtime_secret_exists,
+)
+from siege_utilities.databricks.session import get_active_spark_session, get_dbutils
+
+
+def test_get_workspace_client_with_pat(monkeypatch):
+    """Workspace client should receive PAT/profile args."""
+    databricks_module = types.ModuleType("databricks")
+    sdk_module = types.ModuleType("databricks.sdk")
+
+    class FakeWorkspaceClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    sdk_module.WorkspaceClient = FakeWorkspaceClient
+    monkeypatch.setitem(sys.modules, "databricks", databricks_module)
+    monkeypatch.setitem(sys.modules, "databricks.sdk", sdk_module)
+
+    client = get_workspace_client(
+        profile="SUZY_USER",
+        host="https://adb.example.net",
+        token="abc123",
+    )
+    assert client.kwargs["profile"] == "SUZY_USER"
+    assert client.kwargs["host"] == "https://adb.example.net"
+    assert client.kwargs["token"] == "abc123"
+
+
+def test_get_workspace_client_requires_full_azure_sp(monkeypatch):
+    """Azure SP auth should require all three SP fields."""
+    databricks_module = types.ModuleType("databricks")
+    sdk_module = types.ModuleType("databricks.sdk")
+    sdk_module.WorkspaceClient = object
+    monkeypatch.setitem(sys.modules, "databricks", databricks_module)
+    monkeypatch.setitem(sys.modules, "databricks.sdk", sdk_module)
+
+    with pytest.raises(ValueError):
+        get_workspace_client(
+            azure_client_id="client-id-only",
+            azure_client_secret=None,
+            azure_tenant_id=None,
+        )
+
+
+def test_get_active_spark_session_existing(monkeypatch):
+    """Existing active Spark session should be returned."""
+    pyspark_module = types.ModuleType("pyspark")
+    sql_module = types.ModuleType("pyspark.sql")
+
+    class FakeSparkSession:
+        @staticmethod
+        def getActiveSession():
+            return "ACTIVE_SPARK"
+
+    sql_module.SparkSession = FakeSparkSession
+    monkeypatch.setitem(sys.modules, "pyspark", pyspark_module)
+    monkeypatch.setitem(sys.modules, "pyspark.sql", sql_module)
+
+    assert get_active_spark_session() == "ACTIVE_SPARK"
+
+
+def test_get_dbutils_from_pyspark_dbutils(monkeypatch):
+    """DBUtils should resolve from pyspark.dbutils when available."""
+    pyspark_module = types.ModuleType("pyspark")
+    sql_module = types.ModuleType("pyspark.sql")
+    dbutils_module = types.ModuleType("pyspark.dbutils")
+
+    class FakeBuilder:
+        def appName(self, _name):
+            return self
+
+        def getOrCreate(self):
+            return "SPARK_FROM_BUILDER"
+
+    class FakeSparkSession:
+        builder = FakeBuilder()
+
+        @staticmethod
+        def getActiveSession():
+            return None
+
+    class FakeDBUtils:
+        def __init__(self, spark):
+            self.spark = spark
+
+    sql_module.SparkSession = FakeSparkSession
+    dbutils_module.DBUtils = FakeDBUtils
+
+    monkeypatch.setitem(sys.modules, "pyspark", pyspark_module)
+    monkeypatch.setitem(sys.modules, "pyspark.sql", sql_module)
+    monkeypatch.setitem(sys.modules, "pyspark.dbutils", dbutils_module)
+
+    dbutils = get_dbutils()
+    assert dbutils.spark == "SPARK_FROM_BUILDER"
+
+
+def test_runtime_secret_helpers_with_dbutils_stub():
+    """Runtime secret wrappers should use dbutils secrets API."""
+    class SecretItem:
+        def __init__(self, key):
+            self.key = key
+
+    class SecretApi:
+        def get(self, scope, key):
+            return f"{scope}:{key}:value"
+
+        def list(self, scope):
+            assert scope == "my-scope"
+            return [SecretItem("alpha"), SecretItem("beta")]
+
+    class DBUtilsStub:
+        secrets = SecretApi()
+
+    dbutils = DBUtilsStub()
+    assert get_runtime_secret("my-scope", "alpha", dbutils=dbutils) == "my-scope:alpha:value"
+    assert runtime_secret_exists("my-scope", "beta", dbutils=dbutils) is True
+    assert runtime_secret_exists("my-scope", "gamma", dbutils=dbutils) is False
+
+
+def test_workspace_secret_scope_and_put():
+    """Workspace scope helpers should call list/create/put APIs."""
+    class ScopeItem:
+        def __init__(self, name):
+            self.name = name
+
+    class SecretsApi:
+        def __init__(self):
+            self.created = []
+            self.puts = []
+
+        def list_scopes(self):
+            return [ScopeItem("existing-scope")]
+
+        def create_scope(self, scope):
+            self.created.append(scope)
+
+        def put_secret(self, scope, key, string_value):
+            self.puts.append((scope, key, string_value))
+
+    class WorkspaceClientStub:
+        def __init__(self):
+            self.secrets = SecretsApi()
+
+    client = WorkspaceClientStub()
+    assert ensure_secret_scope("existing-scope", workspace_client=client) is True
+    assert ensure_secret_scope("new-scope", workspace_client=client) is True
+    assert client.secrets.created == ["new-scope"]
+
+    assert put_secret("new-scope", "token", "abc", workspace_client=client) is True
+    assert client.secrets.puts == [("new-scope", "token", "abc")]

--- a/tests/test_databricks_dataframe_bridge.py
+++ b/tests/test_databricks_dataframe_bridge.py
@@ -1,0 +1,51 @@
+"""Tests for dataframe bridge helpers."""
+
+import pandas as pd
+import pytest
+
+from siege_utilities.databricks.dataframe_bridge import (
+    _validate_geometry_format,
+    pandas_to_spark,
+    spark_to_pandas,
+)
+
+
+def test_pandas_to_spark_uses_create_dataframe():
+    """Pandas conversion should call Spark createDataFrame."""
+    called = {"value": None}
+
+    class SparkStub:
+        def createDataFrame(self, dataframe):
+            called["value"] = dataframe
+            return "SPARK_DF"
+
+    pandas_df = pd.DataFrame({"id": [1, 2], "name": ["a", "b"]})
+    output = pandas_to_spark(pandas_df, spark=SparkStub())
+    assert output == "SPARK_DF"
+    assert called["value"].equals(pandas_df)
+
+
+def test_spark_to_pandas_with_limit():
+    """Spark conversion should support optional row limit."""
+    expected = pd.DataFrame({"id": [1]})
+
+    class LimitedSparkDf:
+        def toPandas(self):
+            return expected
+
+    class SparkDf:
+        def limit(self, value):
+            assert value == 1
+            return LimitedSparkDf()
+
+    output = spark_to_pandas(SparkDf(), limit=1)
+    assert output.equals(expected)
+
+
+def test_validate_geometry_format():
+    """Geometry format validator should accept supported formats."""
+    assert _validate_geometry_format("wkt") == "wkt"
+    assert _validate_geometry_format("WKB_HEX") == "wkb_hex"
+
+    with pytest.raises(ValueError):
+        _validate_geometry_format("geojson")

--- a/tests/test_databricks_lakebase_unity.py
+++ b/tests/test_databricks_lakebase_unity.py
@@ -1,0 +1,76 @@
+"""Tests for LakeBase/Unity helpers."""
+
+from siege_utilities.databricks.artifacts import build_databricks_run_url
+from siege_utilities.databricks.lakebase import (
+    build_jdbc_url,
+    build_lakebase_psql_command,
+    build_pgpass_entry,
+    parse_conninfo,
+)
+from siege_utilities.databricks.unity_catalog import (
+    build_foreign_table_sql,
+    build_schema_and_table_sync_sql,
+)
+
+
+def test_parse_conninfo_and_lakebase_builders():
+    """LakeBase helpers should parse/build connection artifacts."""
+    parsed = parse_conninfo(
+        "host=db.example.net user=alice dbname=analytics port=5432 sslmode=require"
+    )
+    assert parsed["host"] == "db.example.net"
+    assert parsed["user"] == "alice"
+    assert parsed["dbname"] == "analytics"
+
+    cmd = build_lakebase_psql_command(
+        host="db.example.net",
+        user="alice",
+        dbname="analytics",
+    )
+    assert 'host=db.example.net user=alice dbname=analytics' in cmd
+
+    pgpass = build_pgpass_entry(
+        host="db.example.net",
+        port=5432,
+        dbname="analytics",
+        user="alice",
+        password="secret",
+    )
+    assert pgpass == "db.example.net:5432:analytics:alice:secret"
+
+    jdbc = build_jdbc_url("db.example.net", "analytics", port=5432)
+    assert jdbc == "jdbc:postgresql://db.example.net:5432/analytics"
+
+
+def test_unity_sql_helpers():
+    """Unity SQL helpers should generate schema + foreign table SQL."""
+    foreign_sql = build_foreign_table_sql(
+        catalog="main",
+        schema="ext",
+        table="zip",
+        connection_name="lakebase_conn",
+        source_schema="census_reference",
+    )
+    assert "CREATE FOREIGN TABLE IF NOT EXISTS `main`.`ext`.`zip`" in foreign_sql
+    assert "USING CONNECTION `lakebase_conn`" in foreign_sql
+    assert "OPTIONS (table 'census_reference.zip')" in foreign_sql
+
+    statements = build_schema_and_table_sync_sql(
+        catalog="main",
+        schema="ext",
+        connection_name="lakebase_conn",
+        source_schema="census_reference",
+        tables=["zip", "tract"],
+    )
+    assert len(statements) == 3
+    assert statements[0].startswith("CREATE SCHEMA IF NOT EXISTS")
+
+
+def test_build_databricks_run_url():
+    """Run URL helper should generate stable links."""
+    url = build_databricks_run_url(
+        host="https://adb-123.azuredatabricks.net/",
+        workspace_id="3912175703892324",
+        run_id="123456789",
+    )
+    assert url == "https://adb-123.azuredatabricks.net/jobs/runs/123456789?o=3912175703892324"


### PR DESCRIPTION
## Summary
- add a new `siege_utilities.databricks` package for general Databricks usage
- add auth helper for PAT/profile/Azure SP `WorkspaceClient` creation
- add session helpers for active Spark resolution and `dbutils` lookup
- add workspace/runtime secret helpers for scope creation, writes, and key checks
- add dataframe bridges for Pandas <-> Spark and GeoPandas <-> Spark using WKT/WKB-hex geometry serialization
- include LakeBase/Unity SQL/run-link helpers in the same package
- expose Databricks helpers at package top-level with fallback wrappers

## Tests
- `pytest -q -c /dev/null tests/test_databricks_auth_session_secrets.py tests/test_databricks_dataframe_bridge.py tests/test_databricks_lakebase_unity.py`
