### PR TITLE
Fix CensusDataSelector primary dataset bonus (su#164)

### DIFF
--- a/siege_utilities/geo/census_data_selector.py
+++ b/siege_utilities/geo/census_data_selector.py
@@ -234,7 +234,7 @@ class CensusDataSelector:
                 score_breakdown["geography_match"] = 2.0
             
             # Pattern dataset preference
-            if dataset.name in pattern.get("primary_datasets", []):
+            if dataset.dataset_id in pattern.get("primary_datasets", []):
                 score_breakdown["primary_dataset"] = 1.5
             
             # Reliability scoring
@@ -332,7 +332,7 @@ class CensusDataSelector:
         
         rationales = []
         
-        if dataset.name in pattern.get("primary_datasets", []):
+        if dataset.dataset_id in pattern.get("primary_datasets", []):
             rationales.append("Matches primary dataset pattern for this analysis type")
         
         if dataset.reliability.value == pattern.get("reliability_requirement", "medium"):
@@ -394,7 +394,7 @@ class CensusDataSelector:
         score = 0.0
         
         # Dataset preference
-        if dataset.name in pattern.get("primary_datasets", []):
+        if dataset.dataset_id in pattern.get("primary_datasets", []):
             score += 2.0
         
         # Variable coverage

--- a/siege_utilities/geo/census_dataset_mapper.py
+++ b/siege_utilities/geo/census_dataset_mapper.py
@@ -78,7 +78,8 @@ class DataReliability(Enum):
 @dataclass
 class CensusDataset:
     """Represents a Census dataset with metadata."""
-    
+
+    dataset_id: str
     name: str
     survey_type: SurveyType
     geography_levels: List[GeographyLevel]
@@ -130,6 +131,7 @@ class CensusDatasetMapper:
         
         # Decennial Census (2020)
         self.datasets["decennial_2020"] = CensusDataset(
+            dataset_id="decennial_2020",
             name="2020 Decennial Census",
             survey_type=SurveyType.DECENNIAL,
             geography_levels=[
@@ -167,6 +169,7 @@ class CensusDatasetMapper:
         
         # ACS 5-Year Estimates (2020)
         self.datasets["acs_5yr_2020"] = CensusDataset(
+            dataset_id="acs_5yr_2020",
             name="ACS 5-Year Estimates (2020)",
             survey_type=SurveyType.ACS_5YR,
             geography_levels=[
@@ -203,6 +206,7 @@ class CensusDatasetMapper:
         
         # ACS 1-Year Estimates (2020)
         self.datasets["acs_1yr_2020"] = CensusDataset(
+            dataset_id="acs_1yr_2020",
             name="ACS 1-Year Estimates (2020)",
             survey_type=SurveyType.ACS_1YR,
             geography_levels=[
@@ -239,6 +243,7 @@ class CensusDatasetMapper:
         
         # Population Estimates (2023)
         self.datasets["population_estimates_2023"] = CensusDataset(
+            dataset_id="population_estimates_2023",
             name="Population Estimates (2023)",
             survey_type=SurveyType.POPULATION_ESTIMATES,
             geography_levels=[
@@ -275,6 +280,7 @@ class CensusDatasetMapper:
         
         # Economic Census (2017)
         self.datasets["economic_census_2017"] = CensusDataset(
+            dataset_id="economic_census_2017",
             name="Economic Census (2017)",
             survey_type=SurveyType.CENSUS_BUSINESS,
             geography_levels=[

--- a/tests/test_census_data_selector_bonus.py
+++ b/tests/test_census_data_selector_bonus.py
@@ -1,0 +1,127 @@
+"""
+Tests for CensusDataSelector primary dataset bonus fix (su#164).
+
+Verifies that the primary_dataset bonus (+1.5) is correctly applied
+when a dataset's ID matches the pattern's primary_datasets list.
+"""
+
+import pytest
+from siege_utilities.geo.census_data_selector import CensusDataSelector
+from siege_utilities.geo.census_dataset_mapper import (
+    CensusDataset, CensusDatasetMapper, SurveyType, GeographyLevel, DataReliability,
+)
+
+
+class TestPrimaryDatasetBonus:
+    """Tests that the primary_dataset bonus is applied correctly."""
+
+    def setup_method(self):
+        self.selector = CensusDataSelector()
+
+    def test_primary_bonus_applied_for_matching_dataset(self):
+        """Primary dataset bonus (+1.5) must be awarded when dataset_id
+        appears in the pattern's primary_datasets list."""
+        pattern = self.selector.analysis_patterns["demographics"]
+        # "acs_5yr_2020" is in demographics.primary_datasets
+        dataset = self.selector.mapper.datasets["acs_5yr_2020"]
+        assert dataset.dataset_id == "acs_5yr_2020"
+        assert dataset.dataset_id in pattern["primary_datasets"]
+
+        # Score via the ranking method
+        ranked = self.selector._rank_datasets_by_suitability(
+            [dataset], pattern, GeographyLevel.TRACT, None
+        )
+        _, breakdown = ranked[0]
+        assert breakdown["primary_dataset"] == 1.5, (
+            "Primary dataset bonus not applied — dataset_id vs name mismatch?"
+        )
+
+    def test_primary_bonus_not_applied_for_non_matching_dataset(self):
+        """Datasets NOT in primary_datasets must receive 0.0 bonus."""
+        pattern = self.selector.analysis_patterns["demographics"]
+        # population_estimates_2023 is NOT in demographics.primary_datasets
+        dataset = self.selector.mapper.datasets["population_estimates_2023"]
+        assert dataset.dataset_id not in pattern["primary_datasets"]
+
+        ranked = self.selector._rank_datasets_by_suitability(
+            [dataset], pattern, GeographyLevel.COUNTY, None
+        )
+        _, breakdown = ranked[0]
+        assert breakdown["primary_dataset"] == 0.0
+
+    def test_decennial_gets_bonus_for_demographics(self):
+        """decennial_2020 is listed in demographics primary_datasets."""
+        pattern = self.selector.analysis_patterns["demographics"]
+        dataset = self.selector.mapper.datasets["decennial_2020"]
+        assert dataset.dataset_id in pattern["primary_datasets"]
+
+        ranked = self.selector._rank_datasets_by_suitability(
+            [dataset], pattern, GeographyLevel.TRACT, None
+        )
+        _, breakdown = ranked[0]
+        assert breakdown["primary_dataset"] == 1.5
+
+    def test_economic_census_gets_bonus_for_business(self):
+        """economic_census_2017 is in business.primary_datasets."""
+        pattern = self.selector.analysis_patterns["business"]
+        dataset = self.selector.mapper.datasets["economic_census_2017"]
+        assert dataset.dataset_id in pattern["primary_datasets"]
+
+        ranked = self.selector._rank_datasets_by_suitability(
+            [dataset], pattern, GeographyLevel.COUNTY, None
+        )
+        _, breakdown = ranked[0]
+        assert breakdown["primary_dataset"] == 1.5
+
+
+class TestDatasetIdField:
+    """Verify that every dataset in the mapper has a dataset_id matching its key."""
+
+    def test_all_datasets_have_matching_id(self):
+        mapper = CensusDatasetMapper()
+        for key, dataset in mapper.datasets.items():
+            assert dataset.dataset_id == key, (
+                f"Dataset key '{key}' doesn't match dataset_id '{dataset.dataset_id}'"
+            )
+
+
+class TestCompatibilityScoreBonus:
+    """Verify _calculate_compatibility_score also uses dataset_id."""
+
+    def setup_method(self):
+        self.selector = CensusDataSelector()
+
+    def test_compatibility_score_includes_primary_bonus(self):
+        pattern = self.selector.analysis_patterns["demographics"]
+        dataset = self.selector.mapper.datasets["acs_5yr_2020"]
+        score = self.selector._calculate_compatibility_score(dataset, pattern)
+        # The +2.0 primary bonus in compatibility score should apply
+        assert score >= 2.0
+
+    def test_compatibility_score_excludes_primary_bonus_for_non_primary(self):
+        pattern = self.selector.analysis_patterns["demographics"]
+        dataset = self.selector.mapper.datasets["economic_census_2017"]
+        assert dataset.dataset_id not in pattern["primary_datasets"]
+        score = self.selector._calculate_compatibility_score(dataset, pattern)
+        # Without primary bonus, base score should be lower
+        # (may still get geography/reliability points)
+        assert score < 4.0
+
+
+class TestRationaleUsesDatasetId:
+    """Verify _generate_rationale checks dataset_id, not name."""
+
+    def setup_method(self):
+        self.selector = CensusDataSelector()
+
+    def test_rationale_includes_primary_match(self):
+        pattern = self.selector.analysis_patterns["demographics"]
+        dataset = self.selector.mapper.datasets["acs_5yr_2020"]
+        rationale = self.selector._generate_rationale(dataset, pattern)
+        assert "primary dataset pattern" in rationale.lower()
+
+    def test_rationale_excludes_primary_match_for_non_primary(self):
+        pattern = self.selector.analysis_patterns["demographics"]
+        dataset = self.selector.mapper.datasets["population_estimates_2023"]
+        rationale = self.selector._generate_rationale(dataset, pattern)
+        assert "primary dataset pattern" not in rationale.lower()


### PR DESCRIPTION
## Summary
- Added `dataset_id` field to `CensusDataset` dataclass
- Fixed 4 comparison sites in `CensusDataSelector` that compared `dataset.name` (human-readable, e.g. "ACS 5-Year Estimates (2020)") against pattern IDs (e.g. "acs_5yr_2020") — bonus was never applied
- Added 9 unit tests covering positive/negative bonus cases, rationale text, and compatibility scoring

Fixes #164

## Test plan
- [x] 9 new tests pass (`test_census_data_selector_bonus.py`)
- [x] Full test suite shows no regressions (pre-existing `test_init_without_api_key` failure unrelated)