### PR TITLE
Replace silent None failures with structured boundary diagnostics

### DIFF
--- a/siege_utilities/geo/__init__.py
+++ b/siege_utilities/geo/__init__.py
@@ -16,6 +16,13 @@ def _register(names, module):
         _LAZY_IMPORTS[name] = module
 
 
+# --- boundary_result (structured diagnostics) ---
+_register([
+    'BoundaryFetchResult',
+    'BoundaryRetrievalError', 'BoundaryInputError', 'BoundaryDiscoveryError',
+    'BoundaryUrlValidationError', 'BoundaryDownloadError', 'BoundaryParseError',
+], '.boundary_result')
+
 # --- spatial_data ---
 _register([
     'CensusDirectoryDiscovery', 'CensusDataSource', 'SpatialDataSource',
@@ -26,7 +33,8 @@ _register([
     'get_census_data', 'download_osm_data',
     'get_available_years', 'get_year_directory_contents',
     'construct_download_url', 'validate_download_url', 'get_optimal_year',
-    'get_geographic_boundaries', 'get_available_boundary_types',
+    'get_geographic_boundaries', 'fetch_geographic_boundaries',
+    'get_available_boundary_types',
     'refresh_discovery_cache', 'get_available_state_fips', 'get_state_abbreviations',
     'get_comprehensive_state_info', 'validate_state_fips',
     'get_state_name', 'get_state_abbreviation', 'download_dataset',

--- a/siege_utilities/geo/boundary_result.py
+++ b/siege_utilities/geo/boundary_result.py
@@ -1,0 +1,151 @@
+"""
+Structured diagnostics for Census boundary retrieval.
+
+Provides typed exceptions and a result object so callers can programmatically
+branch on failure reason without parsing free-text logs.
+
+Usage::
+
+    from siege_utilities.geo import fetch_geographic_boundaries
+
+    result = fetch_geographic_boundaries(2020, 'county', state_fips='48')
+    if result.success:
+        gdf = result.geodataframe
+    else:
+        print(f"Failed at stage '{result.error_stage}': {result.message}")
+        print(f"Context: {result.context}")
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional, Dict, Any
+
+try:
+    import geopandas as gpd
+except ImportError:
+    gpd = None
+
+
+# ---------------------------------------------------------------------------
+# Typed Exceptions
+# ---------------------------------------------------------------------------
+
+class BoundaryRetrievalError(Exception):
+    """Base exception for all boundary retrieval failures."""
+
+    def __init__(self, message: str, stage: str, context: Optional[Dict[str, Any]] = None):
+        self.stage = stage
+        self.context = context or {}
+        super().__init__(message)
+
+
+class BoundaryInputError(BoundaryRetrievalError):
+    """Invalid input parameters (state FIPS, year, geographic level)."""
+
+    def __init__(self, message: str, context: Optional[Dict[str, Any]] = None):
+        super().__init__(message, stage="input_validation", context=context)
+
+
+class BoundaryDiscoveryError(BoundaryRetrievalError):
+    """Failed to discover available boundary types or construct a URL."""
+
+    def __init__(self, message: str, context: Optional[Dict[str, Any]] = None):
+        super().__init__(message, stage="discovery", context=context)
+
+
+class BoundaryUrlValidationError(BoundaryRetrievalError):
+    """Constructed URL is not accessible (HTTP error, timeout, etc.)."""
+
+    def __init__(self, message: str, context: Optional[Dict[str, Any]] = None):
+        super().__init__(message, stage="url_validation", context=context)
+
+
+class BoundaryDownloadError(BoundaryRetrievalError):
+    """Download succeeded but the file is corrupt or not a valid zip."""
+
+    def __init__(self, message: str, context: Optional[Dict[str, Any]] = None):
+        super().__init__(message, stage="download", context=context)
+
+
+class BoundaryParseError(BoundaryRetrievalError):
+    """Downloaded data could not be parsed as a shapefile/GeoDataFrame."""
+
+    def __init__(self, message: str, context: Optional[Dict[str, Any]] = None):
+        super().__init__(message, stage="parse", context=context)
+
+
+# ---------------------------------------------------------------------------
+# Result Object
+# ---------------------------------------------------------------------------
+
+@dataclass
+class BoundaryFetchResult:
+    """Structured result from a boundary retrieval attempt.
+
+    Attributes:
+        success: Whether the retrieval succeeded.
+        geodataframe: The resulting GeoDataFrame (None on failure).
+        error_code: Machine-readable error code (None on success).
+        error_stage: Pipeline stage where failure occurred (None on success).
+            One of: input_validation, discovery, url_validation, download, parse.
+        message: Human-readable description of the outcome.
+        context: Diagnostic details (attempted URLs, year fallback, HTTP status, etc.).
+    """
+
+    success: bool
+    geodataframe: Any = None  # Optional[gpd.GeoDataFrame]
+    error_code: Optional[str] = None
+    error_stage: Optional[str] = None
+    message: str = ""
+    context: Dict[str, Any] = field(default_factory=dict)
+
+    def __bool__(self) -> bool:
+        return self.success
+
+    def raise_on_error(self) -> "BoundaryFetchResult":
+        """Raise the appropriate typed exception if this result is a failure.
+
+        Returns self on success so callers can chain::
+
+            gdf = fetch_geographic_boundaries(...).raise_on_error().geodataframe
+        """
+        if self.success:
+            return self
+
+        exc_map = {
+            "input_validation": BoundaryInputError,
+            "discovery": BoundaryDiscoveryError,
+            "url_validation": BoundaryUrlValidationError,
+            "download": BoundaryDownloadError,
+            "parse": BoundaryParseError,
+        }
+        exc_cls = exc_map.get(self.error_stage, BoundaryRetrievalError)
+        if exc_cls is BoundaryRetrievalError:
+            raise exc_cls(self.message, stage=self.error_stage or "unknown", context=self.context)
+        raise exc_cls(self.message, context=self.context)
+
+    @classmethod
+    def ok(cls, gdf, message: str = "", context: Optional[Dict[str, Any]] = None) -> "BoundaryFetchResult":
+        """Construct a success result."""
+        return cls(
+            success=True,
+            geodataframe=gdf,
+            message=message or f"Retrieved {len(gdf)} features",
+            context=context or {},
+        )
+
+    @classmethod
+    def fail(
+        cls,
+        error_code: str,
+        error_stage: str,
+        message: str,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> "BoundaryFetchResult":
+        """Construct a failure result."""
+        return cls(
+            success=False,
+            error_code=error_code,
+            error_stage=error_stage,
+            message=message,
+            context=context or {},
+        )

--- a/siege_utilities/geo/spatial_data.py
+++ b/siege_utilities/geo/spatial_data.py
@@ -13,6 +13,7 @@ import tempfile
 import os
 from urllib.parse import urljoin, urlparse
 import time
+import warnings as _warnings_mod
 from datetime import datetime, timedelta
 import requests
 from bs4 import BeautifulSoup
@@ -45,6 +46,17 @@ from ..config import (
     validate_geographic_level,
     get_fips_info,
     get_service_timeout
+)
+
+# Structured boundary diagnostics
+from .boundary_result import (
+    BoundaryFetchResult,
+    BoundaryRetrievalError,
+    BoundaryInputError,
+    BoundaryDiscoveryError,
+    BoundaryUrlValidationError,
+    BoundaryDownloadError,
+    BoundaryParseError,
 )
 
 # Get logger for this module
@@ -380,49 +392,69 @@ class CensusDirectoryDiscovery:
         
         return patterns
     
-    def construct_download_url(self, year: int, boundary_type: str, state_fips: Optional[str] = None, 
-                              congress_number: Optional[int] = None) -> Optional[str]:
-        """Construct download URL using FIPS validation and year-specific patterns."""
+    def construct_download_url(self, year: int, boundary_type: str, state_fips: Optional[str] = None,
+                              congress_number: Optional[int] = None) -> str:
+        """Construct download URL using FIPS validation and year-specific patterns.
+
+        Raises:
+            BoundaryInputError: If state_fips is invalid.
+            BoundaryDiscoveryError: If boundary_type is not available or URL cannot be constructed.
+        """
+        ctx = {"year": year, "boundary_type": boundary_type, "state_fips": state_fips}
         try:
             # Validate state_fips using centralized FIPS data
             if state_fips:
                 if state_fips not in FIPS_TO_STATE:
-                    log.error(f"Invalid state FIPS code: {state_fips}. Valid codes: {list(FIPS_TO_STATE.keys())[:10]}...")
-                    return None
-                
+                    raise BoundaryInputError(
+                        f"Invalid state FIPS code: {state_fips}. "
+                        f"Valid codes: {list(FIPS_TO_STATE.keys())[:10]}...",
+                        context=ctx,
+                    )
+
                 state_info = get_fips_info(state_fips)
                 log.info(f"Constructing URL for {state_info['name']} ({state_info['abbreviation']})")
-            
+
             # Get year-specific patterns
             patterns = self.get_year_specific_url_patterns(year)
-            
+
             # Get available boundary types for this year
             available_types = self.discover_boundary_types(year)
-            
+
             if boundary_type not in available_types:
-                log.warning(f"Boundary type '{boundary_type}' not available for year {year}")
-                log.info(f"Available types for {year}: {list(available_types.keys())[:10]}...")
-                return None
-            
+                available_list = list(available_types.keys())[:20]
+                raise BoundaryDiscoveryError(
+                    f"Boundary type '{boundary_type}' not available for year {year}. "
+                    f"Available: {available_list}",
+                    context={**ctx, "available_types": available_list},
+                )
+
             directory = available_types[boundary_type]
             base_url = f"{patterns['base_url']}/{directory}"
-            
+
             # Determine which filename pattern to use
             filename = self._construct_filename_with_fips_validation(
                 year, boundary_type, state_fips, congress_number, patterns
             )
-            
+
             if not filename:
-                return None
-            
+                raise BoundaryDiscoveryError(
+                    f"Could not construct filename for {boundary_type} year={year} "
+                    f"state_fips={state_fips} congress={congress_number}",
+                    context=ctx,
+                )
+
             final_url = f"{base_url}/{filename}"
             log.info(f"Constructed URL: {final_url}")
-            
+
             return final_url
-            
+
+        except (BoundaryInputError, BoundaryDiscoveryError):
+            raise
         except Exception as e:
-            log.error(f"Failed to construct URL for {boundary_type} in year {year}: {e}")
-            return None
+            raise BoundaryDiscoveryError(
+                f"Failed to construct URL for {boundary_type} in year {year}: {e}",
+                context={**ctx, "original_error": str(e)},
+            ) from e
     
     def _construct_filename_with_fips_validation(self, year: int, boundary_type: str, 
                                                state_fips: Optional[str], congress_number: Optional[int],
@@ -515,25 +547,58 @@ class CensusDirectoryDiscovery:
 
         Uses GET with stream=True instead of HEAD because CDNs like Cloudflare
         often block or throttle HEAD requests from non-browser User-Agents.
+
+        Raises:
+            BoundaryUrlValidationError: If the URL is not accessible.
         """
         headers = {'User-Agent': 'siege_utilities/1.0 (Census data client)'}
+        ctx: Dict[str, Any] = {"url": url}
         try:
             response = requests.get(url, timeout=self.timeout, stream=True, headers=headers)
             response.close()
-            return response.status_code == 200
-        except requests.exceptions.SSLError:
+            if response.status_code == 200:
+                return True
+            ctx["http_status"] = response.status_code
+            raise BoundaryUrlValidationError(
+                f"URL returned HTTP {response.status_code}: {url}",
+                context=ctx,
+            )
+        except BoundaryUrlValidationError:
+            raise
+        except requests.exceptions.SSLError as ssl_err:
             log.debug(f"SSL verification failed for {url}, trying without verification...")
+            ctx["ssl_error"] = str(ssl_err)
             try:
                 response = requests.get(url, timeout=self.timeout, stream=True,
                                         headers=headers, verify=False)
                 response.close()
-                return response.status_code == 200
+                if response.status_code == 200:
+                    return True
+                ctx["http_status"] = response.status_code
+                raise BoundaryUrlValidationError(
+                    f"URL returned HTTP {response.status_code} (SSL bypass): {url}",
+                    context=ctx,
+                )
+            except BoundaryUrlValidationError:
+                raise
             except Exception as e:
-                log.debug(f"URL validation failed for {url} (with SSL bypass): {e}")
-                return False
+                ctx["fallback_error"] = str(e)
+                raise BoundaryUrlValidationError(
+                    f"URL validation failed for {url} (with SSL bypass): {e}",
+                    context=ctx,
+                ) from e
+        except requests.exceptions.Timeout as e:
+            ctx["timeout_seconds"] = self.timeout
+            raise BoundaryUrlValidationError(
+                f"URL validation timed out after {self.timeout}s: {url}",
+                context=ctx,
+            ) from e
         except Exception as e:
-            log.debug(f"URL validation failed for {url}: {e}")
-            return False
+            ctx["error_type"] = type(e).__name__
+            raise BoundaryUrlValidationError(
+                f"URL validation failed for {url}: {e}",
+                context=ctx,
+            ) from e
     
     def get_optimal_year(self, requested_year: int, boundary_type: str) -> int:
         """Find the best available year for a requested boundary type."""
@@ -622,7 +687,7 @@ class CensusDataSource(SpatialDataSource):
         """Discover available boundary types for a year."""
         return self.discovery.discover_boundary_types(year)
 
-    def get_geographic_boundaries(self, 
+    def get_geographic_boundaries(self,
                                 year: int = DEFAULT_CENSUS_YEAR,
                                 geographic_level: str = 'county',
                                 state_fips: Optional[str] = None,
@@ -630,64 +695,171 @@ class CensusDataSource(SpatialDataSource):
                                 congress_number: Optional[int] = None) -> Optional[GeoDataFrame]:
         """
         Download geographic boundaries from Census TIGER/Line files with dynamic discovery.
-        
+
+        This method preserves the legacy ``Optional[GeoDataFrame]`` return type.
+        For structured diagnostics, use :meth:`fetch_geographic_boundaries` instead.
+
         Args:
             year: Census year (will find closest available if not available)
             geographic_level: Geographic level (state, county, tract, etc.)
             state_fips: State FIPS code for filtering (required for some levels)
             county_fips: County FIPS code for filtering
             congress_number: Congress number for congressional districts
-            
+
         Returns:
             GeoDataFrame with boundaries or None if failed
         """
+        _warnings_mod.warn(
+            "get_geographic_boundaries() returns None on failure with no diagnostics. "
+            "Use fetch_geographic_boundaries() for structured error reporting.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        result = self.fetch_geographic_boundaries(
+            year=year,
+            geographic_level=geographic_level,
+            state_fips=state_fips,
+            county_fips=county_fips,
+            congress_number=congress_number,
+        )
+        if result.success:
+            return result.geodataframe
+        log.error(f"Boundary retrieval failed at stage '{result.error_stage}': {result.message}")
+        return None
+
+    def fetch_geographic_boundaries(self,
+                                    year: int = DEFAULT_CENSUS_YEAR,
+                                    geographic_level: str = 'county',
+                                    state_fips: Optional[str] = None,
+                                    county_fips: Optional[str] = None,
+                                    congress_number: Optional[int] = None) -> BoundaryFetchResult:
+        """
+        Download geographic boundaries with structured diagnostics.
+
+        Returns a :class:`BoundaryFetchResult` that carries either the
+        GeoDataFrame on success or a machine-readable error code, stage, and
+        context dict on failure.
+
+        Args:
+            year: Census year (will find closest available if not available)
+            geographic_level: Geographic level (state, county, tract, etc.)
+            state_fips: State FIPS code for filtering (required for some levels)
+            county_fips: County FIPS code for filtering
+            congress_number: Congress number for congressional districts
+
+        Returns:
+            BoundaryFetchResult with .success, .geodataframe, .error_stage, etc.
+        """
+        base_ctx: Dict[str, Any] = {
+            "year": year,
+            "geographic_level": geographic_level,
+            "state_fips": state_fips,
+            "county_fips": county_fips,
+            "congress_number": congress_number,
+        }
         try:
-            # Normalize state identifier to FIPS code using centralized function
+            # --- Stage: input_validation ---
             normalized_fips = None
             if state_fips:
                 try:
                     normalized_fips = normalize_state_identifier(state_fips)
                 except ValueError as e:
-                    log.error(f"Invalid state identifier: '{state_fips}' - {e}")
-                    log.info("Valid examples: FIPS ('06'), abbreviation ('CA'), or name ('California')")
-                    return None
-                
-                # Get FIPS info for logging normalized state info using centralized function
+                    return BoundaryFetchResult.fail(
+                        error_code="INVALID_STATE_IDENTIFIER",
+                        error_stage="input_validation",
+                        message=f"Invalid state identifier: '{state_fips}' - {e}. "
+                                "Valid examples: FIPS ('06'), abbreviation ('CA'), or name ('California')",
+                        context=base_ctx,
+                    )
+
                 state_info = get_fips_info(normalized_fips)
-                log.info(f"Normalized '{state_fips}' to FIPS {normalized_fips}: {state_info['name']} ({state_info['abbreviation']})")
+                log.info(
+                    f"Normalized '{state_fips}' to FIPS {normalized_fips}: "
+                    f"{state_info['name']} ({state_info['abbreviation']})"
+                )
                 state_fips = normalized_fips
-            
-            # Validate parameters
-            self._validate_census_parameters(year, geographic_level, state_fips)
-            
-            # Find optimal year (closest available to requested)
+                base_ctx["normalized_fips"] = normalized_fips
+
+            try:
+                self._validate_census_parameters(year, geographic_level, state_fips)
+            except ValueError as e:
+                return BoundaryFetchResult.fail(
+                    error_code="INVALID_PARAMETERS",
+                    error_stage="input_validation",
+                    message=str(e),
+                    context=base_ctx,
+                )
+
+            # --- Stage: discovery ---
             optimal_year = self.discovery.get_optimal_year(year, geographic_level)
-            
-            # Construct URL using discovery service
-            url = self.discovery.construct_download_url(
-                optimal_year, geographic_level, state_fips, congress_number
-            )
-            
-            if not url:
-                log.error(f"Failed to construct URL for {geographic_level} in year {optimal_year}")
-                return None
-            
-            # Validate URL before attempting download
-            if not self.discovery.validate_download_url(url):
-                log.error(f"Download URL not accessible: {url}")
-                return None
-            
+            base_ctx["optimal_year"] = optimal_year
+
+            try:
+                url = self.discovery.construct_download_url(
+                    optimal_year, geographic_level, state_fips, congress_number
+                )
+            except BoundaryRetrievalError as e:
+                return BoundaryFetchResult.fail(
+                    error_code="URL_CONSTRUCTION_FAILED",
+                    error_stage=e.stage,
+                    message=str(e),
+                    context={**base_ctx, **e.context},
+                )
+
+            base_ctx["download_url"] = url
+
+            # --- Stage: url_validation ---
+            try:
+                self.discovery.validate_download_url(url)
+            except BoundaryUrlValidationError as e:
+                return BoundaryFetchResult.fail(
+                    error_code="URL_NOT_ACCESSIBLE",
+                    error_stage="url_validation",
+                    message=str(e),
+                    context={**base_ctx, **e.context},
+                )
+
             log.info(f"Downloading {geographic_level} boundaries for year {optimal_year}")
-            
-            # Download and process using existing library functions
-            return self._download_and_process_tiger(url, geographic_level)
-            
-        except ValueError as e:
-            log.error(f"Invalid parameters: {e}")
-            return None
+
+            # --- Stages: download + parse ---
+            try:
+                gdf = self._download_and_process_tiger(url, geographic_level)
+            except BoundaryRetrievalError as e:
+                return BoundaryFetchResult.fail(
+                    error_code=e.context.get("error_code", "DOWNLOAD_OR_PARSE_FAILED"),
+                    error_stage=e.stage,
+                    message=str(e),
+                    context={**base_ctx, **e.context},
+                )
+
+            if gdf is None:
+                return BoundaryFetchResult.fail(
+                    error_code="NO_DATA_RETURNED",
+                    error_stage="parse",
+                    message=f"_download_and_process_tiger returned None for {url}",
+                    context=base_ctx,
+                )
+
+            return BoundaryFetchResult.ok(
+                gdf,
+                message=f"Retrieved {len(gdf)} {geographic_level} features for year {optimal_year}",
+                context=base_ctx,
+            )
+
+        except BoundaryRetrievalError as e:
+            return BoundaryFetchResult.fail(
+                error_code="RETRIEVAL_ERROR",
+                error_stage=e.stage,
+                message=str(e),
+                context={**base_ctx, **e.context},
+            )
         except Exception as e:
-            log.error(f"Failed to download Census boundaries: {e}")
-            return None
+            return BoundaryFetchResult.fail(
+                error_code="UNEXPECTED_ERROR",
+                error_stage="unknown",
+                message=f"Unexpected error: {type(e).__name__}: {e}",
+                context={**base_ctx, "original_error": str(e)},
+            )
     
     def get_available_boundary_types(self, year: int) -> Dict[str, str]:
         """Get available boundary types for a specific year."""
@@ -810,91 +982,141 @@ class CensusDataSource(SpatialDataSource):
         """Construct TIGER/Line download URL using discovery service."""
         return self.discovery.construct_download_url(year, geographic_level, state_fips)
     
-    def _download_and_process_tiger(self, url: str, geographic_level: str) -> Optional[GeoDataFrame]:
-        """Download and process TIGER/Line shapefile using existing library functions."""
+    def _download_and_process_tiger(self, url: str, geographic_level: str) -> GeoDataFrame:
+        """Download and process TIGER/Line shapefile using existing library functions.
+
+        Raises:
+            BoundaryDownloadError: If the file cannot be downloaded or is not a valid zip.
+            BoundaryParseError: If the shapefile cannot be read by GeoPandas.
+        """
+        ctx: Dict[str, Any] = {"url": url, "geographic_level": geographic_level}
+        zip_filename = None
+        unzip_dir = None
+
         try:
             log.info(f"Downloading TIGER/Line data from: {url}")
-            
+
             # Get user's download directory
             download_dir = get_download_directory()
             ensure_path_exists(download_dir)
-            
+
             # Generate local path using existing function
             zip_filename = generate_local_path_from_url(url, download_dir)
             if not zip_filename:
-                log.error("Failed to generate local path for download")
-                return None
-            
+                raise BoundaryDownloadError(
+                    "Failed to generate local path for download",
+                    context={**ctx, "error_code": "LOCAL_PATH_FAILED"},
+                )
+
+            ctx["local_path"] = str(zip_filename)
+
             # Download file using existing function with SSL fallback
+            download_success = False
             try:
                 download_success = download_file(url, zip_filename)
             except Exception as ssl_error:
                 if "SSL" in str(ssl_error) or "certificate" in str(ssl_error).lower():
                     log.warning(f"SSL verification failed, retrying without verification: {ssl_error}")
-                    # Retry without SSL verification using the download_file function
                     download_success = download_file(url, zip_filename, verify_ssl=False)
                     if download_success:
                         log.info("Successfully downloaded without SSL verification")
-                    else:
-                        log.error("Download failed even without SSL verification")
-                else:
-                    download_success = False
-            
+
             if not download_success:
-                log.error("Failed to download TIGER/Line data")
-                return None
+                raise BoundaryDownloadError(
+                    f"Failed to download TIGER/Line data from {url}",
+                    context={**ctx, "error_code": "DOWNLOAD_FAILED"},
+                )
 
             # Validate downloaded file is actually a zip (not an HTML challenge page)
             import zipfile
             zip_path = Path(zip_filename)
             if not zipfile.is_zipfile(zip_path):
-                log.warning(f"Downloaded file is not a valid zip: {zip_path} "
-                            f"({zip_path.stat().st_size} bytes) — removing and retrying")
+                file_size = zip_path.stat().st_size if zip_path.exists() else 0
+                log.warning(
+                    f"Downloaded file is not a valid zip: {zip_path} "
+                    f"({file_size} bytes) — removing and retrying"
+                )
                 zip_path.unlink(missing_ok=True)
                 # Retry once — the first attempt may have been an anti-bot challenge
                 download_success = download_file(url, zip_filename)
                 if not download_success or not zipfile.is_zipfile(zip_path):
-                    log.error("Retry failed: downloaded file is still not a valid zip")
                     zip_path.unlink(missing_ok=True)
-                    return None
+                    raise BoundaryDownloadError(
+                        f"Downloaded file is not a valid zip after retry: {url}",
+                        context={
+                            **ctx,
+                            "error_code": "INVALID_ZIP",
+                            "file_size_bytes": file_size,
+                        },
+                    )
                 log.info("Retry succeeded — valid zip file downloaded")
 
             # Unzip using existing function
             unzip_dir = unzip_file_to_directory(Path(zip_filename))
             if not unzip_dir:
-                log.error("Failed to unzip TIGER/Line data")
-                return None
-            
+                raise BoundaryDownloadError(
+                    f"Failed to unzip TIGER/Line data from {zip_filename}",
+                    context={**ctx, "error_code": "UNZIP_FAILED"},
+                )
+
             # Find the shapefile
             shapefile_path = None
             for file_path in unzip_dir.rglob("*.shp"):
                 shapefile_path = file_path
                 break
-            
+
             if not shapefile_path:
-                log.error("No shapefile found in downloaded data")
-                return None
-            
+                raise BoundaryParseError(
+                    f"No shapefile (.shp) found in extracted archive from {url}",
+                    context={
+                        **ctx,
+                        "error_code": "NO_SHAPEFILE",
+                        "extracted_files": [str(f.name) for f in unzip_dir.rglob("*") if f.is_file()][:20],
+                    },
+                )
+
             # Read with GeoPandas
-            gdf = gpd.read_file(shapefile_path)
-            
+            try:
+                gdf = gpd.read_file(shapefile_path)
+            except Exception as read_err:
+                raise BoundaryParseError(
+                    f"GeoPandas failed to read shapefile {shapefile_path}: {read_err}",
+                    context={
+                        **ctx,
+                        "error_code": "GEOPANDAS_READ_FAILED",
+                        "shapefile": str(shapefile_path),
+                        "original_error": str(read_err),
+                    },
+                ) from read_err
+
             # Standardize columns
             gdf = self._standardize_census_columns(gdf, geographic_level)
-            
+
             # Cleanup temporary files
             self._cleanup_temp_files(zip_filename, unzip_dir)
-            
+
             log.info(f"Successfully processed {geographic_level} boundaries: {len(gdf)} features")
             return gdf
-            
+
+        except (BoundaryDownloadError, BoundaryParseError):
+            # Cleanup on structured failure
+            if zip_filename and unzip_dir:
+                try:
+                    self._cleanup_temp_files(zip_filename, unzip_dir)
+                except Exception:
+                    pass
+            raise
         except Exception as e:
-            log.error(f"Failed to download and process TIGER/Line data: {e}")
-            # Cleanup on failure
-            try:
-                self._cleanup_temp_files(zip_filename, unzip_dir)
-            except:
-                pass
-            return None
+            # Cleanup on unexpected failure
+            if zip_filename and unzip_dir:
+                try:
+                    self._cleanup_temp_files(zip_filename, unzip_dir)
+                except Exception:
+                    pass
+            raise BoundaryDownloadError(
+                f"Unexpected error downloading/processing TIGER data: {e}",
+                context={**ctx, "error_code": "UNEXPECTED_DOWNLOAD_ERROR", "original_error": str(e)},
+            ) from e
     
     def _standardize_census_columns(self, gdf: GeoDataFrame, geographic_level: str) -> GeoDataFrame:
         """Standardize Census column names and types."""
@@ -1238,10 +1460,39 @@ def download_data(year: int, geographic_level: str, state_fips: Optional[str] = 
     """
     return census_source.get_geographic_boundaries(year, geographic_level, state_fips)
 
-def get_geographic_boundaries(year: int = DEFAULT_CENSUS_YEAR, geographic_level: str = 'county', 
+def get_geographic_boundaries(year: int = DEFAULT_CENSUS_YEAR, geographic_level: str = 'county',
                             state_fips: Optional[str] = None, state_identifier: Optional[str] = None) -> Optional[GeoDataFrame]:
-    """Get geographic boundaries."""
+    """Get geographic boundaries (legacy, returns None on failure).
+
+    .. deprecated::
+        Use :func:`fetch_geographic_boundaries` for structured diagnostics.
+    """
     return census_source.get_geographic_boundaries(year, geographic_level, state_fips, state_identifier)
+
+
+def fetch_geographic_boundaries(year: int = DEFAULT_CENSUS_YEAR, geographic_level: str = 'county',
+                                state_fips: Optional[str] = None,
+                                congress_number: Optional[int] = None) -> BoundaryFetchResult:
+    """Get geographic boundaries with structured diagnostics.
+
+    Returns a :class:`BoundaryFetchResult` instead of ``Optional[GeoDataFrame]``.
+
+    Args:
+        year: Census year
+        geographic_level: Geographic level (state, county, tract, etc.)
+        state_fips: State FIPS code (required for tract, block_group, etc.)
+        congress_number: Congress number for congressional districts
+
+    Returns:
+        BoundaryFetchResult with .success, .geodataframe, .error_stage, etc.
+    """
+    return census_source.fetch_geographic_boundaries(
+        year=year,
+        geographic_level=geographic_level,
+        state_fips=state_fips,
+        congress_number=congress_number,
+    )
+
 
 def get_available_boundary_types(year: int) -> List[str]:
     """Get available boundary types for a year."""

--- a/tests/test_boundary_diagnostics.py
+++ b/tests/test_boundary_diagnostics.py
@@ -1,0 +1,463 @@
+"""
+Tests for su#197: structured boundary retrieval diagnostics.
+
+Verifies that BoundaryFetchResult and typed exceptions provide
+actionable, machine-readable failure information instead of silent None returns.
+"""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from pathlib import Path
+
+from siege_utilities.geo.boundary_result import (
+    BoundaryFetchResult,
+    BoundaryRetrievalError,
+    BoundaryInputError,
+    BoundaryDiscoveryError,
+    BoundaryUrlValidationError,
+    BoundaryDownloadError,
+    BoundaryParseError,
+)
+
+
+# ---------------------------------------------------------------------------
+# BoundaryFetchResult tests
+# ---------------------------------------------------------------------------
+
+class TestBoundaryFetchResult:
+    """Test the result dataclass."""
+
+    def test_ok_result_is_truthy(self):
+        mock_gdf = Mock()
+        mock_gdf.__len__ = Mock(return_value=42)
+        result = BoundaryFetchResult.ok(mock_gdf)
+        assert result
+        assert result.success is True
+        assert result.geodataframe is mock_gdf
+        assert result.error_code is None
+        assert result.error_stage is None
+
+    def test_fail_result_is_falsy(self):
+        result = BoundaryFetchResult.fail(
+            error_code="TEST_ERROR",
+            error_stage="input_validation",
+            message="Test failure",
+        )
+        assert not result
+        assert result.success is False
+        assert result.geodataframe is None
+        assert result.error_code == "TEST_ERROR"
+        assert result.error_stage == "input_validation"
+        assert result.message == "Test failure"
+
+    def test_ok_message_includes_feature_count(self):
+        mock_gdf = Mock()
+        mock_gdf.__len__ = Mock(return_value=100)
+        result = BoundaryFetchResult.ok(mock_gdf)
+        assert "100" in result.message
+
+    def test_fail_context_preserved(self):
+        ctx = {"year": 2020, "state_fips": "48", "url": "https://example.com"}
+        result = BoundaryFetchResult.fail(
+            error_code="X", error_stage="download", message="failed", context=ctx,
+        )
+        assert result.context["year"] == 2020
+        assert result.context["state_fips"] == "48"
+
+    def test_raise_on_error_success_returns_self(self):
+        mock_gdf = Mock()
+        mock_gdf.__len__ = Mock(return_value=1)
+        result = BoundaryFetchResult.ok(mock_gdf)
+        assert result.raise_on_error() is result
+
+    def test_raise_on_error_input_validation(self):
+        result = BoundaryFetchResult.fail(
+            error_code="BAD_FIPS",
+            error_stage="input_validation",
+            message="Invalid FIPS",
+        )
+        with pytest.raises(BoundaryInputError) as exc_info:
+            result.raise_on_error()
+        assert "Invalid FIPS" in str(exc_info.value)
+        assert exc_info.value.stage == "input_validation"
+
+    def test_raise_on_error_discovery(self):
+        result = BoundaryFetchResult.fail(
+            error_code="NO_TYPE",
+            error_stage="discovery",
+            message="Not available",
+        )
+        with pytest.raises(BoundaryDiscoveryError):
+            result.raise_on_error()
+
+    def test_raise_on_error_url_validation(self):
+        result = BoundaryFetchResult.fail(
+            error_code="HTTP_404",
+            error_stage="url_validation",
+            message="Not found",
+        )
+        with pytest.raises(BoundaryUrlValidationError):
+            result.raise_on_error()
+
+    def test_raise_on_error_download(self):
+        result = BoundaryFetchResult.fail(
+            error_code="CORRUPT",
+            error_stage="download",
+            message="Bad zip",
+        )
+        with pytest.raises(BoundaryDownloadError):
+            result.raise_on_error()
+
+    def test_raise_on_error_parse(self):
+        result = BoundaryFetchResult.fail(
+            error_code="NO_SHP",
+            error_stage="parse",
+            message="No shapefile",
+        )
+        with pytest.raises(BoundaryParseError):
+            result.raise_on_error()
+
+    def test_raise_on_error_unknown_stage(self):
+        result = BoundaryFetchResult.fail(
+            error_code="X",
+            error_stage="mystery",
+            message="Unknown",
+        )
+        with pytest.raises(BoundaryRetrievalError):
+            result.raise_on_error()
+
+    def test_chaining_raise_on_error(self):
+        mock_gdf = Mock()
+        mock_gdf.__len__ = Mock(return_value=5)
+        result = BoundaryFetchResult.ok(mock_gdf)
+        gdf = result.raise_on_error().geodataframe
+        assert gdf is mock_gdf
+
+
+# ---------------------------------------------------------------------------
+# Typed exception hierarchy tests
+# ---------------------------------------------------------------------------
+
+class TestExceptionHierarchy:
+    """Verify that all typed exceptions inherit from the base."""
+
+    def test_all_subclass_base(self):
+        for cls in [
+            BoundaryInputError,
+            BoundaryDiscoveryError,
+            BoundaryUrlValidationError,
+            BoundaryDownloadError,
+            BoundaryParseError,
+        ]:
+            assert issubclass(cls, BoundaryRetrievalError)
+            assert issubclass(cls, Exception)
+
+    def test_exception_carries_stage(self):
+        err = BoundaryInputError("bad input", context={"key": "val"})
+        assert err.stage == "input_validation"
+        assert err.context == {"key": "val"}
+
+    def test_discovery_error_stage(self):
+        err = BoundaryDiscoveryError("no types")
+        assert err.stage == "discovery"
+
+    def test_url_validation_error_stage(self):
+        err = BoundaryUrlValidationError("http 404")
+        assert err.stage == "url_validation"
+
+    def test_download_error_stage(self):
+        err = BoundaryDownloadError("bad zip")
+        assert err.stage == "download"
+
+    def test_parse_error_stage(self):
+        err = BoundaryParseError("no shp")
+        assert err.stage == "parse"
+
+    def test_base_error_custom_stage(self):
+        err = BoundaryRetrievalError("general", stage="custom_stage")
+        assert err.stage == "custom_stage"
+
+
+# ---------------------------------------------------------------------------
+# Integration with CensusDataSource.fetch_geographic_boundaries
+# ---------------------------------------------------------------------------
+
+class TestFetchGeographicBoundaries:
+    """Test the new fetch_geographic_boundaries method returns BoundaryFetchResult."""
+
+    @patch('siege_utilities.geo.spatial_data.CensusDirectoryDiscovery')
+    def _make_source(self, MockDiscovery):
+        """Helper to create a CensusDataSource with mocked discovery."""
+        mock_disc = MockDiscovery.return_value
+        mock_disc.get_available_years.return_value = [2020, 2024]
+        mock_disc.discover_boundary_types.return_value = {
+            'county': 'COUNTY', 'tract': 'TRACT', 'state': 'STATE',
+        }
+        mock_disc.get_optimal_year.return_value = 2020
+
+        from siege_utilities.geo.spatial_data import CensusDataSource
+        source = CensusDataSource.__new__(CensusDataSource)
+        source.name = "Census Bureau"
+        source.base_url = "https://www2.census.gov/geo/tiger"
+        source.api_key = None
+        source.user_config = {}
+        source.discovery = mock_disc
+        source.available_years = [2020, 2024]
+        source.state_required_levels = ['tract', 'block_group', 'block', 'tabblock20', 'sldu', 'sldl']
+        source.national_levels = ['nation', 'state', 'county', 'place', 'zcta', 'cd']
+        return source
+
+    def test_invalid_state_fips_returns_fail_result(self):
+        source = self._make_source()
+        result = source.fetch_geographic_boundaries(
+            year=2020, geographic_level='county', state_fips='ZZZZ',
+        )
+        assert not result.success
+        assert result.error_stage == "input_validation"
+        assert result.error_code == "INVALID_STATE_IDENTIFIER"
+        assert "ZZZZ" in result.message
+
+    def test_missing_state_fips_for_tract(self):
+        source = self._make_source()
+        result = source.fetch_geographic_boundaries(
+            year=2020, geographic_level='tract',
+        )
+        assert not result.success
+        assert result.error_stage == "input_validation"
+        assert result.error_code == "INVALID_PARAMETERS"
+
+    def test_url_construction_failure(self):
+        source = self._make_source()
+        source.discovery.construct_download_url.side_effect = BoundaryDiscoveryError(
+            "type not available", context={"year": 2020},
+        )
+        result = source.fetch_geographic_boundaries(
+            year=2020, geographic_level='county',
+        )
+        assert not result.success
+        assert result.error_stage == "discovery"
+
+    def test_url_validation_failure(self):
+        source = self._make_source()
+        source.discovery.construct_download_url.return_value = "https://example.com/bad.zip"
+        source.discovery.validate_download_url.side_effect = BoundaryUrlValidationError(
+            "HTTP 404", context={"http_status": 404},
+        )
+        result = source.fetch_geographic_boundaries(
+            year=2020, geographic_level='county',
+        )
+        assert not result.success
+        assert result.error_stage == "url_validation"
+        assert result.error_code == "URL_NOT_ACCESSIBLE"
+
+    def test_download_failure(self):
+        source = self._make_source()
+        source.discovery.construct_download_url.return_value = "https://example.com/ok.zip"
+        source.discovery.validate_download_url.return_value = True
+
+        with patch.object(source, '_download_and_process_tiger') as mock_dl:
+            mock_dl.side_effect = BoundaryDownloadError(
+                "bad zip", context={"error_code": "INVALID_ZIP"},
+            )
+            result = source.fetch_geographic_boundaries(
+                year=2020, geographic_level='county',
+            )
+        assert not result.success
+        assert result.error_stage == "download"
+
+    def test_parse_failure(self):
+        source = self._make_source()
+        source.discovery.construct_download_url.return_value = "https://example.com/ok.zip"
+        source.discovery.validate_download_url.return_value = True
+
+        with patch.object(source, '_download_and_process_tiger') as mock_dl:
+            mock_dl.side_effect = BoundaryParseError(
+                "no shapefile", context={"error_code": "NO_SHAPEFILE"},
+            )
+            result = source.fetch_geographic_boundaries(
+                year=2020, geographic_level='county',
+            )
+        assert not result.success
+        assert result.error_stage == "parse"
+
+    def test_success_returns_ok_result(self):
+        source = self._make_source()
+        source.discovery.construct_download_url.return_value = "https://example.com/ok.zip"
+        source.discovery.validate_download_url.return_value = True
+
+        mock_gdf = Mock()
+        mock_gdf.__len__ = Mock(return_value=50)
+
+        with patch.object(source, '_download_and_process_tiger', return_value=mock_gdf):
+            result = source.fetch_geographic_boundaries(
+                year=2020, geographic_level='county',
+            )
+        assert result.success
+        assert result.geodataframe is mock_gdf
+        assert "50" in result.message
+        assert result.error_code is None
+
+    def test_context_carries_all_parameters(self):
+        source = self._make_source()
+        source.discovery.construct_download_url.return_value = "https://example.com/ok.zip"
+        source.discovery.validate_download_url.return_value = True
+
+        mock_gdf = Mock()
+        mock_gdf.__len__ = Mock(return_value=10)
+
+        with patch.object(source, '_download_and_process_tiger', return_value=mock_gdf):
+            result = source.fetch_geographic_boundaries(
+                year=2020, geographic_level='county', state_fips='48',
+            )
+        assert result.context["year"] == 2020
+        assert result.context["geographic_level"] == "county"
+        assert result.context["download_url"] == "https://example.com/ok.zip"
+
+    def test_unexpected_exception_returns_fail(self):
+        source = self._make_source()
+        source.discovery.construct_download_url.return_value = "https://example.com/ok.zip"
+        source.discovery.validate_download_url.return_value = True
+
+        with patch.object(source, '_download_and_process_tiger') as mock_dl:
+            mock_dl.side_effect = RuntimeError("disk full")
+            result = source.fetch_geographic_boundaries(
+                year=2020, geographic_level='county',
+            )
+        assert not result.success
+        assert result.error_code == "UNEXPECTED_ERROR"
+        assert "disk full" in result.message
+
+
+# ---------------------------------------------------------------------------
+# Typed exceptions raised by internal methods
+# ---------------------------------------------------------------------------
+
+class TestConstructDownloadUrlExceptions:
+    """Test that construct_download_url raises typed exceptions."""
+
+    def _make_discovery(self):
+        from siege_utilities.geo.spatial_data import CensusDirectoryDiscovery
+        disc = CensusDirectoryDiscovery.__new__(CensusDirectoryDiscovery)
+        disc.base_url = "https://www2.census.gov/geo/tiger"
+        disc.timeout = 30
+        disc.cache = {}
+        disc.cache_timeout = 3600
+        return disc
+
+    def test_invalid_fips_raises_input_error(self):
+        disc = self._make_discovery()
+        with pytest.raises(BoundaryInputError) as exc_info:
+            disc.construct_download_url(2020, 'county', state_fips='ZZ')
+        assert exc_info.value.stage == "input_validation"
+        assert "ZZ" in str(exc_info.value)
+
+    def test_missing_boundary_type_raises_discovery_error(self):
+        disc = self._make_discovery()
+        with patch.object(disc, 'get_year_specific_url_patterns', return_value={}):
+            with patch.object(disc, 'discover_boundary_types', return_value={'county': 'COUNTY'}):
+                with pytest.raises(BoundaryDiscoveryError) as exc_info:
+                    disc.construct_download_url(2020, 'unicorn_level')
+                assert "unicorn_level" in str(exc_info.value)
+                assert exc_info.value.stage == "discovery"
+
+
+class TestValidateDownloadUrlExceptions:
+    """Test that validate_download_url raises typed exceptions."""
+
+    def _make_discovery(self):
+        from siege_utilities.geo.spatial_data import CensusDirectoryDiscovery
+        disc = CensusDirectoryDiscovery.__new__(CensusDirectoryDiscovery)
+        disc.timeout = 5
+        return disc
+
+    @patch('siege_utilities.geo.spatial_data.requests.get')
+    def test_http_404_raises_url_validation_error(self, mock_get):
+        disc = self._make_discovery()
+        mock_resp = Mock()
+        mock_resp.status_code = 404
+        mock_resp.close = Mock()
+        mock_get.return_value = mock_resp
+
+        with pytest.raises(BoundaryUrlValidationError) as exc_info:
+            disc.validate_download_url("https://example.com/missing.zip")
+        assert exc_info.value.context["http_status"] == 404
+
+    @patch('siege_utilities.geo.spatial_data.requests.get')
+    def test_timeout_raises_url_validation_error(self, mock_get):
+        import requests as req
+        disc = self._make_discovery()
+        mock_get.side_effect = req.exceptions.Timeout("timed out")
+
+        with pytest.raises(BoundaryUrlValidationError) as exc_info:
+            disc.validate_download_url("https://example.com/slow.zip")
+        assert "timed out" in str(exc_info.value)
+
+    @patch('siege_utilities.geo.spatial_data.requests.get')
+    def test_success_returns_true(self, mock_get):
+        disc = self._make_discovery()
+        mock_resp = Mock()
+        mock_resp.status_code = 200
+        mock_resp.close = Mock()
+        mock_get.return_value = mock_resp
+
+        assert disc.validate_download_url("https://example.com/ok.zip") is True
+
+
+# ---------------------------------------------------------------------------
+# Legacy backward compatibility
+# ---------------------------------------------------------------------------
+
+class TestLegacyBackwardCompatibility:
+    """Verify get_geographic_boundaries still returns Optional[GeoDataFrame]."""
+
+    @patch('siege_utilities.geo.spatial_data.CensusDirectoryDiscovery')
+    def test_legacy_returns_none_on_failure(self, MockDiscovery):
+        mock_disc = MockDiscovery.return_value
+        mock_disc.get_available_years.return_value = [2020]
+        mock_disc.discover_boundary_types.return_value = {'county': 'COUNTY'}
+        mock_disc.get_optimal_year.return_value = 2020
+        mock_disc.construct_download_url.side_effect = BoundaryDiscoveryError("boom")
+
+        from siege_utilities.geo.spatial_data import CensusDataSource
+        source = CensusDataSource.__new__(CensusDataSource)
+        source.name = "Census Bureau"
+        source.base_url = "https://www2.census.gov/geo/tiger"
+        source.api_key = None
+        source.user_config = {}
+        source.discovery = mock_disc
+        source.available_years = [2020]
+        source.state_required_levels = ['tract', 'block_group', 'block', 'tabblock20', 'sldu', 'sldl']
+        source.national_levels = ['nation', 'state', 'county', 'place', 'zcta', 'cd']
+
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            result = source.get_geographic_boundaries(2020, 'county')
+        assert result is None
+
+    @patch('siege_utilities.geo.spatial_data.CensusDirectoryDiscovery')
+    def test_legacy_emits_deprecation_warning(self, MockDiscovery):
+        mock_disc = MockDiscovery.return_value
+        mock_disc.get_available_years.return_value = [2020]
+        mock_disc.discover_boundary_types.return_value = {'county': 'COUNTY'}
+        mock_disc.get_optimal_year.return_value = 2020
+        mock_disc.construct_download_url.side_effect = BoundaryDiscoveryError("boom")
+
+        from siege_utilities.geo.spatial_data import CensusDataSource
+        source = CensusDataSource.__new__(CensusDataSource)
+        source.name = "Census Bureau"
+        source.base_url = "https://www2.census.gov/geo/tiger"
+        source.api_key = None
+        source.user_config = {}
+        source.discovery = mock_disc
+        source.available_years = [2020]
+        source.state_required_levels = ['tract', 'block_group', 'block', 'tabblock20', 'sldu', 'sldl']
+        source.national_levels = ['nation', 'state', 'county', 'place', 'zcta', 'cd']
+
+        import warnings
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            source.get_geographic_boundaries(2020, 'county')
+            dep_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+            assert len(dep_warnings) >= 1
+            assert "fetch_geographic_boundaries" in str(dep_warnings[0].message)

--- a/tests/test_enhanced_census_utilities.py
+++ b/tests/test_enhanced_census_utilities.py
@@ -339,11 +339,12 @@ class TestCensusDirectoryDiscovery:
 
     @patch('requests.get')
     def test_validate_download_url_failure(self, mock_get):
-        """Test failed URL validation."""
+        """Test failed URL validation raises BoundaryUrlValidationError."""
+        from siege_utilities.geo.boundary_result import BoundaryUrlValidationError
         mock_get.side_effect = Exception("Network error")
 
-        is_valid = self.discovery.validate_download_url("https://example.com/test.zip")
-        assert is_valid is False
+        with pytest.raises(BoundaryUrlValidationError):
+            self.discovery.validate_download_url("https://example.com/test.zip")
 
 
 class TestCensusDataSource:
@@ -646,14 +647,15 @@ class TestErrorHandling:
             assert len(years) == 0
     
     def test_url_construction_with_none_boundary_type(self):
-        """Test URL construction with None boundary type."""
+        """Test URL construction with None boundary type raises BoundaryDiscoveryError."""
+        from siege_utilities.geo.boundary_result import BoundaryDiscoveryError
         discovery = CensusDirectoryDiscovery()
-        
+
         # Mock available boundary types
         discovery.discover_boundary_types = Mock(return_value={})
-        
-        url = discovery.construct_download_url(2020, None)
-        assert url is None
+
+        with pytest.raises(BoundaryDiscoveryError):
+            discovery.construct_download_url(2020, None)
     
     def test_parameter_validation_edge_cases(self):
         """Test parameter validation with edge cases."""


### PR DESCRIPTION
## Summary
- Introduces `BoundaryFetchResult` result object and typed exception hierarchy (`BoundaryInputError`, `BoundaryDiscoveryError`, `BoundaryUrlValidationError`, `BoundaryDownloadError`, `BoundaryParseError`) so callers can programmatically branch on failure reason
- New `fetch_geographic_boundaries()` method returns `BoundaryFetchResult` with `.success`, `.geodataframe`, `.error_stage`, `.error_code`, `.context`
- Legacy `get_geographic_boundaries()` preserved with deprecation warning, still returns `Optional[GeoDataFrame]`
- Internal methods (`construct_download_url`, `validate_download_url`, `_download_and_process_tiger`) now raise typed exceptions with diagnostic context instead of silently returning `None`

Closes #197

## Test plan
- [x] 35 new tests in `test_boundary_diagnostics.py` covering all 5 failure stages
- [x] Result object truthiness, `.raise_on_error()` chaining, context preservation
- [x] Exception hierarchy (all subclass `BoundaryRetrievalError`)
- [x] Backward compatibility: legacy method returns None + emits DeprecationWarning
- [x] 2 existing tests updated to expect typed exceptions instead of None/False
- [x] Full existing test suite passes (77 tests, 0 failures)