### PR TITLE
Fix boundary filtering + demographics API call

### DIFF
--- a/siege_utilities/geo/django/services/demographic_service.py
+++ b/siege_utilities/geo/django/services/demographic_service.py
@@ -166,12 +166,12 @@ class DemographicPopulationService:
             logger.info(
                 f"Fetching {variable_group} data for {geography_type} in state {state_fips}"
             )
-            df = self.client.get_demographics(
-                geography=geography_type,
-                state=state_fips,
+            df = self.client.fetch_data(
+                variables=variable_group,
                 year=year,
-                variable_group=variable_group,
                 dataset=dataset,
+                geography=geography_type,
+                state_fips=state_fips,
             )
         except Exception as e:
             logger.error(f"Error fetching demographics: {e}")

--- a/siege_utilities/geo/spatial_data.py
+++ b/siege_utilities/geo/spatial_data.py
@@ -840,6 +840,36 @@ class CensusDataSource(SpatialDataSource):
                     context=base_ctx,
                 )
 
+            # Post-download filtering for national-only boundary types
+            # These types are only available as nationwide files from Census,
+            # so we download the full national file and filter by state FIPS
+            national_only_types = {
+                'state', 'county', 'cbsa', 'csa', 'metdiv', 'micro',
+                'necta', 'nectadiv', 'cnecta', 'aiannh', 'uac', 'uac10', 'uac20',
+            }
+            if normalized_fips and geographic_level in national_only_types:
+                fips_col = None
+                for col in ['statefp', 'STATEFP', 'statefp20', 'STATEFP20',
+                            'statefp10', 'STATEFP10']:
+                    if col in gdf.columns:
+                        fips_col = col
+                        break
+
+                if fips_col:
+                    original_count = len(gdf)
+                    gdf = gdf[gdf[fips_col] == normalized_fips].copy()
+                    log.info(
+                        f"Filtered {geographic_level} from {original_count} to "
+                        f"{len(gdf)} features for state {normalized_fips}"
+                    )
+                    base_ctx["filtered_from"] = original_count
+                    base_ctx["filtered_to"] = len(gdf)
+                else:
+                    log.warning(
+                        f"No state FIPS column found in {geographic_level} data "
+                        f"— cannot filter by state"
+                    )
+
             return BoundaryFetchResult.ok(
                 gdf,
                 message=f"Retrieved {len(gdf)} {geographic_level} features for year {optimal_year}",


### PR DESCRIPTION
## Summary

Follow-up to #198 / su#197 — two bugs found from Databricks validation runs (see [comment](https://github.com/siege-analytics/siege_utilities/issues/197#issuecomment-3981847845)):

- **`fetch_geographic_boundaries()` missing post-download state FIPS filtering**: For national-only boundary types (county, state, cbsa, etc.), Census only provides nationwide files. The legacy `get_census_boundaries()` wrapper filtered the downloaded GeoDataFrame by `statefp` column, but PR #198's new `fetch_geographic_boundaries()` method did not migrate this logic. This caused empty results when requesting state-specific county/state boundaries.

- **`DemographicPopulationService.populate()` calling wrong method**: Called `self.client.get_demographics()` (doesn't exist as a CensusAPIClient method) with wrong parameter names (`variable_group` instead of `variables`, plus unsupported `dataset`). Fixed to call `self.client.fetch_data()` with the correct signature.

## Test plan

- [x] 35 boundary diagnostics tests pass
- [x] 29 demographic tests pass  
- [x] Full suite: 1487 passed, 0 failures
- [ ] Retest on Databricks with state_fips='48' county boundaries