### PR TITLE
Fix release manager to commit metadata before merge

### DIFF
--- a/scripts/release_manager.py
+++ b/scripts/release_manager.py
@@ -369,6 +369,51 @@ def _is_shallow_repo() -> bool:
     return result.returncode == 0 and result.stdout.strip() == 'true'
 
 
+def commit_release_metadata(version: str, dry_run: bool = False) -> bool:
+    """Commit and push release metadata changes on develop, if present.
+
+    This includes version-bearing files and CHANGELOG.md when modified.
+    It ensures merge_develop_to_main sees a clean worktree and that the
+    release bump commit exists on origin/develop before merging to main.
+    """
+    if _current_branch() != 'develop':
+        logger.error("Release metadata commit requires current branch 'develop'")
+        return False
+
+    candidate_paths = [str(spec['path'].relative_to(PROJECT_ROOT))
+                       for spec in VERSION_FILES.values()]
+    changelog = PROJECT_ROOT / 'CHANGELOG.md'
+    if changelog.exists():
+        candidate_paths.append('CHANGELOG.md')
+
+    changed_paths = []
+    for path in candidate_paths:
+        result = _git(['status', '--porcelain', '--', path], capture=True)
+        if result.stdout.strip():
+            changed_paths.append(path)
+
+    if not changed_paths:
+        logger.info("No release metadata changes to commit")
+        return True
+
+    if dry_run:
+        logger.info(f"[DRY RUN] Would commit and push release metadata: {changed_paths}")
+        return True
+
+    tag = f"v{version}"
+    commit_message = f"chore(release): bump version to {version}"
+    try:
+        logger.info(f"Committing release metadata for {tag}...")
+        _git(['add'] + changed_paths)
+        _git(['commit', '-m', commit_message])
+        logger.info("Pushing develop...")
+        _git(['push', 'origin', 'develop'])
+        return True
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Failed to commit release metadata: {e}")
+        return False
+
+
 def merge_develop_to_main(dry_run: bool = False) -> bool:
     """Merge develop into main (gitflow release merge).
 
@@ -764,6 +809,15 @@ def main():
                 notes = f"Release v{new_ver}"
         else:
             notes = args.release_notes
+
+        # 8b. Persist release metadata on develop
+        logger.info("Committing release metadata on develop...")
+        if _current_branch() == 'develop' or args.dry_run:
+            if not commit_release_metadata(new_ver, args.dry_run):
+                logger.error("Release metadata commit failed")
+                sys.exit(1)
+        else:
+            logger.warning(f"Not on develop (on {_current_branch()}), skipping metadata commit")
 
         # 9. Merge develop → main (gitflow)
         logger.info("Step 9/12: Merging develop → main...")


### PR DESCRIPTION
## Summary
Fixes the release workflow bug where `--release` updates version files but then fails at develop→main merge due to a dirty worktree.

## Changes
- Add `commit_release_metadata()` to stage/commit/push changed release metadata files on `develop` (version files + `CHANGELOG.md` when changed).
- Call this step before `merge_develop_to_main()` in release mode.
- Keep behavior safe with `--dry-run` support and branch checks.

## Validation
- `python -m py_compile scripts/release_manager.py`
