### PR TITLE
Fix release manager lint ratchet regression

### DIFF
--- a/scripts/release_manager.py
+++ b/scripts/release_manager.py
@@ -38,11 +38,9 @@ import shutil
 import json
 import re
 import logging
-import glob as globmod
 from pathlib import Path
 from typing import Dict, List, Optional
 import argparse
-from datetime import datetime
 
 logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
Removes two unused imports in `scripts/release_manager.py` that caused the `lint ratchet phases2-4` check to fail on contributor PRs.

## Changes
- Remove unused `glob as globmod`
- Remove unused `from datetime import datetime`

## Validation
- `python -m py_compile scripts/release_manager.py`
- `flake8 scripts/release_manager.py --select F401,F841,F541`
