### PR TITLE
Document contributor governance and release-admin policy

### DIFF
--- a/CONTRIBUTOR_GOVERNANCE.md
+++ b/CONTRIBUTOR_GOVERNANCE.md
@@ -1,0 +1,120 @@
+# Contributor Governance
+
+This document defines branch protections, merge policy, release permissions, and required validation for `siege_utilities`.
+
+## Branching and Merge Policy
+
+- `develop` is the integration branch for all feature and bugfix work.
+- `main` is the release branch.
+- Contributor branches must be created from `develop` and merged back to `develop` via PR.
+- Releases are produced from `develop` and merged to `main` through the release workflow.
+
+## Protected Branch Rules
+
+`main` and `develop` are governed by an active repository ruleset:
+
+- Pull request required for merges.
+- 1 approving review required.
+- Review threads must be resolved.
+- Stale approvals dismissed on new pushes.
+- Non-fast-forward pushes blocked.
+- Branch deletion blocked.
+- Required status checks enforced and up-to-date with base required.
+
+Required checks include:
+
+- `CodeRabbit`
+- `lint ratchet phase1`
+- `lint ratchet phases2-4`
+- `test file hygiene`
+- `api contract regression`
+- `core-only (no heavy deps)`
+- `geo without GDAL`
+- `smoke tests (fast, no GDAL)`
+- `test (3.11)`
+- `test (3.12)`
+- `pydantic v1 compat`
+- `security`
+- `databricks SDK tests`
+
+## Bypass Policy (Direct Push Authority)
+
+Direct push/bypass is intentionally restricted to:
+
+- `release-admins` team (designated release maintainers)
+- Organization admins (super admins)
+
+All other contributors are expected to use PR-based flow.
+
+Direct pushes are for urgent operational cases (for example: release repair). Normal development still goes through PRs.
+
+## External Contributor Workflow
+
+1. Fork repository and clone your fork.
+2. Add upstream remote to `siege-analytics/siege_utilities`.
+3. Create a feature branch from `upstream/develop`.
+4. Install in virtual environment from cloned repo:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+5. Implement changes and run required checks.
+6. Open PR targeting `develop`.
+7. Link related issue and include verification evidence.
+
+## Required Pre-PR Validation
+
+At minimum:
+
+```bash
+python scripts/check_test_file_hygiene.py
+python scripts/check_lint_ratchet_phase1.py
+python scripts/check_lint_ratchet.py --phase phase2
+python scripts/check_lint_ratchet.py --phase phase3
+python scripts/check_lint_ratchet.py --phase phase4
+python scripts/contracts/generate_public_api_contract.py --output /tmp/contract_candidate.json
+python scripts/contracts/compare_public_api_contracts.py \
+  --baseline /tmp/contract_baseline.json \
+  --candidate /tmp/contract_candidate.json \
+  --release-impact patch \
+  --allowlist scripts/contracts/contract_allowlist.json
+python -m pytest -q --no-cov tests/test_api_contract_tools.py
+```
+
+When applicable:
+
+- Run targeted tests for changed modules.
+- Update and validate impacted notebooks.
+- Ensure `notebooks/output/` artifacts remain reviewable for notebook-driven workflows.
+
+## Documentation and Notebook Change Policy
+
+For user-visible behavior changes:
+
+- Documentation updates are required in the same PR.
+- Notebook updates are required in the same PR when the workflow/API examples change.
+
+## Change Classification and Release
+
+Use canonical policies for release impact:
+
+- `CHANGE_CLASSIFICATION_AND_RELEASE_POLICY.md`
+- `CODING_STYLE.md`
+- `PR_REVIEW_RUBRIC.md`
+
+Release execution uses:
+
+```bash
+python scripts/release_manager.py --release --target-version X.Y.Z --release-notes "..."
+```
+
+Release flow:
+
+- run on `develop`
+- commit release metadata on `develop`
+- merge `develop` -> `main`
+- tag release on `main`
+- publish GitHub release (and PyPI when enabled)

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ See:
 - `CODING_STYLE.md`
 - `PR_REVIEW_RUBRIC.md`
 - `CHANGE_CLASSIFICATION_AND_RELEASE_POLICY.md`
+- `CONTRIBUTOR_GOVERNANCE.md`
 
 ## External Contributor Workflow
 

--- a/docs/CODERABBIT_WORKFLOW.md
+++ b/docs/CODERABBIT_WORKFLOW.md
@@ -4,8 +4,9 @@ This repository uses CodeRabbit for automated PR review.
 
 ## Required Status
 
-- `CodeRabbit` is a required status check on `main`.
+- `CodeRabbit` is a required status check on protected branches (`develop` and `main`).
 - PRs cannot be merged until the check is successful.
+- Standard contributor PR target is `develop`.
 
 ## Scope and Policy
 

--- a/docs/CONTRIBUTOR_GOVERNANCE.md
+++ b/docs/CONTRIBUTOR_GOVERNANCE.md
@@ -1,0 +1,7 @@
+# Contributor Governance
+
+Canonical source: [`../CONTRIBUTOR_GOVERNANCE.md`](../CONTRIBUTOR_GOVERNANCE.md)
+
+This copy exists so contributors browsing `docs/` can quickly find branch protection, PR, and release governance.
+
+Use the root file for updates.

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -145,7 +145,9 @@ python scripts/check_imports.py
 CodeRabbit is part of the required PR workflow.
 
 - Review policy is defined in `.coderabbit.yaml`
-- `CodeRabbit` status must pass before merge to `main`
+- `CodeRabbit` status must pass before merge
+- Contributor PRs target `develop` (not `main`)
+- Branch protection, bypass policy, and required checks are defined in `CONTRIBUTOR_GOVERNANCE.md`
 - See `docs/CODERABBIT_WORKFLOW.md` for merge-readiness expectations
 
 ## 🎯 Adding New Functions

--- a/docs/source/contributor_governance.rst
+++ b/docs/source/contributor_governance.rst
@@ -1,0 +1,9 @@
+Contributor Governance
+======================
+
+The contributor governance policy is maintained in:
+
+- ``CONTRIBUTOR_GOVERNANCE.md`` at repository root (canonical)
+- ``docs/CONTRIBUTOR_GOVERNANCE.md`` (docs-local pointer)
+
+Use the root file as the authoritative source.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -48,6 +48,7 @@ Siege Utilities is a comprehensive Python utilities package with **enhanced auto
    :maxdepth: 2
    :caption: Development & Testing:
 
+   contributor_governance
    coding_style
    pr_review_rubric
    lint_ratchet_plan


### PR DESCRIPTION
## Summary
Adds a canonical contributor governance policy and aligns docs with current branch protection + release administration practices.

## What changed
- Add root canonical policy: `CONTRIBUTOR_GOVERNANCE.md`
- Add docs-local pointer: `docs/CONTRIBUTOR_GOVERNANCE.md`
- Add Sphinx page pointer: `docs/source/contributor_governance.rst`
- Add to Sphinx index toctree
- Link governance policy from `README.md`
- Update `docs/DEVELOPER_GUIDE.md` and `docs/CODERABBIT_WORKFLOW.md` to reflect `develop` PR target and protected-branch policy

## Policy captured
- Protected branches: `develop`, `main`
- Required PR + status checks
- Direct-push bypass restricted to `release-admins` team and org admins
- Required pre-PR validation commands
- Docs/notebooks update policy for user-visible changes

## Validation
- Documentation-only changes (no runtime behavior changes)
