### PR TITLE
Add open-source isochrone support and WKLS guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ See:
 - `docs/policies/CONTRIBUTOR_GOVERNANCE.md`
 - `docs/RELEASE_LINEAGE.md`
 - `docs/EXAMPLES.md`
+- `docs/ISOCHRONES_AND_WKLS.md`
 
 ## External Contributor Workflow
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -10,6 +10,11 @@ Canonical runnable examples are kept with package code.
 - `siege_utilities/reporting/examples/ga_geographic_analysis.py`
 - `siege_utilities/reporting/examples/google_analytics_report_example.py`
 
+## Primary Notebooks
+
+- `notebooks/06_Report_Generation.ipynb` includes an explicit `create_3d_map` demonstration (Section 5, 3D Visualization).
+- `notebooks/07_Geocoding_Address_Processing.ipynb` includes public and custom `server_url` Nominatim usage.
+
 ## Execution
 
 Run examples from repository root:

--- a/docs/ISOCHRONES_AND_WKLS.md
+++ b/docs/ISOCHRONES_AND_WKLS.md
@@ -1,0 +1,73 @@
+# Isochrones and WKLS Guidance
+
+## Current Position
+
+- Use open-source isochrone providers by default.
+- Allow custom server URLs for hosted/self-managed deployments.
+- Keep proprietary backends optional and adapter-based.
+
+## Isochrones
+
+The library now exposes:
+
+- `siege_utilities.get_isochrone(...)`
+- `siege_utilities.build_isochrone_request(...)`
+- `siege_utilities.isochrone_to_geodataframe(...)`
+
+Supported providers:
+
+- `openrouteservice` (`ors`) — default
+- `valhalla`
+
+Both providers support `base_url` so you can point to custom servers.
+
+### OpenRouteService (default or custom)
+
+```python
+import siege_utilities as su
+
+# Hosted ORS
+geojson = su.get_isochrone(
+    latitude=41.8781,
+    longitude=-87.6298,
+    travel_time_minutes=15,
+    provider="openrouteservice",
+    api_key="<ors-key>",
+)
+
+# Self-hosted ORS
+geojson_custom = su.get_isochrone(
+    latitude=41.8781,
+    longitude=-87.6298,
+    travel_time_minutes=15,
+    provider="openrouteservice",
+    base_url="https://ors.internal.example.com",
+)
+```
+
+### Valhalla (custom server)
+
+```python
+geojson = su.get_isochrone(
+    latitude=41.8781,
+    longitude=-87.6298,
+    travel_time_minutes=20,
+    provider="valhalla",
+    base_url="http://valhalla.svc.cluster.local:8002",
+    profile="driving-car",
+)
+```
+
+## WKLS (Recommendation)
+
+WKLS can be valuable for enterprise-scale geospatial workloads, but should be integrated behind a narrow abstraction rather than as a hard dependency.
+
+Recommended implementation model:
+
+1. Define a stable internal adapter interface (`compute_isochrone`, `run_spatial_join`, `resolve_geometry_column`).
+2. Keep `python` and `sedona` backends as baseline open-source paths.
+3. Add a `wkls` adapter as an optional backend selected by runtime config.
+4. Require contract tests so backend swaps preserve output schema and semantics.
+5. For Databricks, prefer WKT/WKB interchange for portability when native spatial support differs by workspace/runtime.
+
+This keeps contributors unblocked in open-source environments while allowing performance-oriented deployments to opt into WKLS.

--- a/docs/QUICK_START_GUIDE.md
+++ b/docs/QUICK_START_GUIDE.md
@@ -233,7 +233,7 @@ create_default_profiles()
 
 ## 🎯 Next Steps
 
-1. **Explore Examples**: Start with `docs/EXAMPLES.md`
+1. **Explore Examples**: Start with `docs/EXAMPLES.md` (`notebooks/06_Report_Generation.ipynb` includes the 3D map demo).
 2. **Read Documentation**: Full documentation in `docs/` directory
 3. **Run Tests**: `python -m pytest tests/` to verify everything works
 4. **Check Imports**: Run `python scripts/check_imports.py` for a quick script-level sanity check

--- a/docs/databricks-quickstart.md
+++ b/docs/databricks-quickstart.md
@@ -130,6 +130,32 @@ sdf = pandas_to_spark(spark, pdf)
 pdf_back = spark_to_pandas(sdf, limit=10000)
 ```
 
+### Isochrones with Open-Source Providers
+
+```python
+import siege_utilities as su
+
+# OpenRouteService hosted API
+iso = su.get_isochrone(
+    latitude=41.8781,
+    longitude=-87.6298,
+    travel_time_minutes=15,
+    provider="openrouteservice",
+    api_key="<ors-key>",
+)
+
+# Self-hosted Valhalla
+iso_internal = su.get_isochrone(
+    latitude=41.8781,
+    longitude=-87.6298,
+    travel_time_minutes=20,
+    provider="valhalla",
+    base_url="http://valhalla.svc.cluster.local:8002",
+)
+```
+
+See `docs/ISOCHRONES_AND_WKLS.md` for provider behavior and WKLS integration guidance.
+
 ## Common Pitfalls
 
 ### GDAL Not Available

--- a/siege_utilities/__init__.py
+++ b/siege_utilities/__init__.py
@@ -188,6 +188,11 @@ _register_lazy([
 ], '.geo.geocoding', deps=['geopandas'])
 
 _register_lazy([
+    'DEFAULT_ORS_BASE_URL', 'DEFAULT_VALHALLA_BASE_URL',
+    'build_isochrone_request', 'get_isochrone', 'isochrone_to_geodataframe',
+], '.geo.isochrones', deps=['requests'])
+
+_register_lazy([
     'get_census_data_selector', 'select_census_datasets', 'get_analysis_approach',
     'select_datasets_for_analysis', 'get_dataset_compatibility_matrix', 'suggest_analysis_approach',
 ], '.geo.census_data_selector', deps=['geopandas'])

--- a/siege_utilities/geo/__init__.py
+++ b/siege_utilities/geo/__init__.py
@@ -72,6 +72,12 @@ _register([
     'validate_geocode_data_pandas', 'mark_valid_geocode_data_pandas',
 ], '.geocoding')
 
+# --- isochrones ---
+_register([
+    'DEFAULT_ORS_BASE_URL', 'DEFAULT_VALHALLA_BASE_URL',
+    'build_isochrone_request', 'get_isochrone', 'isochrone_to_geodataframe',
+], '.isochrones')
+
 # --- census_geocoder ---
 _register([
     'CensusVintage', 'CensusGeocodeResult',

--- a/siege_utilities/geo/isochrones.py
+++ b/siege_utilities/geo/isochrones.py
@@ -1,0 +1,168 @@
+"""Isochrone utilities with open-source-first providers and custom server support."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping, Optional
+
+import requests
+
+DEFAULT_ORS_BASE_URL = "https://api.openrouteservice.org"
+DEFAULT_VALHALLA_BASE_URL = "http://localhost:8002"
+
+_PROVIDER_ORS = "openrouteservice"
+_PROVIDER_VALHALLA = "valhalla"
+
+
+def _normalize_provider(provider: str) -> str:
+    normalized = (provider or "").strip().lower()
+    if normalized in {"ors", "openrouteservice"}:
+        return _PROVIDER_ORS
+    if normalized in {"valhalla"}:
+        return _PROVIDER_VALHALLA
+    raise ValueError(
+        "provider must be one of: openrouteservice (ors), valhalla"
+    )
+
+
+def _validate_inputs(latitude: float, longitude: float, travel_time_minutes: int) -> None:
+    if not (-90 <= latitude <= 90):
+        raise ValueError("latitude must be between -90 and 90")
+    if not (-180 <= longitude <= 180):
+        raise ValueError("longitude must be between -180 and 180")
+    if travel_time_minutes <= 0:
+        raise ValueError("travel_time_minutes must be > 0")
+
+
+def _valhalla_costing(profile: str) -> str:
+    profile_norm = (profile or "").strip().lower()
+    mapping = {
+        "driving-car": "auto",
+        "driving-hgv": "truck",
+        "cycling-regular": "bicycle",
+        "foot-walking": "pedestrian",
+        "auto": "auto",
+        "truck": "truck",
+        "bicycle": "bicycle",
+        "pedestrian": "pedestrian",
+    }
+    return mapping.get(profile_norm, "auto")
+
+
+def build_isochrone_request(
+    latitude: float,
+    longitude: float,
+    travel_time_minutes: int,
+    *,
+    provider: str = _PROVIDER_ORS,
+    base_url: Optional[str] = None,
+    profile: str = "driving-car",
+    api_key: Optional[str] = None,
+    extra_params: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build a provider-specific HTTP request definition for an isochrone call.
+
+    This supports open-source providers and self-hosted/custom endpoints.
+    """
+    _validate_inputs(latitude, longitude, travel_time_minutes)
+    provider_norm = _normalize_provider(provider)
+
+    if provider_norm == _PROVIDER_ORS:
+        root = (base_url or DEFAULT_ORS_BASE_URL).rstrip("/")
+        headers: Dict[str, str] = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+        if api_key:
+            headers["Authorization"] = api_key
+        return {
+            "provider": _PROVIDER_ORS,
+            "method": "POST",
+            "url": f"{root}/v2/isochrones/{profile}",
+            "headers": headers,
+            "params": dict(extra_params or {}),
+            "json": {
+                "locations": [[float(longitude), float(latitude)]],
+                "range": [int(travel_time_minutes) * 60],
+            },
+        }
+
+    root = (base_url or DEFAULT_VALHALLA_BASE_URL).rstrip("/")
+    payload: Dict[str, Any] = {
+        "locations": [{"lat": float(latitude), "lon": float(longitude)}],
+        "costing": _valhalla_costing(profile),
+        "contours": [{"time": int(travel_time_minutes)}],
+        "polygons": True,
+    }
+    if extra_params:
+        payload.update(dict(extra_params))
+    return {
+        "provider": _PROVIDER_VALHALLA,
+        "method": "POST",
+        "url": f"{root}/isochrone",
+        "headers": {"Accept": "application/json", "Content-Type": "application/json"},
+        "params": {},
+        "json": payload,
+    }
+
+
+def get_isochrone(
+    latitude: float,
+    longitude: float,
+    travel_time_minutes: int,
+    *,
+    provider: str = _PROVIDER_ORS,
+    base_url: Optional[str] = None,
+    profile: str = "driving-car",
+    api_key: Optional[str] = None,
+    timeout_seconds: int = 30,
+    extra_params: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Fetch an isochrone GeoJSON response.
+
+    Args:
+        latitude: Center latitude.
+        longitude: Center longitude.
+        travel_time_minutes: Travel-time contour in minutes.
+        provider: `openrouteservice` (default) or `valhalla`.
+        base_url: Custom server root for self-hosted providers.
+        profile: Travel profile (`driving-car`, `cycling-regular`, `foot-walking`, etc.).
+        api_key: Optional API key (commonly used for hosted ORS).
+        timeout_seconds: HTTP timeout.
+        extra_params: Provider-specific extra request fields.
+
+    Returns:
+        Provider response parsed as JSON (typically GeoJSON FeatureCollection).
+    """
+    request_def = build_isochrone_request(
+        latitude,
+        longitude,
+        travel_time_minutes,
+        provider=provider,
+        base_url=base_url,
+        profile=profile,
+        api_key=api_key,
+        extra_params=extra_params,
+    )
+
+    response = requests.post(
+        request_def["url"],
+        headers=request_def["headers"],
+        params=request_def["params"],
+        json=request_def["json"],
+        timeout=timeout_seconds,
+    )
+    response.raise_for_status()
+    data = response.json()
+    if not isinstance(data, dict):
+        raise ValueError("isochrone response must be a JSON object")
+    return data
+
+
+def isochrone_to_geodataframe(isochrone_geojson: Mapping[str, Any]):
+    """Convert an isochrone GeoJSON object to GeoDataFrame when geopandas is available."""
+    try:
+        import geopandas as gpd
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError("geopandas is required for isochrone_to_geodataframe") from exc
+
+    return gpd.GeoDataFrame.from_features(isochrone_geojson.get("features", []), crs="EPSG:4326")

--- a/tests/test_isochrones.py
+++ b/tests/test_isochrones.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import pytest
+
+from siege_utilities.geo.isochrones import (
+    DEFAULT_ORS_BASE_URL,
+    build_isochrone_request,
+    get_isochrone,
+)
+
+
+class _DummyResponse:
+    def __init__(self, data):
+        self._data = data
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._data
+
+
+def test_build_isochrone_request_ors_defaults():
+    req = build_isochrone_request(
+        latitude=41.8781,
+        longitude=-87.6298,
+        travel_time_minutes=15,
+    )
+
+    assert req["provider"] == "openrouteservice"
+    assert req["url"].startswith(f"{DEFAULT_ORS_BASE_URL}/v2/isochrones/")
+    assert req["json"]["locations"] == [[-87.6298, 41.8781]]
+    assert req["json"]["range"] == [900]
+
+
+def test_build_isochrone_request_ors_custom_server_and_key():
+    req = build_isochrone_request(
+        latitude=41.8781,
+        longitude=-87.6298,
+        travel_time_minutes=10,
+        provider="ors",
+        base_url="https://ors.internal.local",
+        api_key="abc123",
+        profile="foot-walking",
+    )
+
+    assert req["url"] == "https://ors.internal.local/v2/isochrones/foot-walking"
+    assert req["headers"]["Authorization"] == "abc123"
+
+
+def test_build_isochrone_request_valhalla_custom_server():
+    req = build_isochrone_request(
+        latitude=30.2672,
+        longitude=-97.7431,
+        travel_time_minutes=20,
+        provider="valhalla",
+        base_url="http://valhalla.svc.cluster.local:8002",
+        profile="driving-car",
+    )
+
+    assert req["provider"] == "valhalla"
+    assert req["url"] == "http://valhalla.svc.cluster.local:8002/isochrone"
+    assert req["json"]["costing"] == "auto"
+    assert req["json"]["contours"][0]["time"] == 20
+
+
+def test_get_isochrone_makes_expected_request(monkeypatch):
+    captured = {}
+
+    def _fake_post(url, headers, params, json, timeout):
+        captured.update(
+            {
+                "url": url,
+                "headers": headers,
+                "params": params,
+                "json": json,
+                "timeout": timeout,
+            }
+        )
+        return _DummyResponse({"type": "FeatureCollection", "features": []})
+
+    monkeypatch.setattr("siege_utilities.geo.isochrones.requests.post", _fake_post)
+
+    result = get_isochrone(
+        latitude=34.0522,
+        longitude=-118.2437,
+        travel_time_minutes=12,
+        provider="openrouteservice",
+        base_url="https://ors.internal",
+        profile="cycling-regular",
+        timeout_seconds=11,
+    )
+
+    assert result["type"] == "FeatureCollection"
+    assert captured["url"] == "https://ors.internal/v2/isochrones/cycling-regular"
+    assert captured["json"]["range"] == [720]
+    assert captured["timeout"] == 11
+
+
+def test_invalid_provider_raises():
+    with pytest.raises(ValueError, match="provider must be one of"):
+        build_isochrone_request(
+            latitude=0,
+            longitude=0,
+            travel_time_minutes=5,
+            provider="unknown",
+        )
+
+
+def test_invalid_travel_time_raises():
+    with pytest.raises(ValueError, match="travel_time_minutes"):
+        build_isochrone_request(
+            latitude=0,
+            longitude=0,
+            travel_time_minutes=0,
+        )


### PR DESCRIPTION
## Summary
- add `siege_utilities.geo.isochrones` with open-source isochrone support and custom server URLs
- expose new isochrone helpers at package root and geo namespace
- add unit tests for ORS/Valhalla request building and request execution plumbing
- update docs with 3D notebook pointer, isochrone usage examples, and WKLS integration guidance

## Details
- New APIs:
  - `build_isochrone_request(...)`
  - `get_isochrone(...)`
  - `isochrone_to_geodataframe(...)`
- Providers:
  - `openrouteservice` (`ors`) [default]
  - `valhalla`
- Both providers support custom `base_url` for self-hosted routing engines.

## Validation
- `python -m pytest -q --no-cov tests/test_isochrones.py`
- `python -m pytest -q --no-cov tests/test_smoke.py`
- `python -m pytest -q --no-cov tests/test_databricks_fallback.py`
