### PR TITLE
Release sync: include CI allowlist/lint fixes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,9 @@ If breaking, include migration notes:
 
 Reason for selected release impact:
 
+API contract note:
+- [ ] If public API symbols were added intentionally, `scripts/contracts/contract_allowlist.json` is updated in this PR.
+
 ## Verification
 
 - [ ] Tests added/updated for changed behavior

--- a/README.md
+++ b/README.md
@@ -52,12 +52,15 @@ python scripts/contracts/generate_public_api_contract.py --output /tmp/contract_
 python scripts/contracts/compare_public_api_contracts.py \
   --baseline /tmp/contract_baseline.json \
   --candidate /tmp/contract_candidate.json \
-  --release-impact patch \
+  --release-impact <patch|minor|major> \
   --allowlist scripts/contracts/contract_allowlist.json
 
 # Contract-tool unit tests
 python -m pytest -q --no-cov tests/test_api_contract_tools.py
 ```
+
+If a PR intentionally adds public API symbols, classify as `minor` and update
+`scripts/contracts/contract_allowlist.json` in the same PR.
 
 See:
 

--- a/docs/policies/CONTRIBUTOR_GOVERNANCE.md
+++ b/docs/policies/CONTRIBUTOR_GOVERNANCE.md
@@ -79,10 +79,16 @@ python scripts/contracts/generate_public_api_contract.py --output /tmp/contract_
 python scripts/contracts/compare_public_api_contracts.py \
   --baseline /tmp/contract_baseline.json \
   --candidate /tmp/contract_candidate.json \
-  --release-impact patch \
+  --release-impact <patch|minor|major> \
   --allowlist scripts/contracts/contract_allowlist.json
 python -m pytest -q --no-cov tests/test_api_contract_tools.py
 ```
+
+API release-impact practice:
+
+- `patch`: no new public symbols.
+- `minor`: new public symbols are allowed; add intentional additions to `scripts/contracts/contract_allowlist.json` in the same PR.
+- `major`: breaking API changes require explicit migration notes and allowlist updates for intentional signature/kind/removal changes.
 
 When applicable:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,6 +31,7 @@ These scripts are part of the expected contributor workflow and are maintained.
 - `python scripts/contracts/compare_public_api_contracts.py --baseline /tmp/base.json --candidate /tmp/candidate.json --release-impact patch --allowlist scripts/contracts/contract_allowlist.json`
   - Compares two manifests and enforces release-impact rules.
   - `--baseline` should come from a released package state (for example `siege-utilities==3.8.0`), and `--candidate` from the current branch output.
+  - Use `--release-impact minor` when intentionally adding public symbols and update `scripts/contracts/contract_allowlist.json` in the same PR.
 
 ## Experimental / One-off Scripts
 

--- a/scripts/archive/diagnose_pyspark.py
+++ b/scripts/archive/diagnose_pyspark.py
@@ -7,7 +7,6 @@ This will help identify the exact cause of the JavaPackage error.
 import os
 import sys
 import subprocess
-import importlib
 
 
 def check_environment():
@@ -49,7 +48,7 @@ def check_imports():
         return False
 
     try:
-        from py4j.java_gateway import JavaGateway, GatewayParameters
+        from py4j import java_gateway  # noqa: F401
         print("✅ JavaGateway imports successfully")
     except Exception as e:
         print(f"❌ JavaGateway import failed: {e}")
@@ -64,7 +63,6 @@ def test_spark_context():
 
     try:
         from pyspark import SparkContext, SparkConf
-        from pyspark.sql import SparkSession
 
         # Clean any existing context
         if SparkContext._active_spark_context:

--- a/scripts/archive/run_tests.py
+++ b/scripts/archive/run_tests.py
@@ -6,7 +6,6 @@ Provides easy access to different test scenarios and configurations.
 Updated 2026-02-28 to match actual test files after su#113 cleanup.
 """
 
-import sys
 import subprocess
 import argparse
 import pathlib
@@ -101,7 +100,7 @@ def run_command(cmd: List[str], description: str) -> bool:
     print(f"Running: {' '.join(cmd)}")
 
     try:
-        result = subprocess.run(cmd, check=True, capture_output=False)
+        subprocess.run(cmd, check=True, capture_output=False)
         print(f"  {description} completed successfully")
         return True
     except subprocess.CalledProcessError as e:
@@ -250,8 +249,8 @@ def check_test_environment() -> bool:
         print(f"    {f.name}")
 
     try:
-        import siege_utilities
-        print(f"\n  siege_utilities package importable")
+        __import__("siege_utilities")
+        print("\n  siege_utilities package importable")
     except ImportError as e:
         print(f"  Cannot import siege_utilities: {e}")
         return False

--- a/scripts/contracts/contract_allowlist.json
+++ b/scripts/contracts/contract_allowlist.json
@@ -1,5 +1,11 @@
 {
-  "added_symbols": [],
+  "added_symbols": [
+    "DEFAULT_ORS_BASE_URL",
+    "DEFAULT_VALHALLA_BASE_URL",
+    "build_isochrone_request",
+    "get_isochrone",
+    "isochrone_to_geodataframe"
+  ],
   "removed_symbols": [],
   "signature_changes": [
     "compare_census_datasets",


### PR DESCRIPTION
## Summary
- sync latest `develop` into `main`
- includes CI fixes from #265:
  - API contract allowlist update for intentional new symbols
  - phase-4 lint regressions fixed in archived scripts
  - governance/PR template release-impact practice updates
