### PR TITLE
Add multi-account Google linkage model foundation

### DIFF
--- a/siege_utilities/config/README.md
+++ b/siege_utilities/config/README.md
@@ -49,6 +49,34 @@ summary = su.get_profile_summary()
 - `EnhancedUserProfile`: Type-safe user configuration with validation
 - `ClientProfile`: Client-specific settings and preferences
 - `SiegeConfig`: Unified configuration container
+- `GoogleLinkedAccount`: Linked Google account metadata for multi-account users
+
+### Google Workspace Multi-Account Support
+
+Users can now link multiple Google identities and select a default account for
+Google Workspace operations (Sheets, Slides, Docs).
+
+```python
+from siege_utilities.config.models.person import Person
+from siege_utilities.config.models.oauth_integration import (
+    GoogleLinkedAccount,
+    GoogleWorkspaceProduct,
+)
+
+person = Person(person_id="u1", name="User One", email="user@example.com")
+person.link_google_account(
+    GoogleLinkedAccount(
+        account_id="google-sub-1",
+        email="user@example.com",
+        granted_scopes=["https://www.googleapis.com/auth/spreadsheets"],
+        is_default=True,
+    )
+)
+
+can_write_sheets = person.can_write_google_product(
+    GoogleWorkspaceProduct.SHEETS
+)
+```
 
 ### Legacy Classes (Backward Compatibility)
 

--- a/siege_utilities/config/__init__.py
+++ b/siege_utilities/config/__init__.py
@@ -290,7 +290,13 @@ try:
     from .models.person import Person
     from .models.actor_types import User, Client, Collaborator, Organization, Collaboration
     from .models.credential import Credential, OnePasswordCredential
-    from .models.oauth_integration import OAuthIntegration, OAuthScope
+    from .models.oauth_integration import (
+        OAuthIntegration,
+        OAuthScope,
+        GoogleLinkedAccount,
+        GoogleAccountStatus,
+        GoogleWorkspaceProduct,
+    )
     from .models.database_connection import DatabaseConnection
     from .models.data_sources import (
         JurisdictionLevel, Jurisdiction,
@@ -337,6 +343,9 @@ except ImportError as e:
     OnePasswordCredential = _config_dependency_wrapper('OnePasswordCredential', _pd)
     OAuthIntegration = _config_dependency_wrapper('OAuthIntegration', _pd)
     OAuthScope = _config_dependency_wrapper('OAuthScope', _pd)
+    GoogleLinkedAccount = _config_dependency_wrapper('GoogleLinkedAccount', _pd)
+    GoogleAccountStatus = _config_dependency_wrapper('GoogleAccountStatus', _pd)
+    GoogleWorkspaceProduct = _config_dependency_wrapper('GoogleWorkspaceProduct', _pd)
     DatabaseConnection = _config_dependency_wrapper('DatabaseConnection', _pd)
     JurisdictionLevel = _config_dependency_wrapper('JurisdictionLevel', _pd)
     Jurisdiction = _config_dependency_wrapper('Jurisdiction', _pd)
@@ -485,6 +494,7 @@ __all__ = [
     # Person/Actor architecture models
     'Person', 'User', 'Client', 'Collaborator', 'Organization', 'Collaboration',
     'Credential', 'OnePasswordCredential', 'OAuthIntegration', 'OAuthScope',
+    'GoogleLinkedAccount', 'GoogleAccountStatus', 'GoogleWorkspaceProduct',
     
     # Migration utilities
     'ConfigurationMigrator', 'migrate_configurations', 'backup_and_migrate',

--- a/siege_utilities/config/models/__init__.py
+++ b/siege_utilities/config/models/__init__.py
@@ -19,6 +19,13 @@ from .data_sources import (
     DataSource,
     SourceCredential,
 )
+from .oauth_integration import (
+    OAuthIntegration,
+    OAuthScope,
+    GoogleLinkedAccount,
+    GoogleAccountStatus,
+    GoogleWorkspaceProduct,
+)
 
 __all__ = [
     "UserProfile",
@@ -34,4 +41,9 @@ __all__ = [
     "DataSourceStatus",
     "DataSource",
     "SourceCredential",
+    "OAuthIntegration",
+    "OAuthScope",
+    "GoogleLinkedAccount",
+    "GoogleAccountStatus",
+    "GoogleWorkspaceProduct",
 ]

--- a/siege_utilities/config/models/oauth_integration.py
+++ b/siege_utilities/config/models/oauth_integration.py
@@ -36,6 +36,127 @@ class OAuthScope(str, Enum):
     CONTACTS = "contacts"
 
 
+class GoogleAccountStatus(str, Enum):
+    """Lifecycle states for linked Google accounts."""
+    ACTIVE = "active"
+    REVOKED = "revoked"
+    DISCONNECTED = "disconnected"
+
+
+class GoogleWorkspaceProduct(str, Enum):
+    """Google Workspace products supported for write checks."""
+    SHEETS = "sheets"
+    SLIDES = "slides"
+    DOCS = "docs"
+
+
+_WORKSPACE_WRITE_SCOPES = {
+    GoogleWorkspaceProduct.SHEETS: {
+        "https://www.googleapis.com/auth/spreadsheets",
+        "https://www.googleapis.com/auth/drive.file",
+        "https://www.googleapis.com/auth/drive",
+    },
+    GoogleWorkspaceProduct.SLIDES: {
+        "https://www.googleapis.com/auth/presentations",
+        "https://www.googleapis.com/auth/drive.file",
+        "https://www.googleapis.com/auth/drive",
+    },
+    GoogleWorkspaceProduct.DOCS: {
+        "https://www.googleapis.com/auth/documents",
+        "https://www.googleapis.com/auth/drive.file",
+        "https://www.googleapis.com/auth/drive",
+    },
+}
+
+
+class GoogleLinkedAccount(BaseModel):
+    """
+    Linked Google account metadata for a user.
+
+    This model is intentionally separate from OAuthIntegration so one user can
+    maintain multiple Google identities with independent scopes and lifecycle.
+    """
+
+    model_config = ConfigDict()
+
+    account_id: str = Field(
+        min_length=1,
+        max_length=128,
+        description="Stable Google account subject identifier (OIDC sub)."
+    )
+    email: str = Field(
+        min_length=3,
+        max_length=320,
+        description="Google account email address."
+    )
+    display_name: Optional[str] = Field(
+        default=None,
+        max_length=200,
+        description="Display name from Google profile."
+    )
+    granted_scopes: List[str] = Field(
+        default_factory=list,
+        description="Granted OAuth scopes for this account."
+    )
+    status: GoogleAccountStatus = Field(
+        default=GoogleAccountStatus.ACTIVE,
+        description="Current lifecycle status for this linked account."
+    )
+    is_default: bool = Field(
+        default=False,
+        description="Whether this account is the default for Google operations."
+    )
+    linked_at: datetime = Field(
+        default_factory=datetime.now,
+        description="When this account was linked."
+    )
+    last_used: Optional[datetime] = Field(
+        default=None,
+        description="Last successful use timestamp."
+    )
+    last_refreshed: Optional[datetime] = Field(
+        default=None,
+        description="Last credential refresh timestamp."
+    )
+    metadata: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Additional metadata for account routing and audit."
+    )
+
+    @field_validator("email")
+    @classmethod
+    def validate_email(cls, value: str) -> str:
+        """Validate email formatting for Google-linked accounts."""
+        candidate = value.strip().lower()
+        if not re.match(r"^[^@]+@[^@]+\.[^@]+$", candidate):
+            raise ValueError("Invalid email format")
+        return candidate
+
+    @field_validator("granted_scopes")
+    @classmethod
+    def validate_granted_scopes(cls, value: List[str]) -> List[str]:
+        """Normalize scopes and ensure uniqueness."""
+        scopes = [scope.strip() for scope in value if scope and scope.strip()]
+        if len(scopes) != len(set(scopes)):
+            raise ValueError("Granted scopes must be unique")
+        return scopes
+
+    def is_active(self) -> bool:
+        """Return True when account can be used for operations."""
+        return self.status == GoogleAccountStatus.ACTIVE
+
+    def grants_scope(self, scope: str) -> bool:
+        """Return True when this account has the requested OAuth scope."""
+        return scope in self.granted_scopes
+
+    def can_write_product(self, product: GoogleWorkspaceProduct) -> bool:
+        """Return True when account has write scope for the selected product."""
+        if not self.is_active():
+            return False
+        required_scopes = _WORKSPACE_WRITE_SCOPES.get(product, set())
+        return any(scope in self.granted_scopes for scope in required_scopes)
+
+
 class OAuthIntegration(BaseModel):
     """
     OAuth integration configuration with comprehensive validation.

--- a/siege_utilities/config/models/person.py
+++ b/siege_utilities/config/models/person.py
@@ -11,7 +11,11 @@ import re
 import yaml
 
 from .credential import Credential, OnePasswordCredential
-from .oauth_integration import OAuthIntegration
+from .oauth_integration import (
+    OAuthIntegration,
+    GoogleLinkedAccount,
+    GoogleWorkspaceProduct,
+)
 from .database_connection import DatabaseConnection
 
 
@@ -69,6 +73,10 @@ class Person(BaseModel):
     oauth_integrations: List[OAuthIntegration] = Field(
         default_factory=list,
         description="OAuth integrations for this person"
+    )
+    google_linked_accounts: List[GoogleLinkedAccount] = Field(
+        default_factory=list,
+        description="Linked Google accounts for account-aware Workspace access"
     )
     database_connections: List[DatabaseConnection] = Field(
         default_factory=list,
@@ -233,6 +241,86 @@ class Person(BaseModel):
     def get_valid_oauth_integrations(self) -> List[OAuthIntegration]:
         """Get all valid OAuth integrations."""
         return [oauth for oauth in self.oauth_integrations if oauth.is_valid()]
+
+    # Linked Google Account Methods
+    def link_google_account(self, account: GoogleLinkedAccount) -> None:
+        """Link a Google account to this person."""
+        if any(existing.account_id == account.account_id
+               for existing in self.google_linked_accounts):
+            raise ValueError(
+                f'Google account "{account.account_id}" is already linked'
+            )
+        if any(existing.email == account.email
+               for existing in self.google_linked_accounts):
+            raise ValueError(
+                f'Google email "{account.email}" is already linked'
+            )
+
+        # Only one default account can exist.
+        if account.is_default:
+            for existing in self.google_linked_accounts:
+                existing.is_default = False
+
+        self.google_linked_accounts.append(account)
+
+        # If no default exists, first linked account becomes default.
+        if not any(a.is_default for a in self.google_linked_accounts):
+            self.google_linked_accounts[0].is_default = True
+
+        self.last_updated = datetime.now()
+
+    def unlink_google_account(self, account_id: str) -> bool:
+        """Unlink a Google account by account_id."""
+        for idx, account in enumerate(self.google_linked_accounts):
+            if account.account_id == account_id:
+                removed_default = account.is_default
+                del self.google_linked_accounts[idx]
+                if removed_default and self.google_linked_accounts:
+                    self.google_linked_accounts[0].is_default = True
+                self.last_updated = datetime.now()
+                return True
+        return False
+
+    def get_google_account(self, account_id: str) -> Optional[GoogleLinkedAccount]:
+        """Return a linked Google account by account_id."""
+        for account in self.google_linked_accounts:
+            if account.account_id == account_id:
+                return account
+        return None
+
+    def set_default_google_account(self, account_id: str) -> bool:
+        """Set a linked Google account as the default account."""
+        account = self.get_google_account(account_id)
+        if account is None:
+            return False
+
+        for existing in self.google_linked_accounts:
+            existing.is_default = False
+        account.is_default = True
+        self.last_updated = datetime.now()
+        return True
+
+    def get_default_google_account(self) -> Optional[GoogleLinkedAccount]:
+        """Return default Google account if one is set."""
+        for account in self.google_linked_accounts:
+            if account.is_default:
+                return account
+        return self.google_linked_accounts[0] if self.google_linked_accounts else None
+
+    def can_write_google_product(
+        self,
+        product: GoogleWorkspaceProduct,
+        account_id: Optional[str] = None,
+    ) -> bool:
+        """Return True when selected/default Google account can write product."""
+        account = (
+            self.get_google_account(account_id)
+            if account_id
+            else self.get_default_google_account()
+        )
+        if account is None:
+            return False
+        return account.can_write_product(product)
     
     # Database Connection Methods
     def add_database_connection(self, connection: DatabaseConnection) -> None:
@@ -334,6 +422,7 @@ class Person(BaseModel):
             'valid_credentials': len(self.get_valid_credentials()),
             'oauth_integrations': len(self.oauth_integrations),
             'valid_oauth_integrations': len(self.get_valid_oauth_integrations()),
+            'google_linked_accounts': len(self.google_linked_accounts),
             'database_connections': len(self.database_connections),
             'onepassword_credentials': len(self.onepassword_credentials),
             'created_date': self.created_date.isoformat(),
@@ -400,6 +489,11 @@ class Person(BaseModel):
                 'valid': len(self.get_valid_oauth_integrations()),
                 'providers': list(set(oauth.provider for oauth in self.oauth_integrations)),
                 'services': list(set(oauth.service for oauth in self.oauth_integrations))
+            },
+            'google_linked_accounts': {
+                'total': len(self.google_linked_accounts),
+                'active': len([a for a in self.google_linked_accounts if a.is_active()]),
+                'default_set': self.get_default_google_account() is not None,
             },
             'onepassword_credentials': {
                 'total': len(self.onepassword_credentials),

--- a/tests/test_google_workspace_accounts.py
+++ b/tests/test_google_workspace_accounts.py
@@ -1,0 +1,155 @@
+"""Tests for multi-linked Google account support on Person/User models."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from siege_utilities.config.models.oauth_integration import (
+    GoogleAccountStatus,
+    GoogleLinkedAccount,
+    GoogleWorkspaceProduct,
+)
+from siege_utilities.config.models.person import Person
+
+pytestmark = pytest.mark.config
+
+
+def _person() -> Person:
+    return Person(
+        person_id="p1",
+        name="Test Person",
+        email="test@example.com",
+    )
+
+
+def _google_account(
+    account_id: str,
+    email: str,
+    scopes=None,
+    is_default: bool = False,
+    status: GoogleAccountStatus = GoogleAccountStatus.ACTIVE,
+) -> GoogleLinkedAccount:
+    return GoogleLinkedAccount(
+        account_id=account_id,
+        email=email,
+        granted_scopes=scopes or [],
+        is_default=is_default,
+        status=status,
+        last_refreshed=datetime.now() - timedelta(minutes=5),
+    )
+
+
+class TestGoogleLinkedAccountModel:
+    def test_scope_uniqueness_enforced(self):
+        with pytest.raises(ValueError):
+            _google_account(
+                "acct1",
+                "a@example.com",
+                scopes=[
+                    "https://www.googleapis.com/auth/spreadsheets",
+                    "https://www.googleapis.com/auth/spreadsheets",
+                ],
+            )
+
+    def test_write_scope_checks(self):
+        acct = _google_account(
+            "acct1",
+            "a@example.com",
+            scopes=["https://www.googleapis.com/auth/spreadsheets"],
+        )
+        assert acct.can_write_product(GoogleWorkspaceProduct.SHEETS) is True
+        assert acct.can_write_product(GoogleWorkspaceProduct.DOCS) is False
+
+    def test_revoked_account_cannot_write(self):
+        acct = _google_account(
+            "acct1",
+            "a@example.com",
+            scopes=["https://www.googleapis.com/auth/documents"],
+            status=GoogleAccountStatus.REVOKED,
+        )
+        assert acct.can_write_product(GoogleWorkspaceProduct.DOCS) is False
+
+
+class TestPersonGoogleAccountLinking:
+    def test_first_linked_account_becomes_default(self):
+        person = _person()
+        person.link_google_account(_google_account("acct1", "a@example.com"))
+        default = person.get_default_google_account()
+        assert default is not None
+        assert default.account_id == "acct1"
+        assert default.is_default is True
+
+    def test_explicit_default_replaces_previous_default(self):
+        person = _person()
+        person.link_google_account(_google_account("acct1", "a@example.com"))
+        person.link_google_account(
+            _google_account("acct2", "b@example.com", is_default=True)
+        )
+        assert person.get_google_account("acct1").is_default is False
+        assert person.get_google_account("acct2").is_default is True
+
+    def test_duplicate_account_id_rejected(self):
+        person = _person()
+        person.link_google_account(_google_account("acct1", "a@example.com"))
+        with pytest.raises(ValueError):
+            person.link_google_account(_google_account("acct1", "b@example.com"))
+
+    def test_duplicate_email_rejected(self):
+        person = _person()
+        person.link_google_account(_google_account("acct1", "a@example.com"))
+        with pytest.raises(ValueError):
+            person.link_google_account(_google_account("acct2", "a@example.com"))
+
+    def test_unlink_default_promotes_next_account(self):
+        person = _person()
+        person.link_google_account(_google_account("acct1", "a@example.com"))
+        person.link_google_account(_google_account("acct2", "b@example.com"))
+        assert person.unlink_google_account("acct1") is True
+        default = person.get_default_google_account()
+        assert default is not None
+        assert default.account_id == "acct2"
+        assert default.is_default is True
+
+    def test_can_write_uses_default_account(self):
+        person = _person()
+        person.link_google_account(
+            _google_account(
+                "acct1",
+                "a@example.com",
+                scopes=["https://www.googleapis.com/auth/spreadsheets"],
+            )
+        )
+        assert person.can_write_google_product(GoogleWorkspaceProduct.SHEETS) is True
+        assert person.can_write_google_product(GoogleWorkspaceProduct.DOCS) is False
+
+    def test_can_write_with_specific_account(self):
+        person = _person()
+        person.link_google_account(
+            _google_account(
+                "acct1",
+                "a@example.com",
+                scopes=["https://www.googleapis.com/auth/spreadsheets"],
+                is_default=True,
+            )
+        )
+        person.link_google_account(
+            _google_account(
+                "acct2",
+                "b@example.com",
+                scopes=["https://www.googleapis.com/auth/documents"],
+            )
+        )
+        assert (
+            person.can_write_google_product(
+                GoogleWorkspaceProduct.DOCS,
+                account_id="acct2",
+            )
+            is True
+        )
+        assert (
+            person.can_write_google_product(
+                GoogleWorkspaceProduct.DOCS,
+                account_id="acct1",
+            )
+            is False
+        )


### PR DESCRIPTION
## Summary
Implements the foundational data model for multi-linked Google accounts per user/person to support upcoming write integrations for Google Sheets/Slides/Docs.

## What Changed
- Added new OAuth-adjacent models in `oauth_integration.py`:
  - `GoogleLinkedAccount`
  - `GoogleAccountStatus`
  - `GoogleWorkspaceProduct`
- Added product write-scope checks (`can_write_product`) for Sheets/Slides/Docs.
- Extended `Person` with:
  - `google_linked_accounts`
  - account link/unlink/default selection helpers
  - account-aware `can_write_google_product(...)`
- Exported new models from config package public surfaces.
- Added focused tests in `tests/test_google_workspace_accounts.py`.

## Validation
- `uv run pytest -q --no-cov tests/test_google_workspace_accounts.py tests/test_person_actor.py`

## Tracking
- Epic: #289
- Subtask implemented by this PR: #290
