### PR TITLE
fix(geo): CensusTIGERProvider.get_boundary forwards all kwargs via CensusDataSource

### DIFF
--- a/siege_utilities/geo/boundary_providers.py
+++ b/siege_utilities/geo/boundary_providers.py
@@ -70,7 +70,7 @@ class CensusTIGERProvider(BoundaryProvider):
     """
     US Census TIGER/Line boundary provider.
 
-    Wraps :func:`siege_utilities.geo.spatial_data.get_census_boundaries` and
+    Wraps :class:`siege_utilities.geo.spatial_data.CensusDataSource` and
     :data:`siege_utilities.config.census_constants.CANONICAL_GEOGRAPHIC_LEVELS`.
     """
 
@@ -83,20 +83,42 @@ class CensusTIGERProvider(BoundaryProvider):
         Fetch US Census TIGER boundaries.
 
         Args:
-            level: A canonical geographic level (e.g. 'county', 'tract', 'state').
+            level: A canonical geographic level (e.g. 'county', 'tract', 'cd').
             identifier: State FIPS code when the level requires it.
-            **kwargs: Forwarded to ``get_census_boundaries`` (e.g. ``year``).
+            **kwargs: Forwarded to
+                :meth:`~siege_utilities.geo.spatial_data.CensusDataSource.fetch_geographic_boundaries`
+                (e.g. ``year``, ``congress_number``).
 
         Returns:
-            GeoDataFrame or None.
-        """
-        from .spatial_data import get_census_boundaries
+            GeoDataFrame or None if the boundary could not be retrieved.
 
-        call_kwargs: dict[str, Any] = {'geographic_level': level}
+        Note:
+            Previously this delegated to the deprecated module-level
+            ``get_census_boundaries()`` function, which silently dropped
+            ``congress_number`` and other kwargs not in its signature.  It now
+            uses ``CensusDataSource.fetch_geographic_boundaries()`` directly so
+            that all parameters — including ``congress_number`` for ``'cd'``
+            boundaries — are honoured.
+        """
+        from .spatial_data import CensusDataSource
+
+        call_kwargs: dict[str, Any] = {
+            'geographic_level': level,
+            **kwargs,
+        }
         if identifier is not None:
             call_kwargs['state_fips'] = identifier
-        call_kwargs.update(kwargs)
-        return get_census_boundaries(**call_kwargs)
+
+        ds = CensusDataSource()
+        result = ds.fetch_geographic_boundaries(**call_kwargs)
+        if not result.success:
+            logger.warning(
+                "CensusTIGERProvider: boundary retrieval failed [%s] %s",
+                result.error_stage,
+                result.message,
+            )
+            return None
+        return result.geodataframe
 
     def list_levels(self) -> list[str]:
         """Return canonical Census geographic level names."""


### PR DESCRIPTION
## Problem

`CensusTIGERProvider.get_boundary()` delegated to the deprecated module-level `get_census_boundaries()` function. That function's signature is:

```python
def get_census_boundaries(year, geographic_level, state_fips, state_identifier)
```

It does **not** accept `congress_number` (or any other structured kwargs). Any extra kwargs forwarded by callers were silently accepted by the `**kwargs` on `get_boundary()` but then raised `TypeError: get_census_boundaries() got an unexpected keyword argument 'congress_number'` at runtime.

In practice, this made it impossible to load congressional-district (CD) boundaries through the provider abstraction because the `congress_number` required to construct the correct TIGER filename (e.g. `tl_2020_us_cd116.zip`) could not be forwarded.

## Fix

Delegate to `CensusDataSource.fetch_geographic_boundaries()` — the structured, non-deprecated API — which accepts `congress_number` and returns a typed `BoundaryFetchResult`. The returned GeoDataFrame (or `None` on failure) preserves the existing return contract.

## Reproduction

```python
from siege_utilities.geo.boundary_providers import CensusTIGERProvider

provider = CensusTIGERProvider()
# Before fix → TypeError: get_census_boundaries() got an unexpected
#               keyword argument 'congress_number'
gdf = provider.get_boundary('cd', year=2020, congress_number=116)
assert gdf is not None and len(gdf) == 444  # 116th Congress districts
```

## Root cause chain

1. TIGER FTP uses `CD/` directory (not `CD116/`) for all years; the congress number appears only in the filename (`tl_{year}_us_cd{congress_num}.zip`).
2. `CensusDataSource.fetch_geographic_boundaries(congress_number=116)` correctly plumbs this into `_construct_filename_with_fips_validation`.
3. But the `CensusTIGERProvider` shortcut bypassed `CensusDataSource` entirely and called the deprecated wrapper which dropped the kwarg.

Discovered while loading TIGER 2020 congressional districts in a downstream project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of geographic parameters (e.g., congressional districts) that were previously ignored when retrieving census boundary data.

* **Improvements**
  * Enhanced error reporting to display detailed messages when boundary data retrieval fails, improving troubleshooting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->