### PR TITLE
fix(geo): CensusTIGERProvider.get_boundary uses CensusDataSource

### DIFF
--- a/siege_utilities/data/dataframe_engine.py
+++ b/siege_utilities/data/dataframe_engine.py
@@ -902,7 +902,6 @@ class SparkEngine(DataFrameEngine):
         if format in ("parquet", "geoparquet"):
             df = self._session.read.parquet(path)
             if geometry_col not in df.columns and "geom" in df.columns:
-                from pyspark.sql.functions import col
                 df = df.withColumnRenamed("geom", geometry_col)
             return df
         # Fallback to GeoPandas for GeoJSON/Shapefile

--- a/siege_utilities/geo/boundary_providers.py
+++ b/siege_utilities/geo/boundary_providers.py
@@ -70,7 +70,7 @@ class CensusTIGERProvider(BoundaryProvider):
     """
     US Census TIGER/Line boundary provider.
 
-    Wraps :func:`siege_utilities.geo.spatial_data.get_census_boundaries` and
+    Wraps :class:`siege_utilities.geo.spatial_data.CensusDataSource` and
     :data:`siege_utilities.config.census_constants.CANONICAL_GEOGRAPHIC_LEVELS`.
     """
 
@@ -83,20 +83,33 @@ class CensusTIGERProvider(BoundaryProvider):
         Fetch US Census TIGER boundaries.
 
         Args:
-            level: A canonical geographic level (e.g. 'county', 'tract', 'state').
+            level: A canonical geographic level (e.g. 'county', 'tract', 'cd').
             identifier: State FIPS code when the level requires it.
-            **kwargs: Forwarded to ``get_census_boundaries`` (e.g. ``year``).
+            **kwargs: Forwarded to ``CensusDataSource.fetch_geographic_boundaries``
+                      (e.g. ``year``, ``congress_number``).
 
         Returns:
             GeoDataFrame or None.
         """
-        from .spatial_data import get_census_boundaries
+        from .spatial_data import CensusDataSource
 
-        call_kwargs: dict[str, Any] = {'geographic_level': level}
+        call_kwargs: dict[str, Any] = {
+            'geographic_level': level,
+            **kwargs,
+        }
         if identifier is not None:
             call_kwargs['state_fips'] = identifier
-        call_kwargs.update(kwargs)
-        return get_census_boundaries(**call_kwargs)
+
+        ds = CensusDataSource()
+        result = ds.fetch_geographic_boundaries(**call_kwargs)
+        if not result.success:
+            logger.warning(
+                'CensusTIGERProvider: boundary retrieval failed [%s] %s',
+                result.error_stage,
+                result.message,
+            )
+            return None
+        return result.geodataframe
 
     def list_levels(self) -> list[str]:
         """Return canonical Census geographic level names."""

--- a/siege_utilities/geo/boundary_providers.py
+++ b/siege_utilities/geo/boundary_providers.py
@@ -93,6 +93,7 @@ class CensusTIGERProvider(BoundaryProvider):
         """
         from .spatial_data import CensusDataSource
 
+        kwargs.pop('geographic_level', None)  # level arg is authoritative
         call_kwargs: dict[str, Any] = {
             'geographic_level': level,
             **kwargs,

--- a/tests/test_boundary_providers.py
+++ b/tests/test_boundary_providers.py
@@ -71,7 +71,7 @@ class TestCensusTIGERProvider:
         mock_get.assert_called_once_with('county', identifier='06')
         assert result is sentinel
 
-    @patch('siege_utilities.geo.boundary_providers.CensusDataSource')
+    @patch('siege_utilities.geo.spatial_data.CensusDataSource')
     def test_get_boundary_passes_kwargs(self, MockDS):
         """Extra kwargs (e.g. year) are forwarded to fetch_geographic_boundaries."""
         sentinel_gdf = MagicMock(name='gdf')
@@ -85,7 +85,7 @@ class TestCensusTIGERProvider:
         )
         assert result is sentinel_gdf
 
-    @patch('siege_utilities.geo.boundary_providers.CensusDataSource')
+    @patch('siege_utilities.geo.spatial_data.CensusDataSource')
     def test_get_boundary_congress_number_forwarded(self, MockDS):
         """congress_number kwarg reaches fetch_geographic_boundaries for CD boundaries."""
         sentinel_gdf = MagicMock(name='cd_gdf')
@@ -99,7 +99,7 @@ class TestCensusTIGERProvider:
         )
         assert result is sentinel_gdf
 
-    @patch('siege_utilities.geo.boundary_providers.CensusDataSource')
+    @patch('siege_utilities.geo.spatial_data.CensusDataSource')
     def test_get_boundary_level_authoritative(self, MockDS):
         """geographic_level in kwargs is silently dropped; the level arg wins."""
         mock_result = MagicMock(success=True, geodataframe=MagicMock())
@@ -110,7 +110,7 @@ class TestCensusTIGERProvider:
         call_kwargs = MockDS.return_value.fetch_geographic_boundaries.call_args[1]
         assert call_kwargs['geographic_level'] == 'county'
 
-    @patch('siege_utilities.geo.boundary_providers.CensusDataSource')
+    @patch('siege_utilities.geo.spatial_data.CensusDataSource')
     def test_get_boundary_failure_returns_none(self, MockDS):
         """result.success=False returns None and logs a warning."""
         mock_result = MagicMock(success=False, error_stage='download', message='404')

--- a/tests/test_boundary_providers.py
+++ b/tests/test_boundary_providers.py
@@ -71,16 +71,58 @@ class TestCensusTIGERProvider:
         mock_get.assert_called_once_with('county', identifier='06')
         assert result is sentinel
 
-    @patch('siege_utilities.geo.spatial_data.get_census_boundaries')
-    def test_get_boundary_passes_kwargs(self, mock_gcb):
-        """Extra kwargs (e.g. year) are forwarded."""
-        mock_gcb.return_value = MagicMock(name='gdf')
+    @patch('siege_utilities.geo.boundary_providers.CensusDataSource')
+    def test_get_boundary_passes_kwargs(self, MockDS):
+        """Extra kwargs (e.g. year) are forwarded to fetch_geographic_boundaries."""
+        sentinel_gdf = MagicMock(name='gdf')
+        mock_result = MagicMock(success=True, geodataframe=sentinel_gdf)
+        MockDS.return_value.fetch_geographic_boundaries.return_value = mock_result
+
         provider = CensusTIGERProvider()
         result = provider.get_boundary('tract', identifier='36', year=2020)
-        mock_gcb.assert_called_once_with(
+        MockDS.return_value.fetch_geographic_boundaries.assert_called_once_with(
             geographic_level='tract', state_fips='36', year=2020,
         )
-        assert result is mock_gcb.return_value
+        assert result is sentinel_gdf
+
+    @patch('siege_utilities.geo.boundary_providers.CensusDataSource')
+    def test_get_boundary_congress_number_forwarded(self, MockDS):
+        """congress_number kwarg reaches fetch_geographic_boundaries for CD boundaries."""
+        sentinel_gdf = MagicMock(name='cd_gdf')
+        mock_result = MagicMock(success=True, geodataframe=sentinel_gdf)
+        MockDS.return_value.fetch_geographic_boundaries.return_value = mock_result
+
+        provider = CensusTIGERProvider()
+        result = provider.get_boundary('cd', year=2020, congress_number=116)
+        MockDS.return_value.fetch_geographic_boundaries.assert_called_once_with(
+            geographic_level='cd', year=2020, congress_number=116,
+        )
+        assert result is sentinel_gdf
+
+    @patch('siege_utilities.geo.boundary_providers.CensusDataSource')
+    def test_get_boundary_level_authoritative(self, MockDS):
+        """geographic_level in kwargs is silently dropped; the level arg wins."""
+        mock_result = MagicMock(success=True, geodataframe=MagicMock())
+        MockDS.return_value.fetch_geographic_boundaries.return_value = mock_result
+
+        provider = CensusTIGERProvider()
+        provider.get_boundary('county', geographic_level='tract')  # kwarg must lose
+        call_kwargs = MockDS.return_value.fetch_geographic_boundaries.call_args[1]
+        assert call_kwargs['geographic_level'] == 'county'
+
+    @patch('siege_utilities.geo.boundary_providers.CensusDataSource')
+    def test_get_boundary_failure_returns_none(self, MockDS):
+        """result.success=False returns None and logs a warning."""
+        mock_result = MagicMock(success=False, error_stage='download', message='404')
+        MockDS.return_value.fetch_geographic_boundaries.return_value = mock_result
+
+        provider = CensusTIGERProvider()
+        import logging
+        with patch.object(logging.getLogger('siege_utilities.geo.boundary_providers'),
+                          'warning') as mock_warn:
+            result = provider.get_boundary('county')
+        assert result is None
+        mock_warn.assert_called_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes TypeError when congress_number is passed. Delegates to CensusDataSource.fetch_geographic_boundaries() instead of the deprecated get_census_boundaries() module function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for geographic boundary requests: failures now log informative warnings and return no result.
  * Positional geographic level argument now reliably takes precedence over any conflicting keyword.

* **Documentation**
  * Clarified example geographic level values and noted that additional parameters (e.g., congressional district) are forwarded.

* **Tests**
  * Expanded tests to cover success, failure, parameter forwarding, and precedence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->