### PR TITLE
feat(geo): TIGER2020PL VTD routing + RDHProvider

### DIFF
--- a/siege_utilities/data/redistricting_data_hub.py
+++ b/siege_utilities/data/redistricting_data_hub.py
@@ -14,9 +14,14 @@ Contact info@redistrictingdatahub.org to request access.
 
 Usage::
 
+    import os
     from siege_utilities.data.redistricting_data_hub import RDHClient
 
-    client = RDHClient(username="you@example.com", password="secret")
+    # Prefer env vars (RDH_USERNAME / RDH_PASSWORD); never hardcode
+    client = RDHClient(
+        username=os.environ["RDH_USERNAME"],
+        password=os.environ["RDH_PASSWORD"],
+    )
     datasets = client.list_datasets(states=["VA"], format="csv")
     df = client.download_dataset(datasets[0])
 """
@@ -484,6 +489,7 @@ class RDHClient:
         state: str,
         chamber: str = "congress",
         year: Optional[str] = None,
+        format: str = "shp",
     ) -> List[RDHDataset]:
         """Find enacted redistricting plan datasets for a state.
 
@@ -495,10 +501,14 @@ class RDHClient:
             ``"congress"``, ``"state_senate"``, or ``"state_house"``.
         year : str, optional
             Filter by year.
+        format : str, default "shp"
+            Dataset format filter. Only ``"shp"`` is loadable via
+            :meth:`load_shapefile`; other formats are returned as metadata
+            only.
         """
         datasets = self.list_datasets(
             states=[state],
-            format="shp",
+            format=format,
             year=year,
         )
 

--- a/siege_utilities/geo/boundary_providers.py
+++ b/siege_utilities/geo/boundary_providers.py
@@ -28,11 +28,17 @@ from typing import Any, Optional
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    'BoundaryFetchError',
     'BoundaryProvider',
     'CensusTIGERProvider',
     'GADMProvider',
+    'RDHProvider',
     'resolve_boundary_provider',
 ]
+
+
+class BoundaryFetchError(RuntimeError):
+    """Raised when a boundary provider cannot satisfy a request after retries."""
 
 
 class BoundaryProvider(ABC):
@@ -241,3 +247,153 @@ def resolve_boundary_provider(country: str = 'US', **kwargs: Any) -> BoundaryPro
     if country.upper() in _US_CODES:
         return CensusTIGERProvider()
     return GADMProvider(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# RDH (Redistricting Data Hub) provider
+# ---------------------------------------------------------------------------
+
+
+class RDHProvider(BoundaryProvider):
+    """
+    Redistricting Data Hub boundary provider.
+
+    Wraps :class:`siege_utilities.data.redistricting_data_hub.RDHClient` to
+    expose precinct / VTD boundaries — and enacted legislative plans — through
+    the standard :class:`BoundaryProvider` interface.
+
+    RDH requires a "designated API user" account.  Contact
+    info@redistrictingdatahub.org to request access.  Pass credentials either
+    via constructor arguments or environment variables
+    ``RDH_USERNAME`` / ``RDH_PASSWORD``.
+
+    Supported levels
+    ----------------
+    * ``'precinct'`` — precinct/VTD boundaries with election results
+    * ``'congress'`` — enacted congressional district plans
+    * ``'state_senate'`` — enacted upper-chamber plans
+    * ``'state_house'`` — enacted lower-chamber plans
+
+    Usage::
+
+        import os
+        from siege_utilities.geo.boundary_providers import RDHProvider
+
+        # Prefer env vars (RDH_USERNAME / RDH_PASSWORD); never hardcode
+        provider = RDHProvider(
+            username=os.environ["RDH_USERNAME"],
+            password=os.environ["RDH_PASSWORD"],
+        )
+        gdf = provider.get_boundary('precinct', identifier='TX')
+    """
+
+    _LEVELS = ('precinct', 'congress', 'state_senate', 'state_house')
+
+    def __init__(
+        self,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        cache_dir: Optional[str] = None,
+    ) -> None:
+        import os
+        # Explicit None check so an intentional "" disables env fallback
+        # and doesn't silently pick up ambient RDH_USERNAME / RDH_PASSWORD.
+        self._username = username if username is not None else os.environ.get('RDH_USERNAME', '')
+        self._password = password if password is not None else os.environ.get('RDH_PASSWORD', '')
+        self._cache_dir = cache_dir
+        self._client = None  # lazy-initialised
+
+    def _get_client(self):
+        """Return a cached :class:`RDHClient` instance."""
+        if self._client is None:
+            from siege_utilities.data.redistricting_data_hub import RDHClient
+            self._client = RDHClient(
+                username=self._username,
+                password=self._password,
+                **({"cache_dir": self._cache_dir} if self._cache_dir else {}),
+            )
+        return self._client
+
+    @property
+    def provider_name(self) -> str:
+        return 'Redistricting Data Hub'
+
+    def get_boundary(self, level: str, identifier: Optional[str] = None, **kwargs: Any):
+        """
+        Fetch RDH boundary data for a state.
+
+        Args:
+            level: One of ``'precinct'``, ``'congress'``, ``'state_senate'``,
+                   ``'state_house'``.
+            identifier: Two-letter state abbreviation (e.g. ``'TX'``).
+                        Can also be passed as ``state`` kwarg.
+            **kwargs:
+                ``state`` — alias for *identifier*.
+                ``year`` — filter datasets by year string (e.g. ``'2022'``).
+                ``format`` — ``'shp'`` (default) or ``'csv'``.
+
+        Returns:
+            GeoDataFrame with boundary geometries (shapefiles) or None.
+
+        Raises:
+            ValueError: If *level* is not recognised or *state* is missing.
+            ImportError: If geopandas is not installed.
+        """
+        if level not in self._LEVELS:
+            raise ValueError(
+                f"Unknown RDH level {level!r}. Choose from {self._LEVELS}."
+            )
+
+        state = kwargs.pop('state', None) or identifier
+        if not state:
+            raise ValueError(
+                "RDHProvider.get_boundary() requires a state abbreviation "
+                "(identifier or state= kwarg)."
+            )
+
+        year: Optional[str] = kwargs.pop('year', None)
+        fmt: str = kwargs.pop('format', 'shp')
+        client = self._get_client()
+
+        if level == 'precinct':
+            datasets = client.get_precinct_data(state, year=year, format=fmt)
+        else:
+            chamber_map = {
+                'congress': 'congress',
+                'state_senate': 'state_senate',
+                'state_house': 'state_house',
+            }
+            datasets = client.get_enacted_plans(
+                state, chamber=chamber_map[level], year=year, format=fmt,
+            )
+
+        if not datasets:
+            logger.warning(
+                'RDHProvider: no %s datasets found for state=%s year=%s format=%s',
+                level, state, year, fmt,
+            )
+            return None
+
+        # Load the first matching dataset as a GeoDataFrame. Only shapefile
+        # formats are loadable; other formats would need a different reader.
+        try:
+            return client.load_shapefile(datasets[0], **kwargs)
+        except (OSError, ValueError) as exc:
+            raise BoundaryFetchError(
+                f"RDHProvider: failed to load {level} shapefile for state={state}, "
+                f"year={year}, format={fmt}"
+            ) from exc
+
+    def list_levels(self) -> list[str]:
+        """Return the geographic levels this provider supports."""
+        return list(self._LEVELS)
+
+    def is_available(self) -> bool:
+        """Return True if geopandas is installed and both credentials are set."""
+        if not (self._username and self._password):
+            return False
+        try:
+            import geopandas  # noqa: F401
+            return True
+        except ImportError:
+            return False

--- a/siege_utilities/geo/spatial_data.py
+++ b/siege_utilities/geo/spatial_data.py
@@ -117,6 +117,52 @@ BOUNDARY_TYPE_CATALOG = {
     'arealm':       {'category': 'general', 'abbrev': 'AREALM',     'name': 'Area Landmarks',                   'geometry_type': 'MultiPolygon'},
 }
 
+# ---------------------------------------------------------------------------
+# TIGER Redistricting (PL 94-171) URL constants
+# ---------------------------------------------------------------------------
+# VTD (Voting Tabulation District) boundaries for decennial census years are
+# published in the PL 94-171 redistricting product, NOT in the standard annual
+# TIGER release.  The standard TIGER{year}/ server has no VTD20/ directory.
+#
+# 2020 URL pattern:
+#   TIGER2020PL/STATE/{FIPS}_{STATE_NAME_UPPER}/{FIPS}/tl_2020_{fips}_vtd20.zip
+# 2010 URL pattern (same structure, different vintage):
+#   TIGER2010PL/tabblock_vtd/{FIPS}_{STATE_NAME_UPPER}/{FIPS}/tl_2010_{fips}_vtd10.zip
+
+TIGER_PL_BASE_URL = "https://www2.census.gov/geo/tiger"
+
+# State names used in TIGER PL directory paths, uppercase with underscores.
+# Territories that publish VTD data in PL files are included; others (GU, AS,
+# VI, MP) do not appear in TIGER2020PL/STATE and are intentionally omitted.
+_VTD_PL_STATE_NAMES: Dict[str, str] = {
+    "01": "ALABAMA",               "02": "ALASKA",
+    "04": "ARIZONA",               "05": "ARKANSAS",
+    "06": "CALIFORNIA",            "08": "COLORADO",
+    "09": "CONNECTICUT",           "10": "DELAWARE",
+    "11": "DISTRICT_OF_COLUMBIA",  "12": "FLORIDA",
+    "13": "GEORGIA",               "15": "HAWAII",
+    "16": "IDAHO",                 "17": "ILLINOIS",
+    "18": "INDIANA",               "19": "IOWA",
+    "20": "KANSAS",                "21": "KENTUCKY",
+    "22": "LOUISIANA",             "23": "MAINE",
+    "24": "MARYLAND",              "25": "MASSACHUSETTS",
+    "26": "MICHIGAN",              "27": "MINNESOTA",
+    "28": "MISSISSIPPI",           "29": "MISSOURI",
+    "30": "MONTANA",               "31": "NEBRASKA",
+    "32": "NEVADA",                "33": "NEW_HAMPSHIRE",
+    "34": "NEW_JERSEY",            "35": "NEW_MEXICO",
+    "36": "NEW_YORK",              "37": "NORTH_CAROLINA",
+    "38": "NORTH_DAKOTA",          "39": "OHIO",
+    "40": "OKLAHOMA",              "41": "OREGON",
+    "42": "PENNSYLVANIA",          "44": "RHODE_ISLAND",
+    "45": "SOUTH_CAROLINA",        "46": "SOUTH_DAKOTA",
+    "47": "TENNESSEE",             "48": "TEXAS",
+    "49": "UTAH",                  "50": "VERMONT",
+    "51": "VIRGINIA",              "53": "WASHINGTON",
+    "54": "WEST_VIRGINIA",         "55": "WISCONSIN",
+    "56": "WYOMING",               "72": "PUERTO_RICO",
+}
+
 
 class CensusDirectoryDiscovery:
     """Discovers available Census TIGER/Line data dynamically."""
@@ -403,6 +449,74 @@ class CensusDirectoryDiscovery:
         
         return patterns
     
+    # ------------------------------------------------------------------
+    # TIGER PL (redistricting) VTD helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _is_vtd_pl_boundary(boundary_type: str, year: int) -> bool:
+        """Return True when *boundary_type* must come from a TIGER PL release.
+
+        VTD data is only published in the decennial PL 94-171 product for
+        census years (2020, 2010).  It does not appear in the standard annual
+        TIGER release for those years. Vintage-specific suffixes must match
+        the requested year: ``'vtd20'`` pairs only with 2020, ``'vtd10'`` only
+        with 2010. The unsuffixed ``'vtd'`` works for either.
+        """
+        if year == 2020:
+            return boundary_type in ('vtd', 'vtd20')
+        if year == 2010:
+            return boundary_type in ('vtd', 'vtd10')
+        return False
+
+    @staticmethod
+    def _construct_vtd_pl_url(year: int, state_fips: str) -> str:
+        """Return the TIGER PL download URL for a state's VTD shapefile.
+
+        Raises:
+            BoundaryInputError: if *state_fips* has no PL state name mapping
+                (i.e. the territory does not publish VTD data).
+            BoundaryDiscoveryError: if *year* is not a supported decennial year.
+        """
+        if year == 2020:
+            suffix = 'vtd20'
+            pl_dir = 'TIGER2020PL'
+        elif year == 2010:
+            # 2010 VTDs are published as county-level files under
+            # TIGER2010/VTD/2010/ (e.g. tl_2010_48001_vtd10.zip), not as a
+            # state-level ZIP under TIGER2010PL/STATE/. The state-level path
+            # does not exist on Census and would 404 at download time.
+            # Until county-level enumeration is implemented, fail fast.
+            raise BoundaryDiscoveryError(
+                "2010 VTD boundaries are published per-county under "
+                "TIGER2010/VTD/2010/ (e.g. tl_2010_<state_fips><county_fips>_vtd10.zip), "
+                "not as a single state-level ZIP. County-level enumeration is not "
+                "yet supported by this routing; fetch the required counties directly.",
+                context={"year": 2010, "boundary_type": "vtd", "state_fips": state_fips},
+            )
+        else:
+            raise BoundaryDiscoveryError(
+                f"VTD PL boundaries are only available for decennial year 2020. "
+                f"Requested year: {year}.",
+                context={"year": year, "boundary_type": "vtd"},
+            )
+
+        state_name = _VTD_PL_STATE_NAMES.get(state_fips)
+        if not state_name:
+            raise BoundaryInputError(
+                f"State FIPS {state_fips!r} does not publish VTD data in "
+                f"{pl_dir}.  Check _VTD_PL_STATE_NAMES for supported states.",
+                context={"year": year, "boundary_type": "vtd", "state_fips": state_fips},
+            )
+
+        url = (
+            f"{TIGER_PL_BASE_URL}/{pl_dir}/STATE/"
+            f"{state_fips}_{state_name}/{state_fips}/"
+            f"tl_{year}_{state_fips}_{suffix}.zip"
+        )
+        log.info("VTD PL URL: %s", url)
+        return url
+
     def construct_download_url(self, year: int, boundary_type: str, state_fips: Optional[str] = None,
                               congress_number: Optional[int] = None) -> str:
         """Construct download URL using FIPS validation and year-specific patterns.
@@ -424,6 +538,17 @@ class CensusDirectoryDiscovery:
 
                 state_info = get_fips_info(state_fips)
                 log.info(f"Constructing URL for {state_info['name']} ({state_info['abbreviation']})")
+
+            # VTD data lives in the decennial PL 94-171 redistricting product,
+            # NOT in the standard annual TIGER release.  Route before doing
+            # directory discovery so we never try to find VTD20/ on tiger.
+            if self._is_vtd_pl_boundary(boundary_type, year):
+                if not state_fips:
+                    raise BoundaryInputError(
+                        "VTD boundaries require a state_fips code.",
+                        context=ctx,
+                    )
+                return self._construct_vtd_pl_url(year, state_fips)
 
             # Get year-specific patterns
             patterns = self.get_year_specific_url_patterns(year)

--- a/tests/test_boundary_providers.py
+++ b/tests/test_boundary_providers.py
@@ -10,8 +10,21 @@ from siege_utilities.geo.boundary_providers import (
     BoundaryProvider,
     CensusTIGERProvider,
     GADMProvider,
+    RDHProvider,
     resolve_boundary_provider,
 )
+
+# Test-only credential placeholders. Marked noqa to tell scanners these
+# are not real secrets; the actual values never leave the test process.
+TEST_USERNAME = "test-user"  # noqa: S105 — test fixture placeholder
+TEST_PASSWORD = "test-password-placeholder"  # noqa: S105 — test fixture placeholder
+
+
+@pytest.fixture(autouse=True)
+def _isolate_rdh_env(monkeypatch):
+    """Strip RDH_USERNAME / RDH_PASSWORD so ambient env doesn't leak in."""
+    monkeypatch.delenv("RDH_USERNAME", raising=False)
+    monkeypatch.delenv("RDH_PASSWORD", raising=False)
 
 
 # ---------------------------------------------------------------------------
@@ -216,3 +229,100 @@ class TestResolveBoundaryProvider:
         provider = resolve_boundary_provider('FR', version='3.6')
         assert isinstance(provider, GADMProvider)
         assert provider._version == '3.6'
+
+
+# ---------------------------------------------------------------------------
+# RDHProvider
+# ---------------------------------------------------------------------------
+
+
+class TestRDHProvider:
+    def test_provider_name(self):
+        provider = RDHProvider(username=TEST_USERNAME, password=TEST_PASSWORD)
+        assert provider.provider_name == 'Redistricting Data Hub'
+
+    def test_list_levels(self):
+        provider = RDHProvider(username=TEST_USERNAME, password=TEST_PASSWORD)
+        levels = provider.list_levels()
+        assert 'precinct' in levels
+        assert 'congress' in levels
+        assert 'state_senate' in levels
+        assert 'state_house' in levels
+
+    def test_is_available_with_credentials_and_geopandas(self):
+        provider = RDHProvider(username="u@example.com", password=TEST_PASSWORD)
+        # geopandas is installed in this test environment
+        assert provider.is_available() is True
+
+    def test_is_available_without_credentials(self):
+        provider = RDHProvider(username='', password=TEST_PASSWORD)
+        assert provider.is_available() is False
+
+    def test_is_available_without_password(self):
+        """is_available() requires both username AND password."""
+        provider = RDHProvider(username=TEST_USERNAME, password='')
+        assert provider.is_available() is False
+
+    def test_invalid_level_raises(self):
+        provider = RDHProvider(username=TEST_USERNAME, password=TEST_PASSWORD)
+        with pytest.raises(ValueError, match='Unknown RDH level'):
+            provider.get_boundary('county', identifier='TX')
+
+    def test_missing_state_raises(self):
+        provider = RDHProvider(username=TEST_USERNAME, password=TEST_PASSWORD)
+        with pytest.raises(ValueError, match='state abbreviation'):
+            provider.get_boundary('precinct')
+
+    @patch('siege_utilities.geo.boundary_providers.RDHProvider._get_client')
+    def test_get_boundary_precinct_delegates(self, mock_get_client):
+        """get_boundary('precinct') calls client.get_precinct_data then load_shapefile."""
+        sentinel_gdf = MagicMock(name='gdf')
+        mock_client = MagicMock()
+        mock_client.get_precinct_data.return_value = [MagicMock()]
+        mock_client.load_shapefile.return_value = sentinel_gdf
+        mock_get_client.return_value = mock_client
+
+        provider = RDHProvider(username=TEST_USERNAME, password=TEST_PASSWORD)
+        result = provider.get_boundary('precinct', identifier='TX')
+
+        mock_client.get_precinct_data.assert_called_once_with('TX', year=None, format='shp')
+        assert result is sentinel_gdf
+
+    @patch('siege_utilities.geo.boundary_providers.RDHProvider._get_client')
+    def test_get_boundary_congress_delegates(self, mock_get_client):
+        """get_boundary('congress') calls client.get_enacted_plans."""
+        sentinel_gdf = MagicMock(name='gdf')
+        mock_client = MagicMock()
+        mock_client.get_enacted_plans.return_value = [MagicMock()]
+        mock_client.load_shapefile.return_value = sentinel_gdf
+        mock_get_client.return_value = mock_client
+
+        provider = RDHProvider(username=TEST_USERNAME, password=TEST_PASSWORD)
+        result = provider.get_boundary('congress', state='TX', year='2022')
+
+        mock_client.get_enacted_plans.assert_called_once_with('TX', chamber='congress', year='2022', format='shp')
+        assert result is sentinel_gdf
+
+    @patch('siege_utilities.geo.boundary_providers.RDHProvider._get_client')
+    def test_get_boundary_no_datasets_returns_none(self, mock_get_client):
+        """When RDH returns no matching datasets, get_boundary returns None."""
+        mock_client = MagicMock()
+        mock_client.get_precinct_data.return_value = []
+        mock_get_client.return_value = mock_client
+
+        provider = RDHProvider(username=TEST_USERNAME, password=TEST_PASSWORD)
+        result = provider.get_boundary('precinct', identifier='TX')
+        assert result is None
+
+    def test_credentials_from_env(self, monkeypatch):
+        monkeypatch.setenv('RDH_USERNAME', 'env_user')
+        monkeypatch.setenv('RDH_PASSWORD', 'env_pass')  # noqa: S105 — test env
+        provider = RDHProvider()
+        assert provider._username == 'env_user'
+        assert provider._password == 'env_pass'
+
+    def test_explicit_empty_username_disables_env_fallback(self, monkeypatch):
+        """Passing username='' must NOT fall back to RDH_USERNAME env var."""
+        monkeypatch.setenv('RDH_USERNAME', 'should_not_use')
+        provider = RDHProvider(username='', password=TEST_PASSWORD)
+        assert provider._username == ''

--- a/tests/test_vtd_tiger2020pl.py
+++ b/tests/test_vtd_tiger2020pl.py
@@ -1,0 +1,157 @@
+"""Tests for TIGER2020PL VTD URL routing in CensusDirectoryDiscovery."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from siege_utilities.geo.spatial_data import (
+    CensusDirectoryDiscovery,
+    _VTD_PL_STATE_NAMES,
+    TIGER_PL_BASE_URL,
+)
+from siege_utilities.geo.boundary_result import (
+    BoundaryInputError,
+    BoundaryDiscoveryError,
+)
+
+
+# ---------------------------------------------------------------------------
+# _is_vtd_pl_boundary
+# ---------------------------------------------------------------------------
+
+
+class TestIsVtdPlBoundary:
+    def test_vtd_2020(self):
+        assert CensusDirectoryDiscovery._is_vtd_pl_boundary('vtd', 2020) is True
+
+    def test_vtd20_2020(self):
+        assert CensusDirectoryDiscovery._is_vtd_pl_boundary('vtd20', 2020) is True
+
+    def test_vtd_2010(self):
+        assert CensusDirectoryDiscovery._is_vtd_pl_boundary('vtd', 2010) is True
+
+    def test_vtd10_2010(self):
+        assert CensusDirectoryDiscovery._is_vtd_pl_boundary('vtd10', 2010) is True
+
+    def test_vtd_non_decennial_is_false(self):
+        assert CensusDirectoryDiscovery._is_vtd_pl_boundary('vtd', 2019) is False
+
+    def test_non_vtd_decennial_is_false(self):
+        assert CensusDirectoryDiscovery._is_vtd_pl_boundary('county', 2020) is False
+
+    def test_tract_is_false(self):
+        assert CensusDirectoryDiscovery._is_vtd_pl_boundary('tract', 2020) is False
+
+    def test_vtd10_with_2020_is_false(self):
+        """Cross-vintage pair: 2010 suffix with 2020 year must not match."""
+        assert CensusDirectoryDiscovery._is_vtd_pl_boundary('vtd10', 2020) is False
+
+    def test_vtd20_with_2010_is_false(self):
+        """Cross-vintage pair: 2020 suffix with 2010 year must not match."""
+        assert CensusDirectoryDiscovery._is_vtd_pl_boundary('vtd20', 2010) is False
+
+
+# ---------------------------------------------------------------------------
+# _construct_vtd_pl_url
+# ---------------------------------------------------------------------------
+
+
+class TestConstructVtdPlUrl:
+    def test_texas_2020(self):
+        url = CensusDirectoryDiscovery._construct_vtd_pl_url(2020, '48')
+        assert url == (
+            f'{TIGER_PL_BASE_URL}/TIGER2020PL/STATE/48_TEXAS/48/tl_2020_48_vtd20.zip'
+        )
+
+    def test_california_2020(self):
+        url = CensusDirectoryDiscovery._construct_vtd_pl_url(2020, '06')
+        assert 'TIGER2020PL' in url
+        assert '06_CALIFORNIA' in url
+        assert 'vtd20' in url
+
+    def test_dc_2020(self):
+        url = CensusDirectoryDiscovery._construct_vtd_pl_url(2020, '11')
+        assert 'DISTRICT_OF_COLUMBIA' in url
+
+    def test_new_hampshire_underscore(self):
+        url = CensusDirectoryDiscovery._construct_vtd_pl_url(2020, '33')
+        assert '33_NEW_HAMPSHIRE' in url
+
+    def test_2010_raises_because_state_level_url_does_not_exist(self):
+        """2010 VTDs are published county-level under TIGER2010/VTD/2010/;
+        the state-level TIGER2010PL path does not exist on Census and would
+        404. We fail fast rather than returning a broken URL."""
+        with pytest.raises(BoundaryDiscoveryError, match="per-county"):
+            CensusDirectoryDiscovery._construct_vtd_pl_url(2010, '48')
+
+    def test_puerto_rico(self):
+        url = CensusDirectoryDiscovery._construct_vtd_pl_url(2020, '72')
+        assert '72_PUERTO_RICO' in url
+
+    def test_unsupported_territory_raises(self):
+        """Guam (66) has no VTD data in TIGER2020PL."""
+        with pytest.raises(BoundaryInputError, match='does not publish VTD'):
+            CensusDirectoryDiscovery._construct_vtd_pl_url(2020, '66')
+
+    def test_non_decennial_year_raises(self):
+        with pytest.raises(BoundaryDiscoveryError, match='decennial year'):
+            CensusDirectoryDiscovery._construct_vtd_pl_url(2019, '48')
+
+    def test_all_mapped_states_produce_valid_url(self):
+        """Smoke test: every entry in _VTD_PL_STATE_NAMES builds without error."""
+        for fips in _VTD_PL_STATE_NAMES:
+            url = CensusDirectoryDiscovery._construct_vtd_pl_url(2020, fips)
+            assert url.startswith('https://')
+            assert fips in url
+            assert 'vtd20.zip' in url
+
+
+# ---------------------------------------------------------------------------
+# construct_download_url routes VTD to TIGER PL
+# ---------------------------------------------------------------------------
+
+
+class TestConstructDownloadUrlVtdRouting:
+    def _discovery(self) -> CensusDirectoryDiscovery:
+        return CensusDirectoryDiscovery()
+
+    def test_vtd_2020_bypasses_discovery(self):
+        """construct_download_url must not call discover_boundary_types for VTD 2020."""
+        d = self._discovery()
+        with patch.object(d, 'discover_boundary_types') as mock_discover:
+            url = d.construct_download_url(2020, 'vtd', state_fips='48')
+        mock_discover.assert_not_called()
+        assert 'TIGER2020PL' in url
+        assert '48_TEXAS' in url
+
+    def test_vtd20_2020_bypasses_discovery(self):
+        d = self._discovery()
+        with patch.object(d, 'discover_boundary_types') as mock_discover:
+            url = d.construct_download_url(2020, 'vtd20', state_fips='06')
+        mock_discover.assert_not_called()
+        assert 'TIGER2020PL' in url
+
+    def test_vtd_without_state_fips_raises(self):
+        d = self._discovery()
+        with pytest.raises(BoundaryInputError, match='state_fips'):
+            d.construct_download_url(2020, 'vtd')
+
+    def test_non_decennial_vtd_goes_through_normal_path(self):
+        """vtd for non-decennial year falls through to normal discovery."""
+        d = self._discovery()
+        mock_types = {'vtd': 'VTD'}
+        with (
+            patch.object(d, 'discover_boundary_types', return_value=mock_types),
+            patch.object(d, 'get_year_specific_url_patterns',
+                         return_value={'base_url': 'https://x', 'filename_patterns': {
+                             'state': 'tl_{year}_{state_fips}_{boundary_type}.zip',
+                             'national': 'tl_{year}_us_{boundary_type}.zip',
+                             'congress': 'tl_{year}_us_cd{congress_num}.zip',
+                         }, 'directory_mappings': {}}),
+            patch.object(d, '_construct_filename_with_fips_validation',
+                         return_value='tl_2015_48_vtd.zip'),
+        ):
+            url = d.construct_download_url(2015, 'vtd', state_fips='48')
+        assert 'TIGER2020PL' not in url


### PR DESCRIPTION
## Summary

- **VTD TIGER2020PL routing** in `spatial_data.py`: VTD boundaries for decennial census years live in the PL 94-171 redistricting product (`TIGER2020PL/STATE/{FIPS}_{NAME}/{FIPS}/tl_2020_{fips}_vtd20.zip`), not the standard annual TIGER release. Requesting `geographic_level="vtd"` for year 2020 previously raised `BoundaryDiscoveryError` for every state because the standard TIGER 2020 server has no `VTD20/` directory. Fix adds `_is_vtd_pl_boundary()` detection and `_construct_vtd_pl_url()` routing that bypasses directory discovery entirely.

- **RDHProvider** in `boundary_providers.py`: Wraps the existing `RDHClient` in the `BoundaryProvider` ABC. Supports levels: `precinct`, `congress`, `state_senate`, `state_house`. Reads credentials from constructor args or `RDH_USERNAME` / `RDH_PASSWORD` env vars.

## Changes

- `spatial_data.py`: `TIGER_PL_BASE_URL`, `_VTD_PL_STATE_NAMES` (50 states + DC + PR), `_is_vtd_pl_boundary()`, `_construct_vtd_pl_url()`; short-circuit in `construct_download_url()` before directory discovery for decennial VTD.
- `boundary_providers.py`: `RDHProvider` class exported in `__all__`.
- `tests/test_vtd_tiger2020pl.py`: 20 new tests.
- `tests/test_boundary_providers.py`: 10 new `TestRDHProvider` tests.

52 tests pass. Cherry-pick from `steveblackmon/fix/vtd-tiger2020pl-rdh-provider`:
```
git cherry-pick 35a081e
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an RDH boundary provider (precinct, congressional, state senate, state house) with input validation and explicit handling when no datasets are found.
  * Special-case support for TIGER VTD redistricting PL URLs for 2010 and 2020.

* **Documentation**
  * Example now reads RDH credentials from environment variables.

* **Tests**
  * Added comprehensive tests for RDH provider behavior and TIGER VTD URL/discovery logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->