### PR TITLE
feat: SAL-63 Clean PollingAnalyzer — remove web-specific methods

### DIFF
--- a/siege_utilities/reporting/analytics/polling_analyzer.py
+++ b/siege_utilities/reporting/analytics/polling_analyzer.py
@@ -8,7 +8,7 @@ column names via keyword arguments.
 
 from __future__ import annotations
 
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -24,10 +24,24 @@ class PollingAnalysisError(RuntimeError):
 
 
 def _choose_heatmap_fmt(df: pd.DataFrame) -> str:
-    """Return ``'d'`` for integer-only data, ``'.2f'`` otherwise."""
+    """Return ``'d'`` when every column is integer-typed and every value is an
+    integer, ``'.2f'`` otherwise.
+
+    Seaborn's ``fmt='d'`` crashes on float values (``ValueError: Unknown format
+    code 'd'``). A crosstab built from integer sums can still surface floats if
+    ``.fillna(0)`` upcast, so check both dtype and actual values.
+    """
     try:
-        return "d" if pd.api.types.is_integer_dtype(df.values.dtype) else ".2f"
-    except (AttributeError, ValueError):
+        if not all(pd.api.types.is_numeric_dtype(df[c]) for c in df.columns):
+            return ".2f"
+        arr = df.to_numpy()
+        if pd.api.types.is_integer_dtype(arr):
+            return "d"
+        # Float dtype but values round-trip as integers (e.g. 30.0) — keep 'd'.
+        if (arr == arr.astype(int)).all():
+            return "d"
+        return ".2f"
+    except (AttributeError, ValueError, TypeError):
         return ".2f"
 
 
@@ -236,16 +250,29 @@ class PollingAnalyzer:
                 how="outer",
             ).fillna(0)
             baseline = merged[f"{metric}_historical"]
+            current = merged[f"{metric}_current"]
             merged["change_pct"] = (
-                (merged[f"{metric}_current"] - baseline)
+                (current - baseline)
                 .div(baseline.replace(0, pd.NA))
                 .mul(100)
-                .fillna(0.0)
             )
-            merged["change_direction"] = merged["change_pct"].apply(
-                lambda x: "growth" if x > 0 else ("decline" if x < 0 else "stable")
-            )
-            return merged
+
+            # Zero-baseline handling: a new geography (historical=0, current>0)
+            # is "growth_from_zero", not silently "stable" via fillna(0).
+            new_geography = baseline.eq(0) & current.gt(0)
+
+            def _classify(row) -> str:
+                if row["_new"]:
+                    return "growth_from_zero"
+                pct = row["change_pct"]
+                if pd.isna(pct):
+                    return "stable"
+                return "growth" if pct > 0 else ("decline" if pct < 0 else "stable")
+
+            merged["_new"] = new_geography
+            merged["change_direction"] = merged.apply(_classify, axis=1)
+            merged["change_pct"] = merged["change_pct"].fillna(0.0)
+            return merged.drop(columns=["_new"])
         except (KeyError, ValueError, TypeError) as e:
             log_error(f"change detection failed (col={geographic_column!r}, metric={metric!r}): {e}")
             raise PollingAnalysisError(
@@ -257,6 +284,7 @@ class PollingAnalyzer:
         data: Dict[str, pd.DataFrame],
         *,
         metric: str = "value",
+        name_column: Optional[str] = None,
     ) -> str:
         """Build an executive-summary string from a dict of data-type frames.
 
@@ -265,6 +293,9 @@ class PollingAnalyzer:
         data : dict of pd.DataFrame
             Keyed by data-type label (e.g. ``"region"``, ``"segment"``).
         metric : str, keyword-only
+        name_column : str, keyword-only, optional
+            Column to read the top performer's label from. If omitted, the
+            first column that is not the metric is used.
 
         Returns
         -------
@@ -274,7 +305,8 @@ class PollingAnalyzer:
         Raises
         ------
         PollingAnalysisError
-            If no frame in ``data`` contains the requested ``metric`` column.
+            If no frame in ``data`` contains the requested ``metric`` column,
+            or a frame has no non-metric column to use as a label.
         """
         try:
             frames_with_metric = {k: df for k, df in data.items() if metric in df.columns and not df.empty}
@@ -288,10 +320,21 @@ class PollingAnalyzer:
 
             top_performers: Dict[str, Dict[str, object]] = {}
             for data_type, df in frames_with_metric.items():
+                # Pick a label column explicitly rather than trusting iloc[0]
+                # to sit on the dimension. Caller can pin via name_column=.
+                if name_column and name_column in df.columns:
+                    label_col = name_column
+                else:
+                    label_col = next((c for c in df.columns if c != metric), None)
+                if label_col is None:
+                    raise PollingAnalysisError(
+                        f"frame for {data_type!r} has no non-metric column to label; "
+                        f"pass name_column= explicitly"
+                    )
                 top_item = df.nlargest(1, metric).iloc[0]
                 value = float(top_item[metric])
                 top_performers[data_type] = {
-                    "name": top_item.iloc[0],
+                    "name": top_item[label_col],
                     "value": value,
                     "percentage": (value / total_value * 100) if total_value else 0.0,
                 }
@@ -348,10 +391,14 @@ class PollingAnalyzer:
         """
         try:
             fig, ax = plt.subplots(figsize=figsize)
+            fmt = _choose_heatmap_fmt(crosstab_data)
+            # Seaborn's fmt='d' expects an integer dtype; cast float-valued
+            # integers (e.g. 30.0) to int so ``format(v, 'd')`` doesn't raise.
+            data_to_plot = crosstab_data.astype(int) if fmt == "d" else crosstab_data
             sns.heatmap(
-                crosstab_data,
+                data_to_plot,
                 annot=True,
-                fmt=_choose_heatmap_fmt(crosstab_data),
+                fmt=fmt,
                 cmap="YlOrRd",
                 ax=ax,
                 cbar_kws={"label": metric.title()},

--- a/siege_utilities/reporting/analytics/polling_analyzer.py
+++ b/siege_utilities/reporting/analytics/polling_analyzer.py
@@ -5,13 +5,11 @@ Provides comprehensive cross-tabulation and longitudinal analysis capabilities
 """
 
 import pandas as pd
-import numpy as np
-from typing import Dict, List, Tuple, Optional, Union
-from datetime import datetime, timedelta
+from typing import Dict, List, Tuple
 import matplotlib.pyplot as plt
 import seaborn as sns
 from ..chart_generator import ChartGenerator
-from siege_utilities.core.logging import get_logger, log_info, log_warning, log_error, log_debug
+from siege_utilities.core.logging import log_error
 
 class PollingAnalyzer:
     """

--- a/siege_utilities/reporting/analytics/polling_analyzer.py
+++ b/siege_utilities/reporting/analytics/polling_analyzer.py
@@ -1,345 +1,420 @@
 #!/usr/bin/env python3
-"""
-Polling Analysis Module for Siege Utilities
-Provides comprehensive cross-tabulation and longitudinal analysis capabilities
+"""Polling analysis — cross-tabulation, longitudinal analysis, change detection.
+
+Operates on long-form DataFrames with at least one dimension column and one
+numeric metric column (default ``metric='value'``). Callers supply their own
+column names via keyword arguments.
 """
 
-import pandas as pd
+from __future__ import annotations
+
 from typing import Dict, List, Tuple
+
 import matplotlib.pyplot as plt
+import pandas as pd
 import seaborn as sns
-from ..chart_generator import ChartGenerator
+
 from siege_utilities.core.logging import log_error
 
+from ..chart_generator import ChartGenerator
+
+
+class PollingAnalysisError(RuntimeError):
+    """Raised when polling analysis cannot complete due to bad input or config."""
+
+
+def _choose_heatmap_fmt(df: pd.DataFrame) -> str:
+    """Return ``'d'`` for integer-only data, ``'.2f'`` otherwise."""
+    try:
+        return "d" if pd.api.types.is_integer_dtype(df.values.dtype) else ".2f"
+    except (AttributeError, ValueError):
+        return ".2f"
+
+
 class PollingAnalyzer:
-    """
-    Comprehensive polling analysis for cross-dimensional analytics
-    """
+    """Cross-dimensional analytics for polling and survey data."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.chart_generator = ChartGenerator()
-        self.analysis_results = {}
+        self.analysis_results: Dict[str, object] = {}
 
-    def create_cross_tabulation_matrix(self,
-                                     data: pd.DataFrame,
-                                     dimensions: List[str],
-                                     metric: str = 'value',
-                                     top_n: int = 10) -> Dict[str, pd.DataFrame]:
-        """
-        Create comprehensive cross-tabulation matrix for all dimension combinations
+    def create_cross_tabulation_matrix(
+        self,
+        data: pd.DataFrame,
+        dimensions: List[str],
+        *,
+        metric: str = "value",
+        top_n: int = 10,
+    ) -> Dict[str, pd.DataFrame]:
+        """Build pairwise cross-tabulations for all dimension combinations.
 
-        Args:
-            data: DataFrame with analytics data
-            dimensions: List of dimension column names
-            metric: Metric column name to aggregate
-            top_n: Number of top items to include per dimension
+        Parameters
+        ----------
+        data : pd.DataFrame
+            Input data with one row per observation.
+        dimensions : list of str
+            Column names to cross-tab. Must exist in ``data``.
+        metric : str, keyword-only
+            Numeric column to aggregate (sum).
+        top_n : int, keyword-only
+            Keep only the top ``top_n`` values per dimension.
 
-        Returns:
-            Dictionary of cross-tabulation DataFrames
+        Returns
+        -------
+        dict
+            Keys ``"{dim1}_x_{dim2}"``; values are filtered cross-tab DataFrames.
+
+        Raises
+        ------
+        PollingAnalysisError
+            If a required column is missing or aggregation fails.
         """
         try:
-            cross_tabs = {}
-
-            # Create all possible 2-way combinations
+            cross_tabs: Dict[str, pd.DataFrame] = {}
             for i, dim1 in enumerate(dimensions):
-                for j, dim2 in enumerate(dimensions[i+1:], i+1):
-                    combo_name = f"{dim1}_x_{dim2}"
-
-                    # Create cross-tabulation
+                for dim2 in dimensions[i + 1:]:
                     crosstab = pd.crosstab(
                         data[dim1],
                         data[dim2],
                         values=data[metric],
-                        aggfunc='sum',
-                        fill_value=0
-                    )
-
-                    # Get top N items for each dimension
+                        aggfunc="sum",
+                    ).fillna(0)
                     top_dim1 = data.groupby(dim1)[metric].sum().nlargest(top_n).index
                     top_dim2 = data.groupby(dim2)[metric].sum().nlargest(top_n).index
-
-                    # Filter to top items
-                    filtered_crosstab = crosstab.loc[top_dim1, top_dim2]
-
-                    cross_tabs[combo_name] = filtered_crosstab
-
+                    cross_tabs[f"{dim1}_x_{dim2}"] = crosstab.loc[top_dim1, top_dim2]
             return cross_tabs
+        except (KeyError, ValueError, TypeError) as e:
+            log_error(f"cross-tabulation failed (dimensions={dimensions!r}, metric={metric!r}): {e}")
+            raise PollingAnalysisError(
+                f"cross-tabulation failed for dimensions={dimensions!r}, metric={metric!r}"
+            ) from e
 
-        except Exception as e:
-            log_error(f"Error creating cross-tabulation matrix: {e}")
-            return {}
+    def create_longitudinal_analysis(
+        self,
+        data: pd.DataFrame,
+        time_column: str,
+        dimensions: List[str],
+        *,
+        metric: str = "value",
+        periods: Tuple[str, ...] = ("daily", "weekly", "monthly", "quarterly"),
+    ) -> Dict[str, Dict[str, pd.DataFrame]]:
+        """Aggregate ``data`` by time period and dimension.
 
-    def create_longitudinal_analysis(self,
-                                   data: pd.DataFrame,
-                                   time_column: str,
-                                   dimensions: List[str],
-                                   metric: str = 'value',
-                                   periods: List[str] = ['daily', 'weekly', 'monthly', 'quarterly']) -> Dict[str, pd.DataFrame]:
+        Parameters
+        ----------
+        data : pd.DataFrame
+            Input with a parseable time column.
+        time_column : str
+            Column to convert to datetime and group by period.
+        dimensions : list of str
+            Dimension columns to group within each period.
+        metric : str, keyword-only
+            Numeric column to sum.
+        periods : tuple of str, keyword-only
+            Subset of ``{"daily", "weekly", "monthly", "quarterly"}``.
+
+        Returns
+        -------
+        dict
+            ``{period: {dimension: DataFrame}}``.
+
+        Raises
+        ------
+        PollingAnalysisError
+            If the time column cannot be parsed or a period name is unknown.
         """
-        Create longitudinal analysis across multiple time periods and dimensions
-
-        Args:
-            data: DataFrame with time series data
-            time_column: Column containing time information
-            dimensions: List of dimension columns to analyze
-            metric: Metric column to analyze
-            periods: List of time periods to aggregate
-
-        Returns:
-            Dictionary of longitudinal analysis DataFrames
-        """
+        period_map = {
+            "daily": lambda s: s.dt.date,
+            "weekly": lambda s: s.dt.to_period("W"),
+            "monthly": lambda s: s.dt.to_period("M"),
+            "quarterly": lambda s: s.dt.to_period("Q"),
+        }
         try:
-            longitudinal_results = {}
-
-            # Ensure time column is datetime
+            data = data.copy()
             data[time_column] = pd.to_datetime(data[time_column])
-
+            results: Dict[str, Dict[str, pd.DataFrame]] = {}
             for period in periods:
-                period_results = {}
+                if period not in period_map:
+                    raise PollingAnalysisError(
+                        f"unknown period {period!r}; expected one of {list(period_map)}"
+                    )
+                data = data.assign(period=period_map[period](data[time_column]))
+                results[period] = {
+                    d: data.groupby(["period", d])[metric].sum().reset_index()
+                    for d in dimensions
+                }
+            return results
+        except (KeyError, ValueError, TypeError) as e:
+            log_error(f"longitudinal analysis failed (time={time_column!r}, dims={dimensions!r}): {e}")
+            raise PollingAnalysisError(
+                f"longitudinal analysis failed for time_column={time_column!r}"
+            ) from e
 
-                # Create time-based aggregation
-                if period == 'daily':
-                    data['period'] = data[time_column].dt.date
-                elif period == 'weekly':
-                    data['period'] = data[time_column].dt.to_period('W')
-                elif period == 'monthly':
-                    data['period'] = data[time_column].dt.to_period('M')
-                elif period == 'quarterly':
-                    data['period'] = data[time_column].dt.to_period('Q')
+    def create_performance_rankings(
+        self,
+        data: pd.DataFrame,
+        dimensions: List[str],
+        *,
+        metric: str = "value",
+        top_n: int = 10,
+    ) -> Dict[str, List[Tuple[object, float, float]]]:
+        """Rank the top-N values per dimension by total ``metric``.
 
-                # Aggregate by period and each dimension
-                for dimension in dimensions:
-                    period_dim_data = data.groupby(['period', dimension])[metric].sum().reset_index()
-                    period_results[dimension] = period_dim_data
+        Parameters
+        ----------
+        data : pd.DataFrame
+        dimensions : list of str
+        metric : str, keyword-only
+        top_n : int, keyword-only
 
-                longitudinal_results[period] = period_results
+        Returns
+        -------
+        dict of list of tuple
+            For each dimension, a list of ``(value, sum_metric, percentage)``.
+            ``percentage`` is the share of the dimension's total, in [0, 100].
 
-            return longitudinal_results
-
-        except Exception as e:
-            log_error(f"Error creating longitudinal analysis: {e}")
-            return {}
-
-    def create_performance_rankings(self,
-                                  data: pd.DataFrame,
-                                  dimensions: List[str],
-                                  metric: str = 'value',
-                                  top_n: int = 10) -> Dict[str, List[Tuple]]:
-        """
-        Create performance rankings across all dimensions
-
-        Args:
-            data: DataFrame with analytics data
-            dimensions: List of dimension columns to rank
-            metric: Metric column to rank by
-            top_n: Number of top performers to return
-
-        Returns:
-            Dictionary of rankings for each dimension
+        Raises
+        ------
+        PollingAnalysisError
+            If a required column is missing.
         """
         try:
-            rankings = {}
-
+            rankings: Dict[str, List[Tuple[object, float, float]]] = {}
             for dimension in dimensions:
-                # Calculate rankings
-                dimension_rankings = data.groupby(dimension)[metric].agg(['sum', 'count']).reset_index()
-                dimension_rankings['percentage'] = (dimension_rankings['sum'] / dimension_rankings['sum'].sum()) * 100
-
-                # Sort by performance
-                dimension_rankings = dimension_rankings.sort_values('sum', ascending=False).head(top_n)
-
-                # Convert to list of tuples
+                agg = data.groupby(dimension)[metric].agg(["sum", "count"]).reset_index()
+                total = agg["sum"].sum()
+                agg["percentage"] = (agg["sum"] / total * 100) if total else 0.0
+                agg = agg.sort_values("sum", ascending=False).head(top_n)
                 rankings[dimension] = [
-                    (row[dimension], row['sum'], row['percentage'])
-                    for _, row in dimension_rankings.iterrows()
+                    (row[dimension], float(row["sum"]), float(row["percentage"]))
+                    for _, row in agg.iterrows()
                 ]
-
             return rankings
+        except (KeyError, ValueError, TypeError) as e:
+            log_error(f"performance rankings failed (dims={dimensions!r}, metric={metric!r}): {e}")
+            raise PollingAnalysisError(
+                f"performance rankings failed for dimensions={dimensions!r}"
+            ) from e
 
-        except Exception as e:
-            log_error(f"Error creating performance rankings: {e}")
-            return {}
+    def create_change_detection_data(
+        self,
+        current_data: pd.DataFrame,
+        historical_data: pd.DataFrame,
+        *,
+        geographic_column: str = "geography",
+        metric: str = "value",
+    ) -> pd.DataFrame:
+        """Compare current vs historical aggregates and compute growth/decline.
 
-    def create_change_detection_data(self,
-                                   current_data: pd.DataFrame,
-                                   historical_data: pd.DataFrame,
-                                   geographic_column: str = 'geography',
-                                   metric: str = 'value') -> pd.DataFrame:
-        """
-        Create change detection data showing growth/decline patterns
+        Parameters
+        ----------
+        current_data, historical_data : pd.DataFrame
+            Long-form data sharing ``geographic_column`` and ``metric`` columns.
+        geographic_column : str, keyword-only
+            Column to aggregate on.
+        metric : str, keyword-only
+            Numeric column to sum.
 
-        Args:
-            current_data: Current period data
-            historical_data: Historical period data
-            geographic_column: Column containing geographic information
-            metric: Metric to compare
+        Returns
+        -------
+        pd.DataFrame
+            Columns: ``geographic_column``, ``{metric}_current``,
+            ``{metric}_historical``, ``change_pct``, ``change_direction``.
 
-        Returns:
-            DataFrame with change detection results
+        Raises
+        ------
+        PollingAnalysisError
+            If either frame is missing the required columns.
         """
         try:
-            # Aggregate current and historical data
             current_agg = current_data.groupby(geographic_column)[metric].sum().reset_index()
             historical_agg = historical_data.groupby(geographic_column)[metric].sum().reset_index()
-
-            # Merge data
             merged = current_agg.merge(
                 historical_agg,
                 on=geographic_column,
-                suffixes=('_current', '_historical'),
-                how='outer'
+                suffixes=("_current", "_historical"),
+                how="outer",
             ).fillna(0)
-
-            # Calculate change percentage
-            merged['change_pct'] = (
-                (merged[f'{metric}_current'] - merged[f'{metric}_historical']) /
-                merged[f'{metric}_historical'] * 100
-            ).fillna(0)
-
-            # Add change direction
-            merged['change_direction'] = merged['change_pct'].apply(
-                lambda x: 'growth' if x > 0 else 'decline' if x < 0 else 'stable'
+            baseline = merged[f"{metric}_historical"]
+            merged["change_pct"] = (
+                (merged[f"{metric}_current"] - baseline)
+                .div(baseline.replace(0, pd.NA))
+                .mul(100)
+                .fillna(0.0)
             )
-
+            merged["change_direction"] = merged["change_pct"].apply(
+                lambda x: "growth" if x > 0 else ("decline" if x < 0 else "stable")
+            )
             return merged
+        except (KeyError, ValueError, TypeError) as e:
+            log_error(f"change detection failed (col={geographic_column!r}, metric={metric!r}): {e}")
+            raise PollingAnalysisError(
+                f"change detection failed for geographic_column={geographic_column!r}"
+            ) from e
 
-        except Exception as e:
-            log_error(f"Error creating change detection data: {e}")
-            return pd.DataFrame()
+    def create_polling_summary(
+        self,
+        data: Dict[str, pd.DataFrame],
+        *,
+        metric: str = "value",
+    ) -> str:
+        """Build an executive-summary string from a dict of data-type frames.
 
-    def create_polling_summary(self,
-                             data: Dict[str, pd.DataFrame],
-                             metric: str = 'value') -> str:
-        """
-        Create executive summary for polling analysis
+        Parameters
+        ----------
+        data : dict of pd.DataFrame
+            Keyed by data-type label (e.g. ``"region"``, ``"segment"``).
+        metric : str, keyword-only
 
-        Args:
-            data: Dictionary of DataFrames with different data types
-            metric: Metric column name
+        Returns
+        -------
+        str
+            Multi-sentence summary.
 
-        Returns:
-            Executive summary string
+        Raises
+        ------
+        PollingAnalysisError
+            If no frame in ``data`` contains the requested ``metric`` column.
         """
         try:
-            # Extract key metrics
-            total_value = 0
-            dimensions_info = {}
-
-            for data_type, df in data.items():
-                if metric in df.columns:
-                    total_value += df[metric].sum()
-                    dimensions_info[data_type] = len(df)
-
-            # Find top performers
-            top_performers = {}
-            for data_type, df in data.items():
-                if metric in df.columns and not df.empty:
-                    top_item = df.nlargest(1, metric).iloc[0]
-                    top_performers[data_type] = {
-                        'name': top_item.iloc[0],  # First column (usually the dimension)
-                        'value': top_item[metric],
-                        'percentage': (top_item[metric] / total_value * 100) if total_value > 0 else 0
-                    }
-
-            # Create summary
-            summary_parts = [
-                f"This comprehensive polling analysis examines {total_value:,} {metric} across multiple dimensions."
-            ]
-
-            for data_type, info in dimensions_info.items():
-                summary_parts.append(f"{data_type.title()}: {info} items")
-
-            summary_parts.append("Key findings include:")
-
-            for data_type, performer in top_performers.items():
-                summary_parts.append(
-                    f"{performer['name']} leads {data_type} with {performer['value']:,} {metric} "
-                    f"({performer['percentage']:.1f}%)"
+            frames_with_metric = {k: df for k, df in data.items() if metric in df.columns and not df.empty}
+            if not frames_with_metric:
+                raise PollingAnalysisError(
+                    f"no frame in data contains metric={metric!r}; keys={list(data)}"
                 )
 
-            summary_parts.append("Cross-dimensional analysis reveals patterns in distribution and performance.")
+            total_value = sum(df[metric].sum() for df in frames_with_metric.values())
+            dimensions_info = {k: len(df) for k, df in frames_with_metric.items()}
 
-            return " ".join(summary_parts)
+            top_performers: Dict[str, Dict[str, object]] = {}
+            for data_type, df in frames_with_metric.items():
+                top_item = df.nlargest(1, metric).iloc[0]
+                value = float(top_item[metric])
+                top_performers[data_type] = {
+                    "name": top_item.iloc[0],
+                    "value": value,
+                    "percentage": (value / total_value * 100) if total_value else 0.0,
+                }
 
-        except Exception as e:
-            return f"Polling analysis summary generation failed: {str(e)}"
+            parts = [
+                f"This comprehensive polling analysis examines {total_value:,.0f} {metric} across multiple dimensions."
+            ]
+            parts.extend(f"{k.title()}: {n} items" for k, n in dimensions_info.items())
+            parts.append("Key findings include:")
+            parts.extend(
+                f"{p['name']} leads {dt} with {p['value']:,.0f} {metric} ({p['percentage']:.1f}%)"
+                for dt, p in top_performers.items()
+            )
+            parts.append("Cross-dimensional analysis reveals patterns in distribution and performance.")
+            return " ".join(parts)
+        except PollingAnalysisError:
+            raise
+        except (KeyError, ValueError, TypeError, IndexError) as e:
+            log_error(f"polling summary failed (metric={metric!r}): {e}")
+            raise PollingAnalysisError(
+                f"polling summary generation failed for metric={metric!r}"
+            ) from e
 
-    def create_heatmap_visualization(self,
-                                   crosstab_data: pd.DataFrame,
-                                   title: str = "Cross-Tabulation Heatmap",
-                                   metric: str = 'value',
-                                   figsize: Tuple[int, int] = (10, 8)) -> plt.Figure:
-        """
-        Create heatmap visualization for cross-tabulation data
+    def create_heatmap_visualization(
+        self,
+        crosstab_data: pd.DataFrame,
+        *,
+        title: str = "Cross-Tabulation Heatmap",
+        metric: str = "value",
+        figsize: Tuple[int, int] = (10, 8),
+    ) -> plt.Figure:
+        """Render a cross-tab as a Seaborn heatmap.
 
-        Args:
-            crosstab_data: DataFrame with cross-tabulation data
-            title: Chart title
-            metric: Metric name for colorbar label
-            figsize: Figure size tuple
+        ``metric`` is keyword-only; it is used only for the colorbar label.
+        The annotation format is chosen automatically from the data dtype
+        (integer data gets ``'d'``, float data gets ``'.2f'``).
 
-        Returns:
-            Matplotlib figure
+        Parameters
+        ----------
+        crosstab_data : pd.DataFrame
+            Output of :meth:`create_cross_tabulation_matrix`.
+        title : str, keyword-only
+        metric : str, keyword-only
+        figsize : tuple of int, keyword-only
+
+        Returns
+        -------
+        matplotlib.figure.Figure
+
+        Raises
+        ------
+        PollingAnalysisError
+            If matplotlib or seaborn cannot render the input.
         """
         try:
             fig, ax = plt.subplots(figsize=figsize)
-
-            # Create heatmap
-            sns.heatmap(crosstab_data,
-                       annot=True,
-                       fmt='d',
-                       cmap='YlOrRd',
-                       ax=ax,
-                       cbar_kws={'label': metric.title()})
-
-            ax.set_title(title, fontsize=14, fontweight='bold')
-            ax.set_xlabel('')
-            ax.set_ylabel('')
-
+            sns.heatmap(
+                crosstab_data,
+                annot=True,
+                fmt=_choose_heatmap_fmt(crosstab_data),
+                cmap="YlOrRd",
+                ax=ax,
+                cbar_kws={"label": metric.title()},
+            )
+            ax.set_title(title, fontsize=14, fontweight="bold")
+            ax.set_xlabel("")
+            ax.set_ylabel("")
             plt.tight_layout()
             return fig
+        except (ValueError, TypeError) as e:
+            log_error(f"heatmap rendering failed (shape={crosstab_data.shape}): {e}")
+            raise PollingAnalysisError("heatmap rendering failed") from e
 
-        except Exception as e:
-            log_error(f"Error creating heatmap visualization: {e}")
-            return None
+    def create_trend_analysis_chart(
+        self,
+        longitudinal_data: Dict[str, pd.DataFrame],
+        dimension: str,
+        *,
+        metric: str = "value",
+        figsize: Tuple[int, int] = (12, 6),
+    ) -> plt.Figure:
+        """Plot per-period trend lines for a single dimension.
 
-    def create_trend_analysis_chart(self,
-                                  longitudinal_data: Dict[str, pd.DataFrame],
-                                  dimension: str,
-                                  metric: str = 'value',
-                                  figsize: Tuple[int, int] = (12, 6)) -> plt.Figure:
-        """
-        Create trend analysis chart for longitudinal data
+        Parameters
+        ----------
+        longitudinal_data : dict of pd.DataFrame
+            Keyed by period label.
+        dimension : str
+            Dimension column name to title/label with.
+        metric : str, keyword-only
+        figsize : tuple of int, keyword-only
 
-        Args:
-            longitudinal_data: Dictionary of longitudinal data by period
-            dimension: Dimension to analyze
-            metric: Metric to plot
-            figsize: Figure size tuple
+        Returns
+        -------
+        matplotlib.figure.Figure
 
-        Returns:
-            Matplotlib figure
+        Raises
+        ------
+        PollingAnalysisError
+            If plotting fails.
         """
         try:
             fig, ax = plt.subplots(figsize=figsize)
-
-            # Plot trends for each period
             for period, data in longitudinal_data.items():
-                if dimension in data.columns and metric in data.columns:
-                    period_data = data.groupby('period')[metric].sum()
-                    ax.plot(period_data.index.astype(str), period_data.values,
-                           marker='o', label=period, linewidth=2)
-
-            ax.set_title(f'Trend Analysis: {dimension.title()}', fontsize=14, fontweight='bold')
-            ax.set_xlabel('Time Period')
+                if "period" in data.columns and metric in data.columns:
+                    period_data = data.groupby("period")[metric].sum()
+                    ax.plot(
+                        period_data.index.astype(str),
+                        period_data.values,
+                        marker="o",
+                        label=period,
+                        linewidth=2,
+                    )
+            ax.set_title(f"Trend Analysis: {dimension.title()}", fontsize=14, fontweight="bold")
+            ax.set_xlabel("Time Period")
             ax.set_ylabel(metric.title())
             ax.legend()
             ax.grid(True, alpha=0.3)
-
             plt.xticks(rotation=45)
             plt.tight_layout()
             return fig
-
-        except Exception as e:
-            log_error(f"Error creating trend analysis chart: {e}")
-            return None
+        except (ValueError, TypeError) as e:
+            log_error(f"trend chart rendering failed (dimension={dimension!r}): {e}")
+            raise PollingAnalysisError(
+                f"trend chart rendering failed for dimension={dimension!r}"
+            ) from e

--- a/siege_utilities/reporting/analytics/polling_analyzer.py
+++ b/siege_utilities/reporting/analytics/polling_analyzer.py
@@ -17,88 +17,88 @@ class PollingAnalyzer:
     """
     Comprehensive polling analysis for cross-dimensional analytics
     """
-    
+
     def __init__(self):
         self.chart_generator = ChartGenerator()
         self.analysis_results = {}
-        
-    def create_cross_tabulation_matrix(self, 
+
+    def create_cross_tabulation_matrix(self,
                                      data: pd.DataFrame,
                                      dimensions: List[str],
-                                     metric: str = 'sessions',
+                                     metric: str = 'value',
                                      top_n: int = 10) -> Dict[str, pd.DataFrame]:
         """
         Create comprehensive cross-tabulation matrix for all dimension combinations
-        
+
         Args:
             data: DataFrame with analytics data
             dimensions: List of dimension column names
             metric: Metric column name to aggregate
             top_n: Number of top items to include per dimension
-            
+
         Returns:
             Dictionary of cross-tabulation DataFrames
         """
         try:
             cross_tabs = {}
-            
+
             # Create all possible 2-way combinations
             for i, dim1 in enumerate(dimensions):
                 for j, dim2 in enumerate(dimensions[i+1:], i+1):
                     combo_name = f"{dim1}_x_{dim2}"
-                    
+
                     # Create cross-tabulation
                     crosstab = pd.crosstab(
-                        data[dim1], 
-                        data[dim2], 
-                        values=data[metric], 
-                        aggfunc='sum', 
+                        data[dim1],
+                        data[dim2],
+                        values=data[metric],
+                        aggfunc='sum',
                         fill_value=0
                     )
-                    
+
                     # Get top N items for each dimension
                     top_dim1 = data.groupby(dim1)[metric].sum().nlargest(top_n).index
                     top_dim2 = data.groupby(dim2)[metric].sum().nlargest(top_n).index
-                    
+
                     # Filter to top items
                     filtered_crosstab = crosstab.loc[top_dim1, top_dim2]
-                    
+
                     cross_tabs[combo_name] = filtered_crosstab
-                    
+
             return cross_tabs
-            
+
         except Exception as e:
             log_error(f"Error creating cross-tabulation matrix: {e}")
             return {}
-    
-    def create_longitudinal_analysis(self, 
+
+    def create_longitudinal_analysis(self,
                                    data: pd.DataFrame,
                                    time_column: str,
                                    dimensions: List[str],
-                                   metric: str = 'sessions',
+                                   metric: str = 'value',
                                    periods: List[str] = ['daily', 'weekly', 'monthly', 'quarterly']) -> Dict[str, pd.DataFrame]:
         """
         Create longitudinal analysis across multiple time periods and dimensions
-        
+
         Args:
             data: DataFrame with time series data
             time_column: Column containing time information
             dimensions: List of dimension columns to analyze
             metric: Metric column to analyze
             periods: List of time periods to aggregate
-            
+
         Returns:
             Dictionary of longitudinal analysis DataFrames
         """
         try:
             longitudinal_results = {}
-            
+
             # Ensure time column is datetime
             data[time_column] = pd.to_datetime(data[time_column])
-            
+
             for period in periods:
                 period_results = {}
-                
+
                 # Create time-based aggregation
                 if period == 'daily':
                     data['period'] = data[time_column].dt.date
@@ -108,143 +108,74 @@ class PollingAnalyzer:
                     data['period'] = data[time_column].dt.to_period('M')
                 elif period == 'quarterly':
                     data['period'] = data[time_column].dt.to_period('Q')
-                
+
                 # Aggregate by period and each dimension
                 for dimension in dimensions:
                     period_dim_data = data.groupby(['period', dimension])[metric].sum().reset_index()
                     period_results[dimension] = period_dim_data
-                
+
                 longitudinal_results[period] = period_results
-                
+
             return longitudinal_results
-            
+
         except Exception as e:
             log_error(f"Error creating longitudinal analysis: {e}")
             return {}
-    
-    def create_performance_rankings(self, 
+
+    def create_performance_rankings(self,
                                   data: pd.DataFrame,
                                   dimensions: List[str],
-                                  metric: str = 'sessions',
+                                  metric: str = 'value',
                                   top_n: int = 10) -> Dict[str, List[Tuple]]:
         """
         Create performance rankings across all dimensions
-        
+
         Args:
             data: DataFrame with analytics data
             dimensions: List of dimension columns to rank
             metric: Metric column to rank by
             top_n: Number of top performers to return
-            
+
         Returns:
             Dictionary of rankings for each dimension
         """
         try:
             rankings = {}
-            
+
             for dimension in dimensions:
                 # Calculate rankings
                 dimension_rankings = data.groupby(dimension)[metric].agg(['sum', 'count']).reset_index()
                 dimension_rankings['percentage'] = (dimension_rankings['sum'] / dimension_rankings['sum'].sum()) * 100
-                
-                # Calculate growth (simplified - would need historical data for real growth)
-                dimension_rankings['growth'] = np.random.normal(5, 15, len(dimension_rankings))  # Simulated growth
-                
+
                 # Sort by performance
                 dimension_rankings = dimension_rankings.sort_values('sum', ascending=False).head(top_n)
-                
+
                 # Convert to list of tuples
                 rankings[dimension] = [
-                    (row[dimension], row['sum'], row['percentage'], row['growth'])
+                    (row[dimension], row['sum'], row['percentage'])
                     for _, row in dimension_rankings.iterrows()
                 ]
-                
+
             return rankings
-            
+
         except Exception as e:
             log_error(f"Error creating performance rankings: {e}")
             return {}
-    
-    def create_time_series_choropleth_data(self, 
-                                         geographic_data: pd.DataFrame,
-                                         time_column: str,
-                                         periods: List[str]) -> Dict[str, pd.DataFrame]:
-        """
-        Create time series data for choropleth sequences
-        
-        Args:
-            geographic_data: DataFrame with geographic and time data
-            time_column: Column containing time information
-            periods: List of time periods to create sequences for
-            
-        Returns:
-            Dictionary of geographic data for each time period
-        """
-        try:
-            time_series_data = {}
-            
-            # Ensure time column is datetime
-            geographic_data[time_column] = pd.to_datetime(geographic_data[time_column])
-            
-            for period in periods:
-                # Filter data for this period
-                if period == 'Q1 2024':
-                    period_data = geographic_data[
-                        (geographic_data[time_column] >= '2024-01-01') & 
-                        (geographic_data[time_column] < '2024-04-01')
-                    ]
-                elif period == 'Q2 2024':
-                    period_data = geographic_data[
-                        (geographic_data[time_column] >= '2024-04-01') & 
-                        (geographic_data[time_column] < '2024-07-01')
-                    ]
-                elif period == 'Q3 2024':
-                    period_data = geographic_data[
-                        (geographic_data[time_column] >= '2024-07-01') & 
-                        (geographic_data[time_column] < '2024-10-01')
-                    ]
-                elif period == 'Q4 2024':
-                    period_data = geographic_data[
-                        (geographic_data[time_column] >= '2024-10-01') & 
-                        (geographic_data[time_column] < '2025-01-01')
-                    ]
-                elif period == 'Q1 2025':
-                    period_data = geographic_data[
-                        (geographic_data[time_column] >= '2025-01-01') & 
-                        (geographic_data[time_column] < '2025-04-01')
-                    ]
-                else:
-                    # Default to all data
-                    period_data = geographic_data
-                
-                # Aggregate by country
-                if not period_data.empty:
-                    aggregated = period_data.groupby('country')['sessions'].sum().reset_index()
-                    time_series_data[period] = aggregated
-                else:
-                    # Create empty DataFrame with same structure
-                    time_series_data[period] = pd.DataFrame(columns=['country', 'sessions'])
-                    
-            return time_series_data
-            
-        except Exception as e:
-            log_error(f"Error creating time series choropleth data: {e}")
-            return {}
-    
-    def create_change_detection_data(self, 
+
+    def create_change_detection_data(self,
                                    current_data: pd.DataFrame,
                                    historical_data: pd.DataFrame,
-                                   geographic_column: str = 'country',
-                                   metric: str = 'sessions') -> pd.DataFrame:
+                                   geographic_column: str = 'geography',
+                                   metric: str = 'value') -> pd.DataFrame:
         """
         Create change detection data showing growth/decline patterns
-        
+
         Args:
             current_data: Current period data
             historical_data: Historical period data
             geographic_column: Column containing geographic information
             metric: Metric to compare
-            
+
         Returns:
             DataFrame with change detection results
         """
@@ -252,117 +183,55 @@ class PollingAnalyzer:
             # Aggregate current and historical data
             current_agg = current_data.groupby(geographic_column)[metric].sum().reset_index()
             historical_agg = historical_data.groupby(geographic_column)[metric].sum().reset_index()
-            
+
             # Merge data
             merged = current_agg.merge(
-                historical_agg, 
-                on=geographic_column, 
+                historical_agg,
+                on=geographic_column,
                 suffixes=('_current', '_historical'),
                 how='outer'
             ).fillna(0)
-            
+
             # Calculate change percentage
             merged['change_pct'] = (
-                (merged[f'{metric}_current'] - merged[f'{metric}_historical']) / 
+                (merged[f'{metric}_current'] - merged[f'{metric}_historical']) /
                 merged[f'{metric}_historical'] * 100
             ).fillna(0)
-            
+
             # Add change direction
             merged['change_direction'] = merged['change_pct'].apply(
                 lambda x: 'growth' if x > 0 else 'decline' if x < 0 else 'stable'
             )
-            
+
             return merged
-            
+
         except Exception as e:
             log_error(f"Error creating change detection data: {e}")
             return pd.DataFrame()
-    
-    def create_geographic_device_crosstab(self, 
-                                        geographic_data: pd.DataFrame,
-                                        device_data: pd.DataFrame,
-                                        geographic_column: str = 'country',
-                                        device_column: str = 'deviceCategory',
-                                        metric: str = 'sessions') -> pd.DataFrame:
-        """
-        Create geographic × device cross-tabulation
-        
-        Args:
-            geographic_data: DataFrame with geographic data
-            device_data: DataFrame with device data
-            geographic_column: Column containing geographic information
-            device_column: Column containing device information
-            metric: Metric to aggregate
-            
-        Returns:
-            DataFrame with geographic × device cross-tabulation
-        """
-        try:
-            # Simulate device distribution by country based on country characteristics
-            crosstab_data = []
-            
-            for _, geo_row in geographic_data.iterrows():
-                country = geo_row[geographic_column]
-                total_sessions = geo_row[metric]
-                
-                # Simulate device distribution based on country characteristics
-                if country in ['United States', 'Canada', 'United Kingdom', 'Germany']:
-                    # Developed countries tend to have more desktop usage
-                    mobile_pct = 0.6
-                    desktop_pct = 0.35
-                    tablet_pct = 0.05
-                elif country in ['India', 'Brazil', 'China']:
-                    # Emerging markets tend to be more mobile-heavy
-                    mobile_pct = 0.8
-                    desktop_pct = 0.15
-                    tablet_pct = 0.05
-                else:
-                    # Default distribution
-                    mobile_pct = 0.7
-                    desktop_pct = 0.25
-                    tablet_pct = 0.05
-                
-                mobile_sessions = int(total_sessions * mobile_pct)
-                desktop_sessions = int(total_sessions * desktop_pct)
-                tablet_sessions = total_sessions - mobile_sessions - desktop_sessions
-                
-                crosstab_data.append({
-                    'country': country,
-                    'mobile_sessions': mobile_sessions,
-                    'desktop_sessions': desktop_sessions,
-                    'tablet_sessions': tablet_sessions,
-                    'total_sessions': total_sessions
-                })
-            
-            return pd.DataFrame(crosstab_data)
-            
-        except Exception as e:
-            log_error(f"Error creating geographic device crosstab: {e}")
-            return pd.DataFrame()
-    
-    def create_polling_summary(self, 
+
+    def create_polling_summary(self,
                              data: Dict[str, pd.DataFrame],
-                             metric: str = 'sessions') -> str:
+                             metric: str = 'value') -> str:
         """
         Create executive summary for polling analysis
-        
+
         Args:
             data: Dictionary of DataFrames with different data types
             metric: Metric column name
-            
+
         Returns:
             Executive summary string
         """
         try:
             # Extract key metrics
-            total_sessions = 0
+            total_value = 0
             dimensions_info = {}
-            
+
             for data_type, df in data.items():
                 if metric in df.columns:
-                    total_sessions += df[metric].sum()
+                    total_value += df[metric].sum()
                     dimensions_info[data_type] = len(df)
-            
+
             # Find top performers
             top_performers = {}
             for data_type, df in data.items():
@@ -371,107 +240,108 @@ class PollingAnalyzer:
                     top_performers[data_type] = {
                         'name': top_item.iloc[0],  # First column (usually the dimension)
                         'value': top_item[metric],
-                        'percentage': (top_item[metric] / total_sessions * 100) if total_sessions > 0 else 0
+                        'percentage': (top_item[metric] / total_value * 100) if total_value > 0 else 0
                     }
-            
+
             # Create summary
             summary_parts = [
-                f"This comprehensive polling analysis examines {total_sessions:,} {metric} across multiple dimensions."
+                f"This comprehensive polling analysis examines {total_value:,} {metric} across multiple dimensions."
             ]
-            
+
             for data_type, info in dimensions_info.items():
                 summary_parts.append(f"{data_type.title()}: {info} items")
-            
+
             summary_parts.append("Key findings include:")
-            
+
             for data_type, performer in top_performers.items():
                 summary_parts.append(
                     f"{performer['name']} leads {data_type} with {performer['value']:,} {metric} "
                     f"({performer['percentage']:.1f}%)"
                 )
-            
+
             summary_parts.append("Cross-dimensional analysis reveals patterns in distribution and performance.")
-            
+
             return " ".join(summary_parts)
-            
+
         except Exception as e:
             return f"Polling analysis summary generation failed: {str(e)}"
-    
-    def create_heatmap_visualization(self, 
+
+    def create_heatmap_visualization(self,
                                    crosstab_data: pd.DataFrame,
                                    title: str = "Cross-Tabulation Heatmap",
+                                   metric: str = 'value',
                                    figsize: Tuple[int, int] = (10, 8)) -> plt.Figure:
         """
         Create heatmap visualization for cross-tabulation data
-        
+
         Args:
             crosstab_data: DataFrame with cross-tabulation data
             title: Chart title
+            metric: Metric name for colorbar label
             figsize: Figure size tuple
-            
+
         Returns:
             Matplotlib figure
         """
         try:
             fig, ax = plt.subplots(figsize=figsize)
-            
+
             # Create heatmap
-            sns.heatmap(crosstab_data, 
-                       annot=True, 
-                       fmt='d', 
+            sns.heatmap(crosstab_data,
+                       annot=True,
+                       fmt='d',
                        cmap='YlOrRd',
                        ax=ax,
-                       cbar_kws={'label': 'Sessions'})
-            
+                       cbar_kws={'label': metric.title()})
+
             ax.set_title(title, fontsize=14, fontweight='bold')
             ax.set_xlabel('')
             ax.set_ylabel('')
-            
+
             plt.tight_layout()
             return fig
-            
+
         except Exception as e:
             log_error(f"Error creating heatmap visualization: {e}")
             return None
-    
-    def create_trend_analysis_chart(self, 
+
+    def create_trend_analysis_chart(self,
                                   longitudinal_data: Dict[str, pd.DataFrame],
                                   dimension: str,
-                                  metric: str = 'sessions',
+                                  metric: str = 'value',
                                   figsize: Tuple[int, int] = (12, 6)) -> plt.Figure:
         """
         Create trend analysis chart for longitudinal data
-        
+
         Args:
             longitudinal_data: Dictionary of longitudinal data by period
             dimension: Dimension to analyze
             metric: Metric to plot
             figsize: Figure size tuple
-            
+
         Returns:
             Matplotlib figure
         """
         try:
             fig, ax = plt.subplots(figsize=figsize)
-            
+
             # Plot trends for each period
             for period, data in longitudinal_data.items():
                 if dimension in data.columns and metric in data.columns:
                     period_data = data.groupby('period')[metric].sum()
-                    ax.plot(period_data.index.astype(str), period_data.values, 
+                    ax.plot(period_data.index.astype(str), period_data.values,
                            marker='o', label=period, linewidth=2)
-            
+
             ax.set_title(f'Trend Analysis: {dimension.title()}', fontsize=14, fontweight='bold')
             ax.set_xlabel('Time Period')
             ax.set_ylabel(metric.title())
             ax.legend()
             ax.grid(True, alpha=0.3)
-            
+
             plt.xticks(rotation=45)
             plt.tight_layout()
             return fig
-            
+
         except Exception as e:
             log_error(f"Error creating trend analysis chart: {e}")
             return None
-

--- a/tests/test_polling_analyzer.py
+++ b/tests/test_polling_analyzer.py
@@ -1,15 +1,21 @@
 """Tests for siege_utilities.reporting.analytics.polling_analyzer (SAL-63)."""
 from __future__ import annotations
 
-import matplotlib
-matplotlib.use("Agg")
-import matplotlib.pyplot as plt
-import pandas as pd
 import pytest
 
-from siege_utilities.reporting.analytics.polling_analyzer import (
+# PollingAnalyzer pulls in ChartGenerator which imports reportlab; skip the
+# whole module in envs (e.g. geo-without-GDAL CI) that don't install it.
+pytest.importorskip("reportlab")
+
+import matplotlib  # noqa: E402
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+import pandas as pd  # noqa: E402
+
+from siege_utilities.reporting.analytics.polling_analyzer import (  # noqa: E402
     PollingAnalysisError,
     PollingAnalyzer,
+    _choose_heatmap_fmt,
 )
 
 
@@ -24,6 +30,16 @@ def sample_long_df() -> pd.DataFrame:
     )
 
 
+class TestChooseHeatmapFmt:
+    def test_integer_data_returns_d(self):
+        df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+        assert _choose_heatmap_fmt(df) == "d"
+
+    def test_float_data_returns_2f(self):
+        df = pd.DataFrame({"a": [1.5, 2.5], "b": [3.25, 4.75]})
+        assert _choose_heatmap_fmt(df) == ".2f"
+
+
 class TestPerformanceRankings:
     def test_returns_expected_shape(self, sample_long_df):
         analyzer = PollingAnalyzer()
@@ -31,7 +47,7 @@ class TestPerformanceRankings:
             sample_long_df, dimensions=["region", "segment"]
         )
         assert set(out) == {"region", "segment"}
-        for dim, entries in out.items():
+        for _, entries in out.items():
             assert isinstance(entries, list)
             for entry in entries:
                 assert len(entry) == 3
@@ -67,23 +83,45 @@ class TestPollingSummary:
         with pytest.raises(PollingAnalysisError):
             analyzer.create_polling_summary({"x": pd.DataFrame({"a": [1]})})
 
+    def test_picks_first_non_metric_column_when_name_unspecified(self):
+        """Caller does not have to tell us which column is the label."""
+        analyzer = PollingAnalyzer()
+        df = pd.DataFrame({"extra_meta": [0, 0, 0], "region": ["N", "S", "E"], "value": [10, 30, 5]})
+        out = analyzer.create_polling_summary({"t": df})
+        # 'extra_meta' is first non-metric col; its value for the max-value row is 0
+        assert "0 leads t" in out or "leads t with 30" in out
+
+    def test_name_column_kwarg_overrides_heuristic(self):
+        """Explicit name_column= wins over positional guessing."""
+        analyzer = PollingAnalyzer()
+        df = pd.DataFrame({"extra_meta": [0, 0, 0], "region": ["N", "S", "E"], "value": [10, 30, 5]})
+        out = analyzer.create_polling_summary({"t": df}, name_column="region")
+        assert "S leads t" in out
+
+    def test_raises_when_no_non_metric_column(self):
+        analyzer = PollingAnalyzer()
+        df = pd.DataFrame({"value": [1, 2, 3]})
+        with pytest.raises(PollingAnalysisError, match="no non-metric column"):
+            analyzer.create_polling_summary({"t": df})
+
 
 class TestHeatmap:
     def test_integer_data_uses_d_format(self, sample_long_df):
+        """Assert both the helper returns 'd' and the heatmap renders."""
         analyzer = PollingAnalyzer()
         ct = analyzer.create_cross_tabulation_matrix(
             sample_long_df, dimensions=["region", "segment"]
         )
         key = next(iter(ct))
+        assert _choose_heatmap_fmt(ct[key]) == "d"
         fig = analyzer.create_heatmap_visualization(ct[key])
         assert isinstance(fig, plt.Figure)
         plt.close(fig)
 
-    def test_float_data_does_not_raise(self):
+    def test_float_data_picks_2f_and_does_not_raise(self):
         analyzer = PollingAnalyzer()
-        float_ct = pd.DataFrame(
-            {"a": [1.5, 2.5], "b": [3.25, 4.75]}, index=["x", "y"]
-        )
+        float_ct = pd.DataFrame({"a": [1.5, 2.5], "b": [3.25, 4.75]}, index=["x", "y"])
+        assert _choose_heatmap_fmt(float_ct) == ".2f"
         fig = analyzer.create_heatmap_visualization(float_ct)
         assert isinstance(fig, plt.Figure)
         plt.close(fig)
@@ -106,12 +144,23 @@ class TestChangeDetection:
         out = analyzer.create_change_detection_data(current, historical)
         assert set(["geography", "change_pct", "change_direction"]).issubset(out.columns)
 
-    def test_zero_baseline_handled(self):
+    def test_zero_baseline_is_growth_from_zero_not_stable(self):
+        """A brand-new geography (historical=0, current>0) must not collapse
+        to 'stable' just because the percent is undefined."""
         analyzer = PollingAnalyzer()
-        current = pd.DataFrame({"geography": ["A"], "value": [50]})
-        historical = pd.DataFrame({"geography": ["A"], "value": [0]})
+        current = pd.DataFrame({"geography": ["NEW"], "value": [500]})
+        historical = pd.DataFrame({"geography": ["NEW"], "value": [0]})
         out = analyzer.create_change_detection_data(current, historical)
-        assert not out.empty
+        direction = out.loc[out["geography"] == "NEW", "change_direction"].iloc[0]
+        assert direction == "growth_from_zero"
+
+    def test_zero_baseline_zero_current_is_stable(self):
+        analyzer = PollingAnalyzer()
+        current = pd.DataFrame({"geography": ["DORMANT"], "value": [0]})
+        historical = pd.DataFrame({"geography": ["DORMANT"], "value": [0]})
+        out = analyzer.create_change_detection_data(current, historical)
+        direction = out.loc[out["geography"] == "DORMANT", "change_direction"].iloc[0]
+        assert direction == "stable"
 
 
 class TestCrossTabulation:
@@ -120,4 +169,80 @@ class TestCrossTabulation:
         with pytest.raises(PollingAnalysisError):
             analyzer.create_cross_tabulation_matrix(
                 sample_long_df, dimensions=["region", "does_not_exist"]
+            )
+
+
+class TestLongitudinalAnalysis:
+    def _time_series_df(self):
+        return pd.DataFrame(
+            {
+                "date": pd.date_range("2026-01-01", periods=12, freq="D"),
+                "region": ["N", "S"] * 6,
+                "value": list(range(1, 13)),
+            }
+        )
+
+    def test_returns_dict_keyed_by_period(self):
+        analyzer = PollingAnalyzer()
+        out = analyzer.create_longitudinal_analysis(
+            self._time_series_df(), time_column="date", dimensions=["region"],
+            periods=("daily", "weekly"),
+        )
+        assert set(out) == {"daily", "weekly"}
+        assert set(out["daily"]) == {"region"}
+        assert not out["daily"]["region"].empty
+
+    def test_metric_is_keyword_only(self):
+        analyzer = PollingAnalyzer()
+        df = self._time_series_df()
+        with pytest.raises(TypeError):
+            analyzer.create_longitudinal_analysis(df, "date", ["region"], "value")
+
+    def test_unknown_period_raises(self):
+        analyzer = PollingAnalyzer()
+        with pytest.raises(PollingAnalysisError, match="unknown period"):
+            analyzer.create_longitudinal_analysis(
+                self._time_series_df(), time_column="date",
+                dimensions=["region"], periods=("yearly",),
+            )
+
+    def test_missing_time_column_raises(self):
+        analyzer = PollingAnalyzer()
+        df = self._time_series_df().drop(columns=["date"])
+        with pytest.raises(PollingAnalysisError):
+            analyzer.create_longitudinal_analysis(
+                df, time_column="date", dimensions=["region"],
+            )
+
+
+class TestTrendAnalysisChart:
+    def _longitudinal_data(self):
+        return {
+            "daily": pd.DataFrame(
+                {
+                    "period": pd.date_range("2026-01-01", periods=5, freq="D"),
+                    "value": [10, 15, 20, 25, 30],
+                }
+            ),
+            "weekly": pd.DataFrame(
+                {
+                    "period": pd.date_range("2026-01-01", periods=2, freq="W"),
+                    "value": [100, 150],
+                }
+            ),
+        }
+
+    def test_returns_figure(self):
+        analyzer = PollingAnalyzer()
+        fig = analyzer.create_trend_analysis_chart(
+            self._longitudinal_data(), dimension="region"
+        )
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_metric_is_keyword_only(self):
+        analyzer = PollingAnalyzer()
+        with pytest.raises(TypeError):
+            analyzer.create_trend_analysis_chart(
+                self._longitudinal_data(), "region", "value",
             )

--- a/tests/test_polling_analyzer.py
+++ b/tests/test_polling_analyzer.py
@@ -1,0 +1,123 @@
+"""Tests for siege_utilities.reporting.analytics.polling_analyzer (SAL-63)."""
+from __future__ import annotations
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+
+from siege_utilities.reporting.analytics.polling_analyzer import (
+    PollingAnalysisError,
+    PollingAnalyzer,
+)
+
+
+@pytest.fixture
+def sample_long_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "region": ["N", "N", "S", "S", "E", "W"],
+            "segment": ["A", "B", "A", "B", "A", "B"],
+            "value": [10, 20, 30, 40, 15, 25],
+        }
+    )
+
+
+class TestPerformanceRankings:
+    def test_returns_expected_shape(self, sample_long_df):
+        analyzer = PollingAnalyzer()
+        out = analyzer.create_performance_rankings(
+            sample_long_df, dimensions=["region", "segment"]
+        )
+        assert set(out) == {"region", "segment"}
+        for dim, entries in out.items():
+            assert isinstance(entries, list)
+            for entry in entries:
+                assert len(entry) == 3
+                _, summed, pct = entry
+                assert isinstance(summed, float)
+                assert isinstance(pct, float)
+                assert 0.0 <= pct <= 100.0
+
+    def test_top_n_limits_results(self, sample_long_df):
+        analyzer = PollingAnalyzer()
+        out = analyzer.create_performance_rankings(
+            sample_long_df, dimensions=["region"], top_n=2
+        )
+        assert len(out["region"]) == 2
+
+    def test_missing_column_raises(self, sample_long_df):
+        analyzer = PollingAnalyzer()
+        with pytest.raises(PollingAnalysisError):
+            analyzer.create_performance_rankings(
+                sample_long_df, dimensions=["does_not_exist"]
+            )
+
+
+class TestPollingSummary:
+    def test_summary_mentions_totals(self, sample_long_df):
+        analyzer = PollingAnalyzer()
+        out = analyzer.create_polling_summary({"region": sample_long_df})
+        assert "value" in out
+        assert "140" in out
+
+    def test_raises_when_metric_missing_everywhere(self):
+        analyzer = PollingAnalyzer()
+        with pytest.raises(PollingAnalysisError):
+            analyzer.create_polling_summary({"x": pd.DataFrame({"a": [1]})})
+
+
+class TestHeatmap:
+    def test_integer_data_uses_d_format(self, sample_long_df):
+        analyzer = PollingAnalyzer()
+        ct = analyzer.create_cross_tabulation_matrix(
+            sample_long_df, dimensions=["region", "segment"]
+        )
+        key = next(iter(ct))
+        fig = analyzer.create_heatmap_visualization(ct[key])
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_float_data_does_not_raise(self):
+        analyzer = PollingAnalyzer()
+        float_ct = pd.DataFrame(
+            {"a": [1.5, 2.5], "b": [3.25, 4.75]}, index=["x", "y"]
+        )
+        fig = analyzer.create_heatmap_visualization(float_ct)
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_metric_is_keyword_only(self, sample_long_df):
+        analyzer = PollingAnalyzer()
+        ct = analyzer.create_cross_tabulation_matrix(
+            sample_long_df, dimensions=["region", "segment"]
+        )
+        key = next(iter(ct))
+        with pytest.raises(TypeError):
+            analyzer.create_heatmap_visualization(ct[key], "my title", "metric_name")
+
+
+class TestChangeDetection:
+    def test_default_column_names(self):
+        analyzer = PollingAnalyzer()
+        current = pd.DataFrame({"geography": ["A", "B"], "value": [100, 200]})
+        historical = pd.DataFrame({"geography": ["A", "B"], "value": [80, 220]})
+        out = analyzer.create_change_detection_data(current, historical)
+        assert set(["geography", "change_pct", "change_direction"]).issubset(out.columns)
+
+    def test_zero_baseline_handled(self):
+        analyzer = PollingAnalyzer()
+        current = pd.DataFrame({"geography": ["A"], "value": [50]})
+        historical = pd.DataFrame({"geography": ["A"], "value": [0]})
+        out = analyzer.create_change_detection_data(current, historical)
+        assert not out.empty
+
+
+class TestCrossTabulation:
+    def test_missing_dimension_raises(self, sample_long_df):
+        analyzer = PollingAnalyzer()
+        with pytest.raises(PollingAnalysisError):
+            analyzer.create_cross_tabulation_matrix(
+                sample_long_df, dimensions=["region", "does_not_exist"]
+            )


### PR DESCRIPTION
Removes `create_time_series_choropleth_data()` and `create_geographic_device_crosstab()` (hardcoded GA/web heuristics), strips `np.random.normal` growth simulation from `create_performance_rankings()`, renames `metric="sessions"` → `metric="value"` and `geographic_column="country"` → `geographic_column="geography"` throughout, and parameterizes the heatmap axis label.

Linear: SAL-63
Parent: SAL-54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified performance ranking outputs by removing simulated growth values
  * Standardized metric and geography defaults across analyses (new defaults)
  * Visualization labels now reflect the selected metric and annotations adapt to data type

* **Bug Fixes**
  * Improved error handling: analysis failures now raise explicit errors instead of silently returning empty results
  * Safer change-percent calculations when historical baselines are zero

* **Removed Features**
  * Time series choropleth and geographic-device cross-tabulation analyses removed

* **Tests**
  * New test suite validating rankings, summaries, heatmaps, change detection, and error handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->