### PR TITLE
feat: SAL-64 Add Argument + TableType to page_models; parameterize TitlePage

### DIFF
--- a/siege_utilities/reporting/__init__.py
+++ b/siege_utilities/reporting/__init__.py
@@ -36,6 +36,7 @@ _register(['PowerPointGenerator'], '.powerpoint_generator')
 _register(['decode_rl_image', 'show_rl_image', 'save_rl_image'], '.image_utils')
 _register(['ChartTypeRegistry'], '.chart_types')
 _register(['PollingAnalyzer'], '.analytics.polling_analyzer')
+_register(['Argument', 'TableType'], '.pages.page_models')
 
 # IDML (InDesign) export
 _register(['IDMLExporter', 'export_report_idml', 'SIMPLEIDML_AVAILABLE'], '.idml_export')

--- a/siege_utilities/reporting/pages/page_models.py
+++ b/siege_utilities/reporting/pages/page_models.py
@@ -2,59 +2,122 @@
 Page Models - OOP hierarchy for report pages
 """
 from abc import ABC, abstractmethod
-from reportlab.lib.styles import ParagraphStyle
-from reportlab.lib import colors
-from reportlab.platypus import Spacer, Paragraph, PageBreak
-from reportlab.lib.styles import getSampleStyleSheet
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+# ---------------------------------------------------------------------------
+# Table type taxonomy
+# ---------------------------------------------------------------------------
+
+class TableType(Enum):
+    SINGLE_RESPONSE   = "single_response"    # percents sum to 100%; one answer per respondent
+    MULTIPLE_RESPONSE = "multiple_response"  # percents sum to >100%; base note required
+    CROSS_TAB         = "cross_tab"          # two-dimension table with sig-test markers
+    LONGITUDINAL      = "longitudinal"       # time periods as columns, delta column
+    RANKING           = "ranking"            # ordered list with value + share columns
+    MEAN_SCALE        = "mean_scale"         # average scores with confidence intervals
+    BANNER            = "banner"             # multi-column cross-tab (OSCAR-style)
+
+
+# ---------------------------------------------------------------------------
+# Argument — atomic report unit
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Argument:
+    """Atomic report unit: headline → narrative → table → visualization(s).
+
+    layout is auto-resolved in __post_init__:
+      - map_figure present  → "full_width"  (stacked: title / table / figure)
+      - map_figure absent   → "side_by_side" (title top, table left, figure right)
+    """
+
+    headline: str
+    narrative: str
+    table: Any                              # pandas DataFrame or Chain
+    table_type: TableType
+    chart: Optional[Any] = None            # matplotlib Figure
+    map_figure: Optional[Any] = None       # ChoroplethFigure; triggers full-width layout
+    layout: str = "auto"                   # "auto" | "side_by_side" | "full_width"
+    base_note: Optional[str] = None        # e.g. "n=342; multiple responses permitted"
+    source_note: Optional[str] = None
+    tags: List[str] = field(default_factory=list)
+
+    def __post_init__(self):
+        if self.layout == "auto":
+            self.layout = "full_width" if self.map_figure is not None else "side_by_side"
+
+
+# ---------------------------------------------------------------------------
+# Base page
+# ---------------------------------------------------------------------------
 
 class Page(ABC):
     """Abstract base class for all report pages"""
-    
+
     def __init__(self, primary_color, secondary_color, accent_color):
         self.primary_color = primary_color
         self.secondary_color = secondary_color
         self.accent_color = accent_color
         self.story = []
-    
+
     @abstractmethod
     def build(self):
         """Build the page content"""
         pass
-    
+
     def add_spacer(self, height):
         """Add spacing to the page"""
+        from reportlab.platypus import Spacer
         self.story.append(Spacer(1, height))
-    
+
     def add_paragraph(self, text, style):
         """Add a paragraph to the page"""
+        from reportlab.platypus import Paragraph
         self.story.append(Paragraph(text, style))
-    
+
     def add_page_break(self):
         """Add a page break"""
+        from reportlab.platypus import PageBreak
         self.story.append(PageBreak())
-    
+
     def get_content(self):
         """Get the complete page content"""
         return self.story
 
+
+# ---------------------------------------------------------------------------
+# TitlePage
+# ---------------------------------------------------------------------------
+
 class TitlePage(Page):
     """Title page implementation"""
-    
-    def __init__(self, primary_color, secondary_color, accent_color, 
-                 client_name, client_url, prepared_by):
+
+    def __init__(self, primary_color, secondary_color, accent_color,
+                 client_name, client_url, prepared_by,
+                 report_type: str = "ANALYTICS REPORT",
+                 tagline: str = "",
+                 phone: Optional[str] = None):
         super().__init__(primary_color, secondary_color, accent_color)
         self.client_name = client_name
         self.client_url = client_url
         self.prepared_by = prepared_by
-        
+        self.report_type = report_type
+        self.tagline = tagline
+        self.phone = phone
+
         # Title page specific spacing
         self.BLUE_BAR_TO_TITLE = 1.2
         self.TITLE_TO_TAGLINE = 0.8
         self.TAGLINE_TO_DETAILS = 1.6
         self.DETAILS_INTERNAL = 0.4
-    
+
     def create_blue_bar_style(self):
         """Create the blue header bar style"""
+        from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+        from reportlab.lib import colors
         styles = getSampleStyleSheet()
         return ParagraphStyle(
             'BlueBar',
@@ -70,9 +133,11 @@ class TitlePage(Page):
             borderWidth=0,
             borderRadius=0
         )
-    
+
     def create_title_style(self):
         """Create the main title style"""
+        from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+        from reportlab.lib import colors
         styles = getSampleStyleSheet()
         return ParagraphStyle(
             'CustomTitle',
@@ -87,9 +152,11 @@ class TitlePage(Page):
             rightIndent=0,
             wordWrap='LTR'
         )
-    
+
     def create_tagline_style(self):
         """Create the tagline style"""
+        from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+        from reportlab.lib import colors
         styles = getSampleStyleSheet()
         return ParagraphStyle(
             'Tagline',
@@ -100,9 +167,11 @@ class TitlePage(Page):
             spaceAfter=0,
             fontName='Helvetica'
         )
-    
+
     def create_details_style(self):
         """Create the details style"""
+        from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+        from reportlab.lib import colors
         styles = getSampleStyleSheet()
         return ParagraphStyle(
             'Details',
@@ -113,53 +182,65 @@ class TitlePage(Page):
             spaceAfter=int(0.3 * 72),
             fontName='Helvetica'
         )
-    
+
     def build(self, start_date, end_date):
         """Build the complete title page"""
         from datetime import datetime
-        
+
         # Blue header bar
         blue_bar_style = self.create_blue_bar_style()
-        self.add_paragraph("GOOGLE ANALYTICS REPORT", blue_bar_style)
+        self.add_paragraph(self.report_type, blue_bar_style)
         self.add_spacer(self.BLUE_BAR_TO_TITLE)
-        
+
         # Main title
         title_style = self.create_title_style()
         client_name_fixed = self.client_name.replace(" & ", "&nbsp;& ")
         self.add_paragraph(client_name_fixed, title_style)
         self.add_spacer(self.TITLE_TO_TAGLINE)
-        
-        # Tagline
-        tagline_style = self.create_tagline_style()
-        self.add_paragraph("Promoting wellness and well-being for over 200 years", tagline_style)
+
+        # Tagline (omitted if empty)
+        if self.tagline:
+            tagline_style = self.create_tagline_style()
+            self.add_paragraph(self.tagline, tagline_style)
         self.add_spacer(self.TAGLINE_TO_DETAILS)
-        
+
         # Report details
         details_style = self.create_details_style()
         self.add_paragraph("<b>Report Date:</b><br/>" + datetime.now().strftime('%B %d, %Y'), details_style)
         self.add_spacer(self.DETAILS_INTERNAL)
         self.add_paragraph(f"<b>Period Covered:</b><br/>{start_date} to {end_date}", details_style)
         self.add_spacer(self.DETAILS_INTERNAL)
-        self.add_paragraph(f"<b>Phone:</b><br/><a href=\"tel:+12022326100\">(202) 232-6100</a>", details_style)
+        if self.phone:
+            self.add_paragraph(
+                f'<b>Phone:</b><br/><a href="tel:{self.phone}">{self.phone}</a>',
+                details_style,
+            )
+            self.add_spacer(self.DETAILS_INTERNAL)
+        self.add_paragraph(f'<b>Website:</b><br/><a href="{self.client_url}">{self.client_url}</a>', details_style)
         self.add_spacer(self.DETAILS_INTERNAL)
-        self.add_paragraph(f"<b>Website:</b><br/><a href=\"{self.client_url}\">{self.client_url}</a>", details_style)
-        self.add_spacer(self.DETAILS_INTERNAL)
-        self.add_paragraph(f"<b>Prepared By:</b><br/><a href=\"https://masaiinteractive.com\">Masai Interactive</a> / <a href=\"https://siegeanalytics.com\">Siege Analytics</a>", details_style)
+        self.add_paragraph(f"<b>Prepared By:</b><br/>{self.prepared_by}", details_style)
         self.add_page_break()
-        
+
         return self.get_content()
+
+
+# ---------------------------------------------------------------------------
+# TableOfContentsPage
+# ---------------------------------------------------------------------------
 
 class TableOfContentsPage(Page):
     """Table of contents page implementation"""
-    
+
     def __init__(self, primary_color, secondary_color, accent_color):
         super().__init__(primary_color, secondary_color, accent_color)
         self.HEADER_SPACING = 0.6
         self.SECTION_SPACING = 0.4
         self.ITEM_SPACING = 0.2
-    
+
     def create_header_style(self):
         """Create the TOC header style"""
+        from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+        from reportlab.lib import colors
         styles = getSampleStyleSheet()
         return ParagraphStyle(
             'TOCHeader',
@@ -170,9 +251,11 @@ class TableOfContentsPage(Page):
             spaceAfter=self.HEADER_SPACING,
             fontName='Helvetica-Bold'
         )
-    
+
     def create_section_style(self):
         """Create the TOC section style"""
+        from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+        from reportlab.lib import colors
         styles = getSampleStyleSheet()
         return ParagraphStyle(
             'TOCSection',
@@ -183,23 +266,71 @@ class TableOfContentsPage(Page):
             spaceAfter=self.SECTION_SPACING,
             fontName='Helvetica-Bold'
         )
-    
-    def build(self, toc_data):
-        """Build the table of contents page"""
-        # Implementation for TOC page
-        pass
+
+    def create_item_style(self):
+        """Create the TOC item style"""
+        from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+        from reportlab.lib import colors
+        styles = getSampleStyleSheet()
+        return ParagraphStyle(
+            'TOCItem',
+            parent=styles['Normal'],
+            fontSize=12,
+            textColor=colors.black,
+            alignment=0,
+            spaceAfter=self.ITEM_SPACING,
+            fontName='Helvetica',
+            leftIndent=20,
+        )
+
+    def build(self, toc_data: List[Dict]):
+        """Build the table of contents page.
+
+        Args:
+            toc_data: list of dicts with keys 'section', 'title', and optional 'page_num'
+        """
+        header_style = self.create_header_style()
+        section_style = self.create_section_style()
+        item_style = self.create_item_style()
+
+        self.add_paragraph("Table of Contents", header_style)
+        self.add_spacer(self.HEADER_SPACING)
+
+        current_section = None
+        for entry in toc_data:
+            section = entry.get("section", "")
+            title = entry.get("title", "")
+            page_num = entry.get("page_num")
+
+            if section != current_section:
+                self.add_spacer(self.SECTION_SPACING)
+                self.add_paragraph(section, section_style)
+                current_section = section
+
+            label = f"{title}{'  ·  ' + str(page_num) if page_num else ''}"
+            self.add_paragraph(label, item_style)
+
+        self.add_page_break()
+        return self.get_content()
+
+
+# ---------------------------------------------------------------------------
+# ContentPage
+# ---------------------------------------------------------------------------
 
 class ContentPage(Page):
     """Base class for content pages (sections, charts, tables)"""
-    
+
     def __init__(self, primary_color, secondary_color, accent_color):
         super().__init__(primary_color, secondary_color, accent_color)
         self.SECTION_HEADER_SPACING = 0.6
         self.HEADER_TO_CONTENT_SPACING = 0.5
         self.ELEMENT_SPACING = 0.4
-    
+
     def create_section_header_style(self):
         """Create section header style"""
+        from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+        from reportlab.lib import colors
         styles = getSampleStyleSheet()
         return ParagraphStyle(
             'SectionHeader',
@@ -210,9 +341,11 @@ class ContentPage(Page):
             spaceAfter=self.SECTION_HEADER_SPACING,
             fontName='Helvetica-Bold'
         )
-    
+
     def create_subsection_header_style(self):
         """Create subsection header style"""
+        from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+        from reportlab.lib import colors
         styles = getSampleStyleSheet()
         return ParagraphStyle(
             'SubsectionHeader',

--- a/tests/test_argument_pattern.py
+++ b/tests/test_argument_pattern.py
@@ -1,0 +1,208 @@
+"""
+Tests for Argument + TableType additions (SAL-64).
+"""
+import pandas as pd
+import pytest
+
+try:
+    import reportlab  # noqa: F401
+    REPORTLAB_AVAILABLE = True
+except ImportError:
+    REPORTLAB_AVAILABLE = False
+
+requires_reportlab = pytest.mark.skipif(
+    not REPORTLAB_AVAILABLE, reason="reportlab not installed"
+)
+
+
+# ---------------------------------------------------------------------------
+# TableType
+# ---------------------------------------------------------------------------
+
+class TestTableTypeEnum:
+    def test_all_seven_variants_importable(self):
+        from siege_utilities.reporting.pages.page_models import TableType
+        expected = {
+            "SINGLE_RESPONSE", "MULTIPLE_RESPONSE", "CROSS_TAB",
+            "LONGITUDINAL", "RANKING", "MEAN_SCALE", "BANNER",
+        }
+        actual = {m.name for m in TableType}
+        assert actual == expected
+
+    def test_values_are_snake_case_strings(self):
+        from siege_utilities.reporting.pages.page_models import TableType
+        for member in TableType:
+            assert member.value == member.name.lower()
+
+    def test_importable_from_reporting_top_level(self):
+        from siege_utilities.reporting import TableType
+        assert TableType is not None
+        assert hasattr(TableType, "MULTIPLE_RESPONSE")
+
+
+# ---------------------------------------------------------------------------
+# Argument
+# ---------------------------------------------------------------------------
+
+class TestArgumentDefaults:
+    def test_layout_auto_side_by_side_without_map(self):
+        from siege_utilities.reporting.pages.page_models import Argument, TableType
+        df = pd.DataFrame({"q": ["yes", "no"], "n": [60, 40]})
+        arg = Argument(
+            headline="Party ID",
+            narrative="Most respondents lean left.",
+            table=df,
+            table_type=TableType.SINGLE_RESPONSE,
+        )
+        assert arg.layout == "side_by_side"
+
+    def test_layout_auto_full_width_with_map(self):
+        from siege_utilities.reporting.pages.page_models import Argument, TableType
+        df = pd.DataFrame({"q": ["yes"], "n": [100]})
+        arg = Argument(
+            headline="Geographic spread",
+            narrative="Heavy concentration in metro areas.",
+            table=df,
+            table_type=TableType.CROSS_TAB,
+            map_figure=object(),  # any truthy value
+        )
+        assert arg.layout == "full_width"
+
+    def test_explicit_layout_overrides_auto(self):
+        from siege_utilities.reporting.pages.page_models import Argument, TableType
+        df = pd.DataFrame()
+        arg = Argument(
+            headline="X", narrative="Y", table=df,
+            table_type=TableType.RANKING,
+            layout="full_width",
+        )
+        assert arg.layout == "full_width"
+
+    def test_tags_default_to_empty_list(self):
+        from siege_utilities.reporting.pages.page_models import Argument, TableType
+        arg = Argument(
+            headline="H", narrative="N", table=None,
+            table_type=TableType.BANNER,
+        )
+        assert arg.tags == []
+
+    def test_importable_from_reporting_top_level(self):
+        from siege_utilities.reporting import Argument
+        assert Argument is not None
+
+    def test_base_note_and_source_note_default_none(self):
+        from siege_utilities.reporting.pages.page_models import Argument, TableType
+        arg = Argument(headline="H", narrative="N", table=None,
+                       table_type=TableType.MEAN_SCALE)
+        assert arg.base_note is None
+        assert arg.source_note is None
+
+
+# ---------------------------------------------------------------------------
+# TitlePage — parameterized
+# ---------------------------------------------------------------------------
+
+@requires_reportlab
+class TestTitlePageParameterized:
+    PRIMARY = "#1a3a5c"
+    SECONDARY = "#2d6a9f"
+    ACCENT = "#e8a020"
+
+    def _make_page(self, **kwargs):
+        from siege_utilities.reporting.pages.page_models import TitlePage
+        defaults = dict(
+            primary_color=self.PRIMARY,
+            secondary_color=self.SECONDARY,
+            accent_color=self.ACCENT,
+            client_name="Acme Corp",
+            client_url="https://acme.example.com",
+            prepared_by="Siege Analytics",
+        )
+        defaults.update(kwargs)
+        return TitlePage(**defaults)
+
+    def test_default_report_type_has_no_google_analytics(self):
+        page = self._make_page()
+        # build() returns a story list; inspect the first paragraph's text
+        story = page.build("2025-01-01", "2025-12-31")
+        first_para = story[0]
+        assert "GOOGLE ANALYTICS" not in first_para.text
+        assert "ANALYTICS REPORT" in first_para.text
+
+    def test_custom_report_type_appears_in_header(self):
+        page = self._make_page(report_type="DONOR INTELLIGENCE REPORT")
+        story = page.build("2025-01-01", "2025-12-31")
+        assert "DONOR INTELLIGENCE REPORT" in story[0].text
+
+    def test_tagline_omitted_when_empty(self):
+        page = self._make_page(tagline="")
+        story = page.build("2025-01-01", "2025-12-31")
+        texts = [getattr(el, "text", "") for el in story]
+        assert not any("200 years" in t for t in texts)
+
+    def test_tagline_rendered_when_provided(self):
+        page = self._make_page(tagline="Serving democracy since 1960")
+        story = page.build("2025-01-01", "2025-12-31")
+        texts = [getattr(el, "text", "") for el in story]
+        assert any("Serving democracy" in t for t in texts)
+
+    def test_no_masai_or_siege_hardcoded(self):
+        page = self._make_page(prepared_by="Custom Firm LLC")
+        story = page.build("2025-01-01", "2025-12-31")
+        combined = " ".join(getattr(el, "text", "") for el in story)
+        assert "Masai Interactive" not in combined
+
+    def test_phone_omitted_when_none(self):
+        page = self._make_page(phone=None)
+        story = page.build("2025-01-01", "2025-12-31")
+        texts = [getattr(el, "text", "") for el in story]
+        assert not any("Phone" in t for t in texts)
+
+    def test_phone_present_when_provided(self):
+        page = self._make_page(phone="+12025550100")
+        story = page.build("2025-01-01", "2025-12-31")
+        texts = [getattr(el, "text", "") for el in story]
+        assert any("+12025550100" in t for t in texts)
+
+
+# ---------------------------------------------------------------------------
+# TableOfContentsPage.build()
+# ---------------------------------------------------------------------------
+
+@requires_reportlab
+class TestTocBuild:
+    PRIMARY = "#1a3a5c"
+    SECONDARY = "#2d6a9f"
+    ACCENT = "#e8a020"
+
+    def _make_page(self):
+        from siege_utilities.reporting.pages.page_models import TableOfContentsPage
+        return TableOfContentsPage(self.PRIMARY, self.SECONDARY, self.ACCENT)
+
+    def test_build_returns_non_empty_story(self):
+        page = self._make_page()
+        toc_data = [
+            {"section": "Overview", "title": "Executive Summary", "page_num": 2},
+            {"section": "Overview", "title": "Methodology", "page_num": 3},
+            {"section": "Results", "title": "Party ID", "page_num": 5},
+        ]
+        story = page.build(toc_data)
+        assert len(story) > 0
+
+    def test_build_with_empty_list(self):
+        page = self._make_page()
+        story = page.build([])
+        assert isinstance(story, list)
+
+    def test_build_includes_title_text(self):
+        page = self._make_page()
+        story = page.build([{"section": "S1", "title": "Item A"}])
+        texts = [getattr(el, "text", "") for el in story]
+        assert any("Table of Contents" in t for t in texts)
+
+    def test_build_includes_section_and_item(self):
+        page = self._make_page()
+        story = page.build([{"section": "Demographics", "title": "Age Breakdown"}])
+        texts = [getattr(el, "text", "") for el in story]
+        assert any("Demographics" in t for t in texts)
+        assert any("Age Breakdown" in t for t in texts)


### PR DESCRIPTION
Adds `TableType` enum (7 variants) and `Argument` dataclass with auto-layout logic to `page_models.py`. Parameterizes all hardcoded strings in `TitlePage` (report type, tagline, phone, vendor credit). Implements `TableOfContentsPage.build()`. Exports both from `reporting/__init__.py`.

Linear: SAL-64
Depends on: SAL-63