### PR TITLE
feat: SAL-65 Build siege_utilities.survey module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,10 @@ dev = [
     "djangorestframework-gis>=1.0.0",
     "psycopg2-binary>=2.9.0",
 ]
+# Survey/polling report engine (RIM weighting)
+survey = [
+    "weightipy>=0.4.0",
+]
 # Everything — convenience meta-extra for full installs
 all = [
     # data

--- a/siege_utilities/reporting/pages/page_models.py
+++ b/siege_utilities/reporting/pages/page_models.py
@@ -296,19 +296,27 @@ class TableOfContentsPage(Page):
         self.add_paragraph("Table of Contents", header_style)
         self.add_spacer(self.HEADER_SPACING)
 
-        current_section = None
+        # Group entries by section while preserving first-appearance order of
+        # both sections and of titles within each section. This keeps the
+        # output stable even when toc_data interleaves sections
+        # (e.g. ``[A, B, A]`` still produces one A block and one B block).
+        grouped: Dict[str, list] = {}
+        section_order: list = []
         for entry in toc_data:
             section = entry.get("section", "")
-            title = entry.get("title", "")
-            page_num = entry.get("page_num")
+            if section not in grouped:
+                grouped[section] = []
+                section_order.append(section)
+            grouped[section].append(entry)
 
-            if section != current_section:
-                self.add_spacer(self.SECTION_SPACING)
-                self.add_paragraph(section, section_style)
-                current_section = section
-
-            label = f"{title}{'  ·  ' + str(page_num) if page_num else ''}"
-            self.add_paragraph(label, item_style)
+        for section in section_order:
+            self.add_spacer(self.SECTION_SPACING)
+            self.add_paragraph(section, section_style)
+            for entry in grouped[section]:
+                title = entry.get("title", "")
+                page_num = entry.get("page_num")
+                label = f"{title}{'  ·  ' + str(page_num) if page_num else ''}"
+                self.add_paragraph(label, item_style)
 
         self.add_page_break()
         return self.get_content()

--- a/siege_utilities/survey/__init__.py
+++ b/siege_utilities/survey/__init__.py
@@ -1,0 +1,52 @@
+"""
+siege_utilities.survey — Survey/crosstab report engine.
+
+Modelled on the Quantipy Stack → Cluster → Chain → View hierarchy,
+built fresh for Python 3.12 on pandas + weightipy.
+
+Install the optional dependency:
+    pip install siege-utilities[survey]
+
+Quick start::
+
+    from siege_utilities.survey import build_chain, chain_to_argument
+    from siege_utilities.reporting.pages.page_models import TableType
+
+    chain = build_chain(df, row_var="party", break_vars=["county"],
+                        table_type=TableType.SINGLE_RESPONSE, geo_column="county")
+    argument = chain_to_argument(chain, headline="Party ID by County",
+                                 narrative="Democrats lead in metro counties.")
+"""
+
+import importlib
+import sys
+
+_LAZY = {
+    "Stack":           ".models",
+    "Cluster":         ".models",
+    "Chain":           ".models",
+    "View":            ".models",
+    "WeightScheme":    ".models",
+    "WeightingConvergenceError": ".weights",
+    "apply_rim_weights": ".weights",
+    "build_chain":     ".crosstab",
+    "column_proportion_test": ".significance",
+    "chi_square_flag": ".significance",
+    "chain_to_argument":   ".render",
+    "stack_to_arguments":  ".render",
+}
+
+__all__ = list(_LAZY.keys())
+
+
+def __getattr__(name):
+    if name in _LAZY:
+        mod = importlib.import_module(_LAZY[name], __package__)
+        val = getattr(mod, name)
+        setattr(sys.modules[__name__], name, val)
+        return val
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(list(globals().keys()) + list(_LAZY.keys())))

--- a/siege_utilities/survey/crosstab.py
+++ b/siege_utilities/survey/crosstab.py
@@ -93,10 +93,17 @@ def _weighted_counts(
     return df.groupby(group_col).size().astype(float)
 
 
-def _base_respondents(df: pd.DataFrame, weight_var: Optional[str]) -> int:
+def _base_respondents(df: pd.DataFrame, weight_var: Optional[str]) -> float:
+    """Return the effective respondent base — weighted sum or unweighted count.
+
+    Returns a float so fractional weighted bases (e.g. ``1234.7``) are not
+    silently truncated. Callers that need an integer for display should
+    cast explicitly; downstream math (significance tests, CI bounds) now
+    uses the full-precision value.
+    """
     if weight_var and weight_var in df.columns:
-        return int(df[weight_var].sum())
-    return len(df)
+        return float(df[weight_var].sum())
+    return float(len(df))
 
 
 def _views_from_counts(
@@ -169,7 +176,11 @@ def _build_multiple_response(
                 counts, base=n_respondents, pct_base=float(n_respondents)
             )
     n_total = _base_respondents(df, weight_var)
-    base_note = f"n={n_total:,} respondents; multiple responses permitted; percentages sum to more than 100%"
+    # Display-only: round for the base_note; downstream math keeps full precision.
+    base_note = (
+        f"n={int(round(n_total)):,} respondents; multiple responses permitted; "
+        "percentages sum to more than 100%"
+    )
     return Chain(
         row_var=row_var, break_vars=break_vars, views=views,
         table_type=TableType.MULTIPLE_RESPONSE,

--- a/siege_utilities/survey/crosstab.py
+++ b/siege_utilities/survey/crosstab.py
@@ -244,13 +244,20 @@ def _build_ranking(
 def _build_mean_scale(
     df, row_var, break_vars, metric, weight_var, top_n, geo_column
 ) -> Chain:
-    """Computes mean + 95% CI per break variable value."""
-    views: Dict[str, List[View]] = {}
+    """Computes mean + 95% CI per break variable value.
+
+    MEAN_SCALE requires the ``metric`` column — unlike count-based types,
+    there is no fallback to row counts. Missing metric raises so callers
+    don't receive a silently-empty chain that'd render as a blank page
+    with no diagnostic.
+    """
     if metric not in df.columns:
-        return Chain(
-            row_var=row_var, break_vars=break_vars, views={},
-            table_type=TableType.MEAN_SCALE, geo_column=geo_column,
+        raise ValueError(
+            f"MEAN_SCALE requires numeric metric column {metric!r}; "
+            f"available columns: {list(df.columns)}"
         )
+
+    views: Dict[str, List[View]] = {}
 
     for bv in break_vars:
         for bval in df[bv].dropna().unique():

--- a/siege_utilities/survey/crosstab.py
+++ b/siege_utilities/survey/crosstab.py
@@ -1,0 +1,298 @@
+"""
+Chain builder — converts a respondent/donor-level DataFrame into a Chain.
+
+Delegates chi-square to siege_utilities.data.cross_tabulation (not reimplemented here).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import pandas as pd
+
+from ..reporting.pages.page_models import TableType
+from .models import Chain, View
+
+
+def build_chain(
+    df: pd.DataFrame,
+    row_var: str,
+    break_vars: List[str],
+    metric: str = "value",
+    weight_var: Optional[str] = None,
+    table_type: TableType = TableType.CROSS_TAB,
+    top_n: Optional[int] = None,
+    geo_column: Optional[str] = None,
+) -> Chain:
+    """Build a Chain from a respondent/donor-level DataFrame.
+
+    Parameters
+    ----------
+    df:
+        Input DataFrame; one row per respondent.
+    row_var:
+        Column whose distinct values become row categories.
+    break_vars:
+        Columns to cross-tab against (become column groups).
+    metric:
+        Numeric column to aggregate (default "value"; use column count if absent).
+    weight_var:
+        Optional weight column name.
+    table_type:
+        Drives cell computation, chart type, and base note.
+    top_n:
+        If set, keep only the top N row categories by total volume.
+    geo_column:
+        If set, attached to Chain to signal map generation.
+
+    Returns
+    -------
+    Chain
+    """
+    dispatchers = {
+        TableType.SINGLE_RESPONSE:   _build_single_response,
+        TableType.MULTIPLE_RESPONSE: _build_multiple_response,
+        TableType.CROSS_TAB:         _build_cross_tab,
+        TableType.LONGITUDINAL:      _build_longitudinal,
+        TableType.RANKING:           _build_ranking,
+        TableType.MEAN_SCALE:        _build_mean_scale,
+        TableType.BANNER:            _build_banner,
+    }
+    fn = dispatchers[table_type]
+    return fn(
+        df=df,
+        row_var=row_var,
+        break_vars=break_vars,
+        metric=metric,
+        weight_var=weight_var,
+        top_n=top_n,
+        geo_column=geo_column,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _weighted_counts(
+    df: pd.DataFrame,
+    group_col: str,
+    metric: str,
+    weight_var: Optional[str],
+) -> pd.Series:
+    """Return weighted sum (or unweighted count if metric absent)."""
+    if metric in df.columns:
+        if weight_var and weight_var in df.columns:
+            return df.groupby(group_col).apply(
+                lambda g: (g[metric] * g[weight_var]).sum(), include_groups=False
+            )
+        return df.groupby(group_col)[metric].sum()
+    # Fall back to respondent count
+    if weight_var and weight_var in df.columns:
+        return df.groupby(group_col)[weight_var].sum()
+    return df.groupby(group_col).size().astype(float)
+
+
+def _base_respondents(df: pd.DataFrame, weight_var: Optional[str]) -> int:
+    if weight_var and weight_var in df.columns:
+        return int(df[weight_var].sum())
+    return len(df)
+
+
+def _views_from_counts(
+    counts: pd.Series,
+    base: int,
+    pct_base: Optional[float] = None,
+) -> List[View]:
+    total = pct_base if pct_base is not None else float(counts.sum())
+    views = []
+    for cat, cnt in counts.items():
+        pct = float(cnt) / total if total > 0 else 0.0
+        views.append(View(metric=str(cat), base=base, count=float(cnt), pct=pct))
+    return views
+
+
+# ---------------------------------------------------------------------------
+# Per-type builders
+# ---------------------------------------------------------------------------
+
+def _build_single_response(
+    df, row_var, break_vars, metric, weight_var, top_n, geo_column
+) -> Chain:
+    views: Dict[str, List[View]] = {}
+    for bv in break_vars:
+        for bval in df[bv].dropna().unique():
+            subset = df[df[bv] == bval]
+            base = _base_respondents(subset, weight_var)
+            counts = _weighted_counts(subset, row_var, metric, weight_var)
+            if top_n:
+                counts = counts.nlargest(top_n)
+            key = f"{bv}={bval}"
+            views[key] = _views_from_counts(counts, base)
+    return Chain(
+        row_var=row_var, break_vars=break_vars, views=views,
+        table_type=TableType.SINGLE_RESPONSE, geo_column=geo_column,
+    )
+
+
+def _build_multiple_response(
+    df, row_var, break_vars, metric, weight_var, top_n, geo_column
+) -> Chain:
+    """Percents are per-respondent (sum can exceed 100%); auto-sets base_note."""
+    views: Dict[str, List[View]] = {}
+    for bv in break_vars:
+        for bval in df[bv].dropna().unique():
+            subset = df[df[bv] == bval]
+            n_respondents = _base_respondents(subset, weight_var)
+            counts = _weighted_counts(subset, row_var, metric, weight_var)
+            if top_n:
+                counts = counts.nlargest(top_n)
+            key = f"{bv}={bval}"
+            # Percent base = respondents, not responses (items sum > 100%)
+            views[key] = _views_from_counts(
+                counts, base=n_respondents, pct_base=float(n_respondents)
+            )
+    n_total = _base_respondents(df, weight_var)
+    base_note = f"n={n_total:,} respondents; multiple responses permitted; percentages sum to more than 100%"
+    return Chain(
+        row_var=row_var, break_vars=break_vars, views=views,
+        table_type=TableType.MULTIPLE_RESPONSE,
+        base_note=base_note, geo_column=geo_column,
+    )
+
+
+def _build_cross_tab(
+    df, row_var, break_vars, metric, weight_var, top_n, geo_column
+) -> Chain:
+    views: Dict[str, List[View]] = {}
+    for bv in break_vars:
+        for bval in df[bv].dropna().unique():
+            subset = df[df[bv] == bval]
+            base = _base_respondents(subset, weight_var)
+            counts = _weighted_counts(subset, row_var, metric, weight_var)
+            if top_n:
+                counts = counts.nlargest(top_n)
+            key = f"{bv}={bval}"
+            views[key] = _views_from_counts(counts, base)
+    return Chain(
+        row_var=row_var, break_vars=break_vars, views=views,
+        table_type=TableType.CROSS_TAB, geo_column=geo_column,
+    )
+
+
+def _build_longitudinal(
+    df, row_var, break_vars, metric, weight_var, top_n, geo_column
+) -> Chain:
+    """Time periods become columns; adds a delta column (last − first period)."""
+    views: Dict[str, List[View]] = {}
+    time_col = break_vars[0] if break_vars else row_var
+    periods = sorted(df[time_col].dropna().unique())
+
+    for period in periods:
+        subset = df[df[time_col] == period]
+        base = _base_respondents(subset, weight_var)
+        counts = _weighted_counts(subset, row_var, metric, weight_var)
+        if top_n:
+            counts = counts.nlargest(top_n)
+        key = str(period)
+        views[key] = _views_from_counts(counts, base)
+
+    # Compute delta: last period − first period
+    delta_col = None
+    if len(periods) >= 2:
+        first_key = str(periods[0])
+        last_key = str(periods[-1])
+        first_map = {v.metric: v.count for v in views.get(first_key, [])}
+        last_map  = {v.metric: v.count for v in views.get(last_key, [])}
+        all_cats = set(first_map) | set(last_map)
+        base = _base_respondents(df, weight_var)
+        delta_views = []
+        for cat in sorted(all_cats):
+            d = last_map.get(cat, 0.0) - first_map.get(cat, 0.0)
+            delta_views.append(View(metric=cat, base=base, count=d, pct=None))
+        delta_col = "Δ (change)"
+        views[delta_col] = delta_views
+
+    return Chain(
+        row_var=row_var, break_vars=break_vars, views=views,
+        table_type=TableType.LONGITUDINAL,
+        delta_column=delta_col, geo_column=geo_column,
+    )
+
+
+def _build_ranking(
+    df, row_var, break_vars, metric, weight_var, top_n, geo_column
+) -> Chain:
+    """Sorted descending; includes rank and share columns."""
+    views: Dict[str, List[View]] = {}
+    for bv in break_vars:
+        for bval in df[bv].dropna().unique():
+            subset = df[df[bv] == bval]
+            base = _base_respondents(subset, weight_var)
+            counts = _weighted_counts(subset, row_var, metric, weight_var)
+            counts = counts.sort_values(ascending=False)
+            if top_n:
+                counts = counts.head(top_n)
+            key = f"{bv}={bval}"
+            views[key] = _views_from_counts(counts, base)
+    return Chain(
+        row_var=row_var, break_vars=break_vars, views=views,
+        table_type=TableType.RANKING, geo_column=geo_column,
+    )
+
+
+def _build_mean_scale(
+    df, row_var, break_vars, metric, weight_var, top_n, geo_column
+) -> Chain:
+    """Computes mean + 95% CI per break variable value."""
+    views: Dict[str, List[View]] = {}
+    if metric not in df.columns:
+        return Chain(
+            row_var=row_var, break_vars=break_vars, views={},
+            table_type=TableType.MEAN_SCALE, geo_column=geo_column,
+        )
+
+    for bv in break_vars:
+        for bval in df[bv].dropna().unique():
+            subset = df[df[bv] == bval]
+            base = _base_respondents(subset, weight_var)
+            key = f"{bv}={bval}"
+            cell_views = []
+            for cat in df[row_var].dropna().unique():
+                cat_vals = subset[subset[row_var] == cat][metric].dropna()
+                if len(cat_vals) == 0:
+                    continue
+                mean = float(cat_vals.mean())
+                ci = 1.96 * float(cat_vals.std(ddof=1)) / (len(cat_vals) ** 0.5) if len(cat_vals) > 1 else 0.0
+                v = View(metric=str(cat), base=base, count=mean, pct=None)
+                v.ci = ci  # type: ignore[attr-defined]  # attached dynamically
+                cell_views.append(v)
+            if top_n:
+                cell_views = sorted(cell_views, key=lambda v: v.count, reverse=True)[:top_n]
+            views[key] = cell_views
+
+    return Chain(
+        row_var=row_var, break_vars=break_vars, views=views,
+        table_type=TableType.MEAN_SCALE, geo_column=geo_column,
+    )
+
+
+def _build_banner(
+    df, row_var, break_vars, metric, weight_var, top_n, geo_column
+) -> Chain:
+    """Multi-column cross-tab (OSCAR-style): each break var is a banner column."""
+    views: Dict[str, List[View]] = {}
+    for bv in break_vars:
+        for bval in df[bv].dropna().unique():
+            subset = df[df[bv] == bval]
+            base = _base_respondents(subset, weight_var)
+            counts = _weighted_counts(subset, row_var, metric, weight_var)
+            if top_n:
+                counts = counts.nlargest(top_n)
+            key = f"{bv}={bval}"
+            views[key] = _views_from_counts(counts, base)
+    return Chain(
+        row_var=row_var, break_vars=break_vars, views=views,
+        table_type=TableType.BANNER, geo_column=geo_column,
+    )

--- a/siege_utilities/survey/crosstab.py
+++ b/siege_utilities/survey/crosstab.py
@@ -271,8 +271,7 @@ def _build_mean_scale(
                     continue
                 mean = float(cat_vals.mean())
                 ci = 1.96 * float(cat_vals.std(ddof=1)) / (len(cat_vals) ** 0.5) if len(cat_vals) > 1 else 0.0
-                v = View(metric=str(cat), base=base, count=mean, pct=None)
-                v.ci = ci  # type: ignore[attr-defined]  # attached dynamically
+                v = View(metric=str(cat), base=base, count=mean, pct=None, ci=ci)
                 cell_views.append(v)
             if top_n:
                 cell_views = sorted(cell_views, key=lambda v: v.count, reverse=True)[:top_n]

--- a/siege_utilities/survey/crosstab.py
+++ b/siege_utilities/survey/crosstab.py
@@ -6,9 +6,8 @@ Delegates chi-square to siege_utilities.data.cross_tabulation (not reimplemented
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
-import numpy as np
 import pandas as pd
 
 from ..reporting.pages.page_models import TableType

--- a/siege_utilities/survey/crosstab.py
+++ b/siege_utilities/survey/crosstab.py
@@ -116,9 +116,16 @@ def _views_from_counts(
 # Per-type builders
 # ---------------------------------------------------------------------------
 
-def _build_single_response(
-    df, row_var, break_vars, metric, weight_var, top_n, geo_column
-) -> Chain:
+def _grouped_counts_views(
+    df, row_var, break_vars, metric, weight_var, top_n
+) -> Dict[str, List[View]]:
+    """Shared loop: for each (break_var, break_value) subset, compute weighted
+    counts of row_var and wrap as Views keyed ``"{bv}={bval}"``.
+
+    Used by SINGLE_RESPONSE, CROSS_TAB, and BANNER builders (identical body).
+    Separate helper keeps the three type-tagged wrappers honest — a change
+    here ripples to all three without drift.
+    """
     views: Dict[str, List[View]] = {}
     for bv in break_vars:
         for bval in df[bv].dropna().unique():
@@ -127,10 +134,16 @@ def _build_single_response(
             counts = _weighted_counts(subset, row_var, metric, weight_var)
             if top_n:
                 counts = counts.nlargest(top_n)
-            key = f"{bv}={bval}"
-            views[key] = _views_from_counts(counts, base)
+            views[f"{bv}={bval}"] = _views_from_counts(counts, base)
+    return views
+
+
+def _build_single_response(
+    df, row_var, break_vars, metric, weight_var, top_n, geo_column
+) -> Chain:
     return Chain(
-        row_var=row_var, break_vars=break_vars, views=views,
+        row_var=row_var, break_vars=break_vars,
+        views=_grouped_counts_views(df, row_var, break_vars, metric, weight_var, top_n),
         table_type=TableType.SINGLE_RESPONSE, geo_column=geo_column,
     )
 
@@ -138,7 +151,11 @@ def _build_single_response(
 def _build_multiple_response(
     df, row_var, break_vars, metric, weight_var, top_n, geo_column
 ) -> Chain:
-    """Percents are per-respondent (sum can exceed 100%); auto-sets base_note."""
+    """Percents are per-respondent (sum can exceed 100%); auto-sets base_note.
+
+    Distinct from ``_grouped_counts_views`` because MULTIPLE_RESPONSE uses
+    ``pct_base=n_respondents`` — items that sum to >100% are the whole point.
+    """
     views: Dict[str, List[View]] = {}
     for bv in break_vars:
         for bval in df[bv].dropna().unique():
@@ -148,7 +165,6 @@ def _build_multiple_response(
             if top_n:
                 counts = counts.nlargest(top_n)
             key = f"{bv}={bval}"
-            # Percent base = respondents, not responses (items sum > 100%)
             views[key] = _views_from_counts(
                 counts, base=n_respondents, pct_base=float(n_respondents)
             )
@@ -164,18 +180,9 @@ def _build_multiple_response(
 def _build_cross_tab(
     df, row_var, break_vars, metric, weight_var, top_n, geo_column
 ) -> Chain:
-    views: Dict[str, List[View]] = {}
-    for bv in break_vars:
-        for bval in df[bv].dropna().unique():
-            subset = df[df[bv] == bval]
-            base = _base_respondents(subset, weight_var)
-            counts = _weighted_counts(subset, row_var, metric, weight_var)
-            if top_n:
-                counts = counts.nlargest(top_n)
-            key = f"{bv}={bval}"
-            views[key] = _views_from_counts(counts, base)
     return Chain(
-        row_var=row_var, break_vars=break_vars, views=views,
+        row_var=row_var, break_vars=break_vars,
+        views=_grouped_counts_views(df, row_var, break_vars, metric, weight_var, top_n),
         table_type=TableType.CROSS_TAB, geo_column=geo_column,
     )
 
@@ -287,17 +294,8 @@ def _build_banner(
     df, row_var, break_vars, metric, weight_var, top_n, geo_column
 ) -> Chain:
     """Multi-column cross-tab (OSCAR-style): each break var is a banner column."""
-    views: Dict[str, List[View]] = {}
-    for bv in break_vars:
-        for bval in df[bv].dropna().unique():
-            subset = df[df[bv] == bval]
-            base = _base_respondents(subset, weight_var)
-            counts = _weighted_counts(subset, row_var, metric, weight_var)
-            if top_n:
-                counts = counts.nlargest(top_n)
-            key = f"{bv}={bval}"
-            views[key] = _views_from_counts(counts, base)
     return Chain(
-        row_var=row_var, break_vars=break_vars, views=views,
+        row_var=row_var, break_vars=break_vars,
+        views=_grouped_counts_views(df, row_var, break_vars, metric, weight_var, top_n),
         table_type=TableType.BANNER, geo_column=geo_column,
     )

--- a/siege_utilities/survey/models.py
+++ b/siege_utilities/survey/models.py
@@ -1,0 +1,142 @@
+"""
+Survey hierarchy dataclasses: View → Chain → Cluster → Stack.
+
+Stack   = complete report (all sections + shared WeightScheme)
+Cluster = one named section (→ one deck section)
+Chain   = one cross-tab slide (question × break variables)
+View    = one cell statistic (count, pct, sig flag)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+
+
+# ---------------------------------------------------------------------------
+# View — one cell statistic
+# ---------------------------------------------------------------------------
+
+@dataclass
+class View:
+    """A single statistic in one cell of a cross-tabulation."""
+    metric: str                  # column name / statistic label
+    base: int                    # unweighted respondent count
+    count: float                 # weighted or raw count
+    pct: Optional[float] = None  # proportion (0–1); None for non-percent views
+    sig_flag: Optional[str] = None  # column letter if significantly different
+
+
+# ---------------------------------------------------------------------------
+# Chain — one cross-tabulation
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Chain:
+    """One cross-tabulation: row_var × break_vars.
+
+    table_type drives chart selection, significance testing approach, and
+    whether percent bases are respondents (MULTIPLE_RESPONSE) or column totals.
+    """
+
+    row_var: str
+    break_vars: List[str]
+    views: Dict[str, List[View]]       # key = break variable value
+    table_type: "TableType"            # imported lazily to avoid circular dep
+    base_note: str = ""
+    geo_column: Optional[str] = None  # presence triggers map generation
+    delta_column: Optional[str] = None  # for LONGITUDINAL: computed change column
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """Render the chain as a display-ready wide DataFrame.
+
+        Columns = break variable values; rows = row variable categories.
+        For MULTIPLE_RESPONSE, cells are percents (may exceed 100% column-sum).
+        """
+        if not self.views:
+            return pd.DataFrame()
+
+        records: Dict[str, Dict[str, Any]] = {}
+        for break_val, view_list in self.views.items():
+            for v in view_list:
+                if v.metric not in records:
+                    records[v.metric] = {}
+                records[v.metric][break_val] = (
+                    v.pct * 100 if v.pct is not None else v.count
+                )
+
+        df = pd.DataFrame.from_dict(records, orient="index")
+        df.index.name = self.row_var
+        return df
+
+    def to_argument(self, headline: str, narrative: str) -> "Argument":
+        """Wrap this Chain in an Argument (calls chart + map builders)."""
+        from .render import chain_to_argument
+        return chain_to_argument(self, headline=headline, narrative=narrative)
+
+
+# ---------------------------------------------------------------------------
+# Cluster — one named section
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Cluster:
+    """A named group of Chains forming one report section."""
+    name: str
+    chains: List[Chain] = field(default_factory=list)
+
+    def add_chain(self, chain: Chain) -> "Cluster":
+        self.chains.append(chain)
+        return self
+
+
+# ---------------------------------------------------------------------------
+# WeightScheme — RIM target marginals
+# ---------------------------------------------------------------------------
+
+@dataclass
+class WeightScheme:
+    """Target marginals for RIM (raking) weighting.
+
+    Example::
+
+        WeightScheme(targets={
+            "age_group": {"18-34": 0.25, "35-54": 0.40, "55+": 0.35},
+            "gender":    {"M": 0.48, "F": 0.52},
+        })
+    """
+
+    targets: Dict[str, Dict[Any, float]]
+    weight_col: str = "weight"
+    max_iterations: int = 1000
+    convergence: float = 1e-6
+
+    def validate(self) -> None:
+        for var, marginals in self.targets.items():
+            total = sum(marginals.values())
+            if abs(total - 1.0) > 1e-4:
+                raise ValueError(
+                    f"WeightScheme targets for '{var}' sum to {total:.4f}, expected 1.0"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Stack — complete report
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Stack:
+    """A complete survey report: all Clusters + shared WeightScheme."""
+    name: str
+    clusters: List[Cluster] = field(default_factory=list)
+    weight_scheme: Optional[WeightScheme] = None
+
+    def add_cluster(self, cluster: Cluster) -> "Stack":
+        self.clusters.append(cluster)
+        return self
+
+    @property
+    def all_chains(self) -> List[Chain]:
+        return [chain for cluster in self.clusters for chain in cluster.chains]

--- a/siege_utilities/survey/models.py
+++ b/siege_utilities/survey/models.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 class View:
     """A single statistic in one cell of a cross-tabulation."""
     metric: str                  # column name / statistic label
-    base: int                    # unweighted respondent count
+    base: float                  # effective respondent count (weighted sum or raw count)
     count: float                 # weighted or raw count
     pct: Optional[float] = None  # proportion (0–1); None for non-percent views
     sig_flag: Optional[str] = None  # column letter if significantly different

--- a/siege_utilities/survey/models.py
+++ b/siege_utilities/survey/models.py
@@ -10,9 +10,12 @@ View    = one cell statistic (count, pct, sig flag)
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import pandas as pd
+
+if TYPE_CHECKING:
+    from ..reporting.pages.page_models import Argument, TableType
 
 
 # ---------------------------------------------------------------------------
@@ -44,7 +47,7 @@ class Chain:
     row_var: str
     break_vars: List[str]
     views: Dict[str, List[View]]       # key = break variable value
-    table_type: "TableType"            # imported lazily to avoid circular dep
+    table_type: TableType
     base_note: str = ""
     geo_column: Optional[str] = None  # presence triggers map generation
     delta_column: Optional[str] = None  # for LONGITUDINAL: computed change column
@@ -71,7 +74,7 @@ class Chain:
         df.index.name = self.row_var
         return df
 
-    def to_argument(self, headline: str, narrative: str) -> "Argument":
+    def to_argument(self, headline: str, narrative: str) -> Argument:
         """Wrap this Chain in an Argument (calls chart + map builders)."""
         from .render import chain_to_argument
         return chain_to_argument(self, headline=headline, narrative=narrative)

--- a/siege_utilities/survey/models.py
+++ b/siege_utilities/survey/models.py
@@ -30,6 +30,7 @@ class View:
     count: float                 # weighted or raw count
     pct: Optional[float] = None  # proportion (0–1); None for non-percent views
     sig_flag: Optional[str] = None  # column letter if significantly different
+    ci: Optional[float] = None   # 95% confidence interval (MEAN_SCALE only)
 
 
 # ---------------------------------------------------------------------------
@@ -40,8 +41,14 @@ class View:
 class Chain:
     """One cross-tabulation: row_var × break_vars.
 
-    table_type drives chart selection, significance testing approach, and
+    ``table_type`` drives chart selection, significance testing approach, and
     whether percent bases are respondents (MULTIPLE_RESPONSE) or column totals.
+
+    Fields populated by later pipeline stages (significance testing,
+    weighting) are declared here with ``None`` defaults so
+    :func:`dataclasses.fields` / :func:`dataclasses.asdict` see them — the
+    previous pattern of attaching them dynamically via ``setattr`` broke
+    introspection.
     """
 
     row_var: str
@@ -51,6 +58,11 @@ class Chain:
     base_note: str = ""
     geo_column: Optional[str] = None  # presence triggers map generation
     delta_column: Optional[str] = None  # for LONGITUDINAL: computed change column
+
+    # Populated by siege_utilities.survey.significance.chi_square_flag.
+    # None = not yet tested; True/False = tested.
+    chi_square_significant: Optional[bool] = None
+    chi_square_p: Optional[float] = None
 
     def to_dataframe(self) -> pd.DataFrame:
         """Render the chain as a display-ready wide DataFrame.

--- a/siege_utilities/survey/render.py
+++ b/siege_utilities/survey/render.py
@@ -16,7 +16,8 @@ Chart type selection by TableType:
 
 from __future__ import annotations
 
-from typing import Any, List, Optional, TYPE_CHECKING
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 import pandas as pd
 
@@ -24,6 +25,10 @@ from ..reporting.pages.page_models import Argument, TableType
 
 if TYPE_CHECKING:
     from .models import Chain, Cluster, Stack
+
+
+class RenderError(RuntimeError):
+    """Raised when Chain-to-Argument rendering hits a configuration or data issue."""
 
 
 # ---------------------------------------------------------------------------
@@ -57,7 +62,12 @@ def _select_chart_type(chain: "Chain") -> str:
 # ---------------------------------------------------------------------------
 
 def _build_chart(df: pd.DataFrame, chart_type: str, headline: str) -> Optional[Any]:
-    """Attempt to build a matplotlib Figure. Returns None if matplotlib absent."""
+    """Render a matplotlib Figure for ``chart_type``.
+
+    Returns ``None`` when matplotlib is unavailable (optional dependency)
+    OR when ``df`` is empty. Any plotting failure raises :class:`RenderError`
+    so pipelines don't silently produce reports without figures.
+    """
     try:
         import matplotlib
         matplotlib.use("Agg")
@@ -87,9 +97,12 @@ def _build_chart(df: pd.DataFrame, chart_type: str, headline: str) -> Optional[A
             df.iloc[:, 0].plot.bar(ax=ax, color="#2d6a9f")
         else:
             df.plot.bar(ax=ax)
-    except Exception:
+    except (ValueError, TypeError, KeyError) as e:
         plt.close(fig)
-        return None
+        raise RenderError(
+            f"chart rendering failed for chart_type={chart_type!r}, "
+            f"shape={df.shape}, columns={list(df.columns)[:5]}: {e}"
+        ) from e
 
     ax.set_title(headline, fontsize=12, fontweight="bold")
     plt.tight_layout()
@@ -97,22 +110,69 @@ def _build_chart(df: pd.DataFrame, chart_type: str, headline: str) -> Optional[A
 
 
 def _build_map(chain: "Chain") -> Optional[Any]:
-    """Attempt to build a choropleth from chain.geo_column data. Returns None if unavailable."""
+    """Render a choropleth for geographically-keyed Chains.
+
+    The Chain's ``row_var`` MUST equal its ``geo_column`` — otherwise the
+    values in the row index aren't geographic features and labeling them
+    as such would mislabel (e.g. relabeling ``"Democrat"`` / ``"Republican"``
+    as states).
+
+    Returns ``None`` when no ``geo_column`` is set or when the geo-rendering
+    library is unavailable. Raises :class:`RenderError` on a configuration
+    mismatch or a rendering failure — callers should not silently ship
+    reports missing maps.
+    """
     if not chain.geo_column:
         return None
+
+    if chain.row_var != chain.geo_column:
+        raise RenderError(
+            f"Chain.geo_column={chain.geo_column!r} but Chain.row_var="
+            f"{chain.row_var!r}. Map generation requires the row variable "
+            f"to be the geographic key; otherwise row categories would be "
+            f"mislabeled as geo features."
+        )
+
     try:
         from ..reporting.chart_generator import ChartGenerator
-        cg = ChartGenerator()
-        df = chain.to_dataframe()
-        if df.empty:
-            return None
-        # Aggregate first column across all break values
-        agg = df.iloc[:, 0].reset_index()
-        agg.columns = [chain.geo_column, "value"]
-        fig = cg.create_choropleth_map(agg, geo_column=chain.geo_column, value_column="value")
-        return fig
-    except Exception:
+    except ImportError:
         return None
+
+    df = chain.to_dataframe()
+    if df.empty:
+        return None
+
+    # With row_var == geo_column, the DataFrame index holds geographic values
+    # (e.g. state FIPS, state abbreviations). Aggregate across break columns.
+    agg = df.iloc[:, 0].reset_index()
+    agg.columns = [chain.geo_column, "value"]
+
+    try:
+        cg = ChartGenerator()
+        return cg.create_choropleth_map(
+            agg, geo_column=chain.geo_column, value_column="value"
+        )
+    except (ValueError, TypeError, KeyError) as e:
+        raise RenderError(
+            f"choropleth rendering failed for geo_column={chain.geo_column!r}: {e}"
+        ) from e
+
+
+# ---------------------------------------------------------------------------
+# ArgumentCluster — carrier for stack_to_arguments output
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ArgumentCluster:
+    """A named group of rendered :class:`Argument` objects.
+
+    This is the output of :func:`stack_to_arguments` — a typed companion
+    to :class:`models.Cluster` (which holds Chains). Separate type prevents
+    callers from accidentally feeding Argument-bearing objects into code
+    that expects Chain-bearing Clusters.
+    """
+    name: str
+    arguments: List[Argument] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -123,6 +183,7 @@ def chain_to_argument(
     chain: "Chain",
     headline: str,
     narrative: str,
+    *,
     chart_generator: Any = None,
     map_generator: Any = None,
 ) -> Argument:
@@ -136,19 +197,41 @@ def chain_to_argument(
         Slide headline / section title.
     narrative:
         One-paragraph narrative text for the argument.
-    chart_generator:
-        Optional ChartGenerator instance. Auto-created if None.
-    map_generator:
-        Optional map generator. Uses geo.choropleth if geo_column present.
+    chart_generator, map_generator:
+        Reserved for dependency injection of pre-configured generators.
+        NOT YET IMPLEMENTED — passing a non-None value raises
+        :class:`NotImplementedError` so callers don't silently lose the
+        customization they thought they were providing.
 
     Returns
     -------
-    Argument with chart populated, map_figure populated iff chain.geo_column set.
+    Argument
+        chart populated when matplotlib is available; map_figure populated
+        only when ``chain.geo_column`` is set and equals ``chain.row_var``.
+
+    Raises
+    ------
+    NotImplementedError
+        If ``chart_generator`` or ``map_generator`` is passed; honoring
+        these kwargs requires wiring not yet built.
+    RenderError
+        On plotting failure or geo_column/row_var mismatch.
     """
+    if chart_generator is not None:
+        raise NotImplementedError(
+            "chart_generator injection not yet supported. File an issue "
+            "before relying on it."
+        )
+    if map_generator is not None:
+        raise NotImplementedError(
+            "map_generator injection not yet supported. File an issue "
+            "before relying on it."
+        )
+
     df = chain.to_dataframe()
     chart_type = _select_chart_type(chain)
     chart = _build_chart(df, chart_type, headline)
-    map_figure = _build_map(chain) if chain.geo_column else None
+    map_figure = _build_map(chain)  # None unless geo_column is set
 
     return Argument(
         headline=headline,
@@ -164,10 +247,13 @@ def chain_to_argument(
 
 def stack_to_arguments(
     stack: "Stack",
-    headlines: Optional[dict] = None,
-    narratives: Optional[dict] = None,
-) -> List["Cluster"]:
+    headlines: Optional[Dict] = None,
+    narratives: Optional[Dict] = None,
+) -> List[ArgumentCluster]:
     """Walk all Chains in a Stack, converting each to an Argument.
+
+    Returns a list of :class:`ArgumentCluster` (not :class:`Cluster`) so the
+    result type is explicit: these hold Arguments, not Chains.
 
     Parameters
     ----------
@@ -180,20 +266,16 @@ def stack_to_arguments(
 
     Returns
     -------
-    List of Cluster objects where each chain is replaced by its Argument.
+    List[ArgumentCluster]
+        One per input :class:`Cluster`; preserves cluster name.
     """
-    from .models import Cluster as ClusterModel
-
-    result: List[ClusterModel] = []
+    result: List[ArgumentCluster] = []
     for cluster in stack.clusters:
-        arg_cluster: List[Argument] = []
+        args: List[Argument] = []
         for chain in cluster.chains:
             key = (cluster.name, chain.row_var)
             hl = (headlines or {}).get(key, chain.row_var.replace("_", " ").title())
             na = (narratives or {}).get(key, "")
-            arg_cluster.append(chain_to_argument(chain, headline=hl, narrative=na))
-        # Build a Cluster whose chains slot is repurposed as arguments list
-        c = ClusterModel(name=cluster.name)
-        c.chains = arg_cluster  # type: ignore[assignment]
-        result.append(c)
+            args.append(chain_to_argument(chain, headline=hl, narrative=na))
+        result.append(ArgumentCluster(name=cluster.name, arguments=args))
     return result

--- a/siege_utilities/survey/render.py
+++ b/siege_utilities/survey/render.py
@@ -1,0 +1,199 @@
+"""
+Chain → Argument renderer.
+
+chain_to_argument:  converts one Chain to an Argument with chart and optional map.
+stack_to_arguments: walks all Chains in a Stack.
+
+Chart type selection by TableType:
+  SINGLE_RESPONSE   → horizontal bar
+  MULTIPLE_RESPONSE → grouped bar (NOT stacked — stacked implies mutual exclusivity)
+  CROSS_TAB         → grouped bar (≤5 categories) or heatmap (>5)
+  LONGITUDINAL      → line chart
+  RANKING           → horizontal bar sorted descending
+  MEAN_SCALE        → bar with error bars
+  BANNER            → small-multiple bars
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional, TYPE_CHECKING
+
+import pandas as pd
+
+from ..reporting.pages.page_models import Argument, TableType
+
+if TYPE_CHECKING:
+    from .models import Chain, Cluster, Stack
+
+
+# ---------------------------------------------------------------------------
+# Chart type selection
+# ---------------------------------------------------------------------------
+
+_CHART_TYPE_MAP = {
+    TableType.SINGLE_RESPONSE:   "horizontal_bar",
+    TableType.MULTIPLE_RESPONSE: "grouped_bar",
+    TableType.CROSS_TAB:         "grouped_bar",
+    TableType.LONGITUDINAL:      "line",
+    TableType.RANKING:           "horizontal_bar",
+    TableType.MEAN_SCALE:        "bar_with_error",
+    TableType.BANNER:            "small_multiples",
+}
+
+_HEATMAP_THRESHOLD = 5  # switch CROSS_TAB to heatmap above this many row categories
+
+
+def _select_chart_type(chain: "Chain") -> str:
+    ct = _CHART_TYPE_MAP[chain.table_type]
+    if chain.table_type == TableType.CROSS_TAB:
+        n_cats = len(chain.views) if chain.views else 0
+        if n_cats > _HEATMAP_THRESHOLD:
+            ct = "heatmap"
+    return ct
+
+
+# ---------------------------------------------------------------------------
+# Figure builders
+# ---------------------------------------------------------------------------
+
+def _build_chart(df: pd.DataFrame, chart_type: str, headline: str) -> Optional[Any]:
+    """Attempt to build a matplotlib Figure. Returns None if matplotlib absent."""
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError:
+        return None
+
+    if df.empty:
+        return None
+
+    fig, ax = plt.subplots(figsize=(8, 4))
+
+    try:
+        if chart_type == "horizontal_bar":
+            df.iloc[:, 0].sort_values().plot.barh(ax=ax, color="#1a3a5c")
+        elif chart_type == "grouped_bar":
+            df.plot.bar(ax=ax)
+        elif chart_type == "line":
+            df.plot.line(ax=ax, marker="o")
+        elif chart_type == "heatmap":
+            try:
+                import seaborn as sns
+                sns.heatmap(df, annot=True, fmt=".1f", cmap="YlOrRd", ax=ax)
+            except ImportError:
+                df.plot.bar(ax=ax)
+        elif chart_type == "bar_with_error":
+            df.iloc[:, 0].plot.bar(ax=ax, color="#2d6a9f")
+        else:
+            df.plot.bar(ax=ax)
+    except Exception:
+        plt.close(fig)
+        return None
+
+    ax.set_title(headline, fontsize=12, fontweight="bold")
+    plt.tight_layout()
+    return fig
+
+
+def _build_map(chain: "Chain") -> Optional[Any]:
+    """Attempt to build a choropleth from chain.geo_column data. Returns None if unavailable."""
+    if not chain.geo_column:
+        return None
+    try:
+        from ..reporting.chart_generator import ChartGenerator
+        cg = ChartGenerator()
+        df = chain.to_dataframe()
+        if df.empty:
+            return None
+        # Aggregate first column across all break values
+        agg = df.iloc[:, 0].reset_index()
+        agg.columns = [chain.geo_column, "value"]
+        fig = cg.create_choropleth_map(agg, geo_column=chain.geo_column, value_column="value")
+        return fig
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def chain_to_argument(
+    chain: "Chain",
+    headline: str,
+    narrative: str,
+    chart_generator: Any = None,
+    map_generator: Any = None,
+) -> Argument:
+    """Convert a Chain to an Argument with chart and optional map.
+
+    Parameters
+    ----------
+    chain:
+        Source Chain (output of build_chain).
+    headline:
+        Slide headline / section title.
+    narrative:
+        One-paragraph narrative text for the argument.
+    chart_generator:
+        Optional ChartGenerator instance. Auto-created if None.
+    map_generator:
+        Optional map generator. Uses geo.choropleth if geo_column present.
+
+    Returns
+    -------
+    Argument with chart populated, map_figure populated iff chain.geo_column set.
+    """
+    df = chain.to_dataframe()
+    chart_type = _select_chart_type(chain)
+    chart = _build_chart(df, chart_type, headline)
+    map_figure = _build_map(chain) if chain.geo_column else None
+
+    return Argument(
+        headline=headline,
+        narrative=narrative,
+        table=df,
+        table_type=chain.table_type,
+        chart=chart,
+        map_figure=map_figure,
+        base_note=chain.base_note or None,
+        tags=[chain.table_type.value],
+    )
+
+
+def stack_to_arguments(
+    stack: "Stack",
+    headlines: Optional[dict] = None,
+    narratives: Optional[dict] = None,
+) -> List["Cluster"]:
+    """Walk all Chains in a Stack, converting each to an Argument.
+
+    Parameters
+    ----------
+    stack:
+        Source Stack.
+    headlines:
+        Optional dict mapping (cluster_name, row_var) → headline string.
+    narratives:
+        Optional dict mapping (cluster_name, row_var) → narrative string.
+
+    Returns
+    -------
+    List of Cluster objects where each chain is replaced by its Argument.
+    """
+    from .models import Cluster as ClusterModel
+
+    result: List[ClusterModel] = []
+    for cluster in stack.clusters:
+        arg_cluster: List[Argument] = []
+        for chain in cluster.chains:
+            key = (cluster.name, chain.row_var)
+            hl = (headlines or {}).get(key, chain.row_var.replace("_", " ").title())
+            na = (narratives or {}).get(key, "")
+            arg_cluster.append(chain_to_argument(chain, headline=hl, narrative=na))
+        # Build a Cluster whose chains slot is repurposed as arguments list
+        c = ClusterModel(name=cluster.name)
+        c.chains = arg_cluster  # type: ignore[assignment]
+        result.append(c)
+    return result

--- a/siege_utilities/survey/render.py
+++ b/siege_utilities/survey/render.py
@@ -24,7 +24,7 @@ import pandas as pd
 from ..reporting.pages.page_models import Argument, TableType
 
 if TYPE_CHECKING:
-    from .models import Chain, Cluster, Stack
+    from .models import Chain, Stack
 
 
 class RenderError(RuntimeError):

--- a/siege_utilities/survey/significance.py
+++ b/siege_utilities/survey/significance.py
@@ -12,6 +12,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from siege_utilities.core.logging import log_error
+
 try:
     from scipy.stats import norm as _scipy_norm
     _SCIPY_AVAILABLE = True
@@ -21,6 +23,15 @@ except ImportError:
 
 if TYPE_CHECKING:
     from .models import Chain
+
+
+class SignificanceError(RuntimeError):
+    """Raised when significance testing cannot complete on the given chain."""
+
+
+# Critical z-values for the scipy-less fallback. Only exact matches are honored;
+# any other alpha raises rather than silently using 1.96.
+_FALLBACK_Z_CRIT = {0.05: 1.96, 0.01: 2.576, 0.10: 1.645}
 
 
 def column_proportion_test(chain: "Chain", alpha: float = 0.05) -> "Chain":
@@ -69,9 +80,16 @@ def column_proportion_test(chain: "Chain", alpha: float = 0.05) -> "Chain":
                 z = abs(p1 - p2) / se
                 if _SCIPY_AVAILABLE:
                     z_crit = _scipy_norm.ppf(1 - alpha / 2)
+                elif alpha in _FALLBACK_Z_CRIT:
+                    z_crit = _FALLBACK_Z_CRIT[alpha]
                 else:
-                    # fallback: hardcoded critical values for common alpha levels
-                    z_crit = {0.05: 1.96, 0.01: 2.576, 0.10: 1.645}.get(alpha, 1.96)
+                    # Without scipy, only exact matches are honored — silently
+                    # coercing to 1.96 would run tests at the wrong alpha and
+                    # corrupt the output.
+                    raise SignificanceError(
+                        f"alpha={alpha!r} requires scipy; install scipy or use "
+                        f"one of {sorted(_FALLBACK_Z_CRIT)}"
+                    )
                 if z > z_crit:
                     # Mark the higher column with the lower column's letter
                     higher_key = key_i if p1 > p2 else key_j
@@ -120,10 +138,18 @@ def chi_square_flag(chain: "Chain", alpha: float = 0.05) -> "Chain":
 
     try:
         result = chi_square_test(df)
-        chain.chi_square_significant = result.p_value < alpha  # type: ignore[attr-defined]
-        chain.chi_square_p = result.p_value                    # type: ignore[attr-defined]
-    except Exception:
-        chain.chi_square_significant = False  # type: ignore[attr-defined]
-        chain.chi_square_p = None             # type: ignore[attr-defined]
+    except (ValueError, TypeError, ZeroDivisionError) as e:
+        # A degenerate contingency table (zeros, singleton dimensions) is
+        # distinguishable from "test was run and wasn't significant" — tag
+        # the result as failed rather than collapsing both cases to False.
+        log_error(
+            f"chi_square_test failed on chain row_var={chain.row_var!r}, "
+            f"shape={df.shape}: {e}"
+        )
+        raise SignificanceError(
+            f"chi-square test failed for chain row_var={chain.row_var!r}"
+        ) from e
 
+    chain.chi_square_significant = bool(result.p_value < alpha)
+    chain.chi_square_p = float(result.p_value)
     return chain

--- a/siege_utilities/survey/significance.py
+++ b/siege_utilities/survey/significance.py
@@ -1,0 +1,129 @@
+"""
+Significance testing for survey chains.
+
+column_proportion_test: two-proportion z-test across all column pairs.
+chi_square_flag: wraps data.cross_tabulation.chi_square_test.
+"""
+
+from __future__ import annotations
+
+import string
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+try:
+    from scipy.stats import norm as _scipy_norm
+    _SCIPY_AVAILABLE = True
+except ImportError:
+    _scipy_norm = None
+    _SCIPY_AVAILABLE = False
+
+if TYPE_CHECKING:
+    from .models import Chain
+
+
+def column_proportion_test(chain: "Chain", alpha: float = 0.05) -> "Chain":
+    """Add significance markers (letters A/B/C…) to Chain Views.
+
+    Tests each column proportion against every other column using a
+    two-proportion z-test. When column j is significantly higher than
+    column i (at *alpha*), appends column i's letter to column j's
+    sig_flag for that row category.
+
+    Mutates *chain* in place and returns it.
+    """
+    keys = list(chain.views.keys())
+    n_cols = len(keys)
+    if n_cols < 2:
+        return chain
+
+    letters = list(string.ascii_uppercase)
+    col_labels = {key: letters[i] for i, key in enumerate(keys)}
+
+    # Collect per-column proportions and bases
+    col_data: dict[str, dict] = {}
+    for key, views in chain.views.items():
+        col_data[key] = {
+            "base": views[0].base if views else 0,
+            "pcts": {v.metric: (v.pct if v.pct is not None else 0.0) for v in views},
+        }
+
+    # For each row category, run all pairwise tests
+    all_metrics = {v.metric for views in chain.views.values() for v in views}
+    for metric in all_metrics:
+        for i, key_i in enumerate(keys):
+            for j, key_j in enumerate(keys):
+                if i >= j:
+                    continue
+                p1 = col_data[key_i]["pcts"].get(metric, 0.0)
+                p2 = col_data[key_j]["pcts"].get(metric, 0.0)
+                n1 = col_data[key_i]["base"]
+                n2 = col_data[key_j]["base"]
+                if n1 == 0 or n2 == 0:
+                    continue
+                p_pool = (p1 * n1 + p2 * n2) / (n1 + n2)
+                se = np.sqrt(p_pool * (1 - p_pool) * (1 / n1 + 1 / n2))
+                if se == 0:
+                    continue
+                z = abs(p1 - p2) / se
+                if _SCIPY_AVAILABLE:
+                    z_crit = _scipy_norm.ppf(1 - alpha / 2)
+                else:
+                    # fallback: hardcoded critical values for common alpha levels
+                    z_crit = {0.05: 1.96, 0.01: 2.576, 0.10: 1.645}.get(alpha, 1.96)
+                if z > z_crit:
+                    # Mark the higher column with the lower column's letter
+                    higher_key = key_i if p1 > p2 else key_j
+                    lower_label = col_labels[key_j if p1 > p2 else key_i]
+                    for v in chain.views[higher_key]:
+                        if v.metric == metric:
+                            v.sig_flag = (v.sig_flag or "") + lower_label
+                            break
+
+    return chain
+
+
+def chi_square_flag(chain: "Chain", alpha: float = 0.05) -> "Chain":
+    """Add an overall chi-square flag to *chain*.
+
+    Delegates to siege_utilities.data.cross_tabulation.chi_square_test.
+    Sets chain.chi_square_significant = True/False and chain.chi_square_p.
+
+    Mutates *chain* in place and returns it.
+    """
+    from ..data.cross_tabulation import chi_square_test
+    import pandas as pd
+
+    # Build count-based (not pct-based) contingency table for valid chi-square
+    records: dict = {}
+    for col_key, views in chain.views.items():
+        if col_key == chain.delta_column:
+            continue
+        for v in views:
+            if v.metric not in records:
+                records[v.metric] = {}
+            records[v.metric][col_key] = v.count
+
+    df = pd.DataFrame.from_dict(records, orient="index").fillna(0)
+    df.index.name = chain.row_var
+
+    if "Total" in df.columns:
+        df = df.drop(columns=["Total"])
+    if "Total" in df.index:
+        df = df.drop(index=["Total"])
+
+    if df.empty or df.shape[0] < 2 or df.shape[1] < 2:
+        chain.chi_square_significant = False  # type: ignore[attr-defined]
+        chain.chi_square_p = None             # type: ignore[attr-defined]
+        return chain
+
+    try:
+        result = chi_square_test(df)
+        chain.chi_square_significant = result.p_value < alpha  # type: ignore[attr-defined]
+        chain.chi_square_p = result.p_value                    # type: ignore[attr-defined]
+    except Exception:
+        chain.chi_square_significant = False  # type: ignore[attr-defined]
+        chain.chi_square_p = None             # type: ignore[attr-defined]
+
+    return chain

--- a/siege_utilities/survey/significance.py
+++ b/siege_utilities/survey/significance.py
@@ -132,8 +132,8 @@ def chi_square_flag(chain: "Chain", alpha: float = 0.05) -> "Chain":
         df = df.drop(index=["Total"])
 
     if df.empty or df.shape[0] < 2 or df.shape[1] < 2:
-        chain.chi_square_significant = False  # type: ignore[attr-defined]
-        chain.chi_square_p = None             # type: ignore[attr-defined]
+        chain.chi_square_significant = False
+        chain.chi_square_p = None
         return chain
 
     try:

--- a/siege_utilities/survey/weights.py
+++ b/siege_utilities/survey/weights.py
@@ -2,6 +2,10 @@
 RIM (raking) weighting wrapper around weightipy.
 
 Install: pip install siege-utilities[survey]
+
+weightipy's public API uses :func:`weightipy.scheme_from_dict` + \
+:func:`weightipy.weight_dataframe`; pass iteration / convergence parameters
+via the :class:`weightipy.internal.rim.Rim` constructor's ``rim_params`` dict.
 """
 
 from __future__ import annotations
@@ -18,65 +22,74 @@ class WeightingConvergenceError(RuntimeError):
 def apply_rim_weights(
     df: pd.DataFrame,
     targets: Dict[str, Dict[Any, float]],
+    *,
     weight_col: str = "weight",
     max_iterations: int = 1000,
     convergence: float = 1e-6,
+    verbose: bool = False,
 ) -> pd.DataFrame:
     """Apply RIM (raking / iterative proportional fitting) weights.
 
-    Adds *weight_col* to *df* in-place and returns *df*.
+    Adds *weight_col* to a copy of *df* and returns the result. Does NOT
+    mutate the input.
 
     Parameters
     ----------
-    df:
-        Respondent-level DataFrame.  Each row is one respondent.
-    targets:
-        Dict mapping column name → {category: proportion}.
-        Proportions per variable must sum to 1.0.
-        Example::
+    df : pd.DataFrame
+        Respondent-level DataFrame; each row is one respondent.
+    targets : dict
+        Mapping of column name → {category: proportion}. Proportions per
+        variable must sum to 1.0. Example::
 
             {
                 "age_group": {"18-34": 0.25, "35-54": 0.40, "55+": 0.35},
                 "gender":    {"M": 0.48, "F": 0.52},
             }
-    weight_col:
-        Name of the weight column to add/overwrite.
-    max_iterations:
-        Maximum raking iterations.
-    convergence:
-        Convergence threshold (L-inf norm on marginal differences).
+    weight_col : str, keyword-only, default ``"weight"``
+        Column name for the computed weight values.
+    max_iterations : int, keyword-only, default 1000
+        Upper bound on raking iterations.
+    convergence : float, keyword-only, default ``1e-6``
+        Convergence threshold (``convcrit`` in weightipy terms).
+    verbose : bool, keyword-only, default False
+        If True, weightipy prints per-iteration progress.
 
     Returns
     -------
-    df with *weight_col* added/updated.
+    pd.DataFrame
+        Copy of *df* with *weight_col* populated.
 
     Raises
     ------
+    ImportError
+        If weightipy is not installed.
     WeightingConvergenceError
         If weightipy fails to converge.
-    ImportError
-        If weightipy is not installed (pip install siege-utilities[survey]).
     """
     try:
-        from weightipy import rake
+        import weightipy as wp
     except ImportError as exc:
         raise ImportError(
             "weightipy is required for RIM weighting. "
             "Install it with: pip install siege-utilities[survey]"
         ) from exc
 
-    result = df.copy()
-    try:
-        weights = rake(
-            result,
-            targets=targets,
-            max_iterations=max_iterations,
-            convergence=convergence,
-        )
-    except Exception as exc:
-        raise WeightingConvergenceError(
-            f"RIM weighting failed to converge: {exc}"
-        ) from exc
+    # Map our convergence param to weightipy's Rim-class ``convcrit`` via
+    # the rim_params passthrough. See weightipy.internal.rim.Rim.__init__.
+    scheme = wp.scheme_from_dict(
+        targets,
+        rim_params={"max_iterations": max_iterations, "convcrit": convergence},
+    )
 
-    result[weight_col] = weights
-    return result
+    try:
+        return wp.weight_dataframe(
+            df.copy(),
+            scheme,
+            weight_column=weight_col,
+            verbose=verbose,
+        )
+    except (ValueError, RuntimeError) as exc:
+        raise WeightingConvergenceError(
+            f"RIM weighting failed (max_iterations={max_iterations}, "
+            f"convergence={convergence}): {exc}"
+        ) from exc

--- a/siege_utilities/survey/weights.py
+++ b/siege_utilities/survey/weights.py
@@ -1,0 +1,82 @@
+"""
+RIM (raking) weighting wrapper around weightipy.
+
+Install: pip install siege-utilities[survey]
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import pandas as pd
+
+
+class WeightingConvergenceError(RuntimeError):
+    """Raised when weightipy fails to converge within max_iterations."""
+
+
+def apply_rim_weights(
+    df: pd.DataFrame,
+    targets: Dict[str, Dict[Any, float]],
+    weight_col: str = "weight",
+    max_iterations: int = 1000,
+    convergence: float = 1e-6,
+) -> pd.DataFrame:
+    """Apply RIM (raking / iterative proportional fitting) weights.
+
+    Adds *weight_col* to *df* in-place and returns *df*.
+
+    Parameters
+    ----------
+    df:
+        Respondent-level DataFrame.  Each row is one respondent.
+    targets:
+        Dict mapping column name → {category: proportion}.
+        Proportions per variable must sum to 1.0.
+        Example::
+
+            {
+                "age_group": {"18-34": 0.25, "35-54": 0.40, "55+": 0.35},
+                "gender":    {"M": 0.48, "F": 0.52},
+            }
+    weight_col:
+        Name of the weight column to add/overwrite.
+    max_iterations:
+        Maximum raking iterations.
+    convergence:
+        Convergence threshold (L-inf norm on marginal differences).
+
+    Returns
+    -------
+    df with *weight_col* added/updated.
+
+    Raises
+    ------
+    WeightingConvergenceError
+        If weightipy fails to converge.
+    ImportError
+        If weightipy is not installed (pip install siege-utilities[survey]).
+    """
+    try:
+        from weightipy import rake
+    except ImportError as exc:
+        raise ImportError(
+            "weightipy is required for RIM weighting. "
+            "Install it with: pip install siege-utilities[survey]"
+        ) from exc
+
+    result = df.copy()
+    try:
+        weights = rake(
+            result,
+            targets=targets,
+            max_iterations=max_iterations,
+            convergence=convergence,
+        )
+    except Exception as exc:
+        raise WeightingConvergenceError(
+            f"RIM weighting failed to converge: {exc}"
+        ) from exc
+
+    result[weight_col] = weights
+    return result

--- a/siege_utilities/survey/weights.py
+++ b/siege_utilities/survey/weights.py
@@ -6,7 +6,7 @@ Install: pip install siege-utilities[survey]
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import pandas as pd
 

--- a/tests/test_survey_crosstab.py
+++ b/tests/test_survey_crosstab.py
@@ -1,0 +1,110 @@
+"""Tests for siege_utilities.survey.crosstab.build_chain (SAL-65)."""
+import pytest
+import pandas as pd
+from siege_utilities.survey.crosstab import build_chain
+from siege_utilities.reporting.pages.page_models import TableType
+
+
+@pytest.fixture
+def respondent_df():
+    return pd.DataFrame({
+        "party":   ["D", "D", "R", "R", "D", "I", "R", "I"],
+        "county":  ["Travis", "Travis", "Travis", "Harris", "Harris", "Harris", "Travis", "Harris"],
+        "value":   [1, 1, 1, 1, 1, 1, 1, 1],
+        "year":    [2020, 2022, 2020, 2022, 2020, 2022, 2022, 2020],
+        "support": [8, 7, 3, 4, 9, 6, 2, 5],
+    })
+
+
+class TestBuildChainSingleResponse:
+    def test_returns_chain(self, respondent_df):
+        from siege_utilities.survey.models import Chain
+        chain = build_chain(respondent_df, "party", ["county"],
+                            table_type=TableType.SINGLE_RESPONSE)
+        assert isinstance(chain, Chain)
+
+    def test_table_type_set(self, respondent_df):
+        chain = build_chain(respondent_df, "party", ["county"],
+                            table_type=TableType.SINGLE_RESPONSE)
+        assert chain.table_type == TableType.SINGLE_RESPONSE
+
+    def test_views_keyed_by_break(self, respondent_df):
+        chain = build_chain(respondent_df, "party", ["county"],
+                            table_type=TableType.SINGLE_RESPONSE)
+        assert any("county=" in k for k in chain.views)
+
+    def test_pcts_sum_to_one(self, respondent_df):
+        chain = build_chain(respondent_df, "party", ["county"],
+                            table_type=TableType.SINGLE_RESPONSE)
+        for views in chain.views.values():
+            total_pct = sum(v.pct for v in views if v.pct is not None)
+            assert total_pct == pytest.approx(1.0, abs=0.01)
+
+
+class TestBuildChainMultipleResponse:
+    def test_base_note_contains_multiple_responses(self, respondent_df):
+        chain = build_chain(respondent_df, "party", ["county"],
+                            table_type=TableType.MULTIPLE_RESPONSE)
+        assert "multiple responses" in chain.base_note.lower()
+
+    def test_base_note_contains_respondent_count(self, respondent_df):
+        chain = build_chain(respondent_df, "party", ["county"],
+                            table_type=TableType.MULTIPLE_RESPONSE)
+        assert "n=" in chain.base_note
+
+    def test_table_type_set(self, respondent_df):
+        chain = build_chain(respondent_df, "party", ["county"],
+                            table_type=TableType.MULTIPLE_RESPONSE)
+        assert chain.table_type == TableType.MULTIPLE_RESPONSE
+
+
+class TestBuildChainLongitudinal:
+    def test_delta_column_present(self, respondent_df):
+        chain = build_chain(respondent_df, "party", ["year"],
+                            table_type=TableType.LONGITUDINAL)
+        assert chain.delta_column is not None
+
+    def test_delta_column_in_views(self, respondent_df):
+        chain = build_chain(respondent_df, "party", ["year"],
+                            table_type=TableType.LONGITUDINAL)
+        assert chain.delta_column in chain.views
+
+    def test_two_time_periods_in_views(self, respondent_df):
+        chain = build_chain(respondent_df, "party", ["year"],
+                            table_type=TableType.LONGITUDINAL)
+        period_keys = [k for k in chain.views if k != chain.delta_column]
+        assert len(period_keys) == 2
+
+
+class TestBuildChainRanking:
+    def test_views_not_empty(self, respondent_df):
+        chain = build_chain(respondent_df, "party", ["county"],
+                            table_type=TableType.RANKING)
+        assert chain.views
+
+    def test_top_n_limits_rows(self, respondent_df):
+        chain = build_chain(respondent_df, "party", ["county"],
+                            table_type=TableType.RANKING, top_n=2)
+        for views in chain.views.values():
+            assert len(views) <= 2
+
+
+class TestBuildChainMeanScale:
+    def test_returns_chain(self, respondent_df):
+        chain = build_chain(respondent_df, "party", ["county"],
+                            metric="support",
+                            table_type=TableType.MEAN_SCALE)
+        assert chain.table_type == TableType.MEAN_SCALE
+
+
+class TestBuildChainGeoColumn:
+    def test_geo_column_attached(self, respondent_df):
+        chain = build_chain(respondent_df, "party", ["county"],
+                            table_type=TableType.CROSS_TAB,
+                            geo_column="county")
+        assert chain.geo_column == "county"
+
+    def test_no_geo_column_by_default(self, respondent_df):
+        chain = build_chain(respondent_df, "party", ["county"],
+                            table_type=TableType.CROSS_TAB)
+        assert chain.geo_column is None

--- a/tests/test_survey_models.py
+++ b/tests/test_survey_models.py
@@ -98,5 +98,6 @@ class TestStack:
     def test_add_cluster(self):
         stack = Stack(name="R")
         cluster = Cluster(name="C")
-        stack.add_cluster(cluster)
+        result = stack.add_cluster(cluster)
         assert len(stack.clusters) == 1
+        assert result is stack  # fluent return contract (symmetric with Cluster.add_chain)

--- a/tests/test_survey_models.py
+++ b/tests/test_survey_models.py
@@ -1,0 +1,102 @@
+"""Tests for siege_utilities.survey.models (SAL-65)."""
+import pytest
+import pandas as pd
+from siege_utilities.survey.models import View, Chain, Cluster, Stack, WeightScheme
+from siege_utilities.reporting.pages.page_models import TableType
+
+
+class TestView:
+    def test_construction(self):
+        v = View(metric="yes", base=100, count=60.0, pct=0.6)
+        assert v.metric == "yes"
+        assert v.pct == pytest.approx(0.6)
+
+    def test_default_sig_flag_none(self):
+        v = View(metric="no", base=100, count=40.0)
+        assert v.sig_flag is None
+
+
+class TestChain:
+    def _simple_chain(self):
+        views = {
+            "county=Travis": [
+                View(metric="Democrat", base=200, count=120.0, pct=0.6),
+                View(metric="Republican", base=200, count=80.0, pct=0.4),
+            ]
+        }
+        return Chain(
+            row_var="party",
+            break_vars=["county"],
+            views=views,
+            table_type=TableType.SINGLE_RESPONSE,
+        )
+
+    def test_to_dataframe_shape(self):
+        chain = self._simple_chain()
+        df = chain.to_dataframe()
+        assert isinstance(df, pd.DataFrame)
+        assert df.shape == (2, 1)
+
+    def test_to_dataframe_values_are_pct_times_100(self):
+        chain = self._simple_chain()
+        df = chain.to_dataframe()
+        col = df.iloc[:, 0]
+        assert col["Democrat"] == pytest.approx(60.0)
+        assert col["Republican"] == pytest.approx(40.0)
+
+    def test_empty_chain_returns_empty_df(self):
+        chain = Chain(row_var="x", break_vars=[], views={},
+                      table_type=TableType.CROSS_TAB)
+        assert chain.to_dataframe().empty
+
+    def test_geo_column_default_none(self):
+        chain = self._simple_chain()
+        assert chain.geo_column is None
+
+    def test_base_note_default_empty(self):
+        chain = self._simple_chain()
+        assert chain.base_note == ""
+
+
+class TestCluster:
+    def test_add_chain(self):
+        cluster = Cluster(name="Demographics")
+        chain = Chain(row_var="age", break_vars=["county"], views={},
+                      table_type=TableType.CROSS_TAB)
+        result = cluster.add_chain(chain)
+        assert result is cluster
+        assert len(cluster.chains) == 1
+
+    def test_empty_cluster(self):
+        cluster = Cluster(name="Empty")
+        assert cluster.chains == []
+
+
+class TestWeightScheme:
+    def test_valid_targets_validate_ok(self):
+        ws = WeightScheme(targets={
+            "age_group": {"18-34": 0.25, "35-54": 0.40, "55+": 0.35},
+        })
+        ws.validate()  # should not raise
+
+    def test_invalid_targets_raise(self):
+        ws = WeightScheme(targets={
+            "gender": {"M": 0.60, "F": 0.60},  # sums to 1.2
+        })
+        with pytest.raises(ValueError, match="sum to"):
+            ws.validate()
+
+
+class TestStack:
+    def test_all_chains(self):
+        c1 = Chain(row_var="q1", break_vars=[], views={}, table_type=TableType.SINGLE_RESPONSE)
+        c2 = Chain(row_var="q2", break_vars=[], views={}, table_type=TableType.RANKING)
+        cluster = Cluster(name="S1", chains=[c1, c2])
+        stack = Stack(name="My Report", clusters=[cluster])
+        assert len(stack.all_chains) == 2
+
+    def test_add_cluster(self):
+        stack = Stack(name="R")
+        cluster = Cluster(name="C")
+        stack.add_cluster(cluster)
+        assert len(stack.clusters) == 1

--- a/tests/test_survey_render.py
+++ b/tests/test_survey_render.py
@@ -1,5 +1,7 @@
 """Tests for siege_utilities.survey.render (SAL-65)."""
 import pandas as pd
+import pytest
+
 from siege_utilities.survey.models import Chain, View
 from siege_utilities.survey.render import chain_to_argument
 from siege_utilities.reporting.pages.page_models import Argument, TableType
@@ -81,3 +83,64 @@ class TestChainToArgumentWithGeo:
             map_figure=object(),  # any truthy value
         )
         assert arg.layout == "full_width"
+
+    def test_render_path_invokes_map_builder_and_sets_map_figure(self, monkeypatch):
+        """The render path must actually call _build_map and put the result on
+        the Argument — not just rely on layout logic. Monkeypatches _build_map
+        to return a sentinel, then asserts the sentinel reaches Argument.map_figure.
+        """
+        from siege_utilities.survey import render as render_mod
+        from siege_utilities.survey.models import Chain, View
+        from siege_utilities.reporting.pages.page_models import TableType
+
+        sentinel_fig = object()
+
+        def fake_build_map(chain):
+            assert chain.geo_column == chain.row_var, (
+                "render path must only invoke _build_map when "
+                "row_var and geo_column match (data integrity contract)"
+            )
+            return sentinel_fig
+
+        monkeypatch.setattr(render_mod, "_build_map", fake_build_map)
+
+        views = {
+            "year=2024": [
+                View(metric="TX", base=1000, count=500.0, pct=0.5),
+                View(metric="CA", base=1000, count=500.0, pct=0.5),
+            ]
+        }
+        chain = Chain(
+            row_var="state",
+            break_vars=["year"],
+            views=views,
+            table_type=TableType.CROSS_TAB,
+            geo_column="state",  # matches row_var
+        )
+        arg = render_mod.chain_to_argument(chain, headline="H", narrative="N")
+        assert arg.map_figure is sentinel_fig
+        assert arg.layout == "full_width"
+
+    def test_build_map_raises_on_geo_row_mismatch(self):
+        """RenderError when geo_column is set but row_var is something else —
+        would silently mislabel row categories (e.g. "Democrat") as geo features.
+        """
+        from siege_utilities.survey import render as render_mod
+        from siege_utilities.survey.models import Chain, View
+        from siege_utilities.reporting.pages.page_models import TableType
+
+        views = {
+            "state=TX": [
+                View(metric="Democrat", base=1000, count=400.0, pct=0.4),
+                View(metric="Republican", base=1000, count=600.0, pct=0.6),
+            ]
+        }
+        chain = Chain(
+            row_var="party",       # NOT geographic
+            break_vars=["state"],
+            views=views,
+            table_type=TableType.CROSS_TAB,
+            geo_column="state",    # mismatch
+        )
+        with pytest.raises(render_mod.RenderError, match="mislabeled as geo features"):
+            render_mod._build_map(chain)

--- a/tests/test_survey_render.py
+++ b/tests/test_survey_render.py
@@ -1,0 +1,84 @@
+"""Tests for siege_utilities.survey.render (SAL-65)."""
+import pytest
+import pandas as pd
+from siege_utilities.survey.models import Chain, View
+from siege_utilities.survey.render import chain_to_argument
+from siege_utilities.reporting.pages.page_models import Argument, TableType
+
+
+def _chain(table_type, geo_column=None):
+    views = {
+        "county=Travis": [
+            View(metric="D", base=200, count=120.0, pct=0.6),
+            View(metric="R", base=200, count=80.0, pct=0.4),
+        ]
+    }
+    return Chain(
+        row_var="party", break_vars=["county"],
+        views=views, table_type=table_type, geo_column=geo_column,
+    )
+
+
+class TestChainToArgument:
+    def test_returns_argument(self):
+        chain = _chain(TableType.SINGLE_RESPONSE)
+        arg = chain_to_argument(chain, headline="Party ID", narrative="Text")
+        assert isinstance(arg, Argument)
+
+    def test_headline_and_narrative_set(self):
+        chain = _chain(TableType.CROSS_TAB)
+        arg = chain_to_argument(chain, headline="H", narrative="N")
+        assert arg.headline == "H"
+        assert arg.narrative == "N"
+
+    def test_table_is_dataframe(self):
+        chain = _chain(TableType.SINGLE_RESPONSE)
+        arg = chain_to_argument(chain, headline="H", narrative="N")
+        assert isinstance(arg.table, pd.DataFrame)
+
+    def test_table_type_preserved(self):
+        for tt in TableType:
+            chain = _chain(tt)
+            arg = chain_to_argument(chain, headline="H", narrative="N")
+            assert arg.table_type == tt
+
+    def test_map_figure_none_without_geo_column(self):
+        chain = _chain(TableType.SINGLE_RESPONSE, geo_column=None)
+        arg = chain_to_argument(chain, headline="H", narrative="N")
+        assert arg.map_figure is None
+
+    def test_layout_side_by_side_without_map(self):
+        chain = _chain(TableType.SINGLE_RESPONSE, geo_column=None)
+        arg = chain_to_argument(chain, headline="H", narrative="N")
+        assert arg.layout == "side_by_side"
+
+    def test_tags_include_table_type_value(self):
+        chain = _chain(TableType.MULTIPLE_RESPONSE)
+        arg = chain_to_argument(chain, headline="H", narrative="N")
+        assert "multiple_response" in arg.tags
+
+    def test_base_note_from_multiple_response_chain(self):
+        from siege_utilities.survey.crosstab import build_chain
+        df = pd.DataFrame({
+            "party": ["D", "R", "D", "I"],
+            "county": ["T", "T", "H", "H"],
+            "value": [1, 1, 1, 1],
+        })
+        chain = build_chain(df, "party", ["county"],
+                            table_type=TableType.MULTIPLE_RESPONSE)
+        arg = chain_to_argument(chain, headline="H", narrative="N")
+        assert "multiple responses" in (arg.base_note or "").lower()
+
+
+class TestChainToArgumentWithGeo:
+    def test_layout_influenced_by_map_figure(self):
+        """If chain.geo_column is set and map_figure is generated, layout = full_width."""
+        # We can't guarantee the map builder succeeds without geo deps, but we can
+        # force-test the Argument auto-layout logic by injecting a map_figure.
+        from siege_utilities.reporting.pages.page_models import Argument, TableType
+        arg = Argument(
+            headline="H", narrative="N", table=pd.DataFrame(),
+            table_type=TableType.CROSS_TAB,
+            map_figure=object(),  # any truthy value
+        )
+        assert arg.layout == "full_width"

--- a/tests/test_survey_render.py
+++ b/tests/test_survey_render.py
@@ -1,5 +1,4 @@
 """Tests for siege_utilities.survey.render (SAL-65)."""
-import pytest
 import pandas as pd
 from siege_utilities.survey.models import Chain, View
 from siege_utilities.survey.render import chain_to_argument

--- a/tests/test_survey_significance.py
+++ b/tests/test_survey_significance.py
@@ -1,0 +1,82 @@
+"""Tests for siege_utilities.survey.significance (SAL-65)."""
+import pytest
+import pandas as pd
+from siege_utilities.survey.models import Chain, View
+from siege_utilities.survey.significance import column_proportion_test, chi_square_flag
+from siege_utilities.reporting.pages.page_models import TableType
+
+try:
+    import scipy  # noqa: F401
+    SCIPY_AVAILABLE = True
+except ImportError:
+    SCIPY_AVAILABLE = False
+
+requires_scipy = pytest.mark.skipif(not SCIPY_AVAILABLE, reason="scipy not installed")
+
+
+def _make_chain_two_cols():
+    """Chain with two clearly different column proportions for sig testing."""
+    views = {
+        "county=Travis": [
+            View(metric="D", base=1000, count=700.0, pct=0.70),
+            View(metric="R", base=1000, count=300.0, pct=0.30),
+        ],
+        "county=Harris": [
+            View(metric="D", base=1000, count=400.0, pct=0.40),
+            View(metric="R", base=1000, count=600.0, pct=0.60),
+        ],
+    }
+    return Chain(row_var="party", break_vars=["county"],
+                 views=views, table_type=TableType.CROSS_TAB)
+
+
+class TestColumnProportionTest:
+    @requires_scipy
+    def test_returns_chain(self):
+        chain = _make_chain_two_cols()
+        result = column_proportion_test(chain)
+        assert result is chain
+
+    @requires_scipy
+    def test_mutates_in_place(self):
+        chain = _make_chain_two_cols()
+        column_proportion_test(chain)
+        # At least one view should have a sig flag for such extreme difference
+        all_flags = [
+            v.sig_flag
+            for views in chain.views.values()
+            for v in views
+            if v.sig_flag
+        ]
+        assert len(all_flags) > 0
+
+    def test_single_column_no_change(self):
+        views = {"A": [View(metric="x", base=100, count=50.0, pct=0.5)]}
+        chain = Chain(row_var="q", break_vars=["g"], views=views,
+                      table_type=TableType.CROSS_TAB)
+        result = column_proportion_test(chain)
+        assert result is chain
+
+
+class TestChiSquareFlag:
+    def test_returns_chain(self):
+        chain = _make_chain_two_cols()
+        result = chi_square_flag(chain)
+        assert result is chain
+
+    def test_sets_chi_square_significant(self):
+        chain = _make_chain_two_cols()
+        chi_square_flag(chain)
+        assert hasattr(chain, "chi_square_significant")
+
+    @requires_scipy
+    def test_significant_for_strong_association(self):
+        chain = _make_chain_two_cols()
+        chi_square_flag(chain, alpha=0.05)
+        assert chain.chi_square_significant is True
+
+    def test_empty_chain_no_crash(self):
+        chain = Chain(row_var="q", break_vars=[], views={},
+                      table_type=TableType.CROSS_TAB)
+        chi_square_flag(chain)
+        assert chain.chi_square_significant is False

--- a/tests/test_survey_significance.py
+++ b/tests/test_survey_significance.py
@@ -1,6 +1,4 @@
 """Tests for siege_utilities.survey.significance (SAL-65)."""
-import sys
-
 import pytest
 from siege_utilities.survey.models import Chain, View
 from siege_utilities.survey.significance import (

--- a/tests/test_survey_significance.py
+++ b/tests/test_survey_significance.py
@@ -1,6 +1,5 @@
 """Tests for siege_utilities.survey.significance (SAL-65)."""
 import pytest
-import pandas as pd
 from siege_utilities.survey.models import Chain, View
 from siege_utilities.survey.significance import column_proportion_test, chi_square_flag
 from siege_utilities.reporting.pages.page_models import TableType

--- a/tests/test_survey_significance.py
+++ b/tests/test_survey_significance.py
@@ -1,7 +1,13 @@
 """Tests for siege_utilities.survey.significance (SAL-65)."""
+import sys
+
 import pytest
 from siege_utilities.survey.models import Chain, View
-from siege_utilities.survey.significance import column_proportion_test, chi_square_flag
+from siege_utilities.survey.significance import (
+    SignificanceError,
+    column_proportion_test,
+    chi_square_flag,
+)
 from siege_utilities.reporting.pages.page_models import TableType
 
 try:
@@ -55,6 +61,30 @@ class TestColumnProportionTest:
                       table_type=TableType.CROSS_TAB)
         result = column_proportion_test(chain)
         assert result is chain
+
+    def test_scipy_fallback_flags_extreme_difference(self, monkeypatch):
+        """When scipy is absent, the z=1.96 fallback still flags clear
+        differences — the fallback is *correct* for alpha=0.05, just limited.
+        """
+        monkeypatch.setattr(
+            "siege_utilities.survey.significance._SCIPY_AVAILABLE", False
+        )
+        chain = _make_chain_two_cols()
+        column_proportion_test(chain, alpha=0.05)
+        all_flags = [
+            v.sig_flag for vs in chain.views.values() for v in vs if v.sig_flag
+        ]
+        assert len(all_flags) > 0
+
+    def test_scipy_fallback_rejects_unknown_alpha(self, monkeypatch):
+        """alpha=0.02 has no exact fallback z-crit; must raise rather than
+        silently use 1.96."""
+        monkeypatch.setattr(
+            "siege_utilities.survey.significance._SCIPY_AVAILABLE", False
+        )
+        chain = _make_chain_two_cols()
+        with pytest.raises(SignificanceError, match="requires scipy"):
+            column_proportion_test(chain, alpha=0.02)
 
 
 class TestChiSquareFlag:

--- a/tests/test_survey_significance.py
+++ b/tests/test_survey_significance.py
@@ -72,10 +72,10 @@ class TestChiSquareFlag:
     def test_significant_for_strong_association(self):
         chain = _make_chain_two_cols()
         chi_square_flag(chain, alpha=0.05)
-        assert chain.chi_square_significant is True
+        assert bool(chain.chi_square_significant) is True
 
     def test_empty_chain_no_crash(self):
         chain = Chain(row_var="q", break_vars=[], views={},
                       table_type=TableType.CROSS_TAB)
         chi_square_flag(chain)
-        assert chain.chi_square_significant is False
+        assert bool(chain.chi_square_significant) is False

--- a/tests/test_survey_weights.py
+++ b/tests/test_survey_weights.py
@@ -16,7 +16,6 @@ class TestApplyRimWeightsImport:
         """When weightipy is absent, apply_rim_weights raises ImportError."""
         import sys
         monkeypatch.setitem(sys.modules, "weightipy", None)
-        from importlib import reload
         import siege_utilities.survey.weights as wmod
         with pytest.raises((ImportError, ModuleNotFoundError)):
             wmod.apply_rim_weights(

--- a/tests/test_survey_weights.py
+++ b/tests/test_survey_weights.py
@@ -34,6 +34,63 @@ class TestWeightingConvergenceError:
         assert "converge" in str(err)
 
 
+class TestApplyRimWeightsWithFakeWeightipy:
+    """Success-path coverage that does NOT require weightipy to be installed.
+
+    Runs even in the slim CI env. Catches API drift between our wrapper and
+    weightipy's public surface (scheme_from_dict + weight_dataframe signatures).
+    """
+
+    def test_wrapper_calls_documented_api(self, monkeypatch):
+        import sys
+        import types
+
+        calls = {}
+
+        fake_wp = types.ModuleType("weightipy")
+
+        def fake_scheme_from_dict(distributions, rim_params=None, name=None):
+            calls["scheme_from_dict"] = {
+                "distributions": distributions,
+                "rim_params": rim_params,
+                "name": name,
+            }
+            return {"_fake_scheme": True, "rim_params": rim_params}
+
+        def fake_weight_dataframe(df, scheme, weight_column="weights", verbose=False):
+            calls["weight_dataframe"] = {
+                "df_shape": df.shape,
+                "scheme": scheme,
+                "weight_column": weight_column,
+                "verbose": verbose,
+            }
+            out = df.copy()
+            out[weight_column] = [1.0] * len(out)
+            return out
+
+        fake_wp.scheme_from_dict = fake_scheme_from_dict
+        fake_wp.weight_dataframe = fake_weight_dataframe
+        monkeypatch.setitem(sys.modules, "weightipy", fake_wp)
+
+        from siege_utilities.survey.weights import apply_rim_weights
+        df = pd.DataFrame({"age": ["18-34", "35+"], "gender": ["M", "F"]})
+        result = apply_rim_weights(
+            df,
+            targets={"age": {"18-34": 0.5, "35+": 0.5}, "gender": {"M": 0.5, "F": 0.5}},
+            weight_col="w",
+            max_iterations=42,
+            convergence=1e-8,
+        )
+
+        assert "w" in result.columns
+        assert calls["scheme_from_dict"]["rim_params"] == {
+            "max_iterations": 42,
+            "convcrit": 1e-8,
+        }
+        assert calls["weight_dataframe"]["weight_column"] == "w"
+        assert calls["weight_dataframe"]["df_shape"] == (2, 2)
+
+
 @pytest.mark.skipif(not WEIGHTIPY_AVAILABLE, reason="weightipy not installed")
 class TestApplyRimWeightsWithWeightipy:
     def _sample_df(self):

--- a/tests/test_survey_weights.py
+++ b/tests/test_survey_weights.py
@@ -1,0 +1,82 @@
+"""Tests for siege_utilities.survey.weights (SAL-65)."""
+import pytest
+import pandas as pd
+
+try:
+    import weightipy  # noqa: F401
+    WEIGHTIPY_AVAILABLE = True
+except ImportError:
+    WEIGHTIPY_AVAILABLE = False
+
+from siege_utilities.survey.weights import WeightingConvergenceError
+
+
+class TestApplyRimWeightsImport:
+    def test_import_error_without_weightipy(self, monkeypatch):
+        """When weightipy is absent, apply_rim_weights raises ImportError."""
+        import sys
+        monkeypatch.setitem(sys.modules, "weightipy", None)
+        from importlib import reload
+        import siege_utilities.survey.weights as wmod
+        with pytest.raises((ImportError, ModuleNotFoundError)):
+            wmod.apply_rim_weights(
+                pd.DataFrame({"age": ["18-34"], "gender": ["M"]}),
+                targets={"age": {"18-34": 1.0}, "gender": {"M": 1.0}},
+            )
+
+
+class TestWeightingConvergenceError:
+    def test_is_runtime_error_subclass(self):
+        err = WeightingConvergenceError("test")
+        assert isinstance(err, RuntimeError)
+
+    def test_message(self):
+        err = WeightingConvergenceError("did not converge")
+        assert "converge" in str(err)
+
+
+@pytest.mark.skipif(not WEIGHTIPY_AVAILABLE, reason="weightipy not installed")
+class TestApplyRimWeightsWithWeightipy:
+    def _sample_df(self):
+        return pd.DataFrame({
+            "age_group": ["18-34", "18-34", "35-54", "55+", "55+", "35-54"],
+            "gender":    ["M", "F", "M", "F", "M", "F"],
+        })
+
+    def test_weight_col_added(self):
+        from siege_utilities.survey.weights import apply_rim_weights
+        df = self._sample_df()
+        result = apply_rim_weights(
+            df,
+            targets={
+                "age_group": {"18-34": 0.30, "35-54": 0.40, "55+": 0.30},
+                "gender":    {"M": 0.50, "F": 0.50},
+            },
+        )
+        assert "weight" in result.columns
+        assert len(result) == len(df)
+
+    def test_custom_weight_col_name(self):
+        from siege_utilities.survey.weights import apply_rim_weights
+        df = self._sample_df()
+        result = apply_rim_weights(
+            df,
+            targets={
+                "age_group": {"18-34": 0.30, "35-54": 0.40, "55+": 0.30},
+                "gender":    {"M": 0.50, "F": 0.50},
+            },
+            weight_col="w",
+        )
+        assert "w" in result.columns
+
+    def test_weights_are_positive(self):
+        from siege_utilities.survey.weights import apply_rim_weights
+        df = self._sample_df()
+        result = apply_rim_weights(
+            df,
+            targets={
+                "age_group": {"18-34": 0.30, "35-54": 0.40, "55+": 0.30},
+                "gender":    {"M": 0.50, "F": 0.50},
+            },
+        )
+        assert (result["weight"] > 0).all()


### PR DESCRIPTION
New `siege_utilities/survey/` module with Stack/Cluster/Chain/View hierarchy, `build_chain()` for all 7 TableTypes, RIM weighting via weightipy, column-proportion z-test significance testing, and `chain_to_argument()` renderer. Adds `weightipy>=0.4.0` to `[survey]` optional extra.

Linear: SAL-65
Depends on: SAL-64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launched comprehensive survey analysis module with cross-tabulations, rankings, longitudinal analysis, and RIM (raking) weighting
  * Added statistical significance testing for survey data comparisons
  * Enhanced report generation with customizable title pages, dynamic table of contents, and flexible page layouts
  * Introduced structured data models for organizing survey report components

* **Chores**
  * Added optional weightipy dependency for advanced survey weighting capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->