### PR TITLE
feat: SAL-66 Extend google_slides.py for Argument-level operations

### DIFF
--- a/siege_utilities/analytics/google_slides.py
+++ b/siege_utilities/analytics/google_slides.py
@@ -287,3 +287,162 @@ def batch_update(
         The API response dict.
     """
     return client.batch_update_presentation(presentation_id, requests)
+
+
+# ---------------------------------------------------------------------------
+# Argument-level operations (SAL-66)
+# ---------------------------------------------------------------------------
+
+# Slide dimensions (points): Google Slides default 10in × 5.625in
+_SLIDE_W = 720
+_SLIDE_H = 405
+
+# Layout configs: (title_box, narrative_box, figure_box)
+# Each box is (left, top, width, height) in points
+_LAYOUTS = {
+    "full_width": {
+        "title":     (36,  20,  648,  44),
+        "narrative": (36,  72,  648,  80),
+        "figure":    (36, 162,  648, 220),
+    },
+    "side_by_side": {
+        "title":     (36,  20,  648,  44),
+        "narrative": (36,  72,  304, 300),
+        "figure":    (358, 72,  326, 300),
+    },
+}
+
+
+def upload_figure_to_drive(
+    client,
+    figure,
+    filename: str,
+    folder_id: Optional[str] = None,
+) -> str:
+    """Save a matplotlib Figure to a temp PNG, upload to Google Drive, return URL.
+
+    Args:
+        client: Authenticated GoogleWorkspaceClient.
+        figure: matplotlib Figure object.
+        filename: Name for the uploaded file (without extension).
+        folder_id: Optional Drive folder ID.
+
+    Returns:
+        Public URL string for the uploaded image (suitable for insert_image).
+    """
+    import tempfile
+    import os
+
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+        tmp_path = tmp.name
+
+    try:
+        figure.savefig(tmp_path, format="png", dpi=150, bbox_inches="tight")
+        file_id = client.upload_file(
+            local_path=tmp_path,
+            name=f"{filename}.png",
+            mime_type="image/png",
+            folder_id=folder_id,
+        )
+        url = client.public_url(file_id)
+        log.info("Uploaded figure %r → Drive %s", filename, file_id)
+        return url
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+
+def create_argument_slide(
+    client,
+    presentation_id: str,
+    argument,
+    slide_index: Optional[int] = None,
+) -> str:
+    """Add one slide for an Argument.
+
+    Layout is derived from argument.layout:
+      "full_width"   → title / narrative / figure stacked vertically
+      "side_by_side" → title top; narrative left, figure right
+
+    Args:
+        client: Authenticated GoogleWorkspaceClient.
+        presentation_id: Target presentation ID.
+        argument: Argument dataclass instance.
+        slide_index: Insertion position. None → append at end.
+
+    Returns:
+        Slide object ID.
+    """
+    layout_key = argument.layout if argument.layout in _LAYOUTS else "side_by_side"
+    layout = _LAYOUTS[layout_key]
+
+    # Add blank slide
+    slide_id = add_blank_slide(client, presentation_id, insertion_index=slide_index)
+
+    # Headline text box
+    tl, tt, tw, th = layout["title"]
+    create_textbox(client, presentation_id, slide_id,
+                   argument.headline, left=tl, top=tt, width=tw, height=th)
+
+    # Narrative text box (includes base_note if present)
+    body_text = argument.narrative
+    if argument.base_note:
+        body_text = f"{body_text}\n\n{argument.base_note}"
+    if argument.source_note:
+        body_text = f"{body_text}\n{argument.source_note}"
+    nl, nt, nw, nh = layout["narrative"]
+    create_textbox(client, presentation_id, slide_id,
+                   body_text, left=nl, top=nt, width=nw, height=nh)
+
+    # Figure (chart or map)
+    fig = argument.map_figure if layout_key == "full_width" and argument.map_figure else argument.chart
+    if fig is not None:
+        fl, ft, fw, fh = layout["figure"]
+        fig_name = f"fig_{slide_id}"
+        try:
+            img_url = upload_figure_to_drive(client, fig, fig_name)
+            insert_image(client, presentation_id, slide_id, img_url,
+                         left=fl, top=ft, width=fw, height=fh)
+        except Exception as exc:
+            log.warning("Could not upload figure for slide %s: %s", slide_id, exc)
+
+    return slide_id
+
+
+def create_report_from_arguments(
+    client,
+    title: str,
+    arguments: List,
+    folder_id: Optional[str] = None,
+    theme_presentation_id: Optional[str] = None,
+) -> str:
+    """Create a complete presentation from a list of Arguments.
+
+    Args:
+        client: Authenticated GoogleWorkspaceClient.
+        title: Presentation title.
+        arguments: List of Argument dataclass instances (one slide each).
+        folder_id: Optional Drive folder to place the presentation in.
+        theme_presentation_id: If given, copies this presentation first
+            (preserves master slides / theme).
+
+    Returns:
+        Presentation ID of the newly created report.
+    """
+    if theme_presentation_id:
+        pres_id = copy_presentation(client, theme_presentation_id, title=title)
+        if folder_id:
+            client.move_to_folder(pres_id, folder_id)
+    else:
+        pres_id = create_presentation(client, title, folder_id=folder_id)
+
+    for i, argument in enumerate(arguments):
+        try:
+            create_argument_slide(client, pres_id, argument, slide_index=i)
+        except Exception as exc:
+            log.error("Failed to create slide %d for argument %r: %s",
+                      i, argument.headline, exc)
+
+    log.info("Created report %r with %d slides → %s",
+             title, len(arguments), client.presentation_url(pres_id))
+    return pres_id

--- a/tests/test_google_slides_argument.py
+++ b/tests/test_google_slides_argument.py
@@ -6,9 +6,7 @@ All tests use a mocked GoogleWorkspaceClient — no live API calls.
 """
 
 import os
-import tempfile
-import uuid
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
@@ -108,7 +106,6 @@ class TestUploadFigureToDrive:
 
     def test_temp_file_cleaned_up(self, mock_client):
         fig, ax = plt.subplots()
-        original_upload = mock_client.upload_file
 
         captured_paths = []
 

--- a/tests/test_google_slides_argument.py
+++ b/tests/test_google_slides_argument.py
@@ -1,0 +1,238 @@
+"""
+Tests for upload_figure_to_drive, create_argument_slide,
+and create_report_from_arguments in google_slides.py (SAL-66).
+
+All tests use a mocked GoogleWorkspaceClient — no live API calls.
+"""
+
+import os
+import tempfile
+import uuid
+from unittest.mock import MagicMock, call, patch
+
+import pandas as pd
+import pytest
+
+from siege_utilities.analytics.google_slides import (
+    create_argument_slide,
+    create_report_from_arguments,
+    upload_figure_to_drive,
+)
+from siege_utilities.reporting.pages.page_models import Argument, TableType
+
+try:
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    MATPLOTLIB_AVAILABLE = True
+except ImportError:
+    MATPLOTLIB_AVAILABLE = False
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_client():
+    client = MagicMock()
+    # slides_service chain
+    slides_svc = MagicMock()
+    client.slides_service.return_value = slides_svc
+    presentations = MagicMock()
+    slides_svc.presentations.return_value = presentations
+    presentations.create.return_value.execute.return_value = {
+        "presentationId": "pres_abc123"
+    }
+
+    # batch_update_presentation returns a response dict
+    client.batch_update_presentation.return_value = {"replies": []}
+
+    # Drive helpers
+    client.copy_file.return_value = "pres_copy_xyz"
+    client.move_to_folder.return_value = None
+    client.upload_file.return_value = "file_img_001"
+    client.public_url.side_effect = lambda fid: f"https://drive.google.com/file/{fid}"
+    client.presentation_url.side_effect = lambda pid: f"https://slides.google.com/{pid}"
+
+    return client
+
+
+@pytest.fixture
+def simple_argument():
+    df = pd.DataFrame({"category": ["D", "R"], "value": [60, 40]})
+    return Argument(
+        headline="Party ID",
+        narrative="Democrats lead by 20 points.",
+        table=df,
+        table_type=TableType.SINGLE_RESPONSE,
+    )
+
+
+@pytest.fixture
+def argument_with_map():
+    df = pd.DataFrame({"category": ["D", "R"], "value": [60, 40]})
+    mock_fig = MagicMock()
+    mock_fig.savefig = MagicMock()
+    return Argument(
+        headline="Geographic Party Split",
+        narrative="Strong metro concentration.",
+        table=df,
+        table_type=TableType.CROSS_TAB,
+        map_figure=mock_fig,
+    )
+
+
+# ---------------------------------------------------------------------------
+# upload_figure_to_drive
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not MATPLOTLIB_AVAILABLE, reason="matplotlib not installed")
+class TestUploadFigureToDrive:
+    def test_calls_savefig_and_upload(self, mock_client):
+        fig, ax = plt.subplots()
+        ax.bar(["A", "B"], [1, 2])
+        url = upload_figure_to_drive(mock_client, fig, "test_fig")
+        mock_client.upload_file.assert_called_once()
+        assert "test_fig.png" in mock_client.upload_file.call_args[1].get(
+            "name", mock_client.upload_file.call_args[0][1] if len(mock_client.upload_file.call_args[0]) > 1 else ""
+        ) or "test_fig.png" in str(mock_client.upload_file.call_args)
+        assert "drive.google.com" in url
+        plt.close(fig)
+
+    def test_returns_public_url(self, mock_client):
+        fig, ax = plt.subplots()
+        url = upload_figure_to_drive(mock_client, fig, "my_chart")
+        assert url.startswith("https://")
+        plt.close(fig)
+
+    def test_temp_file_cleaned_up(self, mock_client):
+        fig, ax = plt.subplots()
+        original_upload = mock_client.upload_file
+
+        captured_paths = []
+
+        def capture_upload(**kwargs):
+            path = kwargs.get("local_path") or (captured_paths.append(None) or "file")
+            if path:
+                captured_paths.append(path)
+            return "file_id_123"
+
+        mock_client.upload_file.side_effect = lambda **kw: (
+            captured_paths.append(kw.get("local_path")) or "file_id_123"
+        )
+
+        upload_figure_to_drive(mock_client, fig, "cleanup_test")
+
+        for path in captured_paths:
+            if path:
+                assert not os.path.exists(path), f"Temp file {path} not cleaned up"
+        plt.close(fig)
+
+    def test_with_folder_id(self, mock_client):
+        fig, ax = plt.subplots()
+        upload_figure_to_drive(mock_client, fig, "fig", folder_id="folder_xyz")
+        call_kwargs = mock_client.upload_file.call_args
+        assert "folder_xyz" in str(call_kwargs)
+        plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# create_argument_slide
+# ---------------------------------------------------------------------------
+
+class TestCreateArgumentSlide:
+    def test_returns_slide_id_string(self, mock_client, simple_argument):
+        slide_id = create_argument_slide(mock_client, "pres_123", simple_argument)
+        assert isinstance(slide_id, str)
+        assert len(slide_id) > 0
+
+    def test_batch_update_called(self, mock_client, simple_argument):
+        create_argument_slide(mock_client, "pres_123", simple_argument)
+        assert mock_client.batch_update_presentation.called
+
+    def test_headline_in_batch_requests(self, mock_client, simple_argument):
+        create_argument_slide(mock_client, "pres_123", simple_argument)
+        all_calls = mock_client.batch_update_presentation.call_args_list
+        all_text = str(all_calls)
+        assert simple_argument.headline in all_text
+
+    def test_narrative_in_batch_requests(self, mock_client, simple_argument):
+        create_argument_slide(mock_client, "pres_123", simple_argument)
+        all_text = str(mock_client.batch_update_presentation.call_args_list)
+        assert simple_argument.narrative in all_text
+
+    def test_side_by_side_layout_used(self, mock_client, simple_argument):
+        assert simple_argument.layout == "side_by_side"
+        slide_id = create_argument_slide(mock_client, "pres_123", simple_argument)
+        assert slide_id  # no exception means layout logic ran
+
+    def test_full_width_layout_used(self, mock_client, argument_with_map):
+        assert argument_with_map.layout == "full_width"
+        slide_id = create_argument_slide(mock_client, "pres_123", argument_with_map)
+        assert slide_id
+
+    def test_base_note_included_if_present(self, mock_client):
+        df = pd.DataFrame()
+        arg = Argument(
+            headline="MR Table", narrative="N",
+            table=df, table_type=TableType.MULTIPLE_RESPONSE,
+            base_note="n=342; multiple responses permitted",
+        )
+        create_argument_slide(mock_client, "pres_123", arg)
+        all_text = str(mock_client.batch_update_presentation.call_args_list)
+        assert "multiple responses" in all_text
+
+    def test_insertion_index_passed_to_create_slide(self, mock_client, simple_argument):
+        create_argument_slide(mock_client, "pres_123", simple_argument, slide_index=3)
+        all_requests = str(mock_client.batch_update_presentation.call_args_list)
+        assert "insertionIndex" in all_requests or "3" in all_requests
+
+
+# ---------------------------------------------------------------------------
+# create_report_from_arguments
+# ---------------------------------------------------------------------------
+
+class TestCreateReportFromArguments:
+    def test_returns_presentation_id(self, mock_client, simple_argument):
+        pres_id = create_report_from_arguments(
+            mock_client, "Test Report", [simple_argument]
+        )
+        assert isinstance(pres_id, str)
+
+    def test_creates_presentation(self, mock_client, simple_argument):
+        create_report_from_arguments(mock_client, "My Report", [simple_argument])
+        mock_client.slides_service().presentations().create.assert_called()
+
+    def test_one_slide_per_argument(self, mock_client):
+        args = [
+            Argument(headline=f"Q{i}", narrative="N", table=pd.DataFrame(),
+                     table_type=TableType.SINGLE_RESPONSE)
+            for i in range(3)
+        ]
+        create_report_from_arguments(mock_client, "Multi-Arg", args)
+        # Each argument generates at least one batch_update call (for createSlide)
+        # 3 args × at least 1 call each = at least 3 calls
+        assert mock_client.batch_update_presentation.call_count >= 3
+
+    def test_uses_theme_copy_if_provided(self, mock_client, simple_argument):
+        create_report_from_arguments(
+            mock_client, "Themed Report", [simple_argument],
+            theme_presentation_id="theme_pres_id",
+        )
+        mock_client.copy_file.assert_called_once_with("theme_pres_id", "Themed Report")
+
+    def test_no_copy_without_theme(self, mock_client, simple_argument):
+        create_report_from_arguments(mock_client, "Plain Report", [simple_argument])
+        mock_client.copy_file.assert_not_called()
+
+    def test_moves_to_folder_if_provided(self, mock_client, simple_argument):
+        create_report_from_arguments(
+            mock_client, "Folder Report", [simple_argument],
+            folder_id="folder_abc",
+        )
+        mock_client.move_to_folder.assert_called()
+
+    def test_empty_arguments_list(self, mock_client):
+        pres_id = create_report_from_arguments(mock_client, "Empty", [])
+        assert pres_id  # presentation still created, just no slides


### PR DESCRIPTION
Adds `upload_figure_to_drive()`, `create_argument_slide()` (auto layout: full-width when map present, side-by-side otherwise), and `create_report_from_arguments()` with optional theme copy to `analytics/google_slides.py`.

Linear: SAL-66
Depends on: SAL-65