### PR TITLE
docs(ELE-2416): intent discovery — per-module purpose + divergence catalog

### DIFF
--- a/docs/INTENT.md
+++ b/docs/INTENT.md
@@ -15,24 +15,24 @@ Status column: **Aligned** (behavior matches intent), **Divergent** (discrepancy
 | Module | Purpose | Status | Planned change |
 |---|---|---|---|
 | `admin/` | Manage profile-directory layout + migrations | Aligned | — |
-| `analytics/` | Third-party connectors (GA, Facebook, Snowflake, Data.world, Google Workspace) | Aligned | D1 wrapper rename (ELE-2427) |
+| `analytics/` | Third-party connectors (GA, Facebook, Snowflake, Data.world, Google Workspace) | Aligned | D1 wrapper rename (ELE-2442) |
 | `conf/` | Foundational settings singleton + hard-coded defaults | Aligned | — |
 | `config/` | Re-exports `conf.settings` + canonical constants (census, FIPS, credentials, pydantic models) | Aligned | — |
 | `configs/` | On-disk config data (palettes, branding templates); not a Python package | Aligned | — |
 | `core/` | Foundational utilities (logging, string, SQL safety); dependency root | Aligned | — |
-| `data/` | Sample datasets + engine-agnostic DataFrame ops + RDH client | **Divergent** | Aggressive split by nature (ELE-2422); RDH moves to `geo/providers/` (ELE-2423) |
-| `databricks/` | Databricks + LakeBase clients, Spark↔pandas bridges | Aligned | Motivation docstring added (ELE-2427) — kept separate from `distributed/` because Azure Databricks lacks Sedona + C-libs |
+| `data/` | Sample datasets + engine-agnostic DataFrame ops + RDH client | **Divergent** | Aggressive split by nature (ELE-2437); RDH moves to `geo/providers/` (ELE-2438) |
+| `databricks/` | Databricks + LakeBase clients, Spark↔pandas bridges | Aligned | Motivation docstring added (ELE-2442) — kept separate from `distributed/` because Azure Databricks lacks Sedona + C-libs |
 | `development/` | Meta tooling (architecture diagrams, structure analysis) | Meta | — |
 | `distributed/` | PySpark + HDFS utilities; re-exports `pyspark.sql.functions` names | Aligned | — |
 | `examples/` | Standalone demo `.py` scripts | Meta | Consolidating with `notebooks/` in ELE-2421 |
 | `exceptions.py` | Unified exception hierarchy (`SiegeError`); `OnErrorStrategy`; `handle_error()` | Aligned | — |
 | `files/` | Path manipulation, file operations, remote download, hashing | Aligned | — |
-| `geo/` | Geospatial data access, boundary providers, geocoding, CRS, Django models | Aligned | External spatial sources consolidate under `geo/providers/` (ELE-2423); silent-swallow sweep under ELE-2420 |
+| `geo/` | Geospatial data access, boundary providers, geocoding, CRS, Django models | Aligned | External spatial sources consolidate under `geo/providers/` (ELE-2438); silent-swallow sweep under ELE-2420 |
 | `git/` | Branch/commit helpers | Aligned | — |
 | `hygiene/` | Maintenance tooling (docstring generation, PyPI release flow) | Meta | — |
-| `reporting/` | PDF/PowerPoint generation, chart types, client branding, page templates | **Divergent** | `reporting/analytics/` subdirectory deleted (ELE-2424); `analytics_reports.py` promoted one level; new `wave_charts.py` lands with ELE-2425 |
+| `reporting/` | PDF/PowerPoint generation, chart types, client branding, page templates | **Divergent** | `reporting/analytics/` subdirectory deleted (ELE-2439); `analytics_reports.py` promoted one level; new `wave_charts.py` lands with ELE-2440 |
 | `runtime.py` | Runtime environment detection + guards | Aligned | — |
-| `survey/` | Survey pipeline (Chain, weights, render, significance) | **Divergent** | `Chain.to_argument()` method removed (ELE-2426); new `Wave`/`WaveSet` subsystem (ELE-2425) |
+| `survey/` | Survey pipeline (Chain, weights, render, significance) | **Divergent** | `Chain.to_argument()` method removed (ELE-2441); new `Wave`/`WaveSet` subsystem (ELE-2440) |
 | `testing/` | Test-only fixtures and helpers | Meta | — |
 
 ---
@@ -43,13 +43,13 @@ All divergences carry a planned resolution and a target sub-issue.
 
 | ID | Where | Decision | Target |
 |---|---|---|---|
-| D1 | `create_ga_connector_from_1password` wrapper name | Rename — auth-mechanism shouldn't leak into analytics API surface | ELE-2427 |
-| D2 | `data/` bundles multiple natures | Aggressive split: `data/statistics/`, `reference/`, top-level `engines/` | ELE-2422 |
-| D3 | External spatial sources scattered across `geo/` | Consolidate under `geo/providers/` (structural moves only; interface unification is a later epic) | ELE-2423 |
-| D4 | `databricks/` vs `distributed/` | Keep separate. Document in `__init__.py` that Azure Databricks lacks Sedona + C-libs — separation is load-bearing | ELE-2427 |
-| D7 | `reporting/analytics/polling_analyzer` | Deprecate `PollingAnalyzer`; extract longitudinal/change-detection to `data/statistics/`; delete `reporting/analytics/` subdirectory; add survey `Wave`/`WaveSet` | ELE-2424 + ELE-2425 |
-| D8 | `Chain.to_argument()` method vs `chain_to_argument()` function | Delete the method; function is sole entry point. Chain stays pure data | ELE-2426 |
-| D9 | `chart_generator` / `map_generator` kwargs ignored on `chain_to_argument` | Honor them (minimal ceremony — duck type, no Protocol yet). Drop from `ChartTypeRegistry.create_chart` (internal dispatch layer) | ELE-2426 |
+| D1 | `create_ga_connector_from_1password` wrapper name | Rename — auth-mechanism shouldn't leak into analytics API surface | ELE-2442 |
+| D2 | `data/` bundles multiple natures | Aggressive split: `data/statistics/`, `reference/`, top-level `engines/` | ELE-2437 |
+| D3 | External spatial sources scattered across `geo/` | Consolidate under `geo/providers/` (structural moves only; interface unification is a later epic) | ELE-2438 |
+| D4 | `databricks/` vs `distributed/` | Keep separate. Document in `__init__.py` that Azure Databricks lacks Sedona + C-libs — separation is load-bearing | ELE-2442 |
+| D7 | `reporting/analytics/polling_analyzer` | Deprecate `PollingAnalyzer`; extract longitudinal/change-detection to `data/statistics/`; delete `reporting/analytics/` subdirectory; add survey `Wave`/`WaveSet` | ELE-2439 + ELE-2440 |
+| D8 | `Chain.to_argument()` method vs `chain_to_argument()` function | Delete the method; function is sole entry point. Chain stays pure data | ELE-2441 |
+| D9 | `chart_generator` / `map_generator` kwargs ignored on `chain_to_argument` | Honor them (minimal ceremony — duck type, no Protocol yet). Drop from `ChartTypeRegistry.create_chart` (internal dispatch layer) | ELE-2441 |
 
 *Closed, no action:*
 - **D5** (`hdfs_legacy/`) — file was already removed; only stale `.pyc` remained.

--- a/docs/INTENT.md
+++ b/docs/INTENT.md
@@ -1,155 +1,66 @@
 # siege_utilities — Intent
 
-Per-module purpose statements. Source: each module's `__init__.py` docstring, cross-referenced with the first substantive commit that introduced the module. Written as part of **ELE-2416** (audit sub-issue 1/6).
+**Goal:** one-line purpose for every top-level module. The definitive answer to "what is this for?" Divergences between this file and actual behavior should be reconciled by changing one or the other — not left to drift.
 
-This file is the definitive answer to "what is this module for?" Any future behavior divergence from what's written here should be reconciled either by updating the behavior or by updating this file — not by letting them drift.
+**Scope:** ELE-2416 (audit sub-issue 1/6). Snapshot date: 2026-04-22.
 
-## Top-level modules
+**Source:** each module's `__init__.py` docstring, cross-referenced with the first substantive commit that introduced the module.
 
-### `siege_utilities/admin/`
+---
 
-**Purpose:** library administration. Manage the on-disk location of user / client profile directories (where credentials and per-profile settings live) and perform migrations between versions of that layout. Re-exports `profile_manager` functions at package level.
+## Module table
 
-**Status (2026-04-22):** aligned with stated intent. Small surface area.
+Status column: **Aligned** (behavior matches intent), **Divergent** (discrepancy with a planned resolution), **Meta** (non-user-facing: docs, examples, dev tools).
 
-### `siege_utilities/analytics/`
-
-**Purpose:** external analytics integrations. Connectors for Google Analytics (read), Facebook Business, Snowflake, Data.world, plus Google Workspace write APIs (Sheets, Docs, Slides). Lazy-loaded via PEP 562 `__getattr__` so importing the package doesn't pull every third-party SDK.
-
-**Status:** aligned. Google Slides writer now includes the `create_argument_slide` / `create_report_from_arguments` public API added in PR #392.
-
-### `siege_utilities/conf/`
-
-**Purpose:** foundational settings singleton and hard-coded defaults. Sits under `config/` and is imported by it; callers should prefer `siege_utilities.config.settings` rather than reaching into `conf`.
-
-**Status:** aligned. Intentionally small (`defaults.py` + `__init__.py`).
-
-### `siege_utilities/config/`
-
-**Purpose:** centralized configuration and constants. Re-exports `conf.settings` for discoverability, plus library metadata (`LIBRARY_NAME`, `LIBRARY_VERSION`, …), canonical geographic level names (`CANONICAL_GEOGRAPHIC_LEVELS`), and per-subject constant modules (census, FIPS, database connections, credentials, pydantic models).
-
-**Status:** aligned. **Divergence candidate:** `credential_manager.py` contains 1Password integration that overlaps with `analytics/google_analytics.py::create_ga_connector_from_1password` — intended coupling? Follow-up to confirm.
-
-### `siege_utilities/configs/` (data directory — not a Python package)
-
-**Purpose:** on-disk config files shipped with the library — e.g. default color palettes, client-branding templates. Populated at install time; callers should not import from it, only read files.
-
-**Status:** aligned (no Python, no API surface).
-
-### `siege_utilities/core/`
-
-**Purpose:** foundational utilities that every other module may import. Logging setup (`log_info` / `log_warning` / `log_error` / `log_debug` family), string manipulation, SQL safety helpers. Lazy-loaded.
-
-**Status:** aligned. Dependency root — nothing in core should import from `geo`, `reporting`, `survey`, etc.
-
-### `siege_utilities/data/`
-
-**Purpose:** two concerns bundled: (1) built-in sample datasets for testing and demo; (2) engine-agnostic DataFrame operations that abstract over pandas, DuckDB, Spark, and PostGIS. The Redistricting Data Hub client (`RDHClient`) also lives here.
-
-**Status:** **Divergence candidate 1:** sample data vs. multi-engine DataFrame ops are two distinct concerns that happen to share a directory. Consider splitting as part of ELE-2417 (architecture). **Divergence candidate 2:** RDH is a specific data provider — could arguably live under `geo/` or in its own `providers/` subtree alongside boundary providers.
-
-### `siege_utilities/databricks/`
-
-**Purpose:** Databricks + LakeBase client utilities. Authenticated workspace clients, Spark↔pandas / Spark↔GeoPandas bridges, LakeBase JDBC URL builders, job-run URL construction for Databricks Asset Bundles.
-
-**Status:** aligned. Surface area is the Databricks runtime API — see ELE-2417 for ADR candidate on whether to move this under `distributed/` or keep it separate.
-
-### `siege_utilities/development/`
-
-**Purpose:** developer tooling for understanding the library's own structure — architecture diagram generation, package-structure analysis. Meta, not user-facing.
-
-**Status:** aligned.
-
-### `siege_utilities/distributed/`
-
-**Purpose:** PySpark utilities and HDFS operations. Lazy-loaded; re-exports `pyspark.sql.functions` names (`col`, `lit`, `when`, …) through `spark_utils` so downstream code can `from siege_utilities.distributed import col`.
-
-**Status:** aligned. **Divergence candidate:** `hdfs_legacy/` subdirectory exists in docs but grep the source for whether it's current — follow-up under ELE-2418.
-
-### `siege_utilities/examples/` (demo scripts — not a Python package)
-
-**Purpose:** standalone `.py` scripts illustrating library usage. Not importable.
-
-**Status:** aligned, but ELE-2421 (notebook redistribution) will consolidate these with the `notebooks/` demos.
-
-### `siege_utilities/exceptions.py` (top-level file, not a package)
-
-**Purpose:** unified exception hierarchy. All domain exceptions inherit from `SiegeError` so a caller can catch the whole family with one `except SiegeError:`. Also defines the `OnErrorStrategy` literal and `handle_error(...)` dispatcher — standardizes the `on_error` parameter across functions that expose a "raise / warn / skip" knob.
-
-**Status:** aligned. This is the place future modules should register new domain exceptions.
-
-### `siege_utilities/files/`
-
-**Purpose:** file operations at the path level — directory management, copy/move/delete, remote downloads with retry, file hashing and integrity verification. Everything is promoted to package-level exports for mutual availability across modules.
-
-**Status:** aligned.
-
-### `siege_utilities/geo/`
-
-**Purpose:** geographic utilities. Census data access (TIGER + TIGER PL for VTDs + RDH + GADM), coordinate reference system operations, spatial data manipulation, mapping. Lazy-loaded so pure-Python modules (`census_constants`, `geoid_utils`) remain importable without `geopandas`.
-
-**Status:** aligned — recently reshaped by PRs #386 (TIGER2020PL VTD routing + RDHProvider) and #388 (CensusTIGERProvider refactor). The `BoundaryProvider` ABC pattern is the canonical extension point.
-
-### `siege_utilities/git/`
-
-**Purpose:** programmatic Git operations for siege-internal tooling (release automation, branch analysis). Not meant for end-user Git workflows — that's what `gh` / `git` are for.
-
-**Status:** aligned.
-
-### `siege_utilities/hygiene/`
-
-**Purpose:** package-maintenance tooling. Auto-generate docstrings, automate PyPI releases (version bump, build, twine upload), cleanup of build artifacts, validate package readiness. Supports both `setup.py` and `pyproject.toml` projects.
-
-**Status:** aligned. **Divergence candidate:** `hygiene/README.md` contains `password="password"` example — harmless but will trip secret scanners; replace with `os.environ` pattern as part of ELE-2420.
-
-### `siege_utilities/profiles/` (data directory)
-
-**Purpose:** on-disk default profile fixtures for clients and users. Loaded by `admin/profile_manager.py` at runtime. Not a Python package.
-
-**Status:** aligned.
-
-### `siege_utilities/reporting/`
-
-**Purpose:** the full reporting pipeline — charts (`chart_generator`, typed chart classes), pages (`page_models` with `TableType`, `Argument`, `TitlePage`, `TableOfContentsPage`, `ContentPage`), engines (`bar_engine`, `map_engine`, `stats_engine`, `composite_engine`, `base_engine`), templates (title / toc / content), and output generators (`report_generator` for PDF, `powerpoint_generator` for PPTX). Also hosts the polling-analytics subpackage `reporting/analytics/` that wraps GA / cross-tab tooling.
-
-**Status:** **Divergence candidate 1:** `reporting/analytics/polling_analyzer.py` is analytics code living inside a reporting namespace — name suggests it should be under `siege_utilities.analytics/` or a new `analytics/polling/` module. Surface in ELE-2417. **Divergence candidate 2:** `reporting/engines/*` — 5+ engine files with suspected copy-paste duplication per PR-386 thread pattern. Flag for ELE-2420 shared-core rewrite. **Divergence candidate 3:** `reporting/pages/page_models.py` now holds `Argument` and `TableType` — both used across `survey/` and `analytics/google_slides.py`. Consider promoting to a neutral location (maybe `core/models.py` or a new `models/` subpackage).
-
-### `siege_utilities/runtime.py` (top-level file)
-
-**Purpose:** runtime compatibility guard for Databricks notebooks. Idempotent bootstrap — verifies (and, when possible, repairs) the Python environment before heavy siege_utilities submodules are imported. Deliberately stdlib-only so it can always be imported even when `pydantic` or other deps are in a broken state.
-
-**Status:** aligned. Critical stability surface; do not add third-party imports here.
-
-### `siege_utilities/survey/`
-
-**Purpose:** survey/crosstab report engine. Quantipy-inspired `Stack → Cluster → Chain → View` hierarchy, built fresh on pandas + weightipy for Python 3.12. Provides `build_chain`, `chain_to_argument`, `stack_to_arguments`, significance tests (`column_proportion_test`, `chi_square_flag`), and RIM weighting (`apply_rim_weights`). Optional install: `pip install siege-utilities[survey]`.
-
-**Status:** aligned — reshaped by PR #391. **Divergence candidate:** `Chain.to_argument()` method duplicates `survey.render.chain_to_argument(chain, ...)` — both are entry points to the same pipeline. Pick one canonical and delegate from the other. Covered by ELE-2417 ADR.
-
-### `siege_utilities/testing/`
-
-**Purpose:** helpers for the library's own tests — environment management (set/restore env vars, isolate working directories) and a pytest-compatible runner. Lazy-loaded.
-
-**Status:** aligned.
-
-## Divergences catalog (summary)
-
-For each divergence called out above, a follow-up issue will be filed under ELE-2415:
-
-| # | Module | Divergence | Proposed resolution |
+| Module | Purpose | Status | Planned change |
 |---|---|---|---|
-| D1 | `config/` | `credential_manager.py` 1Password logic overlaps with `analytics/google_analytics` | Confirm ownership; consolidate to one | 
-| D2 | `data/` | Sample data + multi-engine ops in one directory | Split under ELE-2417 |
-| D3 | `data/` | `RDHClient` is a specific data provider | Consider moving to `geo/providers/` or new `providers/` subtree |
-| D4 | `distributed/` | `hdfs_legacy/` — current or stale? | Audit in ELE-2418 |
-| D5 | `hygiene/README.md` | Contains `password="password"` example | Replace with `os.environ` pattern |
-| D6 | `reporting/` | `reporting/analytics/polling_analyzer.py` is analytics in a reporting namespace | ELE-2417 ADR |
-| D7 | `reporting/engines/` | Suspected copy-paste across 5+ engine files | ELE-2420 shared-core rewrite |
-| D8 | `reporting/pages/page_models.py` | Holds `Argument` / `TableType` used by `survey/` and `analytics/` | Promote to neutral location |
-| D9 | `survey/` | `Chain.to_argument()` + `survey.render.chain_to_argument()` duplicate entry points | ELE-2417 ADR (pipeline ownership) |
+| `admin/` | Manage profile-directory layout + migrations | Aligned | — |
+| `analytics/` | Third-party connectors (GA, Facebook, Snowflake, Data.world, Google Workspace) | Aligned | D1 wrapper rename (ELE-2427) |
+| `conf/` | Foundational settings singleton + hard-coded defaults | Aligned | — |
+| `config/` | Re-exports `conf.settings` + canonical constants (census, FIPS, credentials, pydantic models) | Aligned | — |
+| `configs/` | On-disk config data (palettes, branding templates); not a Python package | Aligned | — |
+| `core/` | Foundational utilities (logging, string, SQL safety); dependency root | Aligned | — |
+| `data/` | Sample datasets + engine-agnostic DataFrame ops + RDH client | **Divergent** | Aggressive split by nature (ELE-2422); RDH moves to `geo/providers/` (ELE-2423) |
+| `databricks/` | Databricks + LakeBase clients, Spark↔pandas bridges | Aligned | Motivation docstring added (ELE-2427) — kept separate from `distributed/` because Azure Databricks lacks Sedona + C-libs |
+| `development/` | Meta tooling (architecture diagrams, structure analysis) | Meta | — |
+| `distributed/` | PySpark + HDFS utilities; re-exports `pyspark.sql.functions` names | Aligned | — |
+| `examples/` | Standalone demo `.py` scripts | Meta | Consolidating with `notebooks/` in ELE-2421 |
+| `exceptions.py` | Unified exception hierarchy (`SiegeError`); `OnErrorStrategy`; `handle_error()` | Aligned | — |
+| `files/` | Path manipulation, file operations, remote download, hashing | Aligned | — |
+| `geo/` | Geospatial data access, boundary providers, geocoding, CRS, Django models | Aligned | External spatial sources consolidate under `geo/providers/` (ELE-2423); silent-swallow sweep under ELE-2420 |
+| `git/` | Branch/commit helpers | Aligned | — |
+| `hygiene/` | Maintenance tooling (docstring generation, PyPI release flow) | Meta | — |
+| `reporting/` | PDF/PowerPoint generation, chart types, client branding, page templates | **Divergent** | `reporting/analytics/` subdirectory deleted (ELE-2424); `analytics_reports.py` promoted one level; new `wave_charts.py` lands with ELE-2425 |
+| `runtime.py` | Runtime environment detection + guards | Aligned | — |
+| `survey/` | Survey pipeline (Chain, weights, render, significance) | **Divergent** | `Chain.to_argument()` method removed (ELE-2426); new `Wave`/`WaveSet` subsystem (ELE-2425) |
+| `testing/` | Test-only fixtures and helpers | Meta | — |
 
-## Next
+---
 
-- ELE-2417 consumes this file as input for architecture decisions
-- ELE-2418 and ELE-2420 will pick up the divergences they're best suited to resolve
-- Keep this file current — any future PR that adds a module must update this file, and any PR that changes a module's purpose must reconcile
+## Divergence catalog
+
+All divergences carry a planned resolution and a target sub-issue.
+
+| ID | Where | Decision | Target |
+|---|---|---|---|
+| D1 | `create_ga_connector_from_1password` wrapper name | Rename — auth-mechanism shouldn't leak into analytics API surface | ELE-2427 |
+| D2 | `data/` bundles multiple natures | Aggressive split: `data/statistics/`, `reference/`, top-level `engines/` | ELE-2422 |
+| D3 | External spatial sources scattered across `geo/` | Consolidate under `geo/providers/` (structural moves only; interface unification is a later epic) | ELE-2423 |
+| D4 | `databricks/` vs `distributed/` | Keep separate. Document in `__init__.py` that Azure Databricks lacks Sedona + C-libs — separation is load-bearing | ELE-2427 |
+| D7 | `reporting/analytics/polling_analyzer` | Deprecate `PollingAnalyzer`; extract longitudinal/change-detection to `data/statistics/`; delete `reporting/analytics/` subdirectory; add survey `Wave`/`WaveSet` | ELE-2424 + ELE-2425 |
+| D8 | `Chain.to_argument()` method vs `chain_to_argument()` function | Delete the method; function is sole entry point. Chain stays pure data | ELE-2426 |
+| D9 | `chart_generator` / `map_generator` kwargs ignored on `chain_to_argument` | Honor them (minimal ceremony — duck type, no Protocol yet). Drop from `ChartTypeRegistry.create_chart` (internal dispatch layer) | ELE-2426 |
+
+*Closed, no action:*
+- **D5** (`hdfs_legacy/`) — file was already removed; only stale `.pyc` remained.
+- **D6** (`geo/` silent-swallow sites) — not architectural; operational debt tracked under ELE-2420.
+
+---
+
+## How to use this file
+
+- **Adding a new module?** Add a row. State purpose in one sentence. If you can't, the module's scope isn't clear enough yet.
+- **Behavior changed in ways that contradict a row?** Update the row, or open a ticket to restore intent.
+- **Found a new divergence?** Add a `Dn` entry to the catalog and link it to a follow-up issue.
+
+See also: [ARCHITECTURE.md](ARCHITECTURE.md) · [FAILURE_MODES.md](FAILURE_MODES.md) · [ADRs](adr/)

--- a/docs/INTENT.md
+++ b/docs/INTENT.md
@@ -1,0 +1,155 @@
+# siege_utilities — Intent
+
+Per-module purpose statements. Source: each module's `__init__.py` docstring, cross-referenced with the first substantive commit that introduced the module. Written as part of **ELE-2416** (audit sub-issue 1/6).
+
+This file is the definitive answer to "what is this module for?" Any future behavior divergence from what's written here should be reconciled either by updating the behavior or by updating this file — not by letting them drift.
+
+## Top-level modules
+
+### `siege_utilities/admin/`
+
+**Purpose:** library administration. Manage the on-disk location of user / client profile directories (where credentials and per-profile settings live) and perform migrations between versions of that layout. Re-exports `profile_manager` functions at package level.
+
+**Status (2026-04-22):** aligned with stated intent. Small surface area.
+
+### `siege_utilities/analytics/`
+
+**Purpose:** external analytics integrations. Connectors for Google Analytics (read), Facebook Business, Snowflake, Data.world, plus Google Workspace write APIs (Sheets, Docs, Slides). Lazy-loaded via PEP 562 `__getattr__` so importing the package doesn't pull every third-party SDK.
+
+**Status:** aligned. Google Slides writer now includes the `create_argument_slide` / `create_report_from_arguments` public API added in PR #392.
+
+### `siege_utilities/conf/`
+
+**Purpose:** foundational settings singleton and hard-coded defaults. Sits under `config/` and is imported by it; callers should prefer `siege_utilities.config.settings` rather than reaching into `conf`.
+
+**Status:** aligned. Intentionally small (`defaults.py` + `__init__.py`).
+
+### `siege_utilities/config/`
+
+**Purpose:** centralized configuration and constants. Re-exports `conf.settings` for discoverability, plus library metadata (`LIBRARY_NAME`, `LIBRARY_VERSION`, …), canonical geographic level names (`CANONICAL_GEOGRAPHIC_LEVELS`), and per-subject constant modules (census, FIPS, database connections, credentials, pydantic models).
+
+**Status:** aligned. **Divergence candidate:** `credential_manager.py` contains 1Password integration that overlaps with `analytics/google_analytics.py::create_ga_connector_from_1password` — intended coupling? Follow-up to confirm.
+
+### `siege_utilities/configs/` (data directory — not a Python package)
+
+**Purpose:** on-disk config files shipped with the library — e.g. default color palettes, client-branding templates. Populated at install time; callers should not import from it, only read files.
+
+**Status:** aligned (no Python, no API surface).
+
+### `siege_utilities/core/`
+
+**Purpose:** foundational utilities that every other module may import. Logging setup (`log_info` / `log_warning` / `log_error` / `log_debug` family), string manipulation, SQL safety helpers. Lazy-loaded.
+
+**Status:** aligned. Dependency root — nothing in core should import from `geo`, `reporting`, `survey`, etc.
+
+### `siege_utilities/data/`
+
+**Purpose:** two concerns bundled: (1) built-in sample datasets for testing and demo; (2) engine-agnostic DataFrame operations that abstract over pandas, DuckDB, Spark, and PostGIS. The Redistricting Data Hub client (`RDHClient`) also lives here.
+
+**Status:** **Divergence candidate 1:** sample data vs. multi-engine DataFrame ops are two distinct concerns that happen to share a directory. Consider splitting as part of ELE-2417 (architecture). **Divergence candidate 2:** RDH is a specific data provider — could arguably live under `geo/` or in its own `providers/` subtree alongside boundary providers.
+
+### `siege_utilities/databricks/`
+
+**Purpose:** Databricks + LakeBase client utilities. Authenticated workspace clients, Spark↔pandas / Spark↔GeoPandas bridges, LakeBase JDBC URL builders, job-run URL construction for Databricks Asset Bundles.
+
+**Status:** aligned. Surface area is the Databricks runtime API — see ELE-2417 for ADR candidate on whether to move this under `distributed/` or keep it separate.
+
+### `siege_utilities/development/`
+
+**Purpose:** developer tooling for understanding the library's own structure — architecture diagram generation, package-structure analysis. Meta, not user-facing.
+
+**Status:** aligned.
+
+### `siege_utilities/distributed/`
+
+**Purpose:** PySpark utilities and HDFS operations. Lazy-loaded; re-exports `pyspark.sql.functions` names (`col`, `lit`, `when`, …) through `spark_utils` so downstream code can `from siege_utilities.distributed import col`.
+
+**Status:** aligned. **Divergence candidate:** `hdfs_legacy/` subdirectory exists in docs but grep the source for whether it's current — follow-up under ELE-2418.
+
+### `siege_utilities/examples/` (demo scripts — not a Python package)
+
+**Purpose:** standalone `.py` scripts illustrating library usage. Not importable.
+
+**Status:** aligned, but ELE-2421 (notebook redistribution) will consolidate these with the `notebooks/` demos.
+
+### `siege_utilities/exceptions.py` (top-level file, not a package)
+
+**Purpose:** unified exception hierarchy. All domain exceptions inherit from `SiegeError` so a caller can catch the whole family with one `except SiegeError:`. Also defines the `OnErrorStrategy` literal and `handle_error(...)` dispatcher — standardizes the `on_error` parameter across functions that expose a "raise / warn / skip" knob.
+
+**Status:** aligned. This is the place future modules should register new domain exceptions.
+
+### `siege_utilities/files/`
+
+**Purpose:** file operations at the path level — directory management, copy/move/delete, remote downloads with retry, file hashing and integrity verification. Everything is promoted to package-level exports for mutual availability across modules.
+
+**Status:** aligned.
+
+### `siege_utilities/geo/`
+
+**Purpose:** geographic utilities. Census data access (TIGER + TIGER PL for VTDs + RDH + GADM), coordinate reference system operations, spatial data manipulation, mapping. Lazy-loaded so pure-Python modules (`census_constants`, `geoid_utils`) remain importable without `geopandas`.
+
+**Status:** aligned — recently reshaped by PRs #386 (TIGER2020PL VTD routing + RDHProvider) and #388 (CensusTIGERProvider refactor). The `BoundaryProvider` ABC pattern is the canonical extension point.
+
+### `siege_utilities/git/`
+
+**Purpose:** programmatic Git operations for siege-internal tooling (release automation, branch analysis). Not meant for end-user Git workflows — that's what `gh` / `git` are for.
+
+**Status:** aligned.
+
+### `siege_utilities/hygiene/`
+
+**Purpose:** package-maintenance tooling. Auto-generate docstrings, automate PyPI releases (version bump, build, twine upload), cleanup of build artifacts, validate package readiness. Supports both `setup.py` and `pyproject.toml` projects.
+
+**Status:** aligned. **Divergence candidate:** `hygiene/README.md` contains `password="password"` example — harmless but will trip secret scanners; replace with `os.environ` pattern as part of ELE-2420.
+
+### `siege_utilities/profiles/` (data directory)
+
+**Purpose:** on-disk default profile fixtures for clients and users. Loaded by `admin/profile_manager.py` at runtime. Not a Python package.
+
+**Status:** aligned.
+
+### `siege_utilities/reporting/`
+
+**Purpose:** the full reporting pipeline — charts (`chart_generator`, typed chart classes), pages (`page_models` with `TableType`, `Argument`, `TitlePage`, `TableOfContentsPage`, `ContentPage`), engines (`bar_engine`, `map_engine`, `stats_engine`, `composite_engine`, `base_engine`), templates (title / toc / content), and output generators (`report_generator` for PDF, `powerpoint_generator` for PPTX). Also hosts the polling-analytics subpackage `reporting/analytics/` that wraps GA / cross-tab tooling.
+
+**Status:** **Divergence candidate 1:** `reporting/analytics/polling_analyzer.py` is analytics code living inside a reporting namespace — name suggests it should be under `siege_utilities.analytics/` or a new `analytics/polling/` module. Surface in ELE-2417. **Divergence candidate 2:** `reporting/engines/*` — 5+ engine files with suspected copy-paste duplication per PR-386 thread pattern. Flag for ELE-2420 shared-core rewrite. **Divergence candidate 3:** `reporting/pages/page_models.py` now holds `Argument` and `TableType` — both used across `survey/` and `analytics/google_slides.py`. Consider promoting to a neutral location (maybe `core/models.py` or a new `models/` subpackage).
+
+### `siege_utilities/runtime.py` (top-level file)
+
+**Purpose:** runtime compatibility guard for Databricks notebooks. Idempotent bootstrap — verifies (and, when possible, repairs) the Python environment before heavy siege_utilities submodules are imported. Deliberately stdlib-only so it can always be imported even when `pydantic` or other deps are in a broken state.
+
+**Status:** aligned. Critical stability surface; do not add third-party imports here.
+
+### `siege_utilities/survey/`
+
+**Purpose:** survey/crosstab report engine. Quantipy-inspired `Stack → Cluster → Chain → View` hierarchy, built fresh on pandas + weightipy for Python 3.12. Provides `build_chain`, `chain_to_argument`, `stack_to_arguments`, significance tests (`column_proportion_test`, `chi_square_flag`), and RIM weighting (`apply_rim_weights`). Optional install: `pip install siege-utilities[survey]`.
+
+**Status:** aligned — reshaped by PR #391. **Divergence candidate:** `Chain.to_argument()` method duplicates `survey.render.chain_to_argument(chain, ...)` — both are entry points to the same pipeline. Pick one canonical and delegate from the other. Covered by ELE-2417 ADR.
+
+### `siege_utilities/testing/`
+
+**Purpose:** helpers for the library's own tests — environment management (set/restore env vars, isolate working directories) and a pytest-compatible runner. Lazy-loaded.
+
+**Status:** aligned.
+
+## Divergences catalog (summary)
+
+For each divergence called out above, a follow-up issue will be filed under ELE-2415:
+
+| # | Module | Divergence | Proposed resolution |
+|---|---|---|---|
+| D1 | `config/` | `credential_manager.py` 1Password logic overlaps with `analytics/google_analytics` | Confirm ownership; consolidate to one | 
+| D2 | `data/` | Sample data + multi-engine ops in one directory | Split under ELE-2417 |
+| D3 | `data/` | `RDHClient` is a specific data provider | Consider moving to `geo/providers/` or new `providers/` subtree |
+| D4 | `distributed/` | `hdfs_legacy/` — current or stale? | Audit in ELE-2418 |
+| D5 | `hygiene/README.md` | Contains `password="password"` example | Replace with `os.environ` pattern |
+| D6 | `reporting/` | `reporting/analytics/polling_analyzer.py` is analytics in a reporting namespace | ELE-2417 ADR |
+| D7 | `reporting/engines/` | Suspected copy-paste across 5+ engine files | ELE-2420 shared-core rewrite |
+| D8 | `reporting/pages/page_models.py` | Holds `Argument` / `TableType` used by `survey/` and `analytics/` | Promote to neutral location |
+| D9 | `survey/` | `Chain.to_argument()` + `survey.render.chain_to_argument()` duplicate entry points | ELE-2417 ADR (pipeline ownership) |
+
+## Next
+
+- ELE-2417 consumes this file as input for architecture decisions
+- ELE-2418 and ELE-2420 will pick up the divergences they're best suited to resolve
+- Keep this file current — any future PR that adds a module must update this file, and any PR that changes a module's purpose must reconcile


### PR DESCRIPTION
Linear: [ELE-2416](https://linear.app/elect-info/issue/ELE-2416/audit-16-intent-discovery-document-every-module-class-purpose) — audit sub-issue 1/6 under [ELE-2415](https://linear.app/elect-info/issue/ELE-2415/epic-siege-utilities-thorough-code-review-refactor).

## What

Adds \`docs/INTENT.md\` — definitive per-module purpose statements for all 18 top-level modules plus \`exceptions.py\` and \`runtime.py\`.

## Why

First step of the audit epic. We can't reason about architecture (ELE-2417) or failure modes (ELE-2418) without first agreeing on what each module is supposed to do.

## What surfaced

Nine divergence candidates — places where a module's code or location doesn't quite match its stated purpose. Each will get a follow-up issue:

- D1: \`config/credential_manager.py\` 1Password overlaps with \`analytics/google_analytics\`
- D2: \`data/\` bundles two concerns (sample data + multi-engine ops)
- D3: \`RDHClient\` lives in \`data/\` but behaves like a \`geo/\` provider
- D4: \`distributed/hdfs_legacy/\` — current or stale?
- D5: \`hygiene/README.md\` example uses literal \"password\"
- D6: \`reporting/analytics/polling_analyzer.py\` is analytics in a reporting namespace
- D7: \`reporting/engines/*\` suspected copy-paste (5+ engine files)
- D8: \`reporting/pages/page_models.py\` holds Argument/TableType used cross-cutting
- D9: \`survey/\` has dual entry points (\`Chain.to_argument\` vs \`render.chain_to_argument\`)

## Review ask

Check each module entry — does the one-paragraph purpose match your mental model? Push back on anything that reads wrong.

## Test plan

- [x] Markdown renders correctly
- [ ] @dheerajchand reviews each module entry for accuracy
- [ ] Divergences D1-D9 either confirmed (file follow-up) or rejected (edit INTENT.md)