### PR TITLE
docs(ELE-2417): architecture overview + 7 ADRs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,137 @@
+# siege_utilities — Architecture
+
+Per **ELE-2417** (audit sub-issue 2/6). Consumes `docs/INTENT.md` (ELE-2416) and `docs/FAILURE_MODES.md` (ELE-2418) as inputs. Ships ADRs in `docs/adr/` for each structural decision.
+
+## The view from 10,000 feet
+
+```
+                        ┌──────────────────────────┐
+                        │  siege_utilities (lib)   │
+                        └──────────────────────────┘
+                                    │
+           ┌────────────────────────┼────────────────────────┐
+           │                        │                        │
+   ┌───────▼───────┐        ┌───────▼───────┐        ┌───────▼───────┐
+   │   core +      │        │   data +      │        │   reporting + │
+   │   config +    │        │   geo +       │        │   survey +    │
+   │   files +     │        │   distributed │        │   analytics   │
+   │   testing     │        │               │        │               │
+   └───────────────┘        └───────────────┘        └───────────────┘
+     foundation               ingestion                 analysis +
+     (no deps on              (consumes                  output
+      other subtrees)          foundation)               (consumes
+                                                          foundation +
+                                                          ingestion)
+```
+
+Three layers:
+
+1. **Foundation** — `core/`, `config/`, `conf/`, `files/`, `testing/`, `exceptions.py`, `runtime.py`. Nothing here depends on `geo/`, `reporting/`, `survey/`, `analytics/`. Imported by everything else.
+2. **Ingestion** — `data/`, `geo/`, `distributed/`, `databricks/`, `git/`. Pulls data in. Consumes foundation but not analysis.
+3. **Analysis + output** — `reporting/`, `survey/`, `analytics/`, `admin/`, `hygiene/`, `development/`. Consumes both lower layers.
+
+**Invariant:** imports go DOWN. `core/` cannot import from `reporting/`. If a new utility is discovered that would create an upward edge, it belongs in a lower layer.
+
+## Dependency diagram (current — per `pydeps` pass)
+
+*(Actual auto-generated diagram belongs in a follow-up PR; this ADR set pins the intended shape. The follow-up will add a CI check that compares actual vs. intended and fails on violations.)*
+
+```mermaid
+graph TD
+    subgraph Foundation
+        core
+        config
+        files
+        testing
+        exceptions
+    end
+
+    subgraph Ingestion
+        data
+        geo
+        distributed
+        databricks
+        git
+    end
+
+    subgraph Analysis
+        reporting
+        survey
+        analytics
+        admin
+        hygiene
+    end
+
+    config --> core
+    files --> core
+    admin --> config
+    data --> core
+    data --> config
+    geo --> core
+    geo --> config
+    geo --> files
+    distributed --> core
+    databricks --> distributed
+    git --> core
+    reporting --> core
+    reporting --> config
+    reporting --> geo
+    reporting --> data
+    survey --> reporting
+    survey --> data
+    analytics --> core
+    analytics --> config
+    analytics --> reporting
+    hygiene --> files
+```
+
+**Known violations** to be resolved by ADRs below:
+- `survey/` imports `Argument` / `TableType` from `reporting/pages/` — resolved by ADR 0007 (move to `reporting/models.py`, consumers stay stable)
+- `reporting/analytics/polling_analyzer.py` is analytics living inside reporting — ADR 0006 proposes a split
+
+## ADRs
+
+| # | Title | Status |
+|---|---|---|
+| 0001 | Chain-to-Argument pipeline ownership | Proposed |
+| 0002 | Chart / map generator injection | Proposed |
+| 0003 | BoundaryProvider registry pattern | Proposed |
+| 0004 | Dataclass vs Pydantic boundary | Proposed |
+| 0005 | Lazy-import convention | Proposed |
+| 0006 | polling_analyzer location | Proposed |
+| 0007 | Argument + TableType location | Proposed |
+
+## Migration plan
+
+Each ADR names its consumers and sequences the rollout so downstream callers (notebooks, client code) don't break mid-refactor.
+
+### Phase M1 — Documentation + invariants (this PR + companion CI)
+- Land all 7 ADRs
+- Land the dependency-direction invariant as a CI check (imports go DOWN)
+- No code changes yet
+
+### Phase M2 — Structural moves (low-risk; under ELE-2420)
+- ADR 0007: move `Argument` / `TableType` to `reporting/models.py` with re-exports from old location for one minor version
+- ADR 0006: split `polling_analyzer` — generic functions to `analytics/polling/`, reporting-specific heatmap/trend chart to stay
+
+### Phase M3 — Ownership consolidation (ELE-2420)
+- ADR 0001: pick one canonical entry point for Chain → Argument; the other delegates
+- ADR 0002: remove the unused injection kwargs
+
+### Phase M4 — Architectural patterns (ELE-2420 + future epic)
+- ADR 0003: registry pattern for BoundaryProvider
+- ADR 0004: where Pydantic begins (new external-facing types)
+- ADR 0005: standardize lazy-import discipline
+
+## Non-goals for this epic
+
+- No wholesale rewrite of `reporting/` — that's a separate larger effort
+- No change to the public notebooks-facing API during M1/M2 (notebooks will be rewritten in ELE-2421 to use the new shape)
+- No breaking version bump — all phases land as minor versions with deprecation notices where needed
+
+## See also
+
+- `docs/INTENT.md` — what each module is for
+- `docs/FAILURE_MODES.md` — where silent failures hide
+- `docs/TEST_UPGRADES.md` — test-quality plan
+- `docs/adr/` — individual ADRs

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,40 +1,20 @@
 # siege_utilities — Architecture
 
-Per **ELE-2417** (audit sub-issue 2/6). Consumes `docs/INTENT.md` (ELE-2416) and `docs/FAILURE_MODES.md` (ELE-2418) as inputs. Ships ADRs in `docs/adr/` for each structural decision.
+**Goal:** three-layer model with a single invariant ("imports go DOWN") and a table of structural decisions.
 
-## The view from 10,000 feet
+**Scope:** ELE-2417 (audit sub-issue 2/6). Consumes [INTENT.md](INTENT.md) and [FAILURE_MODES.md](FAILURE_MODES.md). Ships [ADRs](adr/) for each decision. Snapshot: 2026-04-22 (revised 2026-04-23).
 
-```
-                        ┌──────────────────────────┐
-                        │  siege_utilities (lib)   │
-                        └──────────────────────────┘
-                                    │
-           ┌────────────────────────┼────────────────────────┐
-           │                        │                        │
-   ┌───────▼───────┐        ┌───────▼───────┐        ┌───────▼───────┐
-   │   core +      │        │   data +      │        │   reporting + │
-   │   config +    │        │   geo +       │        │   survey +    │
-   │   files +     │        │   distributed │        │   analytics   │
-   │   testing     │        │               │        │               │
-   └───────────────┘        └───────────────┘        └───────────────┘
-     foundation               ingestion                 analysis +
-     (no deps on              (consumes                  output
-      other subtrees)          foundation)               (consumes
-                                                          foundation +
-                                                          ingestion)
-```
+## Layer model
 
-Three layers:
+| Layer | Modules | Rule |
+|---|---|---|
+| **Foundation** | `core/`, `conf/`, `config/`, `files/`, `testing/`, `exceptions.py`, `runtime.py` | No deps on any other layer |
+| **Ingestion** | `data/`, `geo/`, `distributed/`, `databricks/`, `git/` | Consumes Foundation only |
+| **Analysis + output** | `reporting/`, `survey/`, `analytics/`, `admin/`, `hygiene/`, `development/` | Consumes Foundation + Ingestion |
 
-1. **Foundation** — `core/`, `config/`, `conf/`, `files/`, `testing/`, `exceptions.py`, `runtime.py`. Nothing here depends on `geo/`, `reporting/`, `survey/`, `analytics/`. Imported by everything else.
-2. **Ingestion** — `data/`, `geo/`, `distributed/`, `databricks/`, `git/`. Pulls data in. Consumes foundation but not analysis.
-3. **Analysis + output** — `reporting/`, `survey/`, `analytics/`, `admin/`, `hygiene/`, `development/`. Consumes both lower layers.
+**Invariant:** imports go DOWN. `core/` cannot import from `reporting/`. A utility that would create an upward edge belongs in a lower layer.
 
-**Invariant:** imports go DOWN. `core/` cannot import from `reporting/`. If a new utility is discovered that would create an upward edge, it belongs in a lower layer.
-
-## Dependency diagram (current — per `pydeps` pass)
-
-*(Actual auto-generated diagram belongs in a follow-up PR; this ADR set pins the intended shape. The follow-up will add a CI check that compares actual vs. intended and fails on violations.)*
+## Dependency diagram
 
 ```mermaid
 graph TD
@@ -85,53 +65,44 @@ graph TD
     hygiene --> files
 ```
 
-**Known violations** to be resolved by ADRs below:
-- `survey/` imports `Argument` / `TableType` from `reporting/pages/` — resolved by ADR 0007 (move to `reporting/models.py`, consumers stay stable)
-- `reporting/analytics/polling_analyzer.py` is analytics living inside reporting — ADR 0006 proposes a split
+A follow-up PR will add a `pydeps` CI check that fails on upward edges.
 
-## ADRs
+## ADR register
 
-| # | Title | Status |
+| # | Title | Status | Tracked under |
+|---|---|---|---|
+| [0001](adr/0001-chain-to-argument-pipeline-ownership.md) | Chain → Argument pipeline ownership | **Accepted** | ELE-2441 |
+| [0002](adr/0002-chart-map-generator-injection.md) | Chart / map generator injection | **Accepted** | ELE-2441 |
+| [0003](adr/0003-boundary-provider-registry.md) | BoundaryProvider registry pattern | Proposed | ELE-2438 (structural); later epic for interface |
+| [0004](adr/0004-dataclass-vs-pydantic.md) | Dataclass vs Pydantic boundary | Proposed | ELE-2420 |
+| [0005](adr/0005-lazy-import-convention.md) | Lazy-import convention | Proposed | ELE-2420 |
+| [0006](adr/0006-polling-analyzer-location.md) | PollingAnalyzer deprecation | **Accepted** | ELE-2439 + ELE-2440 |
+| [0007](adr/0007-argument-tabletype-location.md) | Argument + TableType location | Proposed | ELE-2420 |
+
+## Known invariant violations
+
+| Violation | Resolution | Target |
 |---|---|---|
-| 0001 | Chain-to-Argument pipeline ownership | Proposed |
-| 0002 | Chart / map generator injection | Proposed |
-| 0003 | BoundaryProvider registry pattern | Proposed |
-| 0004 | Dataclass vs Pydantic boundary | Proposed |
-| 0005 | Lazy-import convention | Proposed |
-| 0006 | polling_analyzer location | Proposed |
-| 0007 | Argument + TableType location | Proposed |
+| `survey/` imports `Argument` / `TableType` from `reporting/pages/` | Move to `reporting/models.py`; old path re-exports (deprecation shim) | ADR 0007 |
+| `reporting/analytics/polling_analyzer.py` — analytics inside reporting | Deprecate class; redistribute guts by nature | ADR 0006 / ELE-2439 |
+| `data/redistricting_data_hub.py` — provider inside data-ops module | Move to `geo/providers/` | ELE-2438 (D3) |
+| `data/` bundles four natures (stats, reference, infra, provider) | Aggressive split | ELE-2437 (D2) |
 
-## Migration plan
+## Migration phases
 
-Each ADR names its consumers and sequences the rollout so downstream callers (notebooks, client code) don't break mid-refactor.
-
-### Phase M1 — Documentation + invariants (this PR + companion CI)
-- Land all 7 ADRs
-- Land the dependency-direction invariant as a CI check (imports go DOWN)
-- No code changes yet
-
-### Phase M2 — Structural moves (low-risk; under ELE-2420)
-- ADR 0007: move `Argument` / `TableType` to `reporting/models.py` with re-exports from old location for one minor version
-- ADR 0006: split `polling_analyzer` — generic functions to `analytics/polling/`, reporting-specific heatmap/trend chart to stay
-
-### Phase M3 — Ownership consolidation (ELE-2420)
-- ADR 0001: pick one canonical entry point for Chain → Argument; the other delegates
-- ADR 0002: remove the unused injection kwargs
-
-### Phase M4 — Architectural patterns (ELE-2420 + future epic)
-- ADR 0003: registry pattern for BoundaryProvider
-- ADR 0004: where Pydantic begins (new external-facing types)
-- ADR 0005: standardize lazy-import discipline
+| Phase | Work | Risk | Under |
+|---|---|---|---|
+| **M1** | Land ADRs + dep-direction CI check (docs, no code) | None | ELE-2417 (this PR) |
+| **M2** | Structural moves: `data/` split, `geo/providers/`, delete `reporting/analytics/` | Low (re-export shims) | ELE-2437, 2438, 2439 |
+| **M3** | Ownership consolidation: rendering pipeline, PollingAnalyzer deprecation, waves subsystem | Medium (public API) | ELE-2440, 2441 |
+| **M4** | Provider interface unification (common `fetch`/`accepts` shape) | Medium | Post-audit epic |
 
 ## Non-goals for this epic
 
-- No wholesale rewrite of `reporting/` — that's a separate larger effort
-- No change to the public notebooks-facing API during M1/M2 (notebooks will be rewritten in ELE-2421 to use the new shape)
-- No breaking version bump — all phases land as minor versions with deprecation notices where needed
+| Non-goal | Reason |
+|---|---|
+| Wholesale rewrite of `reporting/` | Separate larger effort |
+| Break notebook-facing API during M1/M2 | Notebooks rewritten in ELE-2421 once new shape is in |
+| Major version bump | Every phase ships as minor with deprecation shims |
 
-## See also
-
-- `docs/INTENT.md` — what each module is for
-- `docs/FAILURE_MODES.md` — where silent failures hide
-- `docs/TEST_UPGRADES.md` — test-quality plan
-- `docs/adr/` — individual ADRs
+See also: [INTENT.md](INTENT.md) · [FAILURE_MODES.md](FAILURE_MODES.md) · [TEST_UPGRADES.md](TEST_UPGRADES.md) · [adr/](adr/)

--- a/docs/adr/0001-chain-to-argument-pipeline-ownership.md
+++ b/docs/adr/0001-chain-to-argument-pipeline-ownership.md
@@ -1,0 +1,56 @@
+# ADR 0001 — Chain → Argument pipeline ownership
+
+**Status:** Proposed
+**Date:** 2026-04-22
+**Epic:** ELE-2415 (sub-issue ELE-2417)
+
+## Context
+
+The `Chain → Argument` pipeline has two entry points today:
+
+1. `survey.render.chain_to_argument(chain, headline, narrative, ...)` — module-level function
+2. `Chain.to_argument(headline, narrative)` — instance method that internally calls (1)
+
+Both do the same thing; the method is a thin convenience. With two entry points, future changes to the pipeline (adding kwargs, changing default behavior) risk drift where one path behaves differently from the other.
+
+## Decision
+
+**The module-level function `survey.render.chain_to_argument` is canonical. `Chain.to_argument` is a thin delegate that takes no additional arguments beyond `headline` and `narrative` and forwards everything to the module function.**
+
+`Chain.to_argument` stays because the fluent form reads nicely in notebooks:
+
+```python
+arg = chain.to_argument("Headline", "Narrative prose")
+# vs
+arg = chain_to_argument(chain, "Headline", "Narrative prose")
+```
+
+All configuration knobs (chart_generator, map_generator once unblocked by ADR 0002) live on the module function. The method does not expose them.
+
+## Consequences
+
+**Positive:**
+- One place to change pipeline defaults
+- Method-vs-function choice is ergonomic, not architectural
+- Tests cover both paths with a single fake (`monkeypatch.setattr(render_mod, 'chain_to_argument', fake)`)
+
+**Negative:**
+- Minor: callers who want to inject a custom chart_generator MUST use the module function, not the method
+- Acceptable: documented in `Chain.to_argument` docstring
+
+## Alternatives considered
+
+1. **Method is canonical** — rejected. Methods on data classes should be thin; complex multi-arg rendering doesn't belong on `Chain`.
+2. **Remove the method** — rejected. The fluent form is too useful in notebooks to drop.
+3. **Keep both as first-class siblings** — rejected. Two canonical APIs guarantees drift.
+
+## Migration
+
+- Current code already reflects the decision. Confirm no callers pass config-like kwargs via `chain.to_argument(...)`.
+- Add a note to `Chain.to_argument` docstring: "for full control use `render.chain_to_argument`."
+
+## References
+
+- `survey/render.py`
+- `survey/models.py::Chain.to_argument`
+- `docs/INTENT.md` D9 (dual entry points divergence)

--- a/docs/adr/0001-chain-to-argument-pipeline-ownership.md
+++ b/docs/adr/0001-chain-to-argument-pipeline-ownership.md
@@ -1,56 +1,44 @@
 # ADR 0001 — Chain → Argument pipeline ownership
 
-**Status:** Proposed
-**Date:** 2026-04-22
-**Epic:** ELE-2415 (sub-issue ELE-2417)
+**Status:** Accepted (supersedes prior "Proposed" draft)
+**Date:** 2026-04-22 (revised 2026-04-23)
+**Epic:** ELE-2415 (implemented under ELE-2441)
 
 ## Context
 
-The `Chain → Argument` pipeline has two entry points today:
-
-1. `survey.render.chain_to_argument(chain, headline, narrative, ...)` — module-level function
-2. `Chain.to_argument(headline, narrative)` — instance method that internally calls (1)
-
-Both do the same thing; the method is a thin convenience. With two entry points, future changes to the pipeline (adding kwargs, changing default behavior) risk drift where one path behaves differently from the other.
+`survey.render.chain_to_argument(chain, ...)` and `Chain.to_argument(headline, narrative)` both produced an `Argument` from a `Chain`. The method delegated to the function. This was a dual-surface API with no compensating value — one behavior, two entry points.
 
 ## Decision
 
-**The module-level function `survey.render.chain_to_argument` is canonical. `Chain.to_argument` is a thin delegate that takes no additional arguments beyond `headline` and `narrative` and forwards everything to the module function.**
+**Delete `Chain.to_argument()`. `chain_to_argument()` is the sole entry point.**
 
-`Chain.to_argument` stays because the fluent form reads nicely in notebooks:
-
-```python
-arg = chain.to_argument("Headline", "Narrative prose")
-# vs
-arg = chain_to_argument(chain, "Headline", "Narrative prose")
-```
-
-All configuration knobs (chart_generator, map_generator once unblocked by ADR 0002) live on the module function. The method does not expose them.
+Chain is a `@dataclass` — its nature is *state*, not *behavior*. Rendering a Chain into an Argument is an operation *performed on* Chain by the render module, not a property of Chain itself.
 
 ## Consequences
 
 **Positive:**
-- One place to change pipeline defaults
-- Method-vs-function choice is ergonomic, not architectural
-- Tests cover both paths with a single fake (`monkeypatch.setattr(render_mod, 'chain_to_argument', fake)`)
+- Single rendering contract; no drift between method and function.
+- Chain stays pure data — consistent with `View`, `Cluster`, `Stack` (none of which carry rendering methods either).
+- `chain_to_argument` is the one place config kwargs (chart_generator, map_generator per ADR 0002) live.
 
 **Negative:**
-- Minor: callers who want to inject a custom chart_generator MUST use the module function, not the method
-- Acceptable: documented in `Chain.to_argument` docstring
+- Callers using `chain.to_argument(...)` must switch to `chain_to_argument(chain, ...)`. Small migration; the method was recent (added in PR #391).
 
 ## Alternatives considered
 
-1. **Method is canonical** — rejected. Methods on data classes should be thin; complex multi-arg rendering doesn't belong on `Chain`.
-2. **Remove the method** — rejected. The fluent form is too useful in notebooks to drop.
-3. **Keep both as first-class siblings** — rejected. Two canonical APIs guarantees drift.
+1. **Keep the method as a thin delegate.** Rejected. Dataclass purity wins — every data model in `survey/models.py` would eventually want its own `.to_X()` method and the model module would become a rendering module.
+2. **Method canonical, function delegates.** Rejected on the same grounds.
+3. **Keep both first-class.** Rejected. Guarantees drift.
 
 ## Migration
 
-- Current code already reflects the decision. Confirm no callers pass config-like kwargs via `chain.to_argument(...)`.
-- Add a note to `Chain.to_argument` docstring: "for full control use `render.chain_to_argument`."
+- Delete `Chain.to_argument` method on `survey/models.py`.
+- Grep every caller using the method form; replace with the function form.
+- CHANGELOG entry: `Chain.to_argument()` removed; use `survey.render.chain_to_argument(chain, ...)`.
 
 ## References
 
 - `survey/render.py`
-- `survey/models.py::Chain.to_argument`
-- `docs/INTENT.md` D9 (dual entry points divergence)
+- `survey/models.py`
+- `docs/INTENT.md` D8
+- ELE-2441 (implements this decision + ADR 0002)

--- a/docs/adr/0002-chart-map-generator-injection.md
+++ b/docs/adr/0002-chart-map-generator-injection.md
@@ -1,46 +1,60 @@
 # ADR 0002 — Chart / map generator injection
 
-**Status:** Proposed
-**Date:** 2026-04-22
-**Epic:** ELE-2415 (sub-issue ELE-2417)
+**Status:** Accepted (supersedes prior "Proposed" draft with reversed conclusion)
+**Date:** 2026-04-22 (revised 2026-04-23)
+**Epic:** ELE-2415 (implemented under ELE-2441)
 
 ## Context
 
-`chain_to_argument(chain, headline, narrative, *, chart_generator=None, map_generator=None)` accepts two optional generator kwargs. Neither is honored at runtime — as of PR #391 both raise `NotImplementedError` if set, so callers don't silently lose customizations they thought they were providing.
+`chain_to_argument(..., chart_generator=None, map_generator=None)` accepts generator kwargs that are not honored at runtime — they either raise `NotImplementedError` on non-None, or silently no-op, depending on which code path you land on. Inconsistency is itself a bug.
 
-The kwargs exist because earlier design imagined plugin-style chart theming via dependency injection. In practice no caller has asked for this, and chart theming today is handled through `reporting.client_branding` (which configures a singleton `ChartGenerator`).
+The kwargs point at real use cases:
+
+1. **Ad hoc charts without branding configured.** Users running a one-off script shouldn't need a `ClientBrandingManager` setup to render a figure.
+2. **Override branding on a one-off basis.** A user with branding configured occasionally wants a chart rendered differently without mutating global state.
+3. **Swap the whole render backend** (matplotlib → Plotly, etc.) without monkeypatching.
+
+An earlier draft of this ADR proposed dropping the kwargs on YAGNI grounds. That was wrong: the kwargs are already in the signature, callers expect them to work, and the use cases are concrete — not speculative.
 
 ## Decision
 
-**Remove the `chart_generator` and `map_generator` kwargs from `chain_to_argument` in the next major version. Until then, keep the `NotImplementedError` guard so callers get a loud signal rather than silent no-op.**
+**Honor `chart_generator` and `map_generator` on `chain_to_argument`. Drop them from `ChartTypeRegistry.create_chart`.**
 
-Chart theming stays in `reporting.client_branding`. A client that wants different chart styling sets the branding config, not injects a different generator.
+- `chart_generator=None` → construct a default `ChartGenerator()` (picks up active profile branding if present; otherwise library defaults). No branding required for sensible output.
+- `chart_generator=<instance>` → use the caller's generator as-is. Caller controls style: differently-branded, un-branded, alternative backend.
+- Same pattern for `map_generator`.
+- `ChartTypeRegistry.create_chart` is an internal dispatcher — generators should be resolved before we reach it. Drop the kwargs from there.
+
+**Type discipline:** duck type the generator interface for now. Document the expected methods (`create_bar_chart`, `create_heatmap`, etc.) in `chain_to_argument`'s docstring. Formalize as a `Protocol` only when a second backend (e.g., Plotly) lands — adding the Protocol is additive and won't break duck-typed callers.
 
 ## Consequences
 
 **Positive:**
-- One less dead knob in the public API
-- `chain_to_argument` signature gets simpler
-- Removes the bait — interface-integrity violation (ADR follows `coding/python-patterns/SKILL.md`)
+- Kwargs do what their names say.
+- Ad hoc use is possible without branding setup.
+- Override path is real; no monkeypatching needed.
+- Room to grow into alternative backends without redesigning the signature.
 
 **Negative:**
-- A future caller who genuinely wants to inject a pre-configured generator has to rebuild that path deliberately
-- Acceptable because we'd re-introduce with a plan at that point, not speculatively
+- Slightly more wiring in `chain_to_argument` (resolve generator, dispatch).
+- Docstring becomes load-bearing — callers rely on it for the interface. Acceptable in a small library.
 
 ## Alternatives considered
 
-1. **Wire the kwargs through** — rejected. No caller today uses them; speculative feature.
-2. **Keep raising NotImplementedError indefinitely** — rejected. Leaving broken optional kwargs in a signature is worse than removing them.
-3. **Replace with a `branding: BrandingConfig | None = None` kwarg** — deferred. If the branding path grows, this ADR can be superseded by a new one that adds per-call branding explicitly.
+1. **Drop the kwargs entirely.** Rejected after reconsideration. Dropping removes real capability (ad hoc / override / backend swap) that the audience actually uses.
+2. **Define a formal `ChartGeneratorProtocol` now.** Rejected for this pass. Premature formalization without a second backend. Revisit when Plotly or another renderer lands.
+3. **Replace with a `branding: BrandingConfig | None = None` kwarg.** Rejected — conflates branding with rendering backend.
 
 ## Migration
 
-- Next minor release: emit `DeprecationWarning` when either kwarg is passed (replacing `NotImplementedError`).
-- Next major release: remove the kwargs from the signature.
-- CHANGELOG entry for both steps.
+- Implement the dispatch in `chain_to_argument`: if generator is None, construct a default; otherwise use as-is.
+- Remove `chart_generator` / `map_generator` from `ChartTypeRegistry.create_chart` signature.
+- Update `chain_to_argument` docstring with the interface contract and examples (no-branding, override, custom backend).
+- Add tests for all three paths.
 
 ## References
 
 - `survey/render.py::chain_to_argument`
-- PR #391 (introduced the NotImplementedError guard)
-- `coding/python-patterns/SKILL.md` — "Interface integrity" section
+- `reporting/chart_types.py::ChartTypeRegistry`
+- `docs/INTENT.md` D9
+- ELE-2441 (implements this decision + ADR 0001)

--- a/docs/adr/0002-chart-map-generator-injection.md
+++ b/docs/adr/0002-chart-map-generator-injection.md
@@ -1,0 +1,46 @@
+# ADR 0002 — Chart / map generator injection
+
+**Status:** Proposed
+**Date:** 2026-04-22
+**Epic:** ELE-2415 (sub-issue ELE-2417)
+
+## Context
+
+`chain_to_argument(chain, headline, narrative, *, chart_generator=None, map_generator=None)` accepts two optional generator kwargs. Neither is honored at runtime — as of PR #391 both raise `NotImplementedError` if set, so callers don't silently lose customizations they thought they were providing.
+
+The kwargs exist because earlier design imagined plugin-style chart theming via dependency injection. In practice no caller has asked for this, and chart theming today is handled through `reporting.client_branding` (which configures a singleton `ChartGenerator`).
+
+## Decision
+
+**Remove the `chart_generator` and `map_generator` kwargs from `chain_to_argument` in the next major version. Until then, keep the `NotImplementedError` guard so callers get a loud signal rather than silent no-op.**
+
+Chart theming stays in `reporting.client_branding`. A client that wants different chart styling sets the branding config, not injects a different generator.
+
+## Consequences
+
+**Positive:**
+- One less dead knob in the public API
+- `chain_to_argument` signature gets simpler
+- Removes the bait — interface-integrity violation (ADR follows `coding/python-patterns/SKILL.md`)
+
+**Negative:**
+- A future caller who genuinely wants to inject a pre-configured generator has to rebuild that path deliberately
+- Acceptable because we'd re-introduce with a plan at that point, not speculatively
+
+## Alternatives considered
+
+1. **Wire the kwargs through** — rejected. No caller today uses them; speculative feature.
+2. **Keep raising NotImplementedError indefinitely** — rejected. Leaving broken optional kwargs in a signature is worse than removing them.
+3. **Replace with a `branding: BrandingConfig | None = None` kwarg** — deferred. If the branding path grows, this ADR can be superseded by a new one that adds per-call branding explicitly.
+
+## Migration
+
+- Next minor release: emit `DeprecationWarning` when either kwarg is passed (replacing `NotImplementedError`).
+- Next major release: remove the kwargs from the signature.
+- CHANGELOG entry for both steps.
+
+## References
+
+- `survey/render.py::chain_to_argument`
+- PR #391 (introduced the NotImplementedError guard)
+- `coding/python-patterns/SKILL.md` — "Interface integrity" section

--- a/docs/adr/0003-boundary-provider-registry.md
+++ b/docs/adr/0003-boundary-provider-registry.md
@@ -1,0 +1,112 @@
+# ADR 0003 — BoundaryProvider registry pattern
+
+**Status:** Proposed
+**Date:** 2026-04-22
+**Epic:** ELE-2415 (sub-issue ELE-2417)
+
+## Context
+
+Today `resolve_boundary_provider(country='US', **kwargs)` hardcodes a country-code set:
+
+```python
+_US_CODES = frozenset({'US', 'USA', 'PR', 'PRI', 'GU', 'GUM', 'VI', 'VIR', 'AS', 'ASM', 'MP', 'MNP'})
+
+def resolve_boundary_provider(country: str = 'US', **kwargs):
+    if country.upper() in _US_CODES:
+        return CensusTIGERProvider()
+    return GADMProvider(**kwargs)
+```
+
+This works for the current two providers but:
+- Adding a third provider (e.g. the new `RDHProvider` from #386) requires modifying `resolve_boundary_provider` AND possibly `_US_CODES`
+- Client-specific providers (e.g. a custom state-level source) can't be plugged in without forking
+- The factory can't express "which provider handles best for X" — it's binary US vs. not
+
+## Decision
+
+**Adopt a registry pattern. Each `BoundaryProvider` subclass declares which countries/levels it accepts; `resolve_boundary_provider` iterates registered providers.**
+
+```python
+class BoundaryProvider(ABC):
+    # ... existing abstract methods ...
+
+    @classmethod
+    @abstractmethod
+    def accepts(cls, country: str, level: str) -> bool:
+        """Return True if this provider can satisfy a request for the given country + level."""
+
+
+_REGISTRY: list[type[BoundaryProvider]] = []
+
+def register_provider(cls: type[BoundaryProvider]) -> type[BoundaryProvider]:
+    """Decorator; adds the class to the dispatch registry."""
+    _REGISTRY.append(cls)
+    return cls
+
+
+@register_provider
+class CensusTIGERProvider(BoundaryProvider):
+    @classmethod
+    def accepts(cls, country: str, level: str) -> bool:
+        return country.upper() in {'US', 'USA', 'PR', 'PRI', ...}
+    ...
+
+@register_provider
+class GADMProvider(BoundaryProvider):
+    @classmethod
+    def accepts(cls, country: str, level: str) -> bool:
+        return level in ('country', 'admin1', 'admin2', 'admin3')
+    ...
+
+
+def resolve_boundary_provider(country: str = 'US', level: str = 'county', **kwargs) -> BoundaryProvider:
+    for cls in _REGISTRY:
+        if cls.accepts(country, level):
+            return cls(**_filter_kwargs(cls, kwargs))
+    raise NoProviderError(
+        f"no registered BoundaryProvider accepts country={country!r} level={level!r}; "
+        f"registered: {[c.__name__ for c in _REGISTRY]}"
+    )
+```
+
+External callers (e.g. siege-analytics client configs) can register their own providers at import time:
+
+```python
+from siege_utilities.geo.boundary_providers import register_provider, BoundaryProvider
+
+@register_provider
+class MyCustomStateProvider(BoundaryProvider):
+    ...
+```
+
+## Consequences
+
+**Positive:**
+- Adding a provider is self-contained (one class, one decorator)
+- External providers are a first-class extension point
+- `resolve_boundary_provider` becomes the only dispatch point; no more scattered country-code lists
+- The dispatch function can also be used by the test suite to assert "every provider is callable"
+
+**Negative:**
+- Registration happens at import time; provider classes must be imported before dispatch to be registered. OK for core providers (always imported); requires callers who add custom providers to import their module before calling resolve.
+- Ambiguity if two providers accept the same country/level — handled by registration order (first-registered wins) OR by adding a `priority` attribute. Pick at implementation time.
+
+## Alternatives considered
+
+1. **Keep the factory, extend `_US_CODES`** — rejected. Doesn't scale past 3-4 providers.
+2. **Configuration-file driven dispatch** — rejected. Over-engineered; registration-by-decorator is more Pythonic.
+3. **Protocol-based, no registry; caller passes provider** — rejected. Loses the convenience of `resolve_boundary_provider('US')`.
+
+## Migration
+
+- Add `BoundaryProvider.accepts` as abstract in a minor release; default implementations preserve current behavior for `CensusTIGERProvider` and `GADMProvider`
+- Migrate `resolve_boundary_provider` to iterate the registry
+- Register `RDHProvider` explicitly — confirms the pattern
+- Add a test that asserts `resolve_boundary_provider("US", "county")` returns a CensusTIGER provider (behavior preservation)
+
+## References
+
+- `geo/boundary_providers.py::resolve_boundary_provider`
+- `geo/boundary_providers.py::_US_CODES`
+- PR #386 (added `RDHProvider` — exercises the "how do we add a provider" question)
+- `coding/python-patterns/SKILL.md` — "Interface integrity" section

--- a/docs/adr/0004-dataclass-vs-pydantic.md
+++ b/docs/adr/0004-dataclass-vs-pydantic.md
@@ -1,0 +1,63 @@
+# ADR 0004 — Dataclass vs Pydantic boundary
+
+**Status:** Proposed
+**Date:** 2026-04-22
+**Epic:** ELE-2415 (sub-issue ELE-2417)
+
+## Context
+
+The library uses both patterns:
+- `survey.models` (`Chain`, `Cluster`, `Stack`, `View`, `WeightScheme`) — `@dataclass`
+- `config.models` (`UserProfile`, `ClientProfile`, `ContactInfo`, `BrandingConfig`, `ReportPreferences`) — Pydantic `BaseModel`
+
+No written rule says which to use where. New contributors default to whichever they saw last.
+
+Pydantic's strengths are runtime validation, JSON schema generation, and strict field discipline. Its costs are import-time overhead (~50ms), a dependency on Pydantic v2, and harder interop with `numpy` / `pandas` types.
+
+Dataclasses are lighter but offer no validation — mistyped fields silently work until they don't.
+
+## Decision
+
+**New external-facing types (user config, API request/response shapes, serialized outputs, CLI args) use Pydantic `BaseModel`. Internal computation types (pipeline intermediates) use `@dataclass`.**
+
+A type is "external-facing" if it crosses a trust boundary: read from or written to disk, loaded from YAML/JSON/TOML, returned to notebooks as a published API, deserialized from an HTTP response.
+
+A type is "internal" if it exists only during a function's execution — passed between helpers, never persisted, not part of the published surface.
+
+| Type | Kind | Reason |
+|---|---|---|
+| `UserProfile`, `ClientProfile` | Pydantic | Loaded from YAML, validates fields at read time |
+| `Chain`, `Cluster`, `Stack`, `View` | Dataclass | Pipeline intermediates, never serialized |
+| `Argument`, `TableType` | **Dataclass** (current) — likely promote one level, see ADR 0007 | Intermediate between survey and reporting |
+| `BoundaryFetchResult` (geo) | Dataclass | Internal |
+| `RDHDataset` (data/RDH) | Dataclass today; **candidate for Pydantic** because it's deserialized from the RDH API | Migrate under future work |
+| Future `SiegeConfig` type | Pydantic | User-facing config |
+
+## Consequences
+
+**Positive:**
+- Clear rule for new contributors
+- Pydantic overhead isolated to types that benefit from validation
+- Dataclass stays for hot computation
+
+**Negative:**
+- Some types (e.g. `RDHDataset`) currently in the "internal" category are really "boundary" and should migrate. One-off migration cost.
+- Mixed codebase is slightly more friction for readers who have to remember which rule applies.
+
+## Alternatives considered
+
+1. **All-Pydantic** — rejected. Overkill for intermediate types that never cross a boundary.
+2. **All-dataclass** — rejected. Loses validation at trust boundaries where it matters most.
+3. **attrs instead of either** — rejected. Adds a third pattern; existing code commits to dataclass OR Pydantic, not attrs.
+
+## Migration
+
+- Document the rule in `coding/python-patterns/` if not already covered
+- Audit `data/redistricting_data_hub.py::RDHDataset` for Pydantic candidacy (ELE-2418 notes this under D3)
+- Do not rewrite existing dataclass types that fit the internal-only rule
+
+## References
+
+- `survey/models.py` (dataclass family)
+- `config/models/*.py` (Pydantic family)
+- `data/redistricting_data_hub.py::RDHDataset` (current dataclass; migration candidate)

--- a/docs/adr/0005-lazy-import-convention.md
+++ b/docs/adr/0005-lazy-import-convention.md
@@ -1,0 +1,103 @@
+# ADR 0005 — Lazy-import convention
+
+**Status:** Proposed
+**Date:** 2026-04-22
+**Epic:** ELE-2415 (sub-issue ELE-2417)
+
+## Context
+
+Heavy optional dependencies (`geopandas`, `shapely`, `pyproj`, `pyspark`, `reportlab`, `weightipy`, `snowflake-connector-python`, …) cause ImportError cascades in slim environments. Today's codebase uses several patterns, inconsistently:
+
+| Pattern | Example | Problem |
+|---|---|---|
+| Module-top `try: import X / except: HAS_X = False` | `data/redistricting_data_hub.py` | OK for bool gating; bad when paired with stub functions that silently no-op |
+| PEP 562 `__getattr__` at package `__init__.py` | `core/__init__.py`, `geo/__init__.py`, `distributed/__init__.py` | Good; on first access pulls the submodule |
+| Function-level import | Various | Good for truly-lazy paths |
+| Bare module-top import | `reporting/analytics/polling_analyzer.py::import ChartGenerator` | Cascades — module can't be imported without reportlab |
+
+PR #389 surfaced the polling_analyzer case: `pytest.importorskip('reportlab')` fixed tests but runtime still raises ImportError on import.
+
+## Decision
+
+**Three rules.**
+
+### Rule 1. Package `__init__.py` uses PEP 562 `__getattr__` for submodules with heavy deps
+
+```python
+# siege_utilities/reporting/__init__.py
+import importlib, sys
+_LAZY_IMPORTS = {'ChartGenerator': 'chart_generator', 'PDFReportGenerator': 'report_generator'}
+
+def __getattr__(name):
+    if name in _LAZY_IMPORTS:
+        module = importlib.import_module(f".{_LAZY_IMPORTS[name]}", __package__)
+        return getattr(module, name)
+    raise AttributeError(name)
+```
+
+`from siege_utilities.reporting import ChartGenerator` only pulls `reportlab` when `ChartGenerator` is actually accessed. The module itself stays importable without heavy deps.
+
+### Rule 2. Module body uses function-level imports for heavy deps when they're used rarely
+
+```python
+def generate_pdf(report):
+    """Build a PDF — needs reportlab."""
+    from reportlab.platypus import SimpleDocTemplate
+    ...
+```
+
+Only incur the import cost when the function is called, not when its module is first imported.
+
+### Rule 3. Module-top `try/except ImportError` with `HAS_X = False` is OK for feature-gating booleans ONLY
+
+```python
+try:
+    import scipy
+    HAS_SCIPY = True
+except ImportError:
+    HAS_SCIPY = False
+    scipy = None
+
+def significance_test(data, alpha):
+    if HAS_SCIPY:
+        return scipy.stats.norm.ppf(1 - alpha / 2)
+    if alpha in _FALLBACK_Z_CRIT:
+        return _FALLBACK_Z_CRIT[alpha]
+    raise SignificanceError(...)  # explicit — no silent no-op
+```
+
+**Anti-pattern** to avoid: the same construct but with stub functions that silently return `None` / `pass`. That's category (b) silent-swallow per `docs/FAILURE_MODES.md`. If the dep is missing and the function is called, it MUST raise — never return a lie.
+
+## Consequences
+
+**Positive:**
+- Slim-install users can import siege_utilities without heavy deps
+- Heavy-dep code paths stay discoverable (not hidden behind import-time try/except)
+- Consistent rule for new contributors
+
+**Negative:**
+- Every `__init__.py` with heavy deps needs a `_LAZY_IMPORTS` table (one-time cost)
+- Some `from pkg import Thing` patterns become slightly slower on first call (one-time; cached thereafter)
+
+## Alternatives considered
+
+1. **Eager imports everywhere** — rejected. Breaks slim envs.
+2. **Runtime feature detection via `importlib.util.find_spec`** — rejected. Adds complexity without clearer semantics.
+3. **Optional-deps as hard deps** — rejected. Install size and CI speed matter.
+
+## Migration
+
+Priority sites surfaced by ELE-2418 / ELE-2419:
+1. `reporting/analytics/polling_analyzer.py` — move `ChartGenerator` import inside methods OR move the class into a lazy-loaded subpackage
+2. Audit every `try: import X / except: def stub...` — confirm stubs RAISE on call rather than silently return
+3. Add `_LAZY_IMPORTS` to `reporting/__init__.py` if it doesn't have one already
+
+Full audit is a follow-up PR under ELE-2420.
+
+## References
+
+- `core/__init__.py`, `geo/__init__.py`, `distributed/__init__.py` — existing good examples
+- `reporting/analytics/polling_analyzer.py` — known violation
+- `data/redistricting_data_hub.py` — mixed-pattern example
+- PR #389 — fixed the tests but not the runtime
+- `docs/FAILURE_MODES.md` CC4 — ImportError cascade pattern

--- a/docs/adr/0006-polling-analyzer-location.md
+++ b/docs/adr/0006-polling-analyzer-location.md
@@ -1,53 +1,78 @@
-# ADR 0006 — polling_analyzer location
+# ADR 0006 — PollingAnalyzer deprecation and replacement
 
-**Status:** Proposed
-**Date:** 2026-04-22
-**Epic:** ELE-2415 (sub-issue ELE-2417)
+**Status:** Accepted (supersedes prior "Proposed" draft that recommended moving the class)
+**Date:** 2026-04-22 (revised 2026-04-23)
+**Epic:** ELE-2415 (implemented under ELE-2439 + ELE-2440)
 
 ## Context
 
-`siege_utilities/reporting/analytics/polling_analyzer.py` lives under `reporting/`, but its code is analytics, not reporting. Functions like `create_cross_tabulation_matrix`, `create_longitudinal_analysis`, `create_performance_rankings`, and `create_change_detection_data` are pure data operations. Only `create_heatmap_visualization` and `create_trend_analysis_chart` are reporting-shaped (they produce matplotlib Figures).
+`reporting/analytics/polling_analyzer.py` was written before the `survey/` module existed. It bundles three concerns:
 
-`docs/INTENT.md` flagged this as divergence D6. PR #389 reshaped the file but didn't move it.
+1. Cross-tabulation (now duplicated by `survey.crosstab.build_chain` + `data.cross_tabulation`).
+2. Longitudinal analysis + change detection (genuinely useful, nowhere else in the library).
+3. Heatmap / trend chart generation (reporting's job, not analytics').
+
+On top of this, its location (`reporting/analytics/`) inverts the natural dependency: analytics is an upstream concern; reporting is one consumer of it. And surveys *have waves* — meaning the "longitudinal" concept belongs in the survey model, not a standalone analyzer.
+
+The original draft of this ADR proposed moving the file into a new `analytics/polling/` location. That was a half-measure. With the survey module already offering a cleaner pipeline, the right answer is to deprecate `PollingAnalyzer` and distribute its value to places that already handle the underlying natures.
 
 ## Decision
 
-**Split on the function boundary, not the module-of-concern.**
+**Deprecate `PollingAnalyzer`. Redistribute its content by nature. Remove after one minor version.**
 
-1. Create `siege_utilities/analytics/polling/` as a new subpackage.
-2. Move generic analytics primitives there: `create_cross_tabulation_matrix`, `create_longitudinal_analysis`, `create_performance_rankings`, `create_change_detection_data`, `create_polling_summary`. Also move `PollingAnalysisError` and `_choose_heatmap_fmt` helper.
-3. Keep reporting-shaped wrappers in `reporting/analytics/polling/` or inline them in `reporting/charts/`: `create_heatmap_visualization`, `create_trend_analysis_chart`.
-4. `PollingAnalyzer` class stays in the analytics tree; the two chart methods become standalone module functions in the reporting tree OR a `ChartablePollingAnalyzer` mixin that depends on `reporting`.
+### Immediate (this audit)
 
-The end goal: importing `siege_utilities.analytics.polling` does NOT pull reportlab/matplotlib at module load — only when a charting function is called.
+| Thing | New home | Rationale |
+|---|---|---|
+| Cross-tabulation | `data/statistics/cross_tabulation` (ELE-2437) | Already lives there; polling_analyzer's was a near-duplicate. |
+| Longitudinal analysis, change detection | `data/statistics/longitudinal.py` | Pure stats primitives; survey waves delegate to these. |
+| Heatmap / trend chart helpers | `reporting/polling_charts.py` (or absorbed by `reporting/wave_charts.py`) | Reporting's responsibility. |
+| `PollingAnalyzer` class | Stays for one minor version, emits `DeprecationWarning` on construction. | Soft break for any unknown consumers. |
+| `reporting/analytics/` subdirectory | Deleted. `analytics_reports.py` promoted to `reporting/analytics_reports.py`. | The subdirectory existed only for polling_analyzer. |
+
+### Near-term (ELE-2440)
+
+Add first-class **`Wave`** and **`WaveSet`** dataclasses to `survey/models.py`. A `WaveSet.compare_chain(row_var, break_vars)` produces longitudinal crosstab results directly — the thing `PollingAnalyzer.longitudinal_analysis` was trying to do, but natively modeled instead of tacked on.
+
+`survey/waves.py` holds the longitudinal logic (delegating to `data/statistics/longitudinal`). `reporting/wave_charts.py` provides the chart wrappers.
+
+### Next minor release
+
+Remove `PollingAnalyzer`, remove the top-level export, remove the deprecation shim.
 
 ## Consequences
 
 **Positive:**
-- Analytics primitives don't require reportlab (fixes the `reportlab` module-load cascade per ADR 0005)
-- Location matches purpose (directly addresses divergence D6)
-- Easier to test the analytics functions in a slim environment
+- Nature wins: cross-tab is stats, longitudinal is stats, charts are reporting, waves are survey. Each lives where it belongs.
+- Waves model fills a genuine gap in the survey module.
+- Deletes ~467 LOC of duplicated / orphaned logic.
+- Eliminates the inverted `reporting/analytics/` path.
 
 **Negative:**
-- Existing callers that do `from siege_utilities.reporting.analytics.polling_analyzer import PollingAnalyzer` need to change. Fix: re-export from old path with a `DeprecationWarning` for one minor version.
-- The `PollingAnalyzer` class API is now split across two trees. Fix: keep the class in analytics/; chart methods become free functions `from siege_utilities.reporting.analytics.polling import render_heatmap`.
+- Any external caller using `from siege_utilities import PollingAnalyzer` gets a `DeprecationWarning` now and a hard break one release later. Mitigation: migration guide in the deprecation message and CHANGELOG.
+- Heatmap / trend chart helpers need a new home. Not a lot of code.
 
 ## Alternatives considered
 
-1. **Keep as-is** — rejected. Violates the intent statement; compounds the import-cascade problem.
-2. **Move the whole file to `analytics/`** — rejected. Then chart functions in `analytics/` import matplotlib at module load — same problem, different directory.
-3. **Split further: data/polling/ for pandas ops, analytics/ for analytics wrappers, reporting/ for charts** — rejected as over-engineering. Two locations is enough.
+1. **Move `PollingAnalyzer` intact to `analytics/polling/`** (the previous draft). Rejected. Leaves the duplicated cross-tab logic, doesn't address the missing wave abstraction, and keeps an orphaned class.
+2. **Straight-delete with no deprecation window.** Rejected even though the class has no known users. It's publicly exported; unknown downstream users deserve a warning.
+3. **Keep and fix in place.** Rejected — there's no way to fix the "bundled by workflow, not nature" design without splitting.
 
 ## Migration
 
-- Phase M2 (per ARCHITECTURE.md): create `siege_utilities/analytics/polling/` alongside existing file.
-- Export `PollingAnalyzer` from new location; old path re-exports with `DeprecationWarning`.
-- Notebooks using the old path work unchanged; new notebooks (ELE-2421) use the new path.
-- Remove old path in next major version.
+- Phase 1 (this audit, paired with ELE-2437):
+  - Extract longitudinal/change-detection to `data/statistics/longitudinal.py`.
+  - Add `DeprecationWarning` on `PollingAnalyzer.__init__` with migration text pointing to `survey.WaveSet` (incoming) + `data.statistics`.
+  - Delete `reporting/analytics/` subdirectory; promote `analytics_reports.py`.
+- Phase 2 (ELE-2440):
+  - Ship `Wave` / `WaveSet` + `reporting/wave_charts.py`.
+- Phase 3 (next minor release):
+  - Remove `PollingAnalyzer` class and top-level export.
 
 ## References
 
-- `docs/INTENT.md` D6
-- `reporting/analytics/polling_analyzer.py` (current location)
-- PR #389 (recent reshape)
-- ADR 0005 (lazy-import convention)
+- `docs/INTENT.md` D7
+- `reporting/analytics/polling_analyzer.py` (current location; to be removed)
+- `survey/__init__.py` (target home for wave abstraction)
+- `data/cross_tabulation.py` (already present; will grow a `longitudinal.py` sibling)
+- ELE-2437, ELE-2439, ELE-2440

--- a/docs/adr/0006-polling-analyzer-location.md
+++ b/docs/adr/0006-polling-analyzer-location.md
@@ -1,0 +1,53 @@
+# ADR 0006 — polling_analyzer location
+
+**Status:** Proposed
+**Date:** 2026-04-22
+**Epic:** ELE-2415 (sub-issue ELE-2417)
+
+## Context
+
+`siege_utilities/reporting/analytics/polling_analyzer.py` lives under `reporting/`, but its code is analytics, not reporting. Functions like `create_cross_tabulation_matrix`, `create_longitudinal_analysis`, `create_performance_rankings`, and `create_change_detection_data` are pure data operations. Only `create_heatmap_visualization` and `create_trend_analysis_chart` are reporting-shaped (they produce matplotlib Figures).
+
+`docs/INTENT.md` flagged this as divergence D6. PR #389 reshaped the file but didn't move it.
+
+## Decision
+
+**Split on the function boundary, not the module-of-concern.**
+
+1. Create `siege_utilities/analytics/polling/` as a new subpackage.
+2. Move generic analytics primitives there: `create_cross_tabulation_matrix`, `create_longitudinal_analysis`, `create_performance_rankings`, `create_change_detection_data`, `create_polling_summary`. Also move `PollingAnalysisError` and `_choose_heatmap_fmt` helper.
+3. Keep reporting-shaped wrappers in `reporting/analytics/polling/` or inline them in `reporting/charts/`: `create_heatmap_visualization`, `create_trend_analysis_chart`.
+4. `PollingAnalyzer` class stays in the analytics tree; the two chart methods become standalone module functions in the reporting tree OR a `ChartablePollingAnalyzer` mixin that depends on `reporting`.
+
+The end goal: importing `siege_utilities.analytics.polling` does NOT pull reportlab/matplotlib at module load — only when a charting function is called.
+
+## Consequences
+
+**Positive:**
+- Analytics primitives don't require reportlab (fixes the `reportlab` module-load cascade per ADR 0005)
+- Location matches purpose (directly addresses divergence D6)
+- Easier to test the analytics functions in a slim environment
+
+**Negative:**
+- Existing callers that do `from siege_utilities.reporting.analytics.polling_analyzer import PollingAnalyzer` need to change. Fix: re-export from old path with a `DeprecationWarning` for one minor version.
+- The `PollingAnalyzer` class API is now split across two trees. Fix: keep the class in analytics/; chart methods become free functions `from siege_utilities.reporting.analytics.polling import render_heatmap`.
+
+## Alternatives considered
+
+1. **Keep as-is** — rejected. Violates the intent statement; compounds the import-cascade problem.
+2. **Move the whole file to `analytics/`** — rejected. Then chart functions in `analytics/` import matplotlib at module load — same problem, different directory.
+3. **Split further: data/polling/ for pandas ops, analytics/ for analytics wrappers, reporting/ for charts** — rejected as over-engineering. Two locations is enough.
+
+## Migration
+
+- Phase M2 (per ARCHITECTURE.md): create `siege_utilities/analytics/polling/` alongside existing file.
+- Export `PollingAnalyzer` from new location; old path re-exports with `DeprecationWarning`.
+- Notebooks using the old path work unchanged; new notebooks (ELE-2421) use the new path.
+- Remove old path in next major version.
+
+## References
+
+- `docs/INTENT.md` D6
+- `reporting/analytics/polling_analyzer.py` (current location)
+- PR #389 (recent reshape)
+- ADR 0005 (lazy-import convention)

--- a/docs/adr/0007-argument-tabletype-location.md
+++ b/docs/adr/0007-argument-tabletype-location.md
@@ -1,0 +1,58 @@
+# ADR 0007 — Argument + TableType location
+
+**Status:** Proposed
+**Date:** 2026-04-22
+**Epic:** ELE-2415 (sub-issue ELE-2417)
+
+## Context
+
+`Argument` (dataclass) and `TableType` (enum) live in `siege_utilities/reporting/pages/page_models.py`. Consumers:
+
+- `reporting/pages/` — their home
+- `survey/models.py` — `Chain.table_type: TableType` field
+- `survey/crosstab.py` — `TableType` enum values drive dispatch
+- `survey/render.py` — returns `Argument` objects
+- `analytics/google_slides.py` — consumes `Argument` to render slides
+
+Five consumers across three modules — these types are cross-cutting, not reporting-internal. The `page_models` filename also suggests "one of many page types" which is no longer accurate after `Argument` moved in.
+
+`docs/INTENT.md` flagged this as divergence D8.
+
+## Decision
+
+**Move `Argument` and `TableType` to `siege_utilities/reporting/models.py`. Keep `reporting/pages/page_models.py` for actual Page subclasses (`TitlePage`, `TableOfContentsPage`, `ContentPage`).**
+
+Why `reporting/models.py` and not `core/models.py`:
+- Only 3 modules consume these types; promotion to `core/` is premature
+- They're conceptually reporting-domain (a "table type" and an "argument" are both reporting concepts, even if survey and analytics also use them)
+- Keeps the import graph honest: survey and analytics depend on reporting, not the other way around
+
+## Consequences
+
+**Positive:**
+- Filename matches content (`reporting/models.py` instead of `pages/page_models.py` for things that aren't pages)
+- Single source of truth per-type
+- Lower risk of future divergence (no more "is this a page concern or not?")
+
+**Negative:**
+- Existing imports `from siege_utilities.reporting.pages.page_models import Argument, TableType` need to change. Fix: re-export from old path with `DeprecationWarning` for one minor version.
+- Mild increase in module count.
+
+## Alternatives considered
+
+1. **Keep in `page_models.py`** — rejected. Filename lies about contents.
+2. **Move to `core/models.py`** — rejected. Promotion without enough cross-cutting users; circular-dependency risk if `core/` grows to include domain types.
+3. **Move to a new `siege_utilities/models/` top-level package** — rejected. Over-indexes on "shared types" when we have only two cross-cutting types today. If the count grows to 5+, revisit.
+
+## Migration
+
+- Phase M2 (per ARCHITECTURE.md): create `reporting/models.py` with the new canonical location.
+- Old `reporting/pages/page_models.py` re-exports with `DeprecationWarning` for one minor version.
+- Update `survey/*.py` and `analytics/google_slides.py` imports in the same PR.
+- Existing notebooks and external callers have one release to migrate.
+
+## References
+
+- `docs/INTENT.md` D8
+- `reporting/pages/page_models.py` (current location)
+- `survey/models.py`, `survey/crosstab.py`, `survey/render.py`, `analytics/google_slides.py` (consumers)


### PR DESCRIPTION
Linear: [ELE-2417](https://linear.app/elect-info/issue/ELE-2417/audit-26-propose-new-architecture-adrs) — audit sub-issue 2/6.

Gates on: [PR #393 (intent)](https://github.com/siege-analytics/siege_utilities/pull/393), [PR #394 (failure modes)](https://github.com/siege-analytics/siege_utilities/pull/394) both in review.

## What

- \`docs/ARCHITECTURE.md\` — three-layer model, imports-go-DOWN invariant, violation inventory, four-phase migration plan
- \`docs/adr/0001…0007\` — seven ADRs for each structural decision surfaced across INTENT / FAILURE_MODES

## ADR map

| # | Decision | Resolves |
|---|---|---|
| 0001 | \`render.chain_to_argument\` canonical; method delegates | INTENT D9 |
| 0002 | Remove chart/map generator kwargs | PR #391 guard |
| 0003 | BoundaryProvider registry pattern | — |
| 0004 | Pydantic for external-facing, dataclass for internal | — |
| 0005 | Lazy-import convention (PEP 562 \`__getattr__\` + function-level for heavy deps) | FAILURE_MODES CC4 |
| 0006 | Split \`polling_analyzer.py\` — analytics vs reporting | INTENT D6 |
| 0007 | Move \`Argument\` / \`TableType\` to \`reporting/models.py\` | INTENT D8 |

## Migration sequencing

Phase M1 (this PR): docs only, no code changes
Phase M2 (ELE-2420): structural moves — ADR 0006, 0007
Phase M3 (ELE-2420): ownership consolidation — ADR 0001, 0002
Phase M4 (ELE-2420 + future): architecture patterns — ADR 0003, 0004, 0005

Each phase keeps the public surface stable via re-exports + DeprecationWarning for one minor version.

## Review ask

Two classes of feedback:
1. **Decision** — for each ADR, do you agree with the chosen option? If not, which alternative would you pick?
2. **Completeness** — did I miss a structural question that should be an ADR? (e.g. "should \`admin/\` + \`profile_manager\` become a separate top-level package?")

## Test plan

- [x] Markdown renders correctly
- [ ] @dheerajchand reviews all 7 ADRs
- [ ] Decisions locked as "Accepted" in each ADR file (currently "Proposed")