### PR TITLE
fix(ELE-2420): reporting config exports raise instead of returning False

### DIFF
--- a/siege_utilities/reporting/__init__.py
+++ b/siege_utilities/reporting/__init__.py
@@ -127,35 +127,109 @@ def create_powerpoint_generator(client_name: str, client_code: str = None):
     return _PG(client_name, output_dir)
 
 
+class ReportingConfigError(RuntimeError):
+    """Raised when a reporting configuration export / import cannot complete."""
+
+
 def export_branding_config(client_name: str, export_path: str) -> bool:
-    """Export client branding configuration to a file."""
+    """Export client branding configuration to a file.
+
+    Parameters
+    ----------
+    client_name : str
+        Name of the client whose branding should be exported.
+    export_path : str
+        Destination path for the export.
+
+    Returns
+    -------
+    bool
+        True on success. (Never returns False — failures raise.)
+
+    Raises
+    ------
+    ReportingConfigError
+        On any failure — OS error writing the file, missing client, etc.
+    """
     try:
         from .client_branding import ClientBrandingManager as _CBM
         branding_manager = _CBM()
         return branding_manager.export_branding_config(client_name, Path(export_path))
-    except Exception as e:
-        log.error(f"Failed to export branding config: {e}")
-        return False
+    except (OSError, ValueError, KeyError) as e:
+        log.error(
+            "export_branding_config failed (client=%s, path=%s): %s",
+            client_name, export_path, e,
+        )
+        raise ReportingConfigError(
+            f"failed to export branding for client={client_name!r} to {export_path!r}"
+        ) from e
 
 
 def import_branding_config(import_path: str, client_name: str = None) -> bool:
-    """Import client branding configuration from a file."""
+    """Import client branding configuration from a file.
+
+    Parameters
+    ----------
+    import_path : str
+        Source file to read branding from.
+    client_name : str, optional
+        Client to associate with the imported branding. When omitted, the
+        implementation picks a name from the file.
+
+    Returns
+    -------
+    bool
+        True on success.
+
+    Raises
+    ------
+    ReportingConfigError
+        On any failure — file missing, parse error, client collision.
+    """
     try:
         from .client_branding import ClientBrandingManager as _CBM
         branding_manager = _CBM()
         return branding_manager.import_branding_config(Path(import_path), client_name)
-    except Exception as e:
-        log.error(f"Failed to import branding config: {e}")
-        return False
+    except (OSError, ValueError, KeyError) as e:
+        log.error(
+            "import_branding_config failed (path=%s, client=%s): %s",
+            import_path, client_name, e,
+        )
+        raise ReportingConfigError(
+            f"failed to import branding from {import_path!r} (client={client_name!r})"
+        ) from e
 
 
 def export_chart_type_config(chart_type_name: str, output_path: str) -> bool:
-    """Export chart type configuration to a file."""
+    """Export chart type configuration to a file.
+
+    Parameters
+    ----------
+    chart_type_name : str
+        Name of the chart type (must exist in the registry).
+    output_path : str
+        Destination file path.
+
+    Returns
+    -------
+    bool
+        True on success.
+
+    Raises
+    ------
+    ReportingConfigError
+        On any failure — unknown chart type, OS error writing.
+    """
     try:
         from .chart_types import ChartTypeRegistry as _CTR
         chart_registry = _CTR()
         chart_registry.export_chart_type_config(chart_type_name, output_path)
         return True
-    except Exception as e:
-        log.error(f"Failed to export chart type config: {e}")
-        return False
+    except (OSError, ValueError, KeyError) as e:
+        log.error(
+            "export_chart_type_config failed (chart_type=%s, path=%s): %s",
+            chart_type_name, output_path, e,
+        )
+        raise ReportingConfigError(
+            f"failed to export chart type {chart_type_name!r} to {output_path!r}"
+        ) from e

--- a/tests/test_reporting_config_exports.py
+++ b/tests/test_reporting_config_exports.py
@@ -1,0 +1,112 @@
+"""Tests for reporting top-level config export/import functions (ELE-2420).
+
+Applies PU3 from docs/TEST_UPGRADES.md — every raise path has a negative test.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from siege_utilities.reporting import (
+    ReportingConfigError,
+    export_branding_config,
+    import_branding_config,
+    export_chart_type_config,
+)
+
+
+class TestExportBrandingConfig:
+    def test_raises_on_os_error(self, tmp_path, monkeypatch):
+        """OSError from the branding manager surfaces as ReportingConfigError."""
+        class _Boom:
+            def export_branding_config(self, *a, **kw):
+                raise OSError("disk full")
+
+        with patch("siege_utilities.reporting.client_branding.ClientBrandingManager", return_value=_Boom()):
+            with pytest.raises(ReportingConfigError, match="failed to export"):
+                export_branding_config("acme", str(tmp_path / "out.yaml"))
+
+    def test_raises_on_unknown_client(self, tmp_path):
+        """ValueError from the manager (unknown client) surfaces as ReportingConfigError."""
+        class _Boom:
+            def export_branding_config(self, *a, **kw):
+                raise ValueError("unknown client")
+
+        with patch("siege_utilities.reporting.client_branding.ClientBrandingManager", return_value=_Boom()):
+            with pytest.raises(ReportingConfigError, match="acme"):
+                export_branding_config("acme", str(tmp_path / "out.yaml"))
+
+    def test_success_returns_true(self, tmp_path):
+        class _OK:
+            def export_branding_config(self, *a, **kw):
+                return True
+
+        with patch("siege_utilities.reporting.client_branding.ClientBrandingManager", return_value=_OK()):
+            assert export_branding_config("acme", str(tmp_path / "out.yaml")) is True
+
+
+class TestImportBrandingConfig:
+    def test_raises_on_missing_file(self, tmp_path):
+        class _Boom:
+            def import_branding_config(self, *a, **kw):
+                raise OSError("no such file")
+
+        with patch("siege_utilities.reporting.client_branding.ClientBrandingManager", return_value=_Boom()):
+            with pytest.raises(ReportingConfigError):
+                import_branding_config(str(tmp_path / "missing.yaml"))
+
+    def test_raises_on_parse_error(self, tmp_path):
+        class _Boom:
+            def import_branding_config(self, *a, **kw):
+                raise ValueError("bad yaml")
+
+        with patch("siege_utilities.reporting.client_branding.ClientBrandingManager", return_value=_Boom()):
+            with pytest.raises(ReportingConfigError):
+                import_branding_config(str(tmp_path / "out.yaml"))
+
+    def test_success_passes_client_name(self, tmp_path):
+        captured = {}
+
+        class _OK:
+            def import_branding_config(self, path, client_name):
+                captured["path"] = path
+                captured["client_name"] = client_name
+                return True
+
+        with patch("siege_utilities.reporting.client_branding.ClientBrandingManager", return_value=_OK()):
+            assert import_branding_config(str(tmp_path / "x.yaml"), client_name="acme") is True
+        assert captured["client_name"] == "acme"
+
+
+class TestExportChartTypeConfig:
+    def test_raises_on_unknown_chart_type(self, tmp_path):
+        class _Boom:
+            def export_chart_type_config(self, *a, **kw):
+                raise KeyError("unknown chart type")
+
+        with patch("siege_utilities.reporting.chart_types.ChartTypeRegistry", return_value=_Boom()):
+            with pytest.raises(ReportingConfigError, match="mystery_chart"):
+                export_chart_type_config("mystery_chart", str(tmp_path / "out.json"))
+
+    def test_success_returns_true(self, tmp_path):
+        class _OK:
+            def export_chart_type_config(self, *a, **kw):
+                return None  # implementation returns None; wrapper returns True
+
+        with patch("siege_utilities.reporting.chart_types.ChartTypeRegistry", return_value=_OK()):
+            assert export_chart_type_config("bar", str(tmp_path / "out.json")) is True
+
+
+class TestReportingConfigError:
+    def test_is_runtime_error(self):
+        assert issubclass(ReportingConfigError, RuntimeError)
+
+    def test_preserves_cause(self):
+        """raise ... from e should populate __cause__ for traceback chain."""
+        original = OSError("underlying")
+        wrapped = ReportingConfigError("wrapped")
+        try:
+            raise wrapped from original
+        except ReportingConfigError as e:
+            assert e.__cause__ is original

--- a/tests/test_reporting_config_exports.py
+++ b/tests/test_reporting_config_exports.py
@@ -4,7 +4,7 @@ Applies PU3 from docs/TEST_UPGRADES.md — every raise path has a negative test.
 """
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 


### PR DESCRIPTION
Linear: [ELE-2420](https://linear.app/elect-info/issue/ELE-2420/audit-56-rewrite-functions-tasks-against-current-skill-rubrics) — audit sub-issue 5/6, first rewrite PR.

References [ELE-2418 / PR #394](https://github.com/siege-analytics/siege_utilities/pull/394) — these were the reporting/__init__.py:138,149,161 sites called out as CC1 (silent-swallow).

## What changed

Three top-level reporting functions rewritten:
- \`export_branding_config\`
- \`import_branding_config\`
- \`export_chart_type_config\`

**Before:** \`except Exception: log.error(...); return False\` — caller can't distinguish \"nothing to export\" from \"export crashed.\"

**After:** catches typed (OSError, ValueError, KeyError), logs with input context, raises new \`ReportingConfigError(RuntimeError)\` with \`from e\` chaining.

## Tests added

\`tests/test_reporting_config_exports.py\` — 10 tests:
- Negative tests for every raise path (PU3 from TEST_UPGRADES.md)
- Success paths verified
- \`ReportingConfigError.__cause__\` chain preserved
- Client-name arg forwarding asserted

## Pattern

This is the first of several ELE-2420 rewrite PRs. Same pattern applies to ~20 other CC1 sites called out in docs/FAILURE_MODES.md — each gets its own per-module PR so review stays small.

## Breaking change?

Yes, but scoped:
- Callers that used \`if not export_branding_config(...):\` now need \`try: ... except ReportingConfigError:\`
- Callers that passed through the boolean unchanged (assignment, return value) are unaffected if they never hit a failure

Will be documented in the next CHANGELOG entry under \"Changed.\"