### PR TITLE
fix(ELE-2420): chart_types raises typed exceptions instead of returning None

### DIFF
--- a/siege_utilities/reporting/chart_types.py
+++ b/siege_utilities/reporting/chart_types.py
@@ -4,12 +4,9 @@ Provides base chart types and easy extension capabilities.
 """
 
 import logging
-from pathlib import Path
-from typing import Dict, Any, Optional, List, Union, Callable, Type
+from typing import Dict, Any, Optional, List, Callable
 from dataclasses import dataclass, field
 import yaml
-from abc import ABC, abstractmethod
-import pandas as pd
 from matplotlib.figure import Figure
 
 try:
@@ -18,8 +15,6 @@ try:
 except ImportError:
     gpd = None
     _GEOPANDAS_AVAILABLE = False
-import matplotlib.pyplot as plt
-import seaborn as sns
 
 log = logging.getLogger(__name__)
 

--- a/siege_utilities/reporting/chart_types.py
+++ b/siege_utilities/reporting/chart_types.py
@@ -23,6 +23,19 @@ import seaborn as sns
 
 log = logging.getLogger(__name__)
 
+
+class UnknownChartTypeError(LookupError):
+    """Raised when a chart type name is not in the registry."""
+
+
+class ChartParameterError(ValueError):
+    """Raised when required parameters are missing or invalid."""
+
+
+class ChartCreationError(RuntimeError):
+    """Raised when the underlying create function fails to produce a Figure."""
+
+
 @dataclass
 class ChartType:
     """Base chart type configuration."""
@@ -318,41 +331,64 @@ class ChartTypeRegistry:
     def create_chart(self, chart_type_name: str, **kwargs) -> Optional[Figure]:
         """
         Create a chart using the specified chart type.
-        
-        Args:
-            chart_type_name: Name of the chart type
-            **kwargs: Chart parameters
-            
-        Returns:
-            Matplotlib Figure object or None if creation fails
+
+        Parameters
+        ----------
+        chart_type_name : str
+            Name of the chart type (must exist in the registry).
+        **kwargs
+            Parameters for the chart; must include every entry in the chart
+            type's ``required_parameters``.
+
+        Returns
+        -------
+        matplotlib.figure.Figure
+
+        Raises
+        ------
+        UnknownChartTypeError
+            If ``chart_type_name`` isn't registered.
+        ChartParameterError
+            If required parameters are missing.
+        ChartCreationError
+            If the chart type has no create function, or the create function
+            raised.
         """
         chart_type = self.get_chart_type(chart_type_name)
         if not chart_type:
-            log.error(f"Chart type not found: {chart_type_name}")
-            return None
-        
+            log.error("Chart type not found: %s", chart_type_name)
+            raise UnknownChartTypeError(
+                f"chart type {chart_type_name!r} not in registry; "
+                f"known: {sorted(self.chart_types.keys())}"
+            )
+
         # Validate required parameters
-        missing_params = [param for param in chart_type.required_parameters 
+        missing_params = [param for param in chart_type.required_parameters
                          if param not in kwargs]
         if missing_params:
-            log.error(f"Missing required parameters: {missing_params}")
-            return None
-        
+            log.error("Missing required parameters for %s: %s", chart_type_name, missing_params)
+            raise ChartParameterError(
+                f"chart type {chart_type_name!r} missing required params: {missing_params}"
+            )
+
         # Apply default values for optional parameters
         for param, default_value in chart_type.optional_parameters.items():
             if param not in kwargs:
                 kwargs[param] = default_value
-        
-        # Create chart using the registered function
-        if chart_type.create_function:
-            try:
-                return chart_type.create_function(**kwargs)
-            except Exception as e:
-                log.error(f"Failed to create chart {chart_type_name}: {e}")
-                return None
-        else:
-            log.warning(f"No create function registered for chart type: {chart_type_name}")
-            return None
+
+        if chart_type.create_function is None:
+            raise ChartCreationError(
+                f"chart type {chart_type_name!r} has no create function registered; "
+                f"call add_chart_creator() first"
+            )
+
+        try:
+            return chart_type.create_function(**kwargs)
+        except (ValueError, TypeError, KeyError, AttributeError) as e:
+            log.error("Create function for %s raised: %s", chart_type_name, e)
+            raise ChartCreationError(
+                f"create function for chart type {chart_type_name!r} failed"
+            ) from e
     
     def add_chart_creator(self, chart_type_name: str, create_function: Callable):
         """
@@ -370,36 +406,51 @@ class ChartTypeRegistry:
             log.warning(f"Chart type not found: {chart_type_name}")
     
     def validate_chart_parameters(self, chart_type_name: str, **kwargs) -> bool:
-        """
-        Validate parameters for a chart type.
-        
-        Args:
-            chart_type_name: Name of the chart type
-            **kwargs: Parameters to validate
-            
-        Returns:
-            True if parameters are valid, False otherwise
+        """Validate parameters for a chart type without creating the chart.
+
+        Parameters
+        ----------
+        chart_type_name : str
+        **kwargs
+            Parameters to validate.
+
+        Returns
+        -------
+        bool
+            True iff required params present AND any custom ``validate_function``
+            returns truthy.
+
+        Raises
+        ------
+        UnknownChartTypeError
+            If ``chart_type_name`` isn't registered. (Legitimately-missing
+            validation returns False; unknown chart type is a caller error.)
+        ChartParameterError
+            If the custom validate function raised.
         """
         chart_type = self.get_chart_type(chart_type_name)
         if not chart_type:
-            return False
-        
+            raise UnknownChartTypeError(
+                f"chart type {chart_type_name!r} not in registry"
+            )
+
         # Check required parameters
-        missing_params = [param for param in chart_type.required_parameters 
+        missing_params = [param for param in chart_type.required_parameters
                          if param not in kwargs]
         if missing_params:
-            log.warning(f"Missing required parameters: {missing_params}")
+            log.warning("Missing required parameters for %s: %s", chart_type_name, missing_params)
             return False
-        
-        # Run custom validation if available
-        if chart_type.validate_function:
-            try:
-                return chart_type.validate_function(**kwargs)
-            except Exception as e:
-                log.error(f"Validation function failed: {e}")
-                return False
-        
-        return True
+
+        if chart_type.validate_function is None:
+            return True
+
+        try:
+            return bool(chart_type.validate_function(**kwargs))
+        except (ValueError, TypeError, KeyError, AttributeError) as e:
+            log.error("validate function for %s raised: %s", chart_type_name, e)
+            raise ChartParameterError(
+                f"validate_function for chart type {chart_type_name!r} raised"
+            ) from e
     
     def get_chart_help(self, chart_type_name: str) -> Dict[str, Any]:
         """

--- a/siege_utilities/reporting/chart_types.py
+++ b/siege_utilities/reporting/chart_types.py
@@ -384,7 +384,7 @@ class ChartTypeRegistry:
 
         try:
             return chart_type.create_function(**kwargs)
-        except (ValueError, TypeError, KeyError, AttributeError) as e:
+        except Exception as e:
             log.error("Create function for %s raised: %s", chart_type_name, e)
             raise ChartCreationError(
                 f"create function for chart type {chart_type_name!r} failed"

--- a/tests/test_chart_types.py
+++ b/tests/test_chart_types.py
@@ -1,9 +1,13 @@
 """Tests for siege_utilities.reporting.chart_types module."""
 
+import pytest
 from unittest.mock import MagicMock
 from siege_utilities.reporting.chart_types import (
+    ChartCreationError,
+    ChartParameterError,
     ChartType,
     ChartTypeRegistry,
+    UnknownChartTypeError,
     get_chart_registry,
 )
 
@@ -131,20 +135,20 @@ class TestChartTypeRegistryCreateChart:
             required_parameters=["data", "x_column"],
         )
         registry.register_chart_type(ct)
-        result = registry.create_chart("needs_params", data=[1])
-        assert result is None  # missing x_column
+        with pytest.raises(ChartParameterError):
+            registry.create_chart("needs_params", data=[1])
 
     def test_create_no_function(self):
         registry = ChartTypeRegistry()
         ct = ChartType(name="no_fn", category="test", required_parameters=[])
         registry.register_chart_type(ct)
-        result = registry.create_chart("no_fn")
-        assert result is None
+        with pytest.raises(ChartCreationError):
+            registry.create_chart("no_fn")
 
     def test_create_nonexistent_type(self):
         registry = ChartTypeRegistry()
-        result = registry.create_chart("nonexistent")
-        assert result is None
+        with pytest.raises(UnknownChartTypeError):
+            registry.create_chart("nonexistent")
 
     def test_create_function_raises(self):
         registry = ChartTypeRegistry()
@@ -156,8 +160,9 @@ class TestChartTypeRegistryCreateChart:
             create_function=mock_fn,
         )
         registry.register_chart_type(ct)
-        result = registry.create_chart("error_chart")
-        assert result is None
+        with pytest.raises(ChartCreationError) as exc_info:
+            registry.create_chart("error_chart")
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
 
 
 class TestChartTypeRegistryValidation:
@@ -175,7 +180,8 @@ class TestChartTypeRegistryValidation:
 
     def test_nonexistent_type(self):
         registry = ChartTypeRegistry()
-        assert registry.validate_chart_parameters("nonexistent") is False
+        with pytest.raises(UnknownChartTypeError):
+            registry.validate_chart_parameters("nonexistent")
 
     def test_custom_validation_function(self):
         registry = ChartTypeRegistry()

--- a/tests/test_chart_types_errors.py
+++ b/tests/test_chart_types_errors.py
@@ -1,0 +1,101 @@
+"""Tests for the typed exception hierarchy in reporting.chart_types (ELE-2420)."""
+from __future__ import annotations
+
+import pytest
+
+from siege_utilities.reporting.chart_types import (
+    ChartCreationError,
+    ChartParameterError,
+    ChartTypeRegistry,
+    UnknownChartTypeError,
+)
+
+
+@pytest.fixture
+def registry():
+    return ChartTypeRegistry()
+
+
+class TestCreateChart:
+    def test_unknown_chart_type_raises(self, registry):
+        with pytest.raises(UnknownChartTypeError, match="mystery"):
+            registry.create_chart("mystery")
+
+    def test_missing_required_param_raises(self, registry):
+        # pick a registered chart type; bar_chart is a safe assumption
+        known = next(iter(registry.chart_types)) if hasattr(registry, "_chart_types") else "bar_chart"
+        ct = registry.get_chart_type(known)
+        if not ct.required_parameters:
+            pytest.skip("no required params on this chart type")
+        with pytest.raises(ChartParameterError, match="missing required"):
+            registry.create_chart(known)  # no kwargs → missing required
+
+    def test_no_create_function_raises(self, registry):
+        """A chart type registered without a create_function raises on create_chart."""
+        from siege_utilities.reporting.chart_types import ChartType
+        bare = ChartType(name="bare", category="test", required_parameters=[])
+        registry.chart_types[bare.name] = bare
+        with pytest.raises(ChartCreationError, match="no create function"):
+            registry.create_chart("bare")
+
+    def test_create_function_raising_becomes_chart_creation_error(self, registry):
+        """A create_function that raises is translated to ChartCreationError
+        with the original exception as __cause__.
+        """
+        from siege_utilities.reporting.chart_types import ChartType
+        def boom(**kwargs):
+            raise ValueError("boom inside create_function")
+        ct = ChartType(
+            name="boomy",
+            category="test",
+            required_parameters=[],
+            create_function=boom,
+        )
+        registry.chart_types[ct.name] = ct
+
+        with pytest.raises(ChartCreationError, match="create function") as exc_info:
+            registry.create_chart("boomy")
+        assert isinstance(exc_info.value.__cause__, ValueError)
+
+
+class TestValidateChartParameters:
+    def test_unknown_chart_type_raises(self, registry):
+        with pytest.raises(UnknownChartTypeError):
+            registry.validate_chart_parameters("mystery")
+
+    def test_missing_params_returns_false(self, registry):
+        """Missing params is a return-value concern, not an exception."""
+        from siege_utilities.reporting.chart_types import ChartType
+        ct = ChartType(
+            name="strict",
+            category="test",
+            required_parameters=["data"],
+        )
+        registry.chart_types[ct.name] = ct
+        assert registry.validate_chart_parameters("strict") is False
+
+    def test_validate_function_raising_becomes_chart_parameter_error(self, registry):
+        from siege_utilities.reporting.chart_types import ChartType
+        def validator_raises(**kwargs):
+            raise TypeError("validator oops")
+        ct = ChartType(
+            name="bad-validator",
+            category="test",
+            required_parameters=[],
+            validate_function=validator_raises,
+        )
+        registry.chart_types[ct.name] = ct
+        with pytest.raises(ChartParameterError) as exc_info:
+            registry.validate_chart_parameters("bad-validator")
+        assert isinstance(exc_info.value.__cause__, TypeError)
+
+
+class TestExceptionHierarchy:
+    def test_unknown_chart_type_is_lookup_error(self):
+        assert issubclass(UnknownChartTypeError, LookupError)
+
+    def test_chart_parameter_error_is_value_error(self):
+        assert issubclass(ChartParameterError, ValueError)
+
+    def test_chart_creation_error_is_runtime_error(self):
+        assert issubclass(ChartCreationError, RuntimeError)


### PR DESCRIPTION
## Summary
Second per-module rewrite for **ELE-2420**. Replaces silent-swallow returns in `ChartTypeRegistry` with a typed exception hierarchy.

New exceptions in `siege_utilities/reporting/chart_types.py`:
- `UnknownChartTypeError(LookupError)` — unknown chart type name
- `ChartParameterError(ValueError)` — missing or invalid parameters
- `ChartCreationError(RuntimeError)` — `create_function` raised

`create_chart()` and `validate_chart_parameters()` now raise with `from e` chaining instead of returning `None` / `False` on error. This matches the pattern established in #397 for `reporting/__init__.py` and addresses **CC1 (silent-swallow)** from docs/FAILURE_MODES.md (see #394).

## Tests
`tests/test_chart_types_errors.py` — 10 tests, all passing:
- unknown chart type → `UnknownChartTypeError`
- missing required params → `ChartParameterError`
- no `create_function` → `ChartCreationError`
- `create_function` raises → `ChartCreationError` with original `__cause__`
- `validate_chart_parameters` unknown → `UnknownChartTypeError`
- missing params → returns `False` (return-value concern, not exception)
- `validate_function` raises → `ChartParameterError` with original `__cause__`
- exception hierarchy (3 `issubclass` checks)

## Linear
ELE-2420 — https://linear.app/ele/issue/ELE-2420

## References
- #394 (FAILURE_MODES.md — CC1 pattern)
- #397 (first CC1 rewrite — reporting/__init__.py)

## Test plan
- [x] `pytest tests/test_chart_types_errors.py` — 10/10 pass locally
- [ ] CI green