### PR TITLE
fix(ELE-2420): client_branding raises typed exceptions instead of silent-swallow

### DIFF
--- a/siege_utilities/reporting/client_branding.py
+++ b/siege_utilities/reporting/client_branding.py
@@ -12,6 +12,19 @@ import shutil
 
 log = logging.getLogger(__name__)
 
+
+class ClientBrandingError(RuntimeError):
+    """Raised when a client-branding operation fails unexpectedly.
+
+    Use the `__cause__` attribute (set via `raise ... from e`) to inspect
+    the underlying error (YAMLError, OSError, ValidationError, etc.).
+    """
+
+
+class ClientBrandingNotFoundError(LookupError):
+    """Raised when a named client's branding configuration does not exist."""
+
+
 class ClientBrandingManager:
     """
     Manages client branding configurations for reports.
@@ -215,10 +228,11 @@ class ClientBrandingManager:
             
             log.warning(f"No branding configuration found for client: {client_name}")
             return None
-            
+
         except Exception as e:
-            log.error(f"Error loading branding configuration for {client_name}: {e}")
-            return None
+            raise ClientBrandingError(
+                f"Error loading branding configuration for {client_name}: {e}"
+            ) from e
 
     def update_client_branding(self, client_name: str, updates: Dict[str, Any]) -> bool:
         """
@@ -231,32 +245,34 @@ class ClientBrandingManager:
         Returns:
             True if successful, False otherwise
         """
+        current_config = self.get_client_branding(client_name)
+        if not current_config:
+            raise ClientBrandingNotFoundError(
+                f"No existing branding configuration found for {client_name}"
+            )
+
         try:
-            current_config = self.get_client_branding(client_name)
-            if not current_config:
-                log.warning(f"No existing branding configuration found for {client_name}")
-                return False
-            
             # Apply updates
             for key, value in updates.items():
                 if isinstance(value, dict) and key in current_config:
                     current_config[key].update(value)
                 else:
                     current_config[key] = value
-            
+
             # Save updated configuration
             client_dir = self.config_dir / client_name.lower().replace(' ', '_')
             config_file = client_dir / f"{client_name.lower().replace(' ', '_')}_branding.yaml"
-            
+
             with open(config_file, 'w') as f:
                 yaml.dump(current_config, f, default_flow_style=False, indent=2)
-            
+
             log.info(f"Updated branding configuration for {client_name}")
             return True
-            
+
         except Exception as e:
-            log.error(f"Error updating branding configuration for {client_name}: {e}")
-            return False
+            raise ClientBrandingError(
+                f"Error updating branding configuration for {client_name}: {e}"
+            ) from e
 
     def list_clients(self) -> List[str]:
         """
@@ -303,8 +319,9 @@ class ClientBrandingManager:
                 return False
                 
         except Exception as e:
-            log.error(f"Error deleting branding configuration for {client_name}: {e}")
-            return False
+            raise ClientBrandingError(
+                f"Error deleting branding configuration for {client_name}: {e}"
+            ) from e
 
     def create_branding_from_template(self, client_name: str, template_name: str, 
                                     customizations: Optional[Dict[str, Any]] = None) -> Path:
@@ -392,11 +409,13 @@ class ClientBrandingManager:
         Returns:
             True if successful, False otherwise
         """
+        branding_config = self.get_client_branding(client_name)
+        if not branding_config:
+            raise ClientBrandingNotFoundError(
+                f"No branding configuration found for {client_name}"
+            )
+
         try:
-            branding_config = self.get_client_branding(client_name)
-            if not branding_config:
-                return False
-            
             # Export as YAML
             if export_path.suffix.lower() in ['.yaml', '.yml']:
                 with open(export_path, 'w') as f:
@@ -410,13 +429,14 @@ class ClientBrandingManager:
                 export_path = export_path.with_suffix('.yaml')
                 with open(export_path, 'w') as f:
                     yaml.dump(branding_config, f, default_flow_style=False, indent=2)
-            
+
             log.info(f"Exported branding configuration for {client_name} to {export_path}")
             return True
-            
+
         except Exception as e:
-            log.error(f"Error exporting branding configuration for {client_name}: {e}")
-            return False
+            raise ClientBrandingError(
+                f"Error exporting branding configuration for {client_name}: {e}"
+            ) from e
 
     def import_branding_config(self, import_path: Path, client_name: Optional[str] = None) -> bool:
         """
@@ -456,10 +476,13 @@ class ClientBrandingManager:
             # Create client branding
             self.create_client_branding(branding_config['name'], branding_config)
             return True
-            
+
+        except ClientBrandingError:
+            raise
         except Exception as e:
-            log.error(f"Error importing branding configuration: {e}")
-            return False
+            raise ClientBrandingError(
+                f"Error importing branding configuration: {e}"
+            ) from e
 
     def get_branding_summary(self, client_name: str) -> Dict[str, Any]:
         """
@@ -490,5 +513,6 @@ class ClientBrandingManager:
             return summary
             
         except Exception as e:
-            log.error(f"Error getting branding summary for {client_name}: {e}")
-            return {}
+            raise ClientBrandingError(
+                f"Error getting branding summary for {client_name}: {e}"
+            ) from e

--- a/tests/test_client_branding_errors.py
+++ b/tests/test_client_branding_errors.py
@@ -1,7 +1,6 @@
 """Tests for the typed exception hierarchy in reporting.client_branding (ELE-2420)."""
 from __future__ import annotations
 
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest

--- a/tests/test_client_branding_errors.py
+++ b/tests/test_client_branding_errors.py
@@ -1,0 +1,113 @@
+"""Tests for the typed exception hierarchy in reporting.client_branding (ELE-2420)."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from siege_utilities.reporting.client_branding import (
+    ClientBrandingError,
+    ClientBrandingManager,
+    ClientBrandingNotFoundError,
+)
+
+
+@pytest.fixture
+def manager(tmp_path):
+    return ClientBrandingManager(config_dir=tmp_path)
+
+
+class TestExceptionHierarchy:
+    def test_client_branding_error_is_runtime_error(self):
+        assert issubclass(ClientBrandingError, RuntimeError)
+
+    def test_not_found_is_lookup_error(self):
+        assert issubclass(ClientBrandingNotFoundError, LookupError)
+
+
+class TestGetClientBranding:
+    def test_returns_none_when_not_found(self, manager):
+        # No predefined template, no custom dir — legitimate "not found" path
+        assert manager.get_client_branding("nonexistent_xyz") is None
+
+    def test_io_error_raises(self, manager, tmp_path):
+        client_dir = tmp_path / "corrupt_client"
+        client_dir.mkdir()
+        (client_dir / "corrupt_client_branding.yaml").write_text("not: valid: yaml: [")
+        with pytest.raises(ClientBrandingError) as exc_info:
+            manager.get_client_branding("corrupt_client")
+        assert exc_info.value.__cause__ is not None
+
+
+class TestUpdateClientBranding:
+    def test_unknown_client_raises_not_found(self, manager):
+        with pytest.raises(ClientBrandingNotFoundError):
+            manager.update_client_branding("nonexistent_xyz", {"colors": {}})
+
+    def test_io_error_raises_branding_error(self, manager, tmp_path):
+        # Stage an existing client
+        manager.create_client_branding(
+            "tester",
+            {"name": "tester", "colors": {"primary": "#000", "text_color": "#111"}, "fonts": {"default_font": "Helvetica"}},
+        )
+        with patch("builtins.open", side_effect=OSError("disk full")):
+            with pytest.raises(ClientBrandingError) as exc_info:
+                manager.update_client_branding("tester", {"colors": {"primary": "#fff"}})
+            assert isinstance(exc_info.value.__cause__, OSError)
+
+
+class TestDeleteClientBranding:
+    def test_predefined_template_returns_false(self, manager):
+        """Legitimate 'cannot delete template' path stays as False return."""
+        assert manager.delete_client_branding("siege_analytics") is False
+
+    def test_missing_dir_returns_false(self, manager):
+        """Legitimate 'nothing to delete' path stays as False return."""
+        assert manager.delete_client_branding("never_existed") is False
+
+    def test_io_error_raises(self, manager, tmp_path):
+        manager.create_client_branding(
+            "tester",
+            {"name": "tester", "colors": {"primary": "#000", "text_color": "#111"}, "fonts": {"default_font": "Helvetica"}},
+        )
+        with patch("siege_utilities.reporting.client_branding.shutil.rmtree", side_effect=OSError("permission denied")):
+            with pytest.raises(ClientBrandingError) as exc_info:
+                manager.delete_client_branding("tester")
+            assert isinstance(exc_info.value.__cause__, OSError)
+
+
+class TestExportBrandingConfig:
+    def test_unknown_client_raises_not_found(self, manager, tmp_path):
+        with pytest.raises(ClientBrandingNotFoundError):
+            manager.export_branding_config("nonexistent_xyz", tmp_path / "out.yaml")
+
+    def test_io_error_raises(self, manager, tmp_path):
+        with patch("builtins.open", side_effect=OSError("disk full")):
+            with pytest.raises(ClientBrandingError) as exc_info:
+                manager.export_branding_config("siege_analytics", tmp_path / "out.yaml")
+            assert isinstance(exc_info.value.__cause__, OSError)
+
+
+class TestImportBrandingConfig:
+    def test_malformed_yaml_raises(self, manager, tmp_path):
+        bad = tmp_path / "bad.yaml"
+        bad.write_text("not: valid: yaml: [")
+        with pytest.raises(ClientBrandingError) as exc_info:
+            manager.import_branding_config(bad)
+        assert exc_info.value.__cause__ is not None
+
+    def test_unsupported_format_returns_false(self, manager, tmp_path):
+        """Legitimate 'unsupported format' path stays as False return (input validation)."""
+        bogus = tmp_path / "config.txt"
+        bogus.write_text("whatever")
+        assert manager.import_branding_config(bogus) is False
+
+
+class TestGetBrandingSummary:
+    def test_raises_on_corrupt_config(self, manager, tmp_path):
+        client_dir = tmp_path / "corrupt_client"
+        client_dir.mkdir()
+        (client_dir / "corrupt_client_branding.yaml").write_text("not: valid: yaml: [")
+        with pytest.raises(ClientBrandingError):
+            manager.get_branding_summary("corrupt_client")

--- a/tests/test_client_branding_expanded.py
+++ b/tests/test_client_branding_expanded.py
@@ -220,10 +220,14 @@ class TestExportBrandingConfig:
         assert data["name"] == "Siege Analytics"
 
     def test_export_nonexistent_client(self, tmp_path):
+        from siege_utilities.reporting.client_branding import (
+            ClientBrandingNotFoundError,
+        )
+
         mgr = ClientBrandingManager(config_dir=tmp_path / "branding")
         export_path = tmp_path / "export.yaml"
-        result = mgr.export_branding_config("nonexistent", export_path)
-        assert result is False
+        with pytest.raises(ClientBrandingNotFoundError):
+            mgr.export_branding_config("nonexistent", export_path)
 
 
 class TestGetBrandingSummary:


### PR DESCRIPTION
## Summary
Third per-module rewrite for **ELE-2420**. Replaces 5 silent-swallow returns in `ClientBrandingManager` with a typed exception hierarchy.

New exceptions in `siege_utilities/reporting/client_branding.py`:
- `ClientBrandingError(RuntimeError)` — unexpected I/O or parse failure
- `ClientBrandingNotFoundError(LookupError)` — named client has no config

## Sites converted

| Method | Was | Now |
| -- | -- | -- |
| `get_client_branding` | `except: return None` | raises `ClientBrandingError` on I/O/parse failure; still returns `None` when genuinely not found |
| `update_client_branding` | `return False` on not-found; `except: return False` | raises `ClientBrandingNotFoundError` / `ClientBrandingError` |
| `delete_client_branding` | `except: return False` | raises `ClientBrandingError` (keeps `False` for predefined templates + missing dir) |
| `export_branding_config` | `return False` on not-found; `except: return False` | raises `ClientBrandingNotFoundError` / `ClientBrandingError` |
| `import_branding_config` | `except: return False` | raises `ClientBrandingError` (keeps `False` for unsupported format + validation errors) |
| `get_branding_summary` | `except: return {}` | raises `ClientBrandingError` |

Legitimate \"input validation\" `False` paths are preserved. Addresses **CC1 (silent-swallow)** from docs/FAILURE_MODES.md (#394), mirroring #397 and #399.

## Tests
`tests/test_client_branding_errors.py` — 14 tests, all passing.

## Linear
ELE-2420 — https://linear.app/ele/issue/ELE-2420

## References
- #394 (FAILURE_MODES.md)
- #397 (reporting/__init__.py CC1 fix)
- #399 (chart_types.py CC1 fix)

## Test plan
- [x] `pytest tests/test_client_branding_errors.py` — 14/14 pass locally
- [ ] CI green