### PR TITLE
fix(ELE-2420): census_geocoder raises on API failure instead of faking unmatched results

### DIFF
--- a/siege_utilities/geo/census_geocoder.py
+++ b/siege_utilities/geo/census_geocoder.py
@@ -40,6 +40,16 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+class CensusGeocodeError(RuntimeError):
+    """Raised when the Census geocoder API call fails unexpectedly.
+
+    Distinct from "no match" results (which return a CensusGeocodeResult with
+    matched=False). This exception indicates an API / network / parse failure
+    where the geocoder could not even attempt to match. Use `__cause__` to
+    inspect the underlying exception.
+    """
+
+
 class CensusVintage(str, Enum):
     """Census geocoder benchmark/vintage pairs.
 
@@ -247,8 +257,9 @@ def geocode_single(
         return parsed
 
     except Exception as e:
-        log_error(f"Census geocode failed for {input_addr}: {e}")
-        return CensusGeocodeResult(input_address=input_addr)
+        raise CensusGeocodeError(
+            f"Census geocode failed for {input_addr}: {e}"
+        ) from e
 
 
 def geocode_batch(
@@ -301,14 +312,9 @@ def geocode_batch(
     try:
         result = cg.addressbatch(csv_path, returntype="geographies")
     except Exception as e:
-        log_error(f"Census batch geocode failed: {e}")
-        return [
-            CensusGeocodeResult(
-                input_id=addr.get("id", ""),
-                input_address=f"{addr.get('street', '')}, {addr.get('city', '')}, {addr.get('state', '')} {addr.get('zipcode', '')}",
-            )
-            for addr in addresses
-        ]
+        raise CensusGeocodeError(
+            f"Census batch geocode failed for {len(addresses)} addresses: {e}"
+        ) from e
 
     # Parse batch results
     results_by_id = {}

--- a/tests/test_census_geocoder.py
+++ b/tests/test_census_geocoder.py
@@ -1,6 +1,5 @@
 """Tests for siege_utilities.geo.census_geocoder module."""
 
-import json
 import pytest
 from unittest.mock import patch, MagicMock
 

--- a/tests/test_census_geocoder.py
+++ b/tests/test_census_geocoder.py
@@ -5,13 +5,14 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 from siege_utilities.geo.census_geocoder import (
-    CensusVintage,
+    CensusGeocodeError,
     CensusGeocodeResult,
-    select_vintage_for_cycle,
-    geocode_single,
+    CensusVintage,
+    _safe_float,
     geocode_batch,
     geocode_batch_chunked,
-    _safe_float,
+    geocode_single,
+    select_vintage_for_cycle,
 )
 
 
@@ -155,13 +156,15 @@ class TestGeocodeSingle:
         assert result.input_address == "123 Fake St, Nowhere, XX 00000"
 
     @patch("siege_utilities.geo.census_geocoder._get_geocoder")
-    def test_api_error_returns_unmatched(self, mock_get_geocoder):
+    def test_api_error_raises_census_geocode_error(self, mock_get_geocoder):
+        """API failure now raises CensusGeocodeError instead of faking an
+        unmatched result — see ELE-2420 FAILURE_MODES.md CC1."""
         mock_cg = MagicMock()
         mock_cg.onelineaddress.side_effect = Exception("API timeout")
         mock_get_geocoder.return_value = mock_cg
 
-        result = geocode_single("1600 Pennsylvania Ave", "Washington", "DC", "20500")
-        assert not result.matched
+        with pytest.raises(CensusGeocodeError):
+            geocode_single("1600 Pennsylvania Ave", "Washington", "DC", "20500")
 
 
 # --- geocode_batch (mocked) ---

--- a/tests/test_census_geocoder_errors.py
+++ b/tests/test_census_geocoder_errors.py
@@ -8,7 +8,6 @@ import pytest
 from siege_utilities.geo.census_geocoder import (
     CensusGeocodeError,
     CensusGeocodeResult,
-    CensusVintage,
     geocode_batch,
     geocode_single,
 )

--- a/tests/test_census_geocoder_errors.py
+++ b/tests/test_census_geocoder_errors.py
@@ -1,0 +1,73 @@
+"""Tests for the typed exception hierarchy in geo.census_geocoder (ELE-2420)."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from siege_utilities.geo.census_geocoder import (
+    CensusGeocodeError,
+    CensusGeocodeResult,
+    CensusVintage,
+    geocode_batch,
+    geocode_single,
+)
+
+
+class TestExceptionHierarchy:
+    def test_is_runtime_error(self):
+        assert issubclass(CensusGeocodeError, RuntimeError)
+
+
+class TestGeocodeSingle:
+    def test_api_failure_raises(self):
+        fake = MagicMock()
+        fake.onelineaddress.side_effect = ConnectionError("network down")
+        with patch(
+            "siege_utilities.geo.census_geocoder._get_geocoder",
+            return_value=fake,
+        ):
+            with pytest.raises(CensusGeocodeError) as exc_info:
+                geocode_single("1600 Pennsylvania Ave", "Washington", "DC", "20500")
+        assert isinstance(exc_info.value.__cause__, ConnectionError)
+        assert "1600 Pennsylvania Ave" in str(exc_info.value)
+
+    def test_no_match_returns_unmatched_result_not_error(self):
+        """No match is a return-value concern, not an exception."""
+        fake = MagicMock()
+        fake.onelineaddress.return_value = {"result": {"addressMatches": []}}
+        with patch(
+            "siege_utilities.geo.census_geocoder._get_geocoder",
+            return_value=fake,
+        ):
+            result = geocode_single("garbage", "nowhere", "ZZ", "00000")
+        assert isinstance(result, CensusGeocodeResult)
+        assert result.matched is False
+        assert result.input_address == "garbage, nowhere, ZZ 00000"
+
+
+class TestGeocodeBatch:
+    def test_api_failure_raises(self):
+        fake = MagicMock()
+        fake.addressbatch.side_effect = ConnectionError("network down")
+        addresses = [
+            {"id": "1", "street": "a", "city": "b", "state": "c", "zipcode": "d"},
+            {"id": "2", "street": "e", "city": "f", "state": "g", "zipcode": "h"},
+        ]
+        with patch(
+            "siege_utilities.geo.census_geocoder._get_geocoder",
+            return_value=fake,
+        ):
+            with pytest.raises(CensusGeocodeError) as exc_info:
+                geocode_batch(addresses)
+        assert isinstance(exc_info.value.__cause__, ConnectionError)
+        assert "2 addresses" in str(exc_info.value)
+
+    def test_oversize_batch_still_raises_value_error(self):
+        """Input-validation ValueError should not be swallowed or converted."""
+        with pytest.raises(ValueError):
+            geocode_batch([{"id": str(i)} for i in range(10_001)])
+
+    def test_empty_batch_returns_empty_list(self):
+        """Empty input is a legitimate empty-success path."""
+        assert geocode_batch([]) == []


### PR DESCRIPTION
## Summary
Fourth per-module rewrite for **ELE-2420**. Converts two particularly dangerous silent-swallow sites in `siege_utilities/geo/census_geocoder.py`.

Previously, `geocode_single()` and `geocode_batch()` would catch any exception (network, API, parse) and return \`CensusGeocodeResult(matched=False)\`. Downstream pipelines treat unmatched rows as \"address not findable\" and drop them — so API failures silently poisoned entire batches with fake unmatched rows that looked legitimate.

New exception:
- `CensusGeocodeError(RuntimeError)` — API / network / parse failure (distinct from genuine \"no match\" results)

Legitimate \"no match\" → still returns `CensusGeocodeResult(matched=False)`.

## Tests
`tests/test_census_geocoder_errors.py` — 6 tests, all passing:
- `geocode_single` API failure → raises with `__cause__` set
- `geocode_single` no-match → returns unmatched result (return-value path preserved)
- `geocode_batch` API failure → raises with `__cause__` set and batch size in message
- `geocode_batch` oversize → raises input-validation ValueError (preserved)
- `geocode_batch` empty → returns `[]` (preserved)

## Linear
ELE-2420 — https://linear.app/ele/issue/ELE-2420

## References
- #394 (FAILURE_MODES.md CC1)
- #397, #399, #400 (prior CC1 rewrites)

## Test plan
- [x] `pytest tests/test_census_geocoder_errors.py` — 6/6 pass locally
- [ ] CI green