### PR TITLE
fix(ELE-2420): spatial_data raises SpatialDataError instead of silent-swallow

### DIFF
--- a/siege_utilities/geo/spatial_data.py
+++ b/siege_utilities/geo/spatial_data.py
@@ -54,6 +54,18 @@ from .boundary_result import (
 # Get logger for this module
 log = logging.getLogger(__name__)
 
+
+class SpatialDataError(RuntimeError):
+    """Raised when a non-boundary spatial data fetch fails unexpectedly.
+
+    Used by GovernmentDataSource and OpenStreetMapDataSource, which load
+    generic portal datasets and OSM Overpass results respectively. Boundary
+    retrieval has its own exception hierarchy in boundary_result.py.
+
+    Use the ``__cause__`` attribute (set via ``raise ... from e``) to inspect
+    the underlying exception (HTTPError, JSONDecodeError, etc.).
+    """
+
 # Type aliases
 FilePath = Union[str, Path]
 GeoDataFrame = gpd.GeoDataFrame
@@ -1392,9 +1404,12 @@ class GovernmentDataSource(SpatialDataSource):
             # Download and process
             return self._download_and_process_dataset(resource_url, format_type)
             
+        except SpatialDataError:
+            raise
         except Exception as e:
-            log.error(f"Failed to download dataset {dataset_id}: {e}")
-            return None
+            raise SpatialDataError(
+                f"Failed to download dataset {dataset_id}: {e}"
+            ) from e
     
     def _get_dataset_metadata(self, url: str) -> Optional[Dict[str, Any]]:
         """Get dataset metadata from the portal."""
@@ -1410,8 +1425,9 @@ class GovernmentDataSource(SpatialDataSource):
                 return None
                 
         except Exception as e:
-            log.error(f"Error getting dataset metadata: {e}")
-            return None
+            raise SpatialDataError(
+                f"Error getting dataset metadata from {url}: {e}"
+            ) from e
     
     def _find_best_format(self, metadata: Dict[str, Any], preferred_format: str) -> Optional[str]:
         """Find the best available format for download."""
@@ -1431,8 +1447,9 @@ class GovernmentDataSource(SpatialDataSource):
             return None
             
         except Exception as e:
-            log.error(f"Error finding format: {e}")
-            return None
+            raise SpatialDataError(
+                f"Error finding format in dataset metadata: {e}"
+            ) from e
     
     def _download_and_process_dataset(self, url: str, format_type: str) -> Optional[GeoDataFrame]:
         """Download and process the dataset."""
@@ -1482,8 +1499,9 @@ class GovernmentDataSource(SpatialDataSource):
             return gdf
             
         except Exception as e:
-            log.error(f"Failed to process dataset: {e}")
-            return None
+            raise SpatialDataError(
+                f"Failed to process dataset from {url}: {e}"
+            ) from e
 
 class OpenStreetMapDataSource(SpatialDataSource):
     """OpenStreetMap data source using Overpass API."""
@@ -1534,8 +1552,9 @@ class OpenStreetMapDataSource(SpatialDataSource):
             return gdf
             
         except Exception as e:
-            log.error(f"Failed to download OSM data: {e}")
-            return None
+            raise SpatialDataError(
+                f"Failed to download OSM data: {e}"
+            ) from e
 
 # Convenience functions for backward compatibility
 def get_census_data(api_key: Optional[str] = None) -> CensusDataSource:

--- a/tests/test_spatial_data_errors.py
+++ b/tests/test_spatial_data_errors.py
@@ -1,0 +1,97 @@
+"""Tests for the SpatialDataError hierarchy in geo.spatial_data (ELE-2420).
+
+See docs/FAILURE_MODES.md CC1. Previously, every HTTP / parse failure in
+GovernmentDataSource and OpenStreetMapDataSource was caught and silently
+turned into ``return None`` — producing fake "no data" results
+indistinguishable from legitimate empty responses.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from siege_utilities.geo.spatial_data import (
+    GovernmentDataSource,
+    OpenStreetMapDataSource,
+    SpatialDataError,
+)
+
+
+class TestExceptionHierarchy:
+    def test_is_runtime_error(self):
+        assert issubclass(SpatialDataError, RuntimeError)
+
+
+class TestGovernmentDataSource:
+    def test_metadata_http_failure_raises(self):
+        src = GovernmentDataSource(portal_url="https://example.com")
+        with patch(
+            "siege_utilities.geo.spatial_data.requests.get",
+            side_effect=ConnectionError("network down"),
+        ):
+            with pytest.raises(SpatialDataError) as exc_info:
+                src._get_dataset_metadata("https://example.com/api/x")
+        assert isinstance(exc_info.value.__cause__, ConnectionError)
+
+    def test_metadata_http_error_status_returns_none(self):
+        """HTTP 4xx/5xx without exception goes through the response.ok
+        branch and returns None — that's a legitimate 'no metadata' path,
+        not a silent-swallow of a transport-level failure."""
+        src = GovernmentDataSource(portal_url="https://example.com")
+        fake_response = MagicMock()
+        fake_response.ok = False
+        fake_response.status_code = 404
+        with patch(
+            "siege_utilities.geo.spatial_data.requests.get",
+            return_value=fake_response,
+        ):
+            result = src._get_dataset_metadata("https://example.com/api/x")
+        assert result is None
+
+    def test_format_finder_error_raises(self):
+        src = GovernmentDataSource(portal_url="https://example.com")
+        # Pass a metadata object where resources.get raises
+        broken_metadata = MagicMock()
+        broken_metadata.get.side_effect = RuntimeError("broken metadata")
+        with pytest.raises(SpatialDataError) as exc_info:
+            src._find_best_format(broken_metadata, "geojson")
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+    def test_download_dataset_surface_raises(self):
+        """download_dataset() wraps helper SpatialDataError cleanly
+        (no double-wrap via the outer except Exception)."""
+        src = GovernmentDataSource(portal_url="https://example.com")
+        with patch.object(
+            src,
+            "_get_dataset_metadata",
+            side_effect=SpatialDataError("helper failed"),
+        ):
+            with pytest.raises(SpatialDataError, match="helper failed"):
+                src.download_dataset("abc")
+
+
+class TestOpenStreetMapDataSource:
+    def test_overpass_network_failure_raises(self):
+        src = OpenStreetMapDataSource()
+        with patch(
+            "siege_utilities.geo.spatial_data.requests.get",
+            side_effect=ConnectionError("network down"),
+        ):
+            with pytest.raises(SpatialDataError) as exc_info:
+                src.download_osm_data("node[highway]")
+        assert isinstance(exc_info.value.__cause__, ConnectionError)
+
+    def test_overpass_http_error_status_returns_none(self):
+        """Matches the metadata test — non-2xx responses legitimately
+        return None rather than raising."""
+        src = OpenStreetMapDataSource()
+        fake_response = MagicMock()
+        fake_response.ok = False
+        fake_response.status_code = 429
+        with patch(
+            "siege_utilities.geo.spatial_data.requests.get",
+            return_value=fake_response,
+        ):
+            result = src.download_osm_data("node[highway]")
+        assert result is None


### PR DESCRIPTION
## Summary
Fifth per-module rewrite for **ELE-2420**. Converts 5 silent-swallow sites in \`siege_utilities/geo/spatial_data.py\`.

New exception:
- \`SpatialDataError(RuntimeError)\` — dataset / OSM Overpass fetch failure (distinct from boundary retrieval, which has its own hierarchy in \`boundary_result.py\`)

## Sites converted

| Location | Previous | Now |
| -- | -- | -- |
| \`GovernmentDataSource._get_dataset_metadata\` | \`except: return None\` | raises \`SpatialDataError\` |
| \`GovernmentDataSource._find_best_format\` | \`except: return None\` | raises \`SpatialDataError\` |
| \`GovernmentDataSource._download_and_process_dataset\` | \`except: return None\` | raises \`SpatialDataError\` |
| \`GovernmentDataSource.download_dataset\` | \`except: return None\` | passes through helper errors, wraps unknown as \`SpatialDataError\` |
| \`OpenStreetMapDataSource.download_osm_data\` | \`except: return None\` | raises \`SpatialDataError\` |

Preserves legitimate \"HTTP status not ok\" paths that return None — that's input-level (404 / 429) not a silent-swallow of a transport failure.

## Tests
\`tests/test_spatial_data_errors.py\` — 7 tests, all passing. 10 pre-existing spatial_data tests still pass.

## Linear
ELE-2420 — https://linear.app/ele/issue/ELE-2420

## References
- #394 FAILURE_MODES.md (CC1)
- #397, #399, #400, #401 (prior CC1 rewrites)

## Test plan
- [x] \`pytest tests/test_spatial_data_errors.py\` — 7/7 pass
- [x] pre-existing spatial_data tests — 10/10 pass
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Spatial data downloads from Government portals and OpenStreetMap now raise explicit exceptions on failure instead of silently returning empty results.
  * New dedicated error type introduced for spatial data operations.

* **Tests**
  * Added comprehensive test coverage for error handling, exception wrapping, and propagation in spatial data download operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->