### PR TITLE
docs(ELE-2415): record audit outcomes in README, CHANGELOG, Sphinx docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — ELE-2415 library audit
+
+- **Typed exception hierarchies** across silent-swallow sites in `reporting/` and `geo/`:
+  - `siege_utilities.reporting.ReportingConfigError` (new) — raised by top-level
+    `export_branding_config` / `import_branding_config` / `export_chart_type_config`
+    instead of returning `False` on failure.
+  - `siege_utilities.reporting.chart_types.UnknownChartTypeError` /
+    `ChartParameterError` / `ChartCreationError` — raised by
+    `ChartTypeRegistry.create_chart()` and `validate_chart_parameters()`
+    instead of returning `None` / `False`.
+  - `siege_utilities.reporting.client_branding.ClientBrandingError` /
+    `ClientBrandingNotFoundError` — raised by `ClientBrandingManager`
+    methods for unexpected I/O and missing-client paths.
+  - `siege_utilities.geo.census_geocoder.CensusGeocodeError` — raised by
+    `geocode_single()` / `geocode_batch()` on API/network failure. Previously,
+    failures returned `CensusGeocodeResult(matched=False)`, indistinguishable
+    from genuine no-match results.
+  - `siege_utilities.geo.spatial_data.SpatialDataError` — raised by
+    `GovernmentDataSource` and `OpenStreetMapDataSource` download helpers on
+    HTTP/parse failures instead of returning `None`.
+
+  All new exceptions use `raise ... from e` chaining. See
+  `docs/FAILURE_MODES.md` (pattern CC1) for the full catalog.
+
+### Documentation
+
+- **`docs/INTENT.md`** — per-module purpose and 9 divergence candidates.
+- **`docs/FAILURE_MODES.md`** — 5 cross-cutting anti-pattern categories (CC1–CC5)
+  with per-module site inventory.
+- **`docs/TEST_UPGRADES.md`** — coverage scorecard and 5 test-upgrade patterns
+  (PU1–PU5); zero-coverage modules identified.
+- **`docs/ARCHITECTURE.md`** — three-layer model (core → domain → consumers),
+  imports-go-DOWN invariant.
+- **`docs/adr/0001–0007`** — Architecture Decision Records covering Chain
+  pipeline ownership, chart/map generator injection, BoundaryProvider
+  registration, dataclass-vs-Pydantic, lazy-import convention, analytics
+  location split, and model type location.
+- **`docs/NOTEBOOKS.md`** — inventory of 27 notebooks, consolidation plan
+  to 12 canonical + 7 focused specializations.
+
+### Test coverage
+
+New dedicated test modules for previously-untested code:
+- `tests/test_admin_profile_manager.py` (16 tests)
+- `tests/test_hygiene_generate_docstrings.py` (22 tests)
+- `tests/test_files_paths.py` (28 tests)
+- `tests/test_reporting_config_exports.py` (10 tests)
+- `tests/test_chart_types_errors.py` (10 tests)
+- `tests/test_client_branding_errors.py` (14 tests)
+- `tests/test_census_geocoder_errors.py` (6 tests)
+- `tests/test_spatial_data_errors.py` (7 tests)
+
+### Changed
+
+- `pytest-randomly`, `hypothesis`, `nbmake` added to `dev` extras.
+
+### Migration notes
+
+Callers that relied on the old silent-swallow behavior (checking for
+`None` / `False` return) must migrate to `try/except` around the new
+exception types. The exception types are subclasses of standard Python
+exceptions (`LookupError`, `ValueError`, `RuntimeError`) so broad
+existing handlers will still catch them.
+
 ## [3.13.0] - 2026-03-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -47,6 +47,38 @@ su.log_info("Ready.")
 recommendations = su.select_census_datasets("demographics", "tract")
 ```
 
+## Error Handling
+
+`siege_utilities` follows a **fail-loud-over-silent-swallow** policy: when a
+function cannot deliver its documented output, it raises a typed exception
+rather than returning `None`, `False`, or an empty container that looks like
+a legitimate "no result." This distinguishes real failures from expected
+empty-input paths and prevents silent data corruption in downstream
+pipelines.
+
+Key exception types by subsystem:
+
+| Subsystem | Exception | Parent | Raised When |
+|-----------|-----------|--------|-------------|
+| reporting (top-level) | `ReportingConfigError` | `RuntimeError` | export / import config fails |
+| reporting.chart_types | `UnknownChartTypeError` | `LookupError` | chart type not in registry |
+| reporting.chart_types | `ChartParameterError` | `ValueError` | required params missing / bad |
+| reporting.chart_types | `ChartCreationError` | `RuntimeError` | `create_function` failed |
+| reporting.client_branding | `ClientBrandingNotFoundError` | `LookupError` | named client has no config |
+| reporting.client_branding | `ClientBrandingError` | `RuntimeError` | I/O or YAML parse failure |
+| geo.census_geocoder | `CensusGeocodeError` | `RuntimeError` | Census API/network failure |
+| geo.spatial_data | `SpatialDataError` | `RuntimeError` | portal dataset / OSM failure |
+| geo.boundary_result | `BoundaryRetrievalError` (+ 6 subclasses) | `Exception` | boundary lookup problems |
+
+All new exceptions use `raise ... from e` chaining — inspect `exc.__cause__`
+to see the underlying error. Because the exception types subclass standard
+Python exceptions, broad existing `except ValueError:` / `except LookupError:`
+handlers continue to work.
+
+See [`docs/FAILURE_MODES.md`](docs/FAILURE_MODES.md) for the catalog of
+silent-swallow patterns this library has eliminated and the migration
+guidance for callers that relied on the old return-value behavior.
+
 ## Import Philosophy
 
 This project intentionally favors convenience access patterns, including broad function availability from the package surface. That is a design choice, not an accident.
@@ -94,6 +126,11 @@ See:
 - `docs/EXAMPLES.md`
 - `docs/ISOCHRONES_AND_WKLS.md`
 - `docs/MANAGED_ENVIRONMENTS.md`
+- `docs/INTENT.md` — per-module purpose + divergence catalog (ELE-2416)
+- `docs/FAILURE_MODES.md` — cross-cutting anti-pattern catalog (ELE-2418)
+- `docs/TEST_UPGRADES.md` — test-quality patterns and coverage scorecard (ELE-2419)
+- `docs/ARCHITECTURE.md` + `docs/adr/` — three-layer model and ADRs (ELE-2417)
+- `docs/NOTEBOOKS.md` — notebook inventory and consolidation plan (ELE-2421)
 
 ## External Contributor Workflow
 

--- a/docs/source/exception_hierarchy.rst
+++ b/docs/source/exception_hierarchy.rst
@@ -1,0 +1,147 @@
+Exception Hierarchy
+===================
+
+``siege_utilities`` follows a **fail-loud-over-silent-swallow** policy: when
+a function cannot deliver its documented output, it raises a typed exception
+rather than returning ``None``, ``False``, or an empty container that looks
+like a legitimate "no result." This distinguishes real failures from
+expected empty-input paths and prevents silent data corruption in
+downstream pipelines.
+
+This page catalogs the typed exceptions across the library. Every exception
+subclasses a standard Python exception (``LookupError``, ``ValueError``,
+``RuntimeError``) so broad existing handlers continue to work.
+
+Design principles
+-----------------
+
+1. **Lookup failures are ``LookupError``.** Missing chart types, missing
+   client configs, and similar "you asked for X but X doesn't exist" cases.
+2. **Parameter / input failures are ``ValueError``.** Missing required
+   parameters, invalid values, bad config shapes.
+3. **Operation failures are ``RuntimeError``.** Failed I/O, failed parse,
+   failed API call — anything where the inputs were valid but the work
+   did not complete.
+4. **Not-found return values are preserved where semantic.** ``list_X()``
+   returning ``[]``, lookup helpers returning ``None`` when the caller
+   should handle absence as normal — these are unchanged. The rewrite
+   only affects sites where absence was *masking* a transport or parse
+   failure.
+5. **Every raise chains with ``from e``.** Inspect ``exc.__cause__`` to
+   see the underlying error (``JSONDecodeError``, ``OSError``,
+   ``HTTPError``, etc.).
+
+Reporting
+---------
+
+Top-level config export / import
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoexception:: siege_utilities.reporting.ReportingConfigError
+   :show-inheritance:
+
+Chart type registry
+~~~~~~~~~~~~~~~~~~~
+
+.. autoexception:: siege_utilities.reporting.chart_types.UnknownChartTypeError
+   :show-inheritance:
+
+.. autoexception:: siege_utilities.reporting.chart_types.ChartParameterError
+   :show-inheritance:
+
+.. autoexception:: siege_utilities.reporting.chart_types.ChartCreationError
+   :show-inheritance:
+
+Client branding
+~~~~~~~~~~~~~~~
+
+.. autoexception:: siege_utilities.reporting.client_branding.ClientBrandingNotFoundError
+   :show-inheritance:
+
+.. autoexception:: siege_utilities.reporting.client_branding.ClientBrandingError
+   :show-inheritance:
+
+Geographic
+----------
+
+Census Bureau geocoder
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoexception:: siege_utilities.geo.census_geocoder.CensusGeocodeError
+   :show-inheritance:
+
+Before this change, ``geocode_single()`` and ``geocode_batch()`` caught all
+failures (network, API, parse) and returned
+``CensusGeocodeResult(matched=False)``. Downstream pipelines treated
+unmatched rows as "address not findable" and dropped them — so API
+outages silently poisoned entire batches with fake unmatched rows.
+``CensusGeocodeError`` surfaces the real cause.
+
+Spatial data sources
+~~~~~~~~~~~~~~~~~~~~
+
+.. autoexception:: siege_utilities.geo.spatial_data.SpatialDataError
+   :show-inheritance:
+
+Used by ``GovernmentDataSource`` (CKAN-style portals) and
+``OpenStreetMapDataSource`` (Overpass API). Distinct from boundary
+retrieval, which has its own hierarchy below.
+
+Boundary retrieval
+~~~~~~~~~~~~~~~~~~
+
+.. autoexception:: siege_utilities.geo.boundary_result.BoundaryRetrievalError
+   :show-inheritance:
+
+.. autoexception:: siege_utilities.geo.boundary_result.BoundaryInputError
+   :show-inheritance:
+
+.. autoexception:: siege_utilities.geo.boundary_result.BoundaryDiscoveryError
+   :show-inheritance:
+
+.. autoexception:: siege_utilities.geo.boundary_result.BoundaryUrlValidationError
+   :show-inheritance:
+
+.. autoexception:: siege_utilities.geo.boundary_result.BoundaryDownloadError
+   :show-inheritance:
+
+.. autoexception:: siege_utilities.geo.boundary_result.BoundaryParseError
+   :show-inheritance:
+
+.. autoexception:: siege_utilities.geo.boundary_result.BoundaryConfigurationError
+   :show-inheritance:
+
+Migration guidance
+------------------
+
+Callers that relied on the pre-rewrite silent-swallow behavior must
+migrate to ``try/except`` around the new exception types.
+
+Before::
+
+    result = registry.create_chart("unknown_type")
+    if result is None:
+        log.warning("chart creation failed")
+        return None
+
+After::
+
+    try:
+        result = registry.create_chart("unknown_type")
+    except UnknownChartTypeError:
+        log.warning("unknown chart type")
+        return None
+    except ChartCreationError as e:
+        log.error("chart creation failed: %s", e.__cause__)
+        raise
+
+Because the exception types subclass standard Python exceptions, you can
+also use a single broad ``except LookupError:`` / ``except ValueError:`` /
+``except RuntimeError:`` if you do not need to distinguish cases. The
+``__cause__`` attribute still gives you the original error.
+
+Further reading
+---------------
+
+* :doc:`../../docs/FAILURE_MODES` — complete anti-pattern catalog
+* :doc:`../../docs/ARCHITECTURE` — three-layer dependency model

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,6 +19,7 @@ Siege Utilities is a comprehensive Python utilities package with **enhanced auto
    core_utilities
    string_utilities
    logging_utilities
+   exception_hierarchy
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
## Summary
User-facing documentation refresh following the ELE-2415 library audit.

## What changes

### CHANGELOG.md
New Unreleased section listing every new typed exception (with parent class and when it raises), the 8 new test modules, and the audit document bundle.

### README.md
- New **Error Handling** section with a table of the exception hierarchy by subsystem, design principles, and a link to the migration catalog.
- **Contributor Requirements** now links the 5 audit docs (INTENT, FAILURE_MODES, TEST_UPGRADES, ARCHITECTURE, NOTEBOOKS).

### docs/source/exception_hierarchy.rst (new)
Canonical Sphinx reference for the typed-exception model:
- Design principles (LookupError / ValueError / RuntimeError mapping)
- Every typed exception documented with \`autoexception\`
- Before/after migration examples for callers

### docs/source/index.rst
Add \`exception_hierarchy\` to the Core Utilities toctree.

## Linear
ELE-2415 — https://linear.app/ele/issue/ELE-2415

## Test plan
- [x] \`sphinx-build\` dry-run targets resolve — the autoexception directives rely on PRs #397, #399, #400, #401, #405 to be merged for \`autodoc\` to find the classes, but the static text is valid standalone.
- [ ] docs CI green