### PR TITLE
feat(ELE-2440): survey waves subsystem (D7 part 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   All new exceptions use `raise ... from e` chaining. See
   `docs/FAILURE_MODES.md` (pattern CC1) for the full catalog.
 
+- **Survey waves subsystem** (ELE-2440 / D7 part 2):
+  - `siege_utilities.survey.Wave` — one fielding: `id`, `date`, optional
+    respondent-level `df`, optional per-wave `stack` and `weight_scheme`.
+  - `siege_utilities.survey.WaveSet` — ordered set of Waves with
+    `compare_chain(row_var, break_vars=…)` returning a LONGITUDINAL Chain
+    aligned across waves (columns = wave ids in date order, trailing Δ
+    column when ≥2 waves).
+  - `siege_utilities.survey.waves.compare_waves` — primitive the WaveSet
+    method delegates to; raises `WavesError` on empty WaveSet or missing
+    per-wave DataFrame.
+  - `siege_utilities.reporting.wave_charts` — `trend_chart` and `heatmap`
+    rendering helpers consuming a LONGITUDINAL Chain.
+
+  Completes the PollingAnalyzer migration path: longitudinal polling
+  analysis is now a WaveSet composition on top of the survey primitives
+  rather than a separate analyzer class.
+
 ### Documentation
 
 - **`docs/INTENT.md`** — per-module purpose and 9 divergence candidates.

--- a/siege_utilities/reporting/wave_charts.py
+++ b/siege_utilities/reporting/wave_charts.py
@@ -1,0 +1,149 @@
+"""Rendering helpers for WaveSet longitudinal output.
+
+Takes a LONGITUDINAL :class:`~siege_utilities.survey.models.Chain` (typically
+from :meth:`~siege_utilities.survey.models.WaveSet.compare_chain`) and
+produces matplotlib figures:
+
+* :func:`trend_chart` — line chart of each category across waves
+* :func:`heatmap` — category × wave heatmap of percents or counts
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    import matplotlib.figure
+    from ..survey.models import Chain
+
+
+class WaveChartError(ValueError):
+    """Raised when a WaveSet chart cannot be rendered from the given Chain."""
+
+
+def _longitudinal_dataframe(chain: "Chain"):
+    """Return the chain's DataFrame with any delta column dropped."""
+    df = chain.to_dataframe()
+    if chain.delta_column and chain.delta_column in df.columns:
+        df = df.drop(columns=[chain.delta_column])
+    return df
+
+
+def trend_chart(
+    chain: "Chain",
+    *,
+    title: Optional[str] = None,
+    ylabel: str = "%",
+    figsize: tuple = (10, 6),
+    marker: str = "o",
+):
+    """Line chart of each row category across waves.
+
+    Parameters
+    ----------
+    chain:
+        A LONGITUDINAL Chain. Each wave is a column; each row_var value
+        becomes one line.
+    title:
+        Optional plot title; defaults to ``f"{chain.row_var} over time"``.
+    ylabel:
+        Y-axis label; default "%".
+    figsize:
+        Matplotlib ``figure`` size tuple.
+    marker:
+        Matplotlib marker style for data points.
+    """
+    from ..reporting.pages.page_models import TableType
+
+    if chain.table_type is not TableType.LONGITUDINAL:
+        raise WaveChartError(
+            f"trend_chart requires TableType.LONGITUDINAL, got {chain.table_type}"
+        )
+
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError as e:
+        raise WaveChartError(
+            "matplotlib is required for wave_charts; "
+            "install with pip install 'siege-utilities[reporting]'"
+        ) from e
+
+    df = _longitudinal_dataframe(chain)
+    if df.empty:
+        raise WaveChartError("Chain has no wave views to plot")
+
+    fig, ax = plt.subplots(figsize=figsize)
+    for category, row in df.iterrows():
+        ax.plot(df.columns, row.values, marker=marker, label=str(category))
+    ax.set_title(title or f"{chain.row_var} over time")
+    ax.set_xlabel("Wave")
+    ax.set_ylabel(ylabel)
+    ax.legend(loc="best", fontsize="small")
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+    return fig
+
+
+def heatmap(
+    chain: "Chain",
+    *,
+    title: Optional[str] = None,
+    figsize: tuple = (10, 6),
+    cmap: str = "RdYlBu_r",
+    annotate: bool = True,
+):
+    """Category × wave heatmap.
+
+    Parameters
+    ----------
+    chain:
+        A LONGITUDINAL Chain.
+    title:
+        Optional plot title.
+    figsize:
+        Matplotlib figure size.
+    cmap:
+        Matplotlib colormap name.
+    annotate:
+        If True, write the numeric value in each cell.
+    """
+    from ..reporting.pages.page_models import TableType
+
+    if chain.table_type is not TableType.LONGITUDINAL:
+        raise WaveChartError(
+            f"heatmap requires TableType.LONGITUDINAL, got {chain.table_type}"
+        )
+
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError as e:
+        raise WaveChartError(
+            "matplotlib is required for wave_charts; "
+            "install with pip install 'siege-utilities[reporting]'"
+        ) from e
+
+    df = _longitudinal_dataframe(chain)
+    if df.empty:
+        raise WaveChartError("Chain has no wave views to plot")
+
+    fig, ax = plt.subplots(figsize=figsize)
+    im = ax.imshow(df.values, aspect="auto", cmap=cmap)
+    ax.set_xticks(range(len(df.columns)))
+    ax.set_xticklabels(df.columns, rotation=30, ha="right")
+    ax.set_yticks(range(len(df.index)))
+    ax.set_yticklabels(df.index)
+    ax.set_title(title or f"{chain.row_var} × wave")
+    fig.colorbar(im, ax=ax)
+
+    if annotate:
+        for i in range(len(df.index)):
+            for j in range(len(df.columns)):
+                val = df.values[i, j]
+                ax.text(
+                    j, i, f"{val:.1f}",
+                    ha="center", va="center",
+                    color="black", fontsize="x-small",
+                )
+
+    fig.tight_layout()
+    return fig

--- a/siege_utilities/survey/__init__.py
+++ b/siege_utilities/survey/__init__.py
@@ -7,6 +7,24 @@ built fresh for Python 3.12 on pandas + weightipy.
 Install the optional dependency:
     pip install siege-utilities[survey]
 
+**Hierarchy**
+
+* ``View``  — one cell statistic (count, pct, CI)
+* ``Chain`` — one crosstab (row_var × break_vars)
+* ``Cluster`` — a named group of Chains = one report section
+* ``Stack`` — a complete report (all Clusters + shared WeightScheme)
+
+**Waves (longitudinal surveys)**
+
+* ``Wave``    — the same questionnaire fielded at a single point in time
+                (carries ``df`` and optionally a per-wave ``Stack``)
+* ``WaveSet`` — an ordered set of Waves; ``compare_chain`` produces a
+                LONGITUDINAL Chain aligned across waves
+
+A Stack describes **one** fielding. A WaveSet composes **many** fieldings
+into change detection / trend output. Use a Stack when you have a single
+snapshot; use a WaveSet to track the same question across time.
+
 Quick start::
 
     from siege_utilities.survey import build_chain, chain_to_argument
@@ -16,6 +34,19 @@ Quick start::
                         table_type=TableType.SINGLE_RESPONSE, geo_column="county")
     argument = chain_to_argument(chain, headline="Party ID by County",
                                  narrative="Democrats lead in metro counties.")
+
+Longitudinal (multi-wave) example::
+
+    from datetime import date
+    from siege_utilities.survey import Wave, WaveSet
+
+    waveset = WaveSet(name="2024 tracker", waves=[
+        Wave(id="W1", date=date(2024, 3, 1), df=df_march),
+        Wave(id="W2", date=date(2024, 6, 1), df=df_june),
+        Wave(id="W3", date=date(2024, 9, 1), df=df_sept),
+    ])
+    chain = waveset.compare_chain(row_var="party")
+    # chain.views keyed by wave id; delta column appended automatically.
 """
 
 import importlib
@@ -26,6 +57,8 @@ _LAZY = {
     "Cluster":         ".models",
     "Chain":           ".models",
     "View":            ".models",
+    "Wave":            ".models",
+    "WaveSet":         ".models",
     "WeightScheme":    ".models",
     "WeightingConvergenceError": ".weights",
     "apply_rim_weights": ".weights",
@@ -34,6 +67,8 @@ _LAZY = {
     "chi_square_flag": ".significance",
     "chain_to_argument":   ".render",
     "stack_to_arguments":  ".render",
+    "compare_waves":   ".waves",
+    "WavesError":      ".waves",
 }
 
 __all__ = list(_LAZY.keys())

--- a/siege_utilities/survey/models.py
+++ b/siege_utilities/survey/models.py
@@ -10,6 +10,7 @@ View    = one cell statistic (count, pct, sig flag)
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import date as _date
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import pandas as pd
@@ -150,3 +151,74 @@ class Stack:
     @property
     def all_chains(self) -> List[Chain]:
         return [chain for cluster in self.clusters for chain in cluster.chains]
+
+
+# ---------------------------------------------------------------------------
+# Wave — one survey fielding
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Wave:
+    """One survey wave: the same questionnaire fielded at a point in time.
+
+    ``df`` is the respondent-level DataFrame for this wave and is what
+    :meth:`WaveSet.compare_chain` consumes. ``stack`` is optional: callers
+    that have already built a per-wave Stack (with its own weight scheme)
+    can attach it for later retrieval; longitudinal comparison does not
+    require it.
+    """
+
+    id: str
+    date: _date
+    df: Optional[pd.DataFrame] = None
+    stack: Optional[Stack] = None
+    weight_scheme: Optional[WeightScheme] = None
+
+
+# ---------------------------------------------------------------------------
+# WaveSet — ordered waves of the same survey
+# ---------------------------------------------------------------------------
+
+@dataclass
+class WaveSet:
+    """An ordered set of Waves from the same survey instrument.
+
+    Waves are sorted by ``date`` on access so longitudinal output is always
+    chronological regardless of insertion order.
+    """
+
+    name: str
+    waves: List[Wave] = field(default_factory=list)
+
+    def add_wave(self, wave: Wave) -> "WaveSet":
+        self.waves.append(wave)
+        return self
+
+    @property
+    def ordered(self) -> List[Wave]:
+        return sorted(self.waves, key=lambda w: w.date)
+
+    def compare_chain(
+        self,
+        row_var: str,
+        break_vars: Optional[List[str]] = None,
+        *,
+        metric: str = "value",
+        weight_var: Optional[str] = None,
+        top_n: Optional[int] = None,
+    ) -> Chain:
+        """Return a LONGITUDINAL Chain aligned across waves.
+
+        Columns are ``wave_id`` keys (ordered by date); rows are ``row_var``
+        categories. Delegates to :mod:`siege_utilities.survey.waves` so the
+        primitive lives in one place.
+        """
+        from .waves import compare_waves
+        return compare_waves(
+            self,
+            row_var=row_var,
+            break_vars=break_vars,
+            metric=metric,
+            weight_var=weight_var,
+            top_n=top_n,
+        )

--- a/siege_utilities/survey/waves.py
+++ b/siege_utilities/survey/waves.py
@@ -1,0 +1,131 @@
+"""Longitudinal analysis over a WaveSet.
+
+Builds per-wave Chains via :func:`survey.crosstab.build_chain` and merges
+them into a single LONGITUDINAL Chain whose columns are wave ids (ordered
+by date). A delta column (last − first) is appended when ≥2 waves exist,
+matching the single-DataFrame LONGITUDINAL builder.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict, List, Optional
+
+from ..reporting.pages.page_models import TableType
+from .crosstab import build_chain
+from .models import Chain, View
+
+if TYPE_CHECKING:
+    from .models import WaveSet
+
+
+class WavesError(ValueError):
+    """Raised when a WaveSet operation is given incomplete or mismatched data."""
+
+
+def compare_waves(
+    waveset: "WaveSet",
+    row_var: str,
+    break_vars: Optional[List[str]] = None,
+    *,
+    metric: str = "value",
+    weight_var: Optional[str] = None,
+    top_n: Optional[int] = None,
+) -> Chain:
+    """Merge per-wave crosstabs into one LONGITUDINAL Chain.
+
+    Parameters
+    ----------
+    waveset:
+        The WaveSet to compare. Every Wave must have a non-None ``df``.
+    row_var:
+        Column whose categories become rows (same across all waves).
+    break_vars:
+        Optional secondary breaks applied within each wave (rare for
+        wave comparison but supported). If omitted or empty, each wave
+        contributes a single column keyed by wave id.
+    metric, weight_var, top_n:
+        Passed through to :func:`build_chain` for each wave.
+
+    Returns
+    -------
+    Chain
+        ``table_type == TableType.LONGITUDINAL``; ``views`` keyed by
+        wave id (or ``"{wave_id}|{break_key}"`` when break_vars are used);
+        ``delta_column`` set when ≥2 waves exist.
+
+    Raises
+    ------
+    WavesError
+        If ``waveset`` has no waves, or any wave lacks a DataFrame.
+    """
+    waves = waveset.ordered
+    if not waves:
+        raise WavesError(f"WaveSet {waveset.name!r} has no waves")
+    missing = [w.id for w in waves if w.df is None]
+    if missing:
+        raise WavesError(
+            f"WaveSet {waveset.name!r} waves missing df: {missing}. "
+            "Attach respondent-level DataFrames before calling compare_chain."
+        )
+
+    use_breaks = list(break_vars) if break_vars else []
+    merged: Dict[str, List[View]] = {}
+
+    for wave in waves:
+        # When no break_vars given, synthesize a single "_all" break so
+        # build_chain has something to iterate. That synthetic column is
+        # collapsed back into the wave id below.
+        if not use_breaks:
+            per_wave_df = wave.df.assign(_all="all")
+            per_wave_breaks = ["_all"]
+        else:
+            per_wave_df = wave.df
+            per_wave_breaks = use_breaks
+
+        per_wave = build_chain(
+            per_wave_df,
+            row_var=row_var,
+            break_vars=per_wave_breaks,
+            metric=metric,
+            weight_var=weight_var,
+            table_type=TableType.SINGLE_RESPONSE,
+            top_n=top_n,
+        )
+
+        for key, views in per_wave.views.items():
+            if not use_breaks:
+                merged_key = wave.id
+            else:
+                merged_key = f"{wave.id}|{key}"
+            merged[merged_key] = views
+
+    delta_col: Optional[str] = None
+    if len(waves) >= 2 and not use_breaks:
+        first_id, last_id = waves[0].id, waves[-1].id
+        first_map = {v.metric: v.count for v in merged.get(first_id, [])}
+        last_map = {v.metric: v.count for v in merged.get(last_id, [])}
+        first_pct = {v.metric: v.pct for v in merged.get(first_id, []) if v.pct is not None}
+        last_pct = {v.metric: v.pct for v in merged.get(last_id, []) if v.pct is not None}
+        all_cats = set(first_map) | set(last_map)
+        base_sum = sum(
+            (merged[w.id][0].base if merged.get(w.id) else 0.0) for w in waves
+        )
+        delta_views = []
+        for cat in sorted(all_cats):
+            count_delta = last_map.get(cat, 0.0) - first_map.get(cat, 0.0)
+            pct_delta: Optional[float] = None
+            if cat in first_pct and cat in last_pct:
+                pct_delta = last_pct[cat] - first_pct[cat]
+            delta_views.append(
+                View(metric=cat, base=base_sum, count=count_delta, pct=pct_delta)
+            )
+        delta_col = "Δ (last − first)"
+        merged[delta_col] = delta_views
+
+    return Chain(
+        row_var=row_var,
+        break_vars=use_breaks or ["wave"],
+        views=merged,
+        table_type=TableType.LONGITUDINAL,
+        delta_column=delta_col,
+    )

--- a/tests/test_survey_waves.py
+++ b/tests/test_survey_waves.py
@@ -1,0 +1,176 @@
+"""Tests for siege_utilities.survey Wave/WaveSet + wave_charts (ELE-2440)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pandas as pd
+import pytest
+
+from siege_utilities.reporting.pages.page_models import TableType
+from siege_utilities.survey import (
+    Wave,
+    WaveSet,
+    WavesError,
+    build_chain,
+    compare_waves,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _wave_df(d_count: int, r_count: int) -> pd.DataFrame:
+    return pd.DataFrame({"party": ["D"] * d_count + ["R"] * r_count})
+
+
+@pytest.fixture
+def three_wave_set() -> WaveSet:
+    return WaveSet(
+        name="2024 tracker",
+        waves=[
+            Wave(id="W1", date=date(2024, 3, 1), df=_wave_df(60, 40)),
+            Wave(id="W2", date=date(2024, 6, 1), df=_wave_df(55, 45)),
+            Wave(id="W3", date=date(2024, 9, 1), df=_wave_df(50, 50)),
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Wave / WaveSet dataclasses
+# ---------------------------------------------------------------------------
+
+
+class TestWaveDataclass:
+    def test_minimal_wave(self):
+        w = Wave(id="W1", date=date(2024, 3, 1))
+        assert w.id == "W1"
+        assert w.df is None
+        assert w.stack is None
+        assert w.weight_scheme is None
+
+    def test_wave_with_df(self):
+        df = _wave_df(10, 10)
+        w = Wave(id="W1", date=date(2024, 3, 1), df=df)
+        assert w.df is df
+
+
+class TestWaveSet:
+    def test_add_wave(self):
+        ws = WaveSet(name="x")
+        w = Wave(id="W1", date=date(2024, 1, 1))
+        ws.add_wave(w)
+        assert ws.waves == [w]
+
+    def test_ordered_sorts_by_date(self):
+        out_of_order = WaveSet(
+            name="mix",
+            waves=[
+                Wave(id="late", date=date(2024, 9, 1)),
+                Wave(id="early", date=date(2024, 3, 1)),
+                Wave(id="mid", date=date(2024, 6, 1)),
+            ],
+        )
+        assert [w.id for w in out_of_order.ordered] == ["early", "mid", "late"]
+
+
+# ---------------------------------------------------------------------------
+# compare_chain / compare_waves
+# ---------------------------------------------------------------------------
+
+
+class TestCompareChain:
+    def test_returns_longitudinal_chain(self, three_wave_set):
+        chain = three_wave_set.compare_chain(row_var="party")
+        assert chain.table_type is TableType.LONGITUDINAL
+
+    def test_columns_are_wave_ids(self, three_wave_set):
+        chain = three_wave_set.compare_chain(row_var="party")
+        # Views keyed by wave id, plus the delta column
+        assert "W1" in chain.views
+        assert "W2" in chain.views
+        assert "W3" in chain.views
+
+    def test_delta_column_present_with_multiple_waves(self, three_wave_set):
+        chain = three_wave_set.compare_chain(row_var="party")
+        assert chain.delta_column is not None
+        assert chain.delta_column in chain.views
+
+    def test_delta_matches_last_minus_first(self, three_wave_set):
+        chain = three_wave_set.compare_chain(row_var="party")
+        # W1: D=60 R=40; W3: D=50 R=50 → ΔD = -10, ΔR = +10
+        delta_views = {v.metric: v.count for v in chain.views[chain.delta_column]}
+        assert delta_views["D"] == pytest.approx(-10.0)
+        assert delta_views["R"] == pytest.approx(10.0)
+
+    def test_single_wave_has_no_delta(self):
+        single = WaveSet(
+            name="one",
+            waves=[Wave(id="W1", date=date(2024, 3, 1), df=_wave_df(10, 10))],
+        )
+        chain = single.compare_chain(row_var="party")
+        assert chain.delta_column is None
+
+    def test_dataframe_columns_ordered_by_date(self, three_wave_set):
+        # Deliberately shuffle insertion order to prove `ordered` is what drives it.
+        ws = WaveSet(
+            name="shuffled",
+            waves=[three_wave_set.waves[2], three_wave_set.waves[0], three_wave_set.waves[1]],
+        )
+        chain = ws.compare_chain(row_var="party")
+        non_delta_cols = [c for c in chain.to_dataframe().columns if c != chain.delta_column]
+        assert non_delta_cols == ["W1", "W2", "W3"]
+
+    def test_empty_waveset_raises(self):
+        with pytest.raises(WavesError, match="no waves"):
+            compare_waves(WaveSet(name="empty"), row_var="party")
+
+    def test_wave_missing_df_raises(self):
+        ws = WaveSet(
+            name="partial",
+            waves=[
+                Wave(id="W1", date=date(2024, 3, 1), df=_wave_df(10, 10)),
+                Wave(id="W2", date=date(2024, 6, 1)),  # no df
+            ],
+        )
+        with pytest.raises(WavesError, match="missing df"):
+            ws.compare_chain(row_var="party")
+
+
+# ---------------------------------------------------------------------------
+# wave_charts — smoke tests
+# ---------------------------------------------------------------------------
+
+
+class TestWaveChartsSmoke:
+    def test_trend_chart_returns_figure(self, three_wave_set):
+        matplotlib = pytest.importorskip("matplotlib")
+        matplotlib.use("Agg")
+        from siege_utilities.reporting.wave_charts import trend_chart
+
+        chain = three_wave_set.compare_chain(row_var="party")
+        fig = trend_chart(chain)
+        assert fig is not None
+        assert len(fig.axes) == 1
+
+    def test_heatmap_returns_figure(self, three_wave_set):
+        matplotlib = pytest.importorskip("matplotlib")
+        matplotlib.use("Agg")
+        from siege_utilities.reporting.wave_charts import heatmap
+
+        chain = three_wave_set.compare_chain(row_var="party")
+        fig = heatmap(chain)
+        assert fig is not None
+
+    def test_rejects_non_longitudinal_chain(self):
+        pytest.importorskip("matplotlib")
+        from siege_utilities.reporting.wave_charts import WaveChartError, trend_chart
+
+        df = _wave_df(10, 10).assign(county="Travis")
+        chain = build_chain(
+            df, row_var="party", break_vars=["county"],
+            table_type=TableType.SINGLE_RESPONSE,
+        )
+        with pytest.raises(WaveChartError, match="LONGITUDINAL"):
+            trend_chart(chain)


### PR DESCRIPTION
## Summary

- Add `Wave` + `WaveSet` dataclasses to `survey/models.py`
- New `survey/waves.py` with `compare_waves()` / `WavesError`
- New `reporting/wave_charts.py` with `trend_chart` + `heatmap`
- Completes the PollingAnalyzer migration destination: longitudinal polling is now `WaveSet.compare_chain(...)` composed on the existing survey primitives.

Closes ELE-2440.

## Test plan
- [x] `pytest tests/test_survey_waves.py` — 15 new tests pass
- [x] `pytest tests/test_survey_*.py tests/test_polling_analyzer_deprecation.py` — 71 pass / 3 skipped, no regression
- [ ] CI