### PR TITLE
feat(survey): ClientSurveyRegistry — associate clients with WaveSets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   analysis is now a WaveSet composition on top of the survey primitives
   rather than a separate analyzer class.
 
+- **Client ↔ Survey registry** (`siege_utilities.survey.registry`):
+  - `WaveSet.client_id` — optional string keying into the branding /
+    profile system or an external CRM.
+  - `ClientSurveyRegistry` — in-memory map of ``client_id → {name →
+    WaveSet}`` with `register` / `register_for` / `surveys_for` /
+    `get_survey` / `require_survey` / `unregister` / `client_of`.
+    Supports `"acme" in reg` and `("acme", "Tracker") in reg`
+    membership checks; `len(reg)` counts all surveys across clients.
+  - `ClientSurveyError` (subclass of `KeyError`) raised on missing
+    lookups, duplicate survey names within a client, or registration
+    without a client_id.
+
+  Survey names are scoped per-client: ``("Acme", "Tracker Q2")`` and
+  ``("Beacon", "Tracker Q2")`` coexist fine. Branding / display info
+  stays in `reporting/client_branding`; the registry only answers
+  "which surveys belong to this client".
+
 ### Documentation
 
 - **`docs/INTENT.md`** — per-module purpose and 9 divergence candidates.

--- a/siege_utilities/survey/__init__.py
+++ b/siege_utilities/survey/__init__.py
@@ -69,6 +69,8 @@ _LAZY = {
     "stack_to_arguments":  ".render",
     "compare_waves":   ".waves",
     "WavesError":      ".waves",
+    "ClientSurveyRegistry": ".registry",
+    "ClientSurveyError":    ".registry",
 }
 
 __all__ = list(_LAZY.keys())

--- a/siege_utilities/survey/models.py
+++ b/siege_utilities/survey/models.py
@@ -189,6 +189,7 @@ class WaveSet:
 
     name: str
     waves: List[Wave] = field(default_factory=list)
+    client_id: Optional[str] = None  # key into ClientBrandingManager / ClientSurveyRegistry
 
     def add_wave(self, wave: Wave) -> "WaveSet":
         self.waves.append(wave)

--- a/siege_utilities/survey/registry.py
+++ b/siege_utilities/survey/registry.py
@@ -1,0 +1,155 @@
+"""Client ↔ Survey registry.
+
+Associates :class:`~siege_utilities.survey.models.WaveSet` instances (each
+one representing a survey instrument with its waves) to the client that
+owns them. Supports many surveys per client and fast lookup without
+scanning a flat list.
+
+Survey identity within a client is the WaveSet's ``name`` — two surveys
+for the same client must have distinct names. Names are **not** required
+to be globally unique; ``("Acme", "Tracker Q2")`` and
+``("Beacon", "Tracker Q2")`` coexist fine.
+
+Client branding / display info continues to live in
+:mod:`siege_utilities.reporting.client_branding`. The registry only
+answers "which surveys belong to this client" — not "how do we render
+this client's report".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from .models import WaveSet
+
+
+class ClientSurveyError(KeyError):
+    """Raised for registry-level lookup / duplication problems.
+
+    Subclasses ``KeyError`` so existing ``except KeyError`` handlers at
+    call sites still catch it; use ``except ClientSurveyError`` when you
+    need the more specific signal.
+    """
+
+
+@dataclass
+class ClientSurveyRegistry:
+    """In-memory map of ``client_id`` → {survey name → WaveSet}.
+
+    Deliberately in-memory and dependency-free. Persistence (YAML, SQL,
+    wherever) is a caller concern — serialize ``_by_client`` directly or
+    build higher-level storage on top.
+    """
+
+    _by_client: Dict[str, Dict[str, WaveSet]] = field(default_factory=dict)
+
+    # -------------------------------------------------------------------
+    # Registration
+    # -------------------------------------------------------------------
+
+    def register(self, waveset: WaveSet) -> WaveSet:
+        """Register a WaveSet whose ``client_id`` is already set.
+
+        Raises :class:`ClientSurveyError` if ``client_id`` is unset or if
+        a WaveSet with the same name is already registered for that
+        client.
+        """
+        if not waveset.client_id:
+            raise ClientSurveyError(
+                f"WaveSet {waveset.name!r} has no client_id; "
+                "use register_for(client_id, waveset) instead or set "
+                "waveset.client_id first."
+            )
+        return self._register_unchecked(waveset.client_id, waveset)
+
+    def register_for(self, client_id: str, waveset: WaveSet) -> WaveSet:
+        """Set ``waveset.client_id = client_id`` and register it.
+
+        Raises :class:`ClientSurveyError` if a WaveSet with the same
+        name is already registered for that client.
+        """
+        if not client_id:
+            raise ClientSurveyError("client_id must be a non-empty string")
+        waveset.client_id = client_id
+        return self._register_unchecked(client_id, waveset)
+
+    def _register_unchecked(self, client_id: str, waveset: WaveSet) -> WaveSet:
+        surveys = self._by_client.setdefault(client_id, {})
+        if waveset.name in surveys:
+            raise ClientSurveyError(
+                f"client {client_id!r} already has a survey named "
+                f"{waveset.name!r}; unregister it first or rename."
+            )
+        surveys[waveset.name] = waveset
+        return waveset
+
+    def unregister(self, client_id: str, name: str) -> WaveSet:
+        """Remove and return the named survey for ``client_id``.
+
+        Raises :class:`ClientSurveyError` if the client or the named
+        survey is not registered.
+        """
+        surveys = self._by_client.get(client_id)
+        if not surveys or name not in surveys:
+            raise ClientSurveyError(
+                f"no survey named {name!r} registered for client {client_id!r}"
+            )
+        removed = surveys.pop(name)
+        if not surveys:
+            del self._by_client[client_id]
+        return removed
+
+    # -------------------------------------------------------------------
+    # Lookup
+    # -------------------------------------------------------------------
+
+    def clients(self) -> List[str]:
+        """Return all registered client ids."""
+        return list(self._by_client.keys())
+
+    def surveys_for(self, client_id: str) -> List[WaveSet]:
+        """Return all WaveSets registered to ``client_id`` (empty list if none)."""
+        return list(self._by_client.get(client_id, {}).values())
+
+    def get_survey(self, client_id: str, name: str) -> Optional[WaveSet]:
+        """Return the named WaveSet for a client, or ``None`` if missing."""
+        return self._by_client.get(client_id, {}).get(name)
+
+    def require_survey(self, client_id: str, name: str) -> WaveSet:
+        """Like :meth:`get_survey` but raises :class:`ClientSurveyError` on miss."""
+        ws = self.get_survey(client_id, name)
+        if ws is None:
+            raise ClientSurveyError(
+                f"no survey named {name!r} registered for client {client_id!r}"
+            )
+        return ws
+
+    def client_of(self, waveset: WaveSet) -> Optional[str]:
+        """Return the client id a WaveSet is registered to, if any.
+
+        Prefers ``waveset.client_id`` but falls back to reverse lookup
+        so callers stay correct even if the field was cleared after
+        registration.
+        """
+        if waveset.client_id:
+            return waveset.client_id
+        for client_id, surveys in self._by_client.items():
+            if any(ws is waveset for ws in surveys.values()):
+                return client_id
+        return None
+
+    # -------------------------------------------------------------------
+    # Introspection
+    # -------------------------------------------------------------------
+
+    def __contains__(self, key) -> bool:
+        """``client_id in registry`` or ``(client_id, name) in registry``."""
+        if isinstance(key, tuple) and len(key) == 2:
+            client_id, name = key
+            return name in self._by_client.get(client_id, {})
+        return key in self._by_client
+
+    def __len__(self) -> int:
+        """Total number of registered surveys across all clients."""
+        return sum(len(s) for s in self._by_client.values())

--- a/tests/test_client_survey_registry.py
+++ b/tests/test_client_survey_registry.py
@@ -1,0 +1,140 @@
+"""Tests for siege_utilities.survey.registry (client ↔ survey mapping)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pandas as pd
+import pytest
+
+from siege_utilities.survey import (
+    ClientSurveyError,
+    ClientSurveyRegistry,
+    Wave,
+    WaveSet,
+)
+
+
+def _ws(name: str, client_id: str | None = None) -> WaveSet:
+    df = pd.DataFrame({"party": ["D", "R"]})
+    return WaveSet(
+        name=name,
+        waves=[Wave(id="W1", date=date(2024, 3, 1), df=df)],
+        client_id=client_id,
+    )
+
+
+class TestRegisterPreset:
+    def test_register_with_client_id_set(self):
+        reg = ClientSurveyRegistry()
+        ws = _ws("Tracker", client_id="acme")
+        reg.register(ws)
+        assert reg.surveys_for("acme") == [ws]
+
+    def test_register_without_client_id_raises(self):
+        reg = ClientSurveyRegistry()
+        with pytest.raises(ClientSurveyError, match="no client_id"):
+            reg.register(_ws("Tracker"))
+
+
+class TestRegisterFor:
+    def test_sets_client_id(self):
+        reg = ClientSurveyRegistry()
+        ws = _ws("Tracker")
+        reg.register_for("acme", ws)
+        assert ws.client_id == "acme"
+
+    def test_empty_client_id_raises(self):
+        reg = ClientSurveyRegistry()
+        with pytest.raises(ClientSurveyError, match="non-empty"):
+            reg.register_for("", _ws("Tracker"))
+
+    def test_duplicate_name_same_client_raises(self):
+        reg = ClientSurveyRegistry()
+        reg.register_for("acme", _ws("Tracker"))
+        with pytest.raises(ClientSurveyError, match="already has a survey"):
+            reg.register_for("acme", _ws("Tracker"))
+
+    def test_same_name_different_clients_allowed(self):
+        reg = ClientSurveyRegistry()
+        reg.register_for("acme", _ws("Tracker"))
+        reg.register_for("beacon", _ws("Tracker"))
+        assert len(reg) == 2
+
+
+class TestLookup:
+    def test_surveys_for_unknown_returns_empty(self):
+        assert ClientSurveyRegistry().surveys_for("nobody") == []
+
+    def test_get_survey_miss_returns_none(self):
+        reg = ClientSurveyRegistry()
+        reg.register_for("acme", _ws("Tracker"))
+        assert reg.get_survey("acme", "Missing") is None
+        assert reg.get_survey("unknown", "Tracker") is None
+
+    def test_require_survey_raises_on_miss(self):
+        reg = ClientSurveyRegistry()
+        with pytest.raises(ClientSurveyError):
+            reg.require_survey("acme", "Tracker")
+
+    def test_client_of_by_field(self):
+        reg = ClientSurveyRegistry()
+        ws = _ws("Tracker", client_id="acme")
+        reg.register(ws)
+        assert reg.client_of(ws) == "acme"
+
+    def test_client_of_reverse_lookup_when_field_cleared(self):
+        reg = ClientSurveyRegistry()
+        ws = _ws("Tracker", client_id="acme")
+        reg.register(ws)
+        ws.client_id = None  # simulate defensive mutation
+        assert reg.client_of(ws) == "acme"
+
+    def test_client_of_unregistered_returns_none(self):
+        assert ClientSurveyRegistry().client_of(_ws("Tracker")) is None
+
+
+class TestUnregister:
+    def test_unregister_returns_waveset(self):
+        reg = ClientSurveyRegistry()
+        ws = reg.register_for("acme", _ws("Tracker"))
+        assert reg.unregister("acme", "Tracker") is ws
+        assert reg.surveys_for("acme") == []
+
+    def test_unregister_last_removes_client_row(self):
+        reg = ClientSurveyRegistry()
+        reg.register_for("acme", _ws("Tracker"))
+        reg.unregister("acme", "Tracker")
+        assert "acme" not in reg
+
+    def test_unregister_miss_raises(self):
+        reg = ClientSurveyRegistry()
+        with pytest.raises(ClientSurveyError):
+            reg.unregister("acme", "Tracker")
+
+
+class TestContainsLen:
+    def test_contains_client_id(self):
+        reg = ClientSurveyRegistry()
+        reg.register_for("acme", _ws("Tracker"))
+        assert "acme" in reg
+        assert "beacon" not in reg
+
+    def test_contains_tuple(self):
+        reg = ClientSurveyRegistry()
+        reg.register_for("acme", _ws("Tracker"))
+        assert ("acme", "Tracker") in reg
+        assert ("acme", "Other") not in reg
+
+    def test_len_counts_all_surveys(self):
+        reg = ClientSurveyRegistry()
+        reg.register_for("acme", _ws("S1"))
+        reg.register_for("acme", _ws("S2"))
+        reg.register_for("beacon", _ws("S1"))
+        assert len(reg) == 3
+
+    def test_clients_lists_registered_ids(self):
+        reg = ClientSurveyRegistry()
+        reg.register_for("acme", _ws("S1"))
+        reg.register_for("beacon", _ws("S1"))
+        assert set(reg.clients()) == {"acme", "beacon"}


### PR DESCRIPTION
## Summary

- `WaveSet` gains optional `client_id: str`
- New `siege_utilities.survey.registry` with `ClientSurveyRegistry` + `ClientSurveyError`
- Survey names scoped per-client; duplicates within one client raise
- Branding / display stays in `reporting/client_branding` — registry only answers "which surveys belong to this client"

## Test plan
- [x] 19 new tests in `tests/test_client_survey_registry.py`
- [x] Full survey suite: 86 pass / 3 skipped, no regression