### PR TITLE
docs(notebooks): unify narrative across merged notebooks

### DIFF
--- a/notebooks/foundations/02_profiles_branding.ipynb
+++ b/notebooks/foundations/02_profiles_branding.ipynb
@@ -14,9 +14,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "> **See also:** NB03 covers the full Person/Actor architecture in depth (Organizations, Collaborations, credential management). This notebook focuses on the practical workflow of creating and managing profiles.\n"
-   ]
+   "source": "> **See also:** Part 2 of this notebook (Person / Actor) covers the full Person/Actor architecture in depth (Organizations, Collaborations, credential management). This notebook focuses on the practical workflow of creating and managing profiles.\n"
   },
   {
    "cell_type": "code",
@@ -35,11 +33,7 @@
    "cell_type": "markdown",
    "id": "cell-2",
    "metadata": {},
-   "source": [
-    "## 1. Creating a User Profile\n",
-    "\n",
-    "Let's create a comprehensive user profile with all available options:"
-   ]
+   "source": "## 1. Creating a User Profile\n\nLet's create a comprehensive user profile with all available options:"
   },
   {
    "cell_type": "code",
@@ -112,26 +106,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cell-14",
    "metadata": {},
-   "source": "## Summary\n\nThis notebook demonstrates how to create and manage user and client profiles using the modern Person/Actor architecture.\n\n### What We Covered:\n1. **User Creation**: Using the `User` model with Person base fields plus user-specific preferences\n2. **Branding Configuration**: Color schemes, fonts, and layout settings with typed `BrandingConfig` validation\n3. **Client Creation**: Using the `Client` model with Person base fields plus client-specific configuration\n4. **User-Client Assignment**: Bidirectional assignment with `assign_client`/`assign_user` and `set_primary_client`/`set_primary_user`\n5. **Validation Examples**: How the system catches and handles invalid data\n6. **YAML Persistence**: Using `HydraConfigManager.save_user()`/`load_user()` and `save_client()`/`load_client()`\n\n### Next Steps:\n- **Run this notebook** to see the profiles in action\n- **Modify the examples** with your own data\n- **See NB03** for the full Person/Actor architecture documentation\n- **Explore the migration system** for existing configurations\n\n### Additional Resources:\n- [Complete Configuration Documentation](../docs/HYDRA_PYDANTIC_CONFIGURATION.md)\n- [User Guide](../docs/USER_GUIDE.md)\n- [Configuration System Demo](./01_Configuration_System_Demo.ipynb)\n- [Person/Actor Architecture](./03_Person_Actor_Architecture.ipynb)"
+   "source": "---\n\n## Part 2: Person / Actor architecture\n\nThe underlying data model. Individuals become `Person` records, organizations become `Actor` records, and a `User` or `Client` profile is the projection of one of those into the reporting system.\n"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Related\n- Source: `siege_utilities/admin/profile_manager.py`, `siege_utilities/reporting/client_branding.py`\n- Tests: `tests/test_admin_profile_manager.py`, `tests/test_client_branding*.py`\n- Consolidates: previous `03_Person_Actor_Architecture` and `10_Profile_Branding_Testing`\n"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "---\n\n# Appendix: Person / Actor architecture\n\n*The sections below originally lived in `03_Person_Actor_Architecture.ipynb`, consolidated here during the ELE-2421 notebook reorg.*\n"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "> **See also:** NB02 covers the practical workflow of creating User and Client profiles. This notebook provides the complete architectural reference for the Person/Actor model system.\n"
-   ]
+   "source": "> **See also:** `foundations/02_profiles_branding.ipynb` covers the practical workflow of creating User and Client profiles. This notebook provides the complete architectural reference for the Person/Actor model system.\n"
   },
   {
    "cell_type": "code",
@@ -247,7 +228,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "---\n\n# Appendix: Branding deep-dive\n\n*The sections below originally lived in `10_Profile_Branding_Testing.ipynb`, consolidated here during the ELE-2421 notebook reorg.*\n"
+   "source": "---\n\n## Part 3: Branding \u2014 colors, fonts, logos, templates\n\nEverything the report / deck / PDF pipelines read when they ask \"how should this look for client X?\". Comes with predefined templates (Siege Analytics, Masai, Hillcrest) and validates unknown overrides.\n"
   },
   {
    "cell_type": "code",
@@ -297,11 +278,7 @@
    "cell_type": "markdown",
    "id": "cell-2",
    "metadata": {},
-   "source": [
-    "## 1. Check Credential Backends\n",
-    "\n",
-    "Check which credential storage backends are available."
-   ]
+   "source": "## 1. Check Credential Backends\n\nCheck which credential storage backends are available."
   },
   {
    "cell_type": "code",
@@ -422,11 +399,7 @@
    "cell_type": "markdown",
    "id": "cell-5",
    "metadata": {},
-   "source": [
-    "## 2. Create User Profile\n",
-    "\n",
-    "Create or load user profile with default preferences."
-   ]
+   "source": "## 2. Create User Profile\n\nCreate or load user profile with default preferences."
   },
   {
    "cell_type": "code",
@@ -580,11 +553,7 @@
    "cell_type": "markdown",
    "id": "cell-9",
    "metadata": {},
-   "source": [
-    "## 3. Create Hillcrest Client Profile\n",
-    "\n",
-    "Create a complete client profile with branding configuration."
-   ]
+   "source": "## 3. Create Hillcrest Client Profile\n\nCreate a complete client profile with branding configuration."
   },
   {
    "cell_type": "code",
@@ -834,11 +803,7 @@
    "cell_type": "markdown",
    "id": "cell-15",
    "metadata": {},
-   "source": [
-    "## 4. Test 1Password Integration\n",
-    "\n",
-    "Retrieve credentials from 1Password (if available)."
-   ]
+   "source": "## 4. Test 1Password Integration\n\nRetrieve credentials from 1Password (if available)."
   },
   {
    "cell_type": "code",
@@ -993,11 +958,7 @@
    "cell_type": "markdown",
    "id": "cell-18",
    "metadata": {},
-   "source": [
-    "## 5. Generate Branded PDF Report\n",
-    "\n",
-    "Create a sample report using Hillcrest branding."
-   ]
+   "source": "## 5. Generate Branded PDF Report\n\nCreate a sample report using Hillcrest branding."
   },
   {
    "cell_type": "code",
@@ -1421,11 +1382,7 @@
    "cell_type": "markdown",
    "id": "cell-26",
    "metadata": {},
-   "source": [
-    "## 6. Verify Profile Persistence\n",
-    "\n",
-    "Verify that profiles are correctly saved and can be reloaded."
-   ]
+   "source": "## 6. Verify Profile Persistence\n\nVerify that profiles are correctly saved and can be reloaded."
   },
   {
    "cell_type": "code",
@@ -1565,16 +1522,6 @@
    "outputs": []
   },
   {
-   "cell_type": "markdown",
-   "id": "cell-29",
-   "metadata": {},
-   "source": [
-    "## Summary\n",
-    "\n",
-    "Test results summary."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "cell-30",
@@ -1593,21 +1540,12 @@
    "cell_type": "markdown",
    "id": "cell-31",
    "metadata": {},
-   "source": [
-    "## Next Steps\n",
-    "\n",
-    "If all tests pass:\n",
-    "\n",
-    "1. **Update Hillcrest branding colors** - Edit the BrandingConfig with actual Hillcrest colors\n",
-    "2. **Add logo** - Set `logo_path` to actual Hillcrest logo file\n",
-    "3. **Store GA credentials** - If you have GA service account, store it:\n",
-    "   ```python\n",
-    "   from siege_utilities.config import store_ga_service_account_from_file\n",
-    "   store_ga_service_account_from_file('/path/to/service-account.json', \n",
-    "                                       item_title='Hillcrest GA Service Account')\n",
-    "   ```\n",
-    "4. **Test with real data** - Use actual polling data from Hillcrest projects"
-   ]
+   "source": "## Next Steps\n\nIf all tests pass:\n\n1. **Update Hillcrest branding colors** - Edit the BrandingConfig with actual Hillcrest colors\n2. **Add logo** - Set `logo_path` to actual Hillcrest logo file\n3. **Store GA credentials** - If you have GA service account, store it:\n   ```python\n   from siege_utilities.config import store_ga_service_account_from_file\n   store_ga_service_account_from_file('/path/to/service-account.json', \n                                       item_title='Hillcrest GA Service Account')\n   ```\n4. **Test with real data** - Use actual polling data from Hillcrest projects"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Related\n- Source: `siege_utilities/admin/profile_manager.py`, `siege_utilities/reporting/client_branding.py`\n- Tests: `tests/test_admin_profile_manager.py`, `tests/test_client_branding*.py`\n- Consolidates: previous `03_Person_Actor_Architecture` and `10_Profile_Branding_Testing`\n"
   }
  ],
  "metadata": {

--- a/notebooks/reports/01_charts_and_pdf.ipynb
+++ b/notebooks/reports/01_charts_and_pdf.ipynb
@@ -123,12 +123,7 @@
    "cell_type": "markdown",
    "id": "cell-3",
    "metadata": {},
-   "source": [
-    "## 2. Standard Charts\n",
-    "\n",
-    "Matplotlib-backed charts that return ReportLab `Image` objects.  We use `show_rl_image()` to\n",
-    "decode the base64 data URI for notebook display."
-   ]
+   "source": "## 2. Standard Charts\n\nMatplotlib-backed charts that return ReportLab `Image` objects.  We use `show_rl_image()` to\ndecode the base64 data URI for notebook display."
   },
   {
    "cell_type": "code",
@@ -199,13 +194,7 @@
    "cell_type": "markdown",
    "id": "cell-9",
    "metadata": {},
-   "source": [
-    "## 3. Geographic Maps (Folium)\n",
-    "\n",
-    "Folium-based methods save HTML files and return placeholder ReportLab images.\n",
-    "We call the ChartGenerator API to exercise it, then also create Folium map objects\n",
-    "directly so we get interactive output in the notebook."
-   ]
+   "source": "## 3. Geographic Maps (Folium)\n\nFolium-based methods save HTML files and return placeholder ReportLab images.\nWe call the ChartGenerator API to exercise it, then also create Folium map objects\ndirectly so we get interactive output in the notebook."
   },
   {
    "cell_type": "code",
@@ -346,13 +335,7 @@
    "cell_type": "markdown",
    "id": "cell-14",
    "metadata": {},
-   "source": [
-    "## 4. Geographic Maps (Matplotlib & Folium Choropleth)\n",
-    "\n",
-    "These methods require a GeoDataFrame with geometry. We load California counties using the\n",
-    "same `get_census_boundaries()` pattern from NB05, then use them for both Folium choropleth\n",
-    "maps and matplotlib-rendered maps."
-   ]
+   "source": "## 4. Geographic Maps (Matplotlib & Folium Choropleth)\n\nThese methods require a GeoDataFrame with geometry. We load California counties using the\nsame `get_census_boundaries()` pattern from `spatial/03_choropleth_maps.ipynb`, then use them for both Folium choropleth\nmaps and matplotlib-rendered maps."
   },
   {
    "cell_type": "code",
@@ -452,11 +435,7 @@
    "cell_type": "markdown",
    "id": "cell-18",
    "metadata": {},
-   "source": [
-    "## 5. 3D Visualization\n",
-    "\n",
-    "Uses matplotlib's 3D projection for point-cloud and surface plots."
-   ]
+   "source": "## 5. 3D Visualization\n\nUses matplotlib's 3D projection for point-cloud and surface plots."
   },
   {
    "cell_type": "code",
@@ -474,11 +453,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 5b. Isochrone Service Areas\n",
-    "\n",
-    "This demonstrates the open-source isochrone API integration (ORS/Valhalla), including custom server support.\n"
-   ]
+   "source": "## 5b. Isochrone Service Areas\n\nThis demonstrates the open-source isochrone API integration (ORS/Valhalla), including custom server support.\n"
   },
   {
    "cell_type": "code",
@@ -540,12 +515,7 @@
    "cell_type": "markdown",
    "id": "cell-20",
    "metadata": {},
-   "source": [
-    "## 6. Text-Based Charts\n",
-    "\n",
-    "These return HTML strings instead of images \u2014 useful for email reports, lightweight dashboards,\n",
-    "or environments without matplotlib."
-   ]
+   "source": "## 6. Text-Based Charts\n\nThese return HTML strings instead of images \u2014 useful for email reports, lightweight dashboards,\nor environments without matplotlib."
   },
   {
    "cell_type": "code",
@@ -593,11 +563,7 @@
    "cell_type": "markdown",
    "id": "cell-23",
    "metadata": {},
-   "source": [
-    "## 7. Composite Charts & Layout\n",
-    "\n",
-    "Higher-level methods that combine multiple charts or dispatch by configuration."
-   ]
+   "source": "## 7. Composite Charts & Layout\n\nHigher-level methods that combine multiple charts or dispatch by configuration."
   },
   {
    "cell_type": "code",
@@ -655,13 +621,7 @@
    "cell_type": "markdown",
    "id": "cell-28",
    "metadata": {},
-   "source": [
-    "## 8. Complete PDF Report\n",
-    "\n",
-    "Build a multi-page PDF demonstrating `BaseReportTemplate`, `create_chart_with_caption()`,\n",
-    "and `create_chart_section()` \u2014 these return ReportLab flowable lists that only make sense\n",
-    "inside a PDF build pipeline."
-   ]
+   "source": "## 8. Complete PDF Report\n\nBuild a multi-page PDF demonstrating `BaseReportTemplate`, `create_chart_with_caption()`,\nand `create_chart_section()` \u2014 these return ReportLab flowable lists that only make sense\ninside a PDF build pipeline."
   },
   {
    "cell_type": "code",
@@ -680,9 +640,7 @@
    "cell_type": "markdown",
    "id": "cell-30-md",
    "metadata": {},
-   "source": [
-    "## 9. PowerPoint Generation"
-   ]
+   "source": "## 9. PowerPoint Generation"
   },
   {
    "cell_type": "code",
@@ -700,15 +658,7 @@
   {
    "cell_type": "markdown",
    "id": "2om0jbuwkm2",
-   "source": [
-    "## 10. Chart Type Registry\n",
-    "\n",
-    "The `ChartTypeRegistry` provides an extensible catalogue of chart configurations.\n",
-    "Each `ChartType` dataclass describes required/optional parameters, rendering defaults,\n",
-    "and feature flags (interactive, 3D, animation). The registry ships with built-in\n",
-    "types for geographic, statistical, temporal, and comparative charts, and supports\n",
-    "custom registrations at runtime."
-   ],
+   "source": "## 10. Chart Type Registry\n\nThe `ChartTypeRegistry` provides an extensible catalogue of chart configurations.\nEach `ChartType` dataclass describes required/optional parameters, rendering defaults,\nand feature flags (interactive, 3D, animation). The registry ships with built-in\ntypes for geographic, statistical, temporal, and comparative charts, and supports\ncustom registrations at runtime.",
    "metadata": {}
   },
   {
@@ -801,18 +751,7 @@
   {
    "cell_type": "markdown",
    "id": "zzm8sso7j6d",
-   "source": [
-    "## 11. Polling / Survey analysis\n",
-    "\n",
-    "> **Migrated** from `PollingAnalyzer` (deprecated, ELE-2439) to the survey pipeline:\n",
-    "> `siege_utilities.survey.build_chain` \u2192 `Chain` \u2192 `chain_to_argument` \u2192 `Argument`.\n",
-    "> For full end-to-end coverage including multi-wave `WaveSet` comparison and\n",
-    "> trend / heatmap charts, see `notebooks/28_Polling_Survey_Analysis.ipynb`.\n",
-    "\n",
-    "The cell below shows a minimal cross-tab using the new primitives \u2014 no analyzer\n",
-    "class, no `metric='sessions'` legacy default. Works on any tidy respondent-level\n",
-    "DataFrame.\n"
-   ],
+   "source": "## 11. Polling / Survey analysis\n\n> **Migrated** from `PollingAnalyzer` (deprecated, ELE-2439) to the survey pipeline:\n> `siege_utilities.survey.build_chain` \u2192 `Chain` \u2192 `chain_to_argument` \u2192 `Argument`.\n> For full end-to-end coverage including multi-wave `WaveSet` comparison and\n> trend / heatmap charts, see `notebooks/28_Polling_Survey_Analysis.ipynb`.\n\nThe cell below shows a minimal cross-tab using the new primitives \u2014 no analyzer\nclass, no `metric='sessions'` legacy default. Works on any tidy respondent-level\nDataFrame.\n",
    "metadata": {}
   },
   {
@@ -907,12 +846,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Related\n- Source: `siege_utilities/reporting/` (chart_generator, report_generator, chart_types)\n- Tests: `tests/test_chart_types*.py`, `tests/test_reporting_config_exports.py`\n- Consolidates: `11_ReportLab_PDF_Features`\n"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "---\n\n# Appendix: ReportLab advanced PDF features\n\n*The sections below originally lived in `11_ReportLab_PDF_Features.ipynb`, consolidated here during the ELE-2421 notebook reorg.*\n"
+   "source": "---\n\n## Part 2: Advanced ReportLab PDF features\n\nBeyond the one-call PDF exports from Part 1 \u2014 direct ReportLab flowable assembly for fine-grained control over page layout, custom frames, and mixed-content sections.\n"
   },
   {
    "cell_type": "code",
@@ -945,11 +879,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 1. Basic PDF Generation\n",
-    "\n",
-    "Test that basic PDF generation works."
-   ]
+   "source": "## 1. Basic PDF Generation\n\nTest that basic PDF generation works."
   },
   {
    "cell_type": "code",
@@ -989,11 +919,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 2. Multi-Page PDF with Page Breaks\n",
-    "\n",
-    "Test multi-page PDF generation with explicit page breaks."
-   ]
+   "source": "## 2. Multi-Page PDF with Page Breaks\n\nTest multi-page PDF generation with explicit page breaks."
   },
   {
    "cell_type": "code",
@@ -1012,11 +938,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 3. Table of Contents Template\n",
-    "\n",
-    "Test the dedicated Table of Contents template."
-   ]
+   "source": "## 3. Table of Contents Template\n\nTest the dedicated Table of Contents template."
   },
   {
    "cell_type": "code",
@@ -1035,11 +957,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 4. Charts in Reports\n",
-    "\n",
-    "Test embedding matplotlib charts in PDF reports."
-   ]
+   "source": "## 4. Charts in Reports\n\nTest embedding matplotlib charts in PDF reports."
   },
   {
    "cell_type": "code",
@@ -1058,11 +976,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 5. Comprehensive Report with All Features\n",
-    "\n",
-    "Test a full report combining all features."
-   ]
+   "source": "## 5. Comprehensive Report with All Features\n\nTest a full report combining all features."
   },
   {
    "cell_type": "code",
@@ -1072,20 +986,16 @@
    "source": "# Branded comprehensive report with all features\ncomprehensive_report_path = OUTPUT_DIR / f\"comprehensive_report_{timestamp}.pdf\"\n\ntry:\n    story = []\n\n    # --- Title page ---\n    branded_title_page(\n        story,\n        title='Annual Business Report',\n        subtitle='FY 2025 Comprehensive Analysis',\n        meta_lines=[\n            'Prepared by: Siege Analytics',\n            f\"Date: {datetime.now().strftime('%B %d, %Y')}\",\n        ],\n    )\n\n    # --- Executive Summary ---\n    section_header(story, 'Executive Summary')\n    story.append(Paragraph(\n        \"This comprehensive report presents the financial and operational performance \"\n        \"for FY 2025. The company achieved strong results across all key metrics, \"\n        \"with revenue growing 15.4% year-over-year to $68.5M.\",\n        styles['SA_Body'],\n    ))\n    story.append(Spacer(1, 20))\n\n    # --- Quarterly Performance ---\n    section_header(story, 'Quarterly Performance')\n    story.append(make_branded_table(sales_data))\n    story.append(Spacer(1, 20))\n\n    # --- Data Visualizations ---\n    section_header(story, 'Data Visualizations')\n    if chart_path.exists():\n        img = RLImage(str(chart_path), width=6*inch, height=3*inch)\n        story.append(img)\n        story.append(Spacer(1, 8))\n        story.append(Paragraph(\n            \"Figure 1: Quarterly Revenue and Regional Market Share\",\n            styles['SA_Caption'],\n        ))\n    story.append(PageBreak())\n\n    # --- Regional Analysis ---\n    section_header(story, 'Regional Analysis')\n    story.append(Paragraph(\n        \"The regional breakdown shows strong performance across all territories. \"\n        \"The West region continues to lead with 33% market share.\",\n        styles['SA_Body'],\n    ))\n    story.append(Spacer(1, 16))\n    story.append(make_branded_table(regional_data))\n    story.append(Spacer(1, 20))\n\n    # --- Strategic Recommendations ---\n    section_header(story, 'Strategic Recommendations')\n    for i, rec in enumerate([\n        \"Continue investment in West region growth initiatives\",\n        \"Expand international presence targeting European markets\",\n        \"Launch customer retention program to reduce churn\",\n        \"Increase R&D spending to maintain technology leadership\",\n        \"Explore strategic acquisitions in adjacent markets\",\n    ], 1):\n        story.append(Paragraph(f\"{i}. {rec}\", styles['SA_Body']))\n        story.append(Spacer(1, 4))\n\n    doc = SimpleDocTemplate(\n        str(comprehensive_report_path), pagesize=letter,\n        topMargin=1*inch, bottomMargin=1*inch,\n        leftMargin=1*inch, rightMargin=1*inch,\n    )\n    doc.build(story)\n\n    if comprehensive_report_path.exists():\n        size_kb = comprehensive_report_path.stat().st_size / 1024\n        print(f\"Comprehensive PDF generated: {comprehensive_report_path.name} ({size_kb:.1f} KB)\")\n    else:\n        print(\"WARNING: PDF was not created\")\nexcept Exception as e:\n    print(f\"ERROR: {e}\")\n    import traceback\n    traceback.print_exc()"
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Summary\n",
-    "\n",
-    "List all generated PDFs."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": "# Summary \u2014 check all generated files\nprint(\"=\" * 50)\nprint(\"REPORTLAB PDF FEATURE TEST RESULTS\")\nprint(\"=\" * 50)\n\ngenerated_files = [\n    ('Basic PDF', basic_pdf_path),\n    ('Multi-page PDF', multipage_pdf_path),\n    ('Table of Contents', toc_pdf_path),\n    ('Charts Report', chart_report_path),\n    ('Comprehensive Report', comprehensive_report_path),\n]\n\nresults = []\nfor name, path in generated_files:\n    if path.exists():\n        size_kb = path.stat().st_size / 1024\n        print(f\"  PASS  {name}: {size_kb:.1f} KB\")\n        results.append(True)\n    else:\n        print(f\"  FAIL  {name}: Not generated\")\n        results.append(False)\n\npassed = sum(results)\ntotal = len(results)\nprint(f\"\\n{passed}/{total} PDFs generated successfully.\")\nprint(f\"Output directory: {OUTPUT_DIR}\")\n\nif passed == total:\n    print(\"\\nAll ReportLab PDF features working!\")\nelse:\n    print(\"\\nSome features need attention.\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Related\n- Source: `siege_utilities/reporting/` (chart_generator, report_generator, chart_types)\n- Tests: `tests/test_chart_types*.py`, `tests/test_reporting_config_exports.py`\n- Consolidates: `11_ReportLab_PDF_Features`\n"
   }
  ],
  "metadata": {

--- a/notebooks/reports/02_slides_pptx_and_google.ipynb
+++ b/notebooks/reports/02_slides_pptx_and_google.ipynb
@@ -41,9 +41,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 1. Create Sample Data"
-   ]
+   "source": "## 1. Create Sample Data"
   },
   {
    "cell_type": "code",
@@ -55,9 +53,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 2. Basic Analytics Presentation"
-   ]
+   "source": "## 2. Basic Analytics Presentation"
   },
   {
    "cell_type": "code",
@@ -83,9 +79,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 3. Performance Presentation"
-   ]
+   "source": "## 3. Performance Presentation"
   },
   {
    "cell_type": "code",
@@ -104,9 +98,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 4. DataFrame Presentation"
-   ]
+   "source": "## 4. DataFrame Presentation"
   },
   {
    "cell_type": "code",
@@ -125,9 +117,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 5. Custom Presentation with Full Control"
-   ]
+   "source": "## 5. Custom Presentation with Full Control"
   },
   {
    "cell_type": "code",
@@ -144,13 +134,6 @@
    "source": "if PPTX_AVAILABLE:\n    try:\n        custom_pptx = pptx_gen.create_custom_presentation(custom_config)\n        \n        if custom_pptx.exists():\n            size_kb = custom_pptx.stat().st_size / 1024\n            print(f\"Custom presentation generated: {custom_pptx.name} ({size_kb:.1f} KB)\")\n        else:\n            print(\"WARNING: Presentation was not created\")\n    except Exception as e:\n        print(f\"ERROR: {e}\")\n        import traceback\n        traceback.print_exc()"
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Summary"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -160,12 +143,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Related\n- Source: `siege_utilities/reporting/powerpoint_generator.py`, `siege_utilities/reporting/pages/`\n- Tests: `tests/test_survey_render.py`\n"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "---\n\n# Appendix: Google Workspace output\n\n*The sections below originally lived in `18_Google_Workspace.ipynb`, consolidated here during the ELE-2421 notebook reorg.*\n"
+   "source": "---\n\n## Part 2: Google Workspace \u2014 Docs, Sheets, Slides\n\nSame `Argument` inputs, different output surface. Google Slides is the canonical target; Docs and Sheets are demoed as peers where they accept the same structured data.\n"
   },
   {
    "cell_type": "code",
@@ -380,6 +358,11 @@
    "metadata": {},
    "execution_count": null,
    "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Related\n- Source: `siege_utilities/reporting/powerpoint_generator.py`, `siege_utilities/reporting/pages/`\n- Tests: `tests/test_survey_render.py`\n"
   }
  ],
  "metadata": {

--- a/notebooks/spatial/01_boundaries.ipynb
+++ b/notebooks/spatial/01_boundaries.ipynb
@@ -2,42 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "cell-8",
    "metadata": {},
-   "source": [
-    "# 04: Spatial Data & Census Boundaries\n",
-    "\n",
-    "This notebook demonstrates the spatial data capabilities of siege_utilities, including:\n",
-    "\n",
-    "1. **Census Boundary Downloads** - Download TIGER/Line shapefiles\n",
-    "2. **State FIPS Normalization** - Convert between state names, abbreviations, and FIPS codes\n",
-    "3. **Geographic Level Discovery** - Find available boundary types for any year\n",
-    "4. **Working with GeoDataFrames** - Basic spatial operations\n",
-    "\n",
-    "## Prerequisites\n",
-    "\n",
-    "```bash\n",
-    "pip install -e /path/to/siege_utilities\n",
-    "```"
-   ]
+   "source": "# Boundaries \u2014 US Census (TIGER), demographics, and international (GADM)\n\n## What this shows\nOne-stop coverage of everything that lives under \"get me geographies\":\nCensus TIGER boundaries (states \u2192 blocks), Census demographics joins,\nGEOID / crosswalk / time-series utilities, H3 hexagonal indexing,\nboundary providers, and international boundaries from GADM.\n\n## Why it matters\nConsolidates what were three separate notebooks (Census boundaries,\nCensus demographics integration, and GADM international boundaries).\nUse this as the canonical entry point for any spatial fetching task \u2014\nif you need a polygon or a demographic value keyed to one, it's here.\n\n## Prereqs\n- `pip install 'siege-utilities[geo]'`\n- Census API key (1Password entry or `CENSUS_API_KEY` env var) for\n  demographics cells. Boundary-only cells need no credentials.\n\n## Next\n- `spatial/02_geocoding.ipynb` for address \u2192 FIPS.\n- `spatial/03_choropleth_maps.ipynb` to render what you've fetched here.\n- `spatial/04_redistricting.ipynb` for RDH + VTD routing.\n"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": "## What this shows\nFetching US Census TIGER boundaries (states, counties, tracts) via the BoundaryProvider registry.\n\n## Why it matters\nCanonical entry point for geographic work; exercises the `geo/providers/` consolidation from ELE-2438.\n\n## Prereqs\n- `pip install 'siege-utilities[geo]'`\n\n## Next\n- `05_Choropleth_Maps.ipynb`, `07_Geocoding_Address_Processing.ipynb`, `23_Redistricting_Analysis.ipynb`.\n"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "> **This is a comprehensive reference notebook** covering 9+ spatial subsystems. ",
-    "For focused introductions, see:\n",
-    "> - **NB05** \u2014 Choropleth maps and classification\n",
-    "> - **NB07** \u2014 Geocoding and address processing\n",
-    "> - **NB15** \u2014 Census demographics quick start\n",
-    "> - **NB25** \u2014 SpatiaLite cache and isochrones\n",
-    "> - **NB26** \u2014 International boundaries (GADM)\n"
-   ]
   },
   {
    "cell_type": "code",
@@ -157,11 +128,7 @@
    "cell_type": "markdown",
    "id": "cell-10",
    "metadata": {},
-   "source": [
-    "## 1. State FIPS Normalization\n",
-    "\n",
-    "The `normalize_state_identifier()` function accepts any state format and returns the FIPS code."
-   ]
+   "source": "## 1. State FIPS Normalization\n\nThe `normalize_state_identifier()` function accepts any state format and returns the FIPS code."
   },
   {
    "cell_type": "code",
@@ -225,11 +192,7 @@
    "cell_type": "markdown",
    "id": "cell-13",
    "metadata": {},
-   "source": [
-    "## 2. Discovering Available Census Data\n",
-    "\n",
-    "Census TIGER/Line files are available for different years. Let's discover what's available."
-   ]
+   "source": "## 2. Discovering Available Census Data\n\nCensus TIGER/Line files are available for different years. Let's discover what's available."
   },
   {
    "cell_type": "code",
@@ -288,11 +251,7 @@
    "cell_type": "markdown",
    "id": "cell-16",
    "metadata": {},
-   "source": [
-    "## 3. Downloading Census Boundaries\n",
-    "\n",
-    "### 3.1 State Boundaries (National)"
-   ]
+   "source": "## 3. Downloading Census Boundaries\n\n### 3.1 State Boundaries (National)"
   },
   {
    "cell_type": "code",
@@ -352,9 +311,7 @@
    "cell_type": "markdown",
    "id": "cell-19",
    "metadata": {},
-   "source": [
-    "### 3.2 County Boundaries (State-specific)"
-   ]
+   "source": "### 3.2 County Boundaries (State-specific)"
   },
   {
    "cell_type": "code",
@@ -414,9 +371,7 @@
    "cell_type": "markdown",
    "id": "cell-22",
    "metadata": {},
-   "source": [
-    "### 3.3 Census Tracts (County-specific)"
-   ]
+   "source": "### 3.3 Census Tracts (County-specific)"
   },
   {
    "cell_type": "code",
@@ -475,11 +430,7 @@
    "cell_type": "markdown",
    "id": "cell-25",
    "metadata": {},
-   "source": [
-    "## 4. Working with Geographic Data\n",
-    "\n",
-    "### 4.1 Calculate Areas"
-   ]
+   "source": "## 4. Working with Geographic Data\n\n### 4.1 Calculate Areas"
   },
   {
    "cell_type": "code",
@@ -509,9 +460,7 @@
    "cell_type": "markdown",
    "id": "cell-27",
    "metadata": {},
-   "source": [
-    "### 4.2 Spatial Joins"
-   ]
+   "source": "### 4.2 Spatial Joins"
   },
   {
    "cell_type": "code",
@@ -553,11 +502,7 @@
    "cell_type": "markdown",
    "id": "cell-29",
    "metadata": {},
-   "source": [
-    "## 5. Alternative Download Function\n",
-    "\n",
-    "The `download_data()` function provides a simpler interface."
-   ]
+   "source": "## 5. Alternative Download Function\n\nThe `download_data()` function provides a simpler interface."
   },
   {
    "cell_type": "code",
@@ -586,39 +531,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cell-31",
    "metadata": {},
-   "source": [
-    "## Summary (Part 1: Boundaries)\n",
-    "\n",
-    "This section demonstrated:\n",
-    "\n",
-    "| Function | Purpose |\n",
-    "|----------|----------|\n",
-    "| `normalize_state_identifier()` | Convert any state format to FIPS |\n",
-    "| `get_available_years()` | List available Census years |\n",
-    "| `discover_boundary_types()` | Find boundary types for a year |\n",
-    "| `get_census_boundaries()` | Download TIGER/Line shapefiles |\n",
-    "| `download_data()` | Simplified download interface |\n",
-    "\n",
-    "**Key Parameters:**\n",
-    "- `year`: Census year (1992-present)\n",
-    "- `geographic_level`: state, county, tract, bg (block group), place, zcta, cd\n",
-    "- `state_fips`: Required for tract, bg, block levels\n",
-    "\n",
-    "---\n",
-    "\n",
-    "## Part 2: Census Demographics (CensusAPIClient)"
-   ]
+   "source": "---\n\n## Part 2: Census demographics integration\n\nThe `CensusAPIClient` fetches demographic data from the Census Bureau API\n(ACS, Decennial). Combined with the TIGER boundary fetches above, you can\nproduce one GeoDataFrame with geometry *and* demographic columns in a single\npipeline.\n"
   },
   {
    "cell_type": "markdown",
    "id": "cell-32",
    "metadata": {},
-   "source": [
-    "The `CensusAPIClient` fetches demographic data from the Census Bureau API (ACS, Decennial).\n",
-    "It complements boundary downloads by providing actual demographic values."
-   ]
+   "source": "The `CensusAPIClient` fetches demographic data from the Census Bureau API (ACS, Decennial).\nIt complements boundary downloads by providing actual demographic values."
   },
   {
    "cell_type": "code",
@@ -655,11 +575,7 @@
    "cell_type": "markdown",
    "id": "cell-6",
    "metadata": {},
-   "source": [
-    "### Quick Demographic Fetch (Convenience Functions)\n",
-    "\n",
-    "These functions work without an API key for basic queries (rate-limited)."
-   ]
+   "source": "### Quick Demographic Fetch (Convenience Functions)\n\nThese functions work without an API key for basic queries (rate-limited)."
   },
   {
    "cell_type": "code",
@@ -697,11 +613,7 @@
    "cell_type": "markdown",
    "id": "cell-4",
    "metadata": {},
-   "source": [
-    "### Combined Geometry + Demographics\n",
-    "\n",
-    "The most powerful function: download boundaries AND demographics in one call."
-   ]
+   "source": "### Combined Geometry + Demographics\n\nThe most powerful function: download boundaries AND demographics in one call."
   },
   {
    "cell_type": "code",
@@ -755,11 +667,7 @@
    "cell_type": "markdown",
    "id": "cell-2",
    "metadata": {},
-   "source": [
-    "### GEOID Utilities\n",
-    "\n",
-    "GEOIDs are standardized identifiers for Census geographies. These utilities help with normalization and joining."
-   ]
+   "source": "### GEOID Utilities\n\nGEOIDs are standardized identifiers for Census geographies. These utilities help with normalization and joining."
   },
   {
    "cell_type": "code",
@@ -821,13 +729,7 @@
    "cell_type": "markdown",
    "id": "yhxdcyyk3d",
    "metadata": {},
-   "source": [
-    "## Part 4: Intelligent Dataset Selection\n",
-    "\n",
-    "The `CensusDataSelector` helps you choose the right Census dataset for your analysis.\n",
-    "Given an analysis type, geography level, and time period, it recommends which datasets\n",
-    "to use and checks compatibility."
-   ]
+   "source": "### Advanced \u2014 Intelligent Dataset Selection\n\nThe `CensusDataSelector` helps you choose the right Census dataset for your analysis.\nGiven an analysis type, geography level, and time period, it recommends which datasets\nto use and checks compatibility."
   },
   {
    "cell_type": "code",
@@ -922,12 +824,7 @@
    "cell_type": "markdown",
    "id": "748phvnrqro",
    "metadata": {},
-   "source": [
-    "## Part 5: Boundary Crosswalks\n",
-    "\n",
-    "Census boundaries change between decennial censuses. Crosswalk files map geographies\n",
-    "from one vintage to another (e.g., 2010 tracts to 2020 tracts), enabling longitudinal analysis."
-   ]
+   "source": "### Advanced \u2014 Boundary Crosswalks\n\nCensus boundaries change between decennial censuses. Crosswalk files map geographies\nfrom one vintage to another (e.g., 2010 tracts to 2020 tracts), enabling longitudinal analysis."
   },
   {
    "cell_type": "code",
@@ -974,12 +871,7 @@
    "cell_type": "markdown",
    "id": "hs06mwusavt",
    "metadata": {},
-   "source": [
-    "## Part 6: Time-Series Analysis\n",
-    "\n",
-    "Analyze longitudinal Census data with change metrics and trend classification.\n",
-    "This section includes dual-mode cells (Pandas + optional Spark)."
-   ]
+   "source": "### Advanced \u2014 Time-Series Analysis\n\nAnalyze longitudinal Census data with change metrics and trend classification.\nThis section includes dual-mode cells (Pandas + optional Spark)."
   },
   {
    "cell_type": "code",
@@ -1192,15 +1084,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Part 7: Isochrones and 3D Geo Visualization\n",
-    "\n",
-    "This section demonstrates:\n",
-    "\n",
-    "- building open-source isochrone requests (ORS/Valhalla)\n",
-    "- optional live isochrone fetch when an API key is available\n",
-    "- rendering a 3D map from city-level geo points\n"
-   ]
+   "source": "### Advanced \u2014 Isochrones and 3D Geo Visualization\n\nThis section demonstrates:\n\n- building open-source isochrone requests (ORS/Valhalla)\n- optional live isochrone fetch when an API key is available\n- rendering a 3D map from city-level geo points\n"
   },
   {
    "cell_type": "code",
@@ -1284,7 +1168,7 @@
   {
    "cell_type": "markdown",
    "id": "x8dfirgpmkc",
-   "source": "## Part 8: H3 Hexagonal Spatial Indexing\n\nH3 is Uber's hexagonal hierarchical spatial index. The `geo.h3_utils` module\nprovides lightweight spatial join approximation using H3 \u2014 a \"geo-lite\" fallback\nwhen full GeoPandas `sjoin` operations are too expensive.\n\nKey functions:\n\n- `h3_index_points(df, lat_col, lon_col, resolution)` \u2014 assign H3 hex IDs to point rows\n- `h3_index_polygon(geometry, resolution)` \u2014 get hex IDs covering a polygon\n- `h3_spatial_join(points_df, polygons_gdf, ...)` \u2014 approximate point-in-polygon via hex overlap\n- `h3_hex_to_boundary(hex_id)` \u2014 get boundary coordinates for a hex cell\n- `h3_resolution_for_area(target_km2)` \u2014 suggest resolution for a target area\n\n**When to use:**\n- Millions of point-in-polygon joins where GeoPandas `sjoin` is too slow\n- Spatial aggregation at multiple resolutions\n- Pre-indexing data for fast lookups in Spark or DuckDB",
+   "source": "### Advanced \u2014 H3 Hexagonal Spatial Indexing\n\nH3 is Uber's hexagonal hierarchical spatial index. The `geo.h3_utils` module\nprovides lightweight spatial join approximation using H3 \u2014 a \"geo-lite\" fallback\nwhen full GeoPandas `sjoin` operations are too expensive.\n\nKey functions:\n\n- `h3_index_points(df, lat_col, lon_col, resolution)` \u2014 assign H3 hex IDs to point rows\n- `h3_index_polygon(geometry, resolution)` \u2014 get hex IDs covering a polygon\n- `h3_spatial_join(points_df, polygons_gdf, ...)` \u2014 approximate point-in-polygon via hex overlap\n- `h3_hex_to_boundary(hex_id)` \u2014 get boundary coordinates for a hex cell\n- `h3_resolution_for_area(target_km2)` \u2014 suggest resolution for a target area\n\n**When to use:**\n- Millions of point-in-polygon joins where GeoPandas `sjoin` is too slow\n- Spatial aggregation at multiple resolutions\n- Pre-indexing data for fast lookups in Spark or DuckDB",
    "metadata": {}
   },
   {
@@ -1306,7 +1190,7 @@
   {
    "cell_type": "markdown",
    "id": "hl4nzk7bp97",
-   "source": "## Part 9: Boundary Providers\n\nThe `geo.boundary_providers` module provides a pluggable architecture for\nfetching administrative boundary geometries from different sources:\n\n- `BoundaryProvider` (ABC) \u2014 with `get_boundary()`, `list_levels()`, `is_available()`\n- `CensusTIGERProvider` \u2014 US Census TIGER/Line shapefiles (wraps `get_census_boundaries()`)\n- `GADMProvider` \u2014 international boundaries via GADM\n- `resolve_boundary_provider(country)` \u2014 factory that picks TIGER for US, GADM otherwise\n\nThis complements the boundary download functions from Part 1 by adding a\nprovider abstraction. Instead of calling `get_census_boundaries()` directly,\nyou can use `resolve_boundary_provider()` to get the right provider for any\ncountry, then call a uniform API.\n\n**When to use:**\n- Building geographic base layers for choropleths\n- Supporting both US and international campaigns from a single API\n- Fetching county, tract, or admin boundaries on demand without\n  knowing which data source to use",
+   "source": "### Advanced \u2014 Boundary Providers\n\nThe `geo.boundary_providers` module provides a pluggable architecture for\nfetching administrative boundary geometries from different sources:\n\n- `BoundaryProvider` (ABC) \u2014 with `get_boundary()`, `list_levels()`, `is_available()`\n- `CensusTIGERProvider` \u2014 US Census TIGER/Line shapefiles (wraps `get_census_boundaries()`)\n- `GADMProvider` \u2014 international boundaries via GADM\n- `resolve_boundary_provider(country)` \u2014 factory that picks TIGER for US, GADM otherwise\n\nThis complements the boundary download functions from Part 1 by adding a\nprovider abstraction. Instead of calling `get_census_boundaries()` directly,\nyou can use `resolve_boundary_provider()` to get the right provider for any\ncountry, then call a uniform API.\n\n**When to use:**\n- Building geographic base layers for choropleths\n- Supporting both US and international campaigns from a single API\n- Fetching county, tract, or admin boundaries on demand without\n  knowing which data source to use",
    "metadata": {}
   },
   {
@@ -1318,27 +1202,6 @@
    "outputs": []
   },
   {
-   "cell_type": "markdown",
-   "id": "cell-0",
-   "metadata": {},
-   "source": "## Complete Summary\n\n### Part 1: Boundary Downloads\n\n| Function | Purpose |\n|----------|--------|\n| `get_census_boundaries()` | Download TIGER/Line shapefiles |\n| `normalize_state_identifier()` | Convert state names/abbrevs to FIPS |\n| `get_available_years()` | List available Census years |\n| `discover_boundary_types()` | Find boundary types for a year |\n\n### Part 2: Demographics (CensusAPIClient)\n\n| Function | Purpose |\n|----------|--------|\n| `get_population()` | Fetch population counts |\n| `get_demographics()` | Fetch demographic variables |\n| `get_income_data()` | Fetch income-related variables |\n| `get_census_data_with_geometry()` | Combined: boundaries + demographics in one GeoDataFrame |\n\n### Part 3: GEOID Utilities\n\n| Function | Purpose |\n|----------|--------|\n| `construct_geoid()` | Build GEOID from components |\n| `parse_geoid()` | Extract components from GEOID |\n| `normalize_geoid()` | Add leading zeros |\n| `validate_geoid()` | Check GEOID format (strict -- requires leading zeros) |\n| `can_normalize_geoid()` | Check if a value can be zero-padded to a valid GEOID |\n\n### Part 4: Intelligent Dataset Selection\n\n| Function | Purpose |\n|----------|--------|\n| `CensusDataSelector()` | Initialize dataset selector |\n| `select_datasets_for_analysis()` | Recommend datasets for an analysis type/geography/time period |\n| `get_dataset_compatibility_matrix()` | Show which datasets support which geographies |\n| `suggest_analysis_approach()` | Get a recommended approach for your analysis |\n\n### Part 5: Boundary Crosswalks\n\n| Function | Purpose |\n|----------|--------|\n| `list_available_crosswalks()` | List available crosswalk files |\n| `get_crosswalk()` | Download a crosswalk table |\n| `get_crosswalk_metadata()` | Get metadata about a crosswalk |\n| `CrosswalkClient` | Full client for crosswalk operations |\n\n### Part 6: Time-Series Analysis\n\n| Function | Purpose |\n|----------|--------|\n| `classify_trends()` | Classify percent-change values into trend categories |\n| `TrendThresholds` | Configure thresholds for trend classification |\n| `identify_outliers()` | Detect outliers using IQR or z-score methods |\n| `get_trend_summary()` | Summarize trend classification results |\n| `calculate_change_metrics()` | Compute change metrics across time periods |\n\n### Part 7: Isochrones and 3D Geo Visualization\n\n| Function | Purpose |\n|----------|--------|\n| `build_isochrone_request()` | Build provider-agnostic isochrone request |\n| `get_isochrone()` | Fetch isochrone polygon from routing service |\n| `ChartGenerator.create_3d_map()` | Render 3D intensity map from geo points |\n\n### Part 8: H3 Hexagonal Spatial Indexing\n\n| Function | Purpose |\n|----------|--------|\n| `h3_index_points()` | Assign H3 hex IDs to point rows |\n| `h3_index_polygon()` | Get hex IDs covering a polygon |\n| `h3_spatial_join()` | Approximate point-in-polygon via hex overlap |\n| `h3_hex_to_boundary()` | Get boundary coordinates for a hex cell |\n| `h3_resolution_for_area()` | Suggest resolution for a target area |\n\n### Part 9: Boundary Providers\n\n| Function | Purpose |\n|----------|--------|\n| `resolve_boundary_provider()` | Factory: TIGER for US, GADM for international |\n| `CensusTIGERProvider` | US Census TIGER/Line boundary provider |\n| `GADMProvider` | International boundaries via GADM |\n| `BoundaryProvider.get_boundary()` | Fetch boundary geometry (uniform API) |\n| `BoundaryProvider.list_levels()` | List available geographic levels |\n\n**API Key**: Get a free Census API key at https://api.census.gov/data/key_signup.html\nSet as `CENSUS_API_KEY` environment variable or pass `api_key` parameter.\n\n### See Also\n\n- **[15_Census_Demographics_Integration.ipynb](15_Census_Demographics_Integration.ipynb)** \u2014 Quick-start convenience functions\n- **[20_Multi_Source_Spatial_Tabulation.ipynb](20_Multi_Source_Spatial_Tabulation.ipynb)** \u2014 Cross-source tabulation (Census \u00d7 NCES \u00d7 NLRB \u00d7 RDH)"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "## Related\n- Source: `siege_utilities/geo/providers/` (boundary_providers, census_geocoder)\n- Tests: `tests/test_census_geocoder.py`, `tests/test_spatial_data*.py`\n- Consolidates: `15_Census_Demographics_Integration`, parts of `26_International_Boundaries_GADM`\n"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "---\n\n# Appendix: Census demographics integration\n\n*The sections below originally lived in `15_Census_Demographics_Integration.ipynb`, consolidated here during the ELE-2421 notebook reorg.*\n"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "# 15: Census Demographics Integration \u2014 Quick Start\n\n> **Comprehensive coverage** of Census boundaries, GEOID utilities, crosswalks, and time-series\n> analysis is in **[04_Spatial_Data_Census_Boundaries.ipynb](04_Spatial_Data_Census_Boundaries.ipynb)**.\n> This notebook is a **quick-start guide** for the convenience functions only.\n\nThis notebook demonstrates the **convenience functions** for fetching Census demographic data:\n\n1. **Variable Groups** \u2014 Predefined sets of common Census variables\n2. **Quick Fetches** \u2014 `get_population()`, `get_income_data()`, etc.\n\nFor `CensusAPIClient`, `get_census_data_with_geometry()`, GEOID utilities,\ncrosswalks, and time-series analysis, see NB04."
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -1348,12 +1211,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 1. Understanding Variable Groups\n",
-    "\n",
-    "The Census Bureau uses standardized variable codes (e.g., `B01001_001E` for total population).\n",
-    "siege_utilities provides predefined groups for common analyses."
-   ]
+   "source": "## 1. Understanding Variable Groups\n\nThe Census Bureau uses standardized variable codes (e.g., `B01001_001E` for total population).\nsiege_utilities provides predefined groups for common analyses."
   },
   {
    "cell_type": "code",
@@ -1376,11 +1234,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 2. Quick Demographic Fetches\n",
-    "\n",
-    "Use convenience functions for common data needs."
-   ]
+   "source": "## 2. Quick Demographic Fetches\n\nUse convenience functions for common data needs."
   },
   {
    "cell_type": "code",
@@ -1440,23 +1294,13 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": "## For More: See NB04\n\nThe following topics are covered in detail in **[04_Spatial_Data_Census_Boundaries.ipynb](04_Spatial_Data_Census_Boundaries.ipynb)**:\n\n- **CensusAPIClient** \u2014 Full control over Census API queries (`fetch_data()`, `get_variable_metadata()`)\n- **Combined Geometry + Demographics** \u2014 `get_census_data_with_geometry()` for one-call GeoDataFrames\n- **Census Tract Analysis** \u2014 Finer-grained analysis below county level\n- **Manual Shape + Data Joins** \u2014 `join_demographics_to_shapes()` for custom joins\n- **GEOID Utilities** \u2014 `construct_geoid()`, `parse_geoid()`, `normalize_geoid()`, `validate_geoid()`\n- **Intelligent Dataset Selection** \u2014 `CensusDataSelector` for dataset recommendations\n- **Boundary Crosswalks** \u2014 `CrosswalkClient` for vintage-to-vintage mappings\n- **Time-Series Analysis** \u2014 `classify_trends()`, `identify_outliers()`, dual-mode Spark support"
-  },
-  {
-   "cell_type": "markdown",
    "source": "## 3. Django Cache Backend\n\nThe `CensusAPIClient` supports Django's cache framework as an alternative to the default\nparquet file cache. This is useful in Django projects where you want shared cache management.\n\n```python\nfrom siege_utilities.geo.census_api_client import CensusAPIClient\n\n# Use Django's cache framework (requires CACHES in settings.py)\nclient = CensusAPIClient(cache_backend='django')\n\n# Fetches are cached in Django's default cache (Redis, Memcached, etc.)\ndf = client.fetch_data(\n    variables='income',\n    year=2022,\n    dataset='acs5',\n    geography='county',\n    state_fips='06',\n)\n# Subsequent calls with same params return from cache\n```",
    "metadata": {}
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Summary\n\n### Quick Convenience Functions\n\n| Function | Description |\n|----------|-------------|\n| `get_population()` | Total population counts |\n| `get_demographics()` | Basic demographic variables |\n| `get_income_data()` | Income-related variables |\n| `get_education_data()` | Educational attainment |\n| `get_housing_data()` | Housing characteristics |\n\n### Common Variable Codes\n\n| Code | Description |\n|------|-------------|\n| B01001_001E | Total Population |\n| B19013_001E | Median Household Income |\n| B25077_001E | Median Home Value |\n| B15003_022E | Bachelor's Degree |\n| B17001_002E | Population Below Poverty |\n\n### See Also\n\n- **[04_Spatial_Data_Census_Boundaries.ipynb](04_Spatial_Data_Census_Boundaries.ipynb)** \u2014 Boundaries, CensusAPIClient, GEOIDs, crosswalks, time-series\n- **[20_Multi_Source_Spatial_Tabulation.ipynb](20_Multi_Source_Spatial_Tabulation.ipynb)** \u2014 Cross-source tabulation (Census \u00d7 NCES \u00d7 NLRB \u00d7 RDH)\n- [Census API Key Signup](https://api.census.gov/data/key_signup.html)"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "---\n\n# Appendix: International boundaries (GADM)\n\n*The sections below originally lived in `26_International_Boundaries_GADM.ipynb`, consolidated here during the ELE-2421 notebook reorg.*\n"
+   "source": "---\n\n## Part 3: International boundaries (GADM)\n\nFor non-US work, GADM publishes administrative boundaries for every\ncountry at up to four nested levels. The helpers below cover country\nresolution, GADM hierarchy, and name \u2194 ISO-code utilities.\n"
   },
   {
    "cell_type": "code",
@@ -1475,9 +1319,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 1. Country Level (GADM Level 0)"
-   ]
+   "source": "## 1. Country Level (GADM Level 0)"
   },
   {
    "cell_type": "code",
@@ -1512,9 +1354,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 2. Admin Level 1 (States/Provinces)"
-   ]
+   "source": "## 2. Admin Level 1 (States/Provinces)"
   },
   {
    "cell_type": "code",
@@ -1562,9 +1402,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 3. Admin Level 2 (Counties/Municipalities)"
-   ]
+   "source": "## 3. Admin Level 2 (Counties/Municipalities)"
   },
   {
    "cell_type": "code",
@@ -1593,38 +1431,12 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 4. The GADM Model Hierarchy\n",
-    "\n",
-    "In production (with PostGIS), the Django models form a hierarchy:\n",
-    "\n",
-    "```\n",
-    "GADMCountry (iso3=\"MEX\")\n",
-    "\u251c\u2500\u2500 GADMAdmin1 (gid=\"MEX.1_1\", name=\"Jalisco\")\n",
-    "\u2502   \u251c\u2500\u2500 GADMAdmin2 (gid=\"MEX.1.1_1\", name=\"Guadalajara\")\n",
-    "\u2502   \u2502   \u251c\u2500\u2500 GADMAdmin3 (if available)\n",
-    "\u2502   \u2502   \u2502   \u2514\u2500\u2500 GADMAdmin4, GADMAdmin5 (finest granularity)\n",
-    "\u2502   \u251c\u2500\u2500 GADMAdmin2 (gid=\"MEX.1.2_1\", name=\"Zapopan\")\n",
-    "\u2502   \u2514\u2500\u2500 ...\n",
-    "\u251c\u2500\u2500 GADMAdmin1 (gid=\"MEX.2_1\", name=\"Ciudad de M\u00e9xico\")\n",
-    "\u2514\u2500\u2500 ...\n",
-    "```\n",
-    "\n",
-    "Key features:\n",
-    "- All models inherit from `TemporalBoundary` (MultiPolygon geometry, vintage_year)\n",
-    "- FK relationships link child \u2192 parent\n",
-    "- `populate_parent_relationships()` resolves string GIDs to FK objects after bulk loading\n",
-    "- Source is always \"GADM\" with version tag"
-   ]
+   "source": "## 4. The GADM Model Hierarchy\n\nIn production (with PostGIS), the Django models form a hierarchy:\n\n```\nGADMCountry (iso3=\"MEX\")\n\u251c\u2500\u2500 GADMAdmin1 (gid=\"MEX.1_1\", name=\"Jalisco\")\n\u2502   \u251c\u2500\u2500 GADMAdmin2 (gid=\"MEX.1.1_1\", name=\"Guadalajara\")\n\u2502   \u2502   \u251c\u2500\u2500 GADMAdmin3 (if available)\n\u2502   \u2502   \u2502   \u2514\u2500\u2500 GADMAdmin4, GADMAdmin5 (finest granularity)\n\u2502   \u251c\u2500\u2500 GADMAdmin2 (gid=\"MEX.1.2_1\", name=\"Zapopan\")\n\u2502   \u2514\u2500\u2500 ...\n\u251c\u2500\u2500 GADMAdmin1 (gid=\"MEX.2_1\", name=\"Ciudad de M\u00e9xico\")\n\u2514\u2500\u2500 ...\n```\n\nKey features:\n- All models inherit from `TemporalBoundary` (MultiPolygon geometry, vintage_year)\n- FK relationships link child \u2192 parent\n- `populate_parent_relationships()` resolves string GIDs to FK objects after bulk loading\n- Source is always \"GADM\" with version tag"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 5. Country Code Utilities\n",
-    "\n",
-    "siege_utilities includes a full country code mapping (270+ entries)."
-   ]
+   "source": "## 5. Country Code Utilities\n\nsiege_utilities includes a full country code mapping (270+ entries)."
   },
   {
    "cell_type": "code",
@@ -1649,22 +1461,12 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Summary\n",
-    "\n",
-    "| Model | Level | Example |\n",
-    "|-------|-------|---------|\n",
-    "| `GADMCountry` | 0 | Mexico, Canada, UK |\n",
-    "| `GADMAdmin1` | 1 | Jalisco, Ontario, Bavaria |\n",
-    "| `GADMAdmin2` | 2 | Guadalajara, Toronto, Munich |\n",
-    "| `GADMAdmin3` | 3 | Sub-municipal |\n",
-    "| `GADMAdmin4-5` | 4-5 | Finest granularity |\n",
-    "\n",
-    "**Data source:** [GADM.org](https://gadm.org) \u2014 free for academic and non-commercial use.\n",
-    "\n",
-    "**Loading:** Use the `GADMProvider` service (or direct ORM bulk creation)\n",
-    "to populate boundaries from GADM shapefiles/GeoJSON downloads."
-   ]
+   "source": "## Complete summary\n\n### TIGER boundaries (Part 1)\n\n| Function | Purpose |\n|----------|---------|\n| `normalize_state_identifier()` | Accept any state form (FIPS / abbr / name) |\n| `get_available_years()` | Discover Census vintages |\n| `get_boundary_types()` | Enumerate what's available per year |\n| `get_census_boundaries()` | Fetch polygons by state / county / tract / block |\n| `download_data()` | Generic fallback downloader |\n\n### Census demographics (Part 2)\n\n| Function | Purpose |\n|----------|---------|\n| `get_population()` | Total population convenience fetch |\n| `get_income_data()` | Median household income |\n| `get_demographic_breakdown()` | Race / age breakdown |\n| `fetch_acs_with_geometry()` | One call \u2192 GeoDataFrame with geometry + demographics |\n| `geoid_utils.*` | Compose / decompose / validate FIPS GEOIDs |\n| `census_data_selector.*` | Intelligent vintage / boundary / variable selection |\n| `crosswalk.*` | Map GEOIDs across vintages (tract 2010 \u2192 2020, etc.) |\n\n### International boundaries (Part 3)\n\n| Model | Level | Example |\n|-------|-------|---------|\n| `GADMCountry` | 0 | Mexico, Canada, UK |\n| `GADMAdmin1` | 1 | Jalisco, Ontario, Scotland |\n| `GADMAdmin2` | 2 | Guadalajara (municipality) |\n| `GADMAdmin3` | 3 | parish / ward level |\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Related\n- Source: `siege_utilities/geo/providers/` (boundary_providers, census_geocoder)\n- Tests: `tests/test_census_geocoder.py`, `tests/test_spatial_data*.py`\n- Consolidates: `15_Census_Demographics_Integration`, parts of `26_International_Boundaries_GADM`\n"
   }
  ],
  "metadata": {

--- a/notebooks/spatial/02_geocoding.ipynb
+++ b/notebooks/spatial/02_geocoding.ipynb
@@ -23,11 +23,7 @@
    "cell_type": "markdown",
    "id": "cell-2",
    "metadata": {},
-   "source": [
-    "## 1. Single Address Geocoding\n",
-    "\n",
-    "Convert an address string to latitude/longitude coordinates."
-   ]
+   "source": "## 1. Single Address Geocoding\n\nConvert an address string to latitude/longitude coordinates."
   },
   {
    "cell_type": "code",
@@ -80,11 +76,7 @@
    "cell_type": "markdown",
    "id": "cell-5",
    "metadata": {},
-   "source": [
-    "## 2. Address Concatenation\n",
-    "\n",
-    "Build standardized address strings from components."
-   ]
+   "source": "## 2. Address Concatenation\n\nBuild standardized address strings from components."
   },
   {
    "cell_type": "code",
@@ -125,11 +117,7 @@
    "cell_type": "markdown",
    "id": "cell-8",
    "metadata": {},
-   "source": [
-    "## 3. Batch Geocoding\n",
-    "\n",
-    "Geocode multiple addresses with rate limiting."
-   ]
+   "source": "## 3. Batch Geocoding\n\nGeocode multiple addresses with rate limiting."
   },
   {
    "cell_type": "code",
@@ -212,11 +200,7 @@
    "cell_type": "markdown",
    "id": "cell-11",
    "metadata": {},
-   "source": [
-    "## 4. Using Nominatim Directly\n",
-    "\n",
-    "The `use_nominatim_geocoder` function provides more control."
-   ]
+   "source": "## 4. Using Nominatim Directly\n\nThe `use_nominatim_geocoder` function provides more control."
   },
   {
    "cell_type": "code",
@@ -247,11 +231,7 @@
    "cell_type": "markdown",
    "id": "cell-13",
    "metadata": {},
-   "source": [
-    "## 5. Visualize Geocoded Points\n",
-    "\n",
-    "Plot geocoded points on a map."
-   ]
+   "source": "## 5. Visualize Geocoded Points\n\nPlot geocoded points on a map."
   },
   {
    "cell_type": "code",
@@ -401,19 +381,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cell-15",
    "metadata": {},
-   "source": "## Summary\n\n| Section | Function | Purpose |\n|---------|----------|---------|\n| Geocoding | `get_coordinates()` | Simple address to lat/lon (supports `server_url`) |\n| Geocoding | `concatenate_addresses()` | Build address strings |\n| Geocoding | `use_nominatim_geocoder()` | Detailed geocoding with options (supports `server_url`) |\n| Census | `geocode_single()` | Single address via Census API, returns FIPS directly |\n| Census | `geocode_batch()` | Up to 10K addresses per Census API call |\n| Census | `geocode_batch_chunked()` | Unlimited addresses, chunked into 10K batches |\n| Census | `CensusVintage` | Historical vintage enum (Census2010, Census2020, Current) |\n| Census | `select_vintage_for_cycle()` | Auto-select vintage for FEC cycle year |\n| Custom Server | `server_url` parameter | Point Nominatim functions at self-hosted instance |\n| Validation | `validate_geocode_data()` | Filter DataFrame to valid lat/lon ranges (Spark) |\n| Validation | `mark_valid_geocode_data()` | Add boolean `is_valid` flag, preserving all rows (Spark) |\n| Validation | `clean_and_reorder_bbox()` | Normalize bounding-box strings for Sedona/GIS tools (Spark) |\n| Isochrones | `IsochroneProvider` | Abstract base class for isochrone providers |\n| Isochrones | `OpenRouteServiceProvider` | ORS-backed isochrone fetching (hosted or self-hosted) |\n| Isochrones | `ValhallaProvider` | Valhalla-backed isochrone fetching (self-hosted) |\n| Isochrones | `get_provider()` | Factory function to instantiate providers by name |\n| Isochrones | `build_isochrone_request()` | Build provider-specific request dicts for inspection |\n\n**Geocoding Strategy:**\n1. **Census Geocoder** (primary) \u2014 returns FIPS codes directly, ~80% match rate, historical vintages\n2. **Self-hosted Nominatim** (fallback) \u2014 returns lat/lon only, needs spatial join for FIPS\n3. **Public Nominatim** \u2014 rate-limited fallback when self-hosted unavailable\n\n**Important Notes:**\n- Public Nominatim requires 1 second delay between requests; self-hosted does not\n- Census batch API accepts max 10,000 addresses per submission\n- Use `select_vintage_for_cycle()` to match FEC data to correct Census boundaries\n- Geocode validation functions live in `siege_utilities.distributed.spark_utils`\n- Isochrone providers live in `siege_utilities.geo.isochrones`\n- Use `get_provider(\"ors\", api_key=...)` or `get_provider(\"valhalla\", base_url=...)` to instantiate"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "## Related\n- Source: `siege_utilities/geo/providers/census_geocoder.py`\n- Tests: `tests/test_census_geocoder.py`, `tests/test_census_geocoder_errors.py`\n- Consolidates: `25_SpatiaLite_Cache_Geocoding`\n"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "---\n\n# Appendix: SpatiaLite caching layer\n\n*The sections below originally lived in `25_SpatiaLite_Cache_Geocoding.ipynb`, consolidated here during the ELE-2421 notebook reorg.*\n"
+   "source": "---\n\n## Part 2: SpatiaLite caching layer\n\nA file-backed cache for repeated geocodes \u2014 amortizes API calls across runs and plays well with partial retries. Same address \u2192 same FIPS codes, no second network round-trip.\n"
   },
   {
    "cell_type": "code",
@@ -435,9 +404,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 1. SpatiaLite Cache \u2014 Setup"
-   ]
+   "source": "## 1. SpatiaLite Cache \u2014 Setup"
   },
   {
    "cell_type": "code",
@@ -457,11 +424,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 2. Geocode Caching\n",
-    "\n",
-    "Store geocoding results so you never pay for the same lookup twice."
-   ]
+   "source": "## 2. Geocode Caching\n\nStore geocoding results so you never pay for the same lookup twice."
   },
   {
    "cell_type": "code",
@@ -508,11 +471,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 3. Bounding Box Queries\n",
-    "\n",
-    "Find all cached geocodes within a geographic rectangle."
-   ]
+   "source": "## 3. Bounding Box Queries\n\nFind all cached geocodes within a geographic rectangle."
   },
   {
    "cell_type": "code",
@@ -537,9 +496,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 4. Boundary Caching"
-   ]
+   "source": "## 4. Boundary Caching"
   },
   {
    "cell_type": "code",
@@ -565,9 +522,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 5. Crosswalk Caching"
-   ]
+   "source": "## 5. Crosswalk Caching"
   },
   {
    "cell_type": "code",
@@ -589,11 +544,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 6. Isochrone Request Building\n",
-    "\n",
-    "Build requests for drive-time/walk-time service areas from routing providers."
-   ]
+   "source": "## 6. Isochrone Request Building\n\nBuild requests for drive-time/walk-time service areas from routing providers."
   },
   {
    "cell_type": "code",
@@ -631,9 +582,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 7. Cleanup"
-   ]
+   "source": "## 7. Cleanup"
   },
   {
    "cell_type": "code",
@@ -652,22 +601,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Summary\n",
-    "\n",
-    "| Feature | Class/Function | Purpose |\n",
-    "|---------|---------------|----------|\n",
-    "| **Geocode cache** | `SpatiaLiteCache.put/get_geocode()` | Cache Nominatim results |\n",
-    "| **Cache-through** | `get_geocode_or_fetch()` | Auto-fetch on miss |\n",
-    "| **Bbox query** | `get_geocodes_in_bbox()` | Spatial search |\n",
-    "| **Boundary cache** | `put/get_boundary()` | Cache TIGER lookups |\n",
-    "| **Crosswalk cache** | `put/get_crosswalk()` | Cache tract mappings |\n",
-    "| **Isochrone request** | `build_isochrone_request()` | ORS/Valhalla API calls |\n",
-    "| **Isochrone fetch** | `get_isochrone()` | Execute + parse response |\n",
-    "\n",
-    "**The cache file is a single SQLite database** \u2014 portable across machines,\n",
-    "no server required, spatial index for fast bbox queries."
-   ]
+   "source": "## Related\n- Source: `siege_utilities/geo/providers/census_geocoder.py`\n- Tests: `tests/test_census_geocoder.py`, `tests/test_census_geocoder_errors.py`\n- Consolidates: `25_SpatiaLite_Cache_Geocoding`\n"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

Prior reorg (#416) did moves + concatenation; narrative surface was left stitched from old sources with stale NB04/NB15/NB26 refs, duplicate \`## Summary\` sections, and appendix dividers that repeated old titles. This PR rewrites that narrative so each merged notebook reads as one coherent document.

### Changed files
- \`spatial/01_boundaries\` (04 + 15 + 26) — 79 → 73 cells
- \`spatial/02_geocoding\` (07 + 25) — 55 → 53 cells
- \`foundations/02_profiles_branding\` (02 + 03 + 10) — 63 → 61 cells
- \`reports/01_charts_and_pdf\` (06 + 11) — 72 → 71 cells
- \`reports/02_slides_pptx_and_google\` (12 + 18) — 54 → 53 cells

### Checks applied
- [x] No remaining \`NB0X\` / \`NB1X\` / \`NB2X\` references
- [x] No remaining \`# Appendix:\` dividers (collapsed into \`## Part N:\` transitions)
- [x] Exactly one \`## Related\` footer per notebook, at the end
- [x] No mid-notebook \`## Summary\` sections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured Jupyter notebooks for improved readability and navigation across foundations, reports, and spatial analysis sections.
  * Updated section organization with clearer introductions and part numbering.
  * Enhanced cross-references and related resources links within notebooks.
  * Standardized markdown formatting for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->