### PR TITLE
feat(ELE-2457): notebook rewrite 1/4 — foundations + scaffolding

### DIFF
--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -5,6 +5,29 @@ by module tree. Each notebook opens with a standard `What this shows / Why it
 matters / Prereqs / Next` header and ends with a `## Related` footer pointing
 at source, tests, and architectural decisions.
 
+## Running example — two Siege Analytics partner firms
+
+The notebooks tell a single story threaded through two partner firms of Siege
+Analytics. A first-time reader sees how the library's modules compose end-to-end
+for realistic work, not 17 disconnected demos.
+
+- **ElectInfo** ([elect.info](https://elect.info)) — political / civic analytics. Owns the spatial,
+  redistricting, survey, FEC / campaign-finance, engine-scaling, PDF reporting,
+  and statistics-primitives notebooks (roughly 13 of 17).
+- **Masai Interactive** ([masaiinteractive.com](https://masaiinteractive.com)) — web / social analytics.
+  Owns the external-connector, GA end-to-end, and slides / Google Workspace
+  delivery notebooks (3 of 17).
+
+Both firms ship as predefined branding templates in
+`siege_utilities/reporting/client_branding.py` (`elect_info` and
+`masai_interactive`); `foundations/02_profiles_branding.ipynb` registers both
+explicitly and proves the wire-up by rendering the same chart under each brand.
+
+Spatial and other larger datasets are **not committed** to the repo — each
+notebook that needs one calls `siege_utilities.cache.ensure_sample_dataset`,
+which downloads on first run into `~/.cache/siege_utilities/notebooks/` (or
+wherever `SIEGE_UTILITIES_CACHE_DIR` points).
+
 ## Layout
 
 ```

--- a/notebooks/foundations/01_configuration.ipynb
+++ b/notebooks/foundations/01_configuration.ipynb
@@ -2,379 +2,302 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "cell-title",
    "metadata": {},
    "source": [
-    "# Siege Utilities: Hydra + Pydantic Configuration System Demo\n",
+    "# ElectInfo bootstraps its reporting environment\n",
     "\n",
-    "This notebook demonstrates the new advanced configuration system with Hydra composition and Pydantic validation.\n",
+    "## What this shows\n",
+    "How to load a layered Hydra configuration, validate it with a Pydantic model, override one field via env var, and catch a bad override at load time. Uses ElectInfo — one of two partner firms that thread through these demos — onboarding a new TX analysis engagement.\n",
     "\n",
-    "## Features Demonstrated\n",
-    "- **Type-safe configuration management** with full IDE support\n",
-    "- **Client-specific customization** with hierarchical overrides\n",
-    "- **Comprehensive validation** with detailed error messages\n",
-    "- **Seamless migration** from legacy configuration systems"
+    "## Why it matters\n",
+    "Every other capability in `siege_utilities` reads settings (cache dirs, API keys, output preferences) from the config layer. Getting this right once means the rest of the library uses sensible, client-scoped defaults automatically — no config re-plumbing inside each downstream notebook.\n",
+    "\n",
+    "## Prereqs\n",
+    "- `pip install 'siege-utilities[config]'`\n",
+    "- No credentials.\n",
+    "\n",
+    "## Next\n",
+    "- `02_profiles_branding.ipynb` — register ElectInfo and Masai Interactive as branded client profiles.\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": "## What this shows\nHow `siege_utilities.config` loads layered Hydra + Pydantic settings from YAML, env vars, and overrides.\n\n## Why it matters\nEvery other module in this library depends on config \u2014 master this first.\n\n## Prereqs\n- `pip install 'siege-utilities[config]'`\n\n## Next\n- `02_Create_User_Client_Profiles.ipynb` \u2014 the profile system that sits on top of config.\n"
-  },
-  {
-   "cell_type": "markdown",
+   "id": "cell-sec-1",
    "metadata": {},
    "source": [
-    "## 1. Basic Setup and Imports"
+    "## 1. Load the shipped base configuration\n",
+    "\n",
+    "`HydraConfigManager` resolves to `siege_utilities/configs/` by default. `load_config` composes YAML files under that root and returns a plain dict we can feed to a validator in the next cell."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
+   "id": "cell-code-1",
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-12T16:31:18.920208Z",
-     "start_time": "2026-02-12T16:31:15.880372Z"
+    "execution": {
+     "iopub.execute_input": "2026-04-24T22:09:21.612115Z",
+     "iopub.status.busy": "2026-04-24T22:09:21.611838Z",
+     "iopub.status.idle": "2026-04-24T22:09:21.774065Z",
+     "shell.execute_reply": "2026-04-24T22:09:21.773856Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[siege_utilities] 2026-04-24 17:09:21,747 INFO: Initialized HydraConfigManager with config directory: /Users/dheerajchand/Documents/Professional/Siege_Analytics/Code/siege_utilities/siege_utilities/configs\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "config directory : /Users/dheerajchand/Documents/Professional/Siege_Analytics/Code/siege_utilities/siege_utilities/configs\n",
+      "\n",
+      "top-level keys   : ['default']\n"
+     ]
+    }
+   ],
    "source": [
+    "from siege_utilities.config.hydra_manager import HydraConfigManager\n",
+    "\n",
+    "mgr = HydraConfigManager()\n",
+    "print('config directory :', mgr.config_dir)\n",
+    "\n",
+    "base = mgr.load_config('default/user_profile')\n",
+    "print('\\ntop-level keys   :', list(base.keys()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-sec-2",
+   "metadata": {},
+   "source": [
+    "## 2. Compose with an ElectInfo client overlay\n",
+    "\n",
+    "Hydra overrides let ElectInfo ship one base profile and stamp client-specific deltas on top. Here we pull the shipped `client_a` overlay as a stand-in — when the ElectInfo client YAML lands it plugs in the same way."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "cell-code-2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-24T22:09:21.775226Z",
+     "iopub.status.busy": "2026-04-24T22:09:21.775153Z",
+     "iopub.status.idle": "2026-04-24T22:09:21.799778Z",
+     "shell.execute_reply": "2026-04-24T22:09:21.799561Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[siege_utilities] 2026-04-24 17:09:21,775 INFO: Initialized HydraConfigManager with config directory: /Users/dheerajchand/Documents/Professional/Siege_Analytics/Code/siege_utilities/siege_utilities/configs\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "overlaid fields : {'organization': 'ElectInfo', 'default_output_format': 'pdf', 'default_dpi': 200}\n"
+     ]
+    }
+   ],
+   "source": [
+    "from hydra.core.global_hydra import GlobalHydra\n",
+    "\n",
+    "# Hydra allows only one init per process; reset before a second compose.\n",
+    "GlobalHydra.instance().clear()\n",
+    "\n",
+    "mgr = HydraConfigManager()\n",
+    "overrides = [\n",
+    "    'default.organization=ElectInfo',\n",
+    "    'default.default_output_format=pdf',\n",
+    "    'default.default_dpi=200',\n",
+    "]\n",
+    "client_cfg = mgr.load_config('default/user_profile', overrides=overrides)\n",
+    "\n",
+    "# Show only the keys that differ from the base so the overlay intent is clear.\n",
+    "diff = {\n",
+    "    k: v for k, v in client_cfg['default'].items()\n",
+    "    if base['default'].get(k) != v\n",
+    "}\n",
+    "print('overlaid fields :', diff)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-sec-3",
+   "metadata": {},
+   "source": [
+    "## 3. Override a single field via env var\n",
+    "\n",
+    "For one-off runs (\"put today's downloads on the fast disk, just for this job\") env vars are lighter than a YAML change. The library's on-disk cache helper reads `SIEGE_UTILITIES_CACHE_DIR` — flip it and the cache relocates without editing any files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cell-code-3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-24T22:09:21.800980Z",
+     "iopub.status.busy": "2026-04-24T22:09:21.800900Z",
+     "iopub.status.idle": "2026-04-24T22:09:21.803139Z",
+     "shell.execute_reply": "2026-04-24T22:09:21.802968Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "default cache dir : /Users/dheerajchand/.cache/siege_utilities/notebooks\n",
+      "overridden to     : /Users/dheerajchand/Documents/Professional/Siege_Analytics/Code/siege_utilities/notebooks/foundations/tmp_electinfo_cache\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
     "from pathlib import Path\n",
-    "from siege_utilities.config import HydraConfigManager\n",
-    "from siege_utilities.config import UserProfile, ClientProfile, BrandingConfig, ReportPreferences, ContactInfo\n",
-    "import siege_utilities as su\n",
+    "from siege_utilities.cache import _default_cache_dir\n",
     "\n",
-    "# Initialize logging (console-only, no file needed for notebooks)\n",
-    "su.configure_shared_logging(level=\"INFO\")\n",
+    "print('default cache dir :', _default_cache_dir())\n",
     "\n",
-    "# --- Output configuration ---\n",
-    "OUTPUT_DIR = Path(\"output\") / \"notebook_01\"\n",
-    "OUTPUT_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "os.environ['SIEGE_UTILITIES_CACHE_DIR'] = str(Path.cwd() / 'tmp_electinfo_cache')\n",
+    "print('overridden to     :', _default_cache_dir())\n",
     "\n",
-    "su.log_info(f\"Output directory: {OUTPUT_DIR}  (exists={OUTPUT_DIR.exists()})\")\n",
-    "su.log_info(\"Configuration system demo initialized\")"
+    "# Clean up so we don't leak the override into later notebooks in the same session.\n",
+    "del os.environ['SIEGE_UTILITIES_CACHE_DIR']"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "cell-sec-4",
    "metadata": {},
    "source": [
-    "## 2. Loading Configuration with HydraConfigManager\n",
+    "## 4. Validate a config dict with a Pydantic model\n",
     "\n",
-    "The HydraConfigManager provides a context manager for loading hierarchical configurations."
+    "Pydantic models live under `siege_utilities.config.models`. `ReportPreferences` is a small, illustrative target — the same pattern applies to every other model the library ships (Person, Client, Credential, DatabaseConnection, …)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
+   "id": "cell-code-4",
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-12T16:31:23.511038Z",
-     "start_time": "2026-02-12T16:31:23.334049Z"
+    "execution": {
+     "iopub.execute_input": "2026-04-24T22:09:21.804086Z",
+     "iopub.status.busy": "2026-04-24T22:09:21.804033Z",
+     "iopub.status.idle": "2026-04-24T22:09:21.806826Z",
+     "shell.execute_reply": "2026-04-24T22:09:21.806633Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'default_format': <ReportFormat.PDF: 'pdf'>,\n",
+       " 'include_executive_summary': True,\n",
+       " 'chart_style': 'professional',\n",
+       " 'page_size': 'Letter',\n",
+       " 'orientation': <PageOrientation.LANDSCAPE: 'landscape'>,\n",
+       " 'include_table_of_contents': True,\n",
+       " 'include_page_numbers': True,\n",
+       " 'include_watermark': False,\n",
+       " 'watermark_text': None,\n",
+       " 'chart_quality': 'high',\n",
+       " 'chart_dpi': 300,\n",
+       " 'include_chart_titles': True,\n",
+       " 'include_chart_legends': True,\n",
+       " 'include_data_labels': False,\n",
+       " 'sections': ['executive_summary',\n",
+       "  'methodology',\n",
+       "  'findings',\n",
+       "  'recommendations'],\n",
+       " 'export_metadata': True,\n",
+       " 'compress_output': False,\n",
+       " 'include_source_data': False}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "# Load configurations using HydraConfigManager\n",
-    "with HydraConfigManager() as manager:\n",
-    "    # Load user profile (uses defaults if no config file exists)\n",
-    "    user_profile = manager.load_user_profile()\n",
-    "    su.log_info(f\"User Profile Loaded: {user_profile.username}\")\n",
-    "    su.log_debug(f\"  Email: {user_profile.email}\")\n",
-    "    su.log_debug(f\"  Default format: {user_profile.default_output_format}\")\n",
-    "    \n",
-    "    # Load default branding configuration\n",
-    "    branding = manager.load_branding_config()\n",
-    "    su.log_info(f\"Default Branding Loaded\")\n",
-    "    su.log_debug(f\"  Primary color: {branding.primary_color}\")\n",
-    "    su.log_debug(f\"  Primary font: {branding.primary_font}\")"
+    "from siege_utilities.config.models.report_preferences import ReportPreferences\n",
+    "\n",
+    "good = ReportPreferences(\n",
+    "    default_format='pdf',\n",
+    "    page_size='Letter',\n",
+    "    chart_dpi=300,\n",
+    "    chart_style='professional',\n",
+    "    include_executive_summary=True,\n",
+    ")\n",
+    "good.model_dump()\n"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "cell-sec-5",
    "metadata": {},
    "source": [
-    "## 3. Creating Profiles Programmatically\n",
+    "## 5. Catching a bad override\n",
     "\n",
-    "You can create profiles with full type checking and validation."
+    "If someone on the team mistypes an override value in YAML or a CI job, validation should fail loudly — not silently fall through to a broken report at 2am. Pydantic's `ValidationError` carries which field was wrong, so this is easy to surface in logs or error notifications."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
+   "id": "cell-code-5",
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-12T16:31:28.884077Z",
-     "start_time": "2026-02-12T16:31:28.862024Z"
+    "execution": {
+     "iopub.execute_input": "2026-04-24T22:09:21.807788Z",
+     "iopub.status.busy": "2026-04-24T22:09:21.807728Z",
+     "iopub.status.idle": "2026-04-24T22:09:21.809487Z",
+     "shell.execute_reply": "2026-04-24T22:09:21.809312Z"
     }
    },
-   "outputs": [],
-   "source": [
-    "# Create a user profile with custom settings\n",
-    "custom_user = UserProfile(\n",
-    "    username=\"dheerajchand\",\n",
-    "    email=\"dheeraj@siegeanalytics.com\",\n",
-    "    full_name=\"Dheeraj Chand\",\n",
-    "    organization=\"Siege Analytics\",\n",
-    "    default_output_format=\"pdf\",\n",
-    "    default_dpi=300,\n",
-    "    preferred_map_style=\"carto-positron\"\n",
-    ")\n",
-    "\n",
-    "su.log_info(f\"Created UserProfile: {custom_user.username}\")\n",
-    "su.log_info(f\"  Organization: {custom_user.organization}\")\n",
-    "su.log_info(f\"  Output format: {custom_user.default_output_format}\")\n",
-    "su.log_info(f\"  Map style: {custom_user.preferred_map_style}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 4. Client Branding Configuration\n",
-    "\n",
-    "Each client can have custom branding with colors, fonts, and layout settings."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-12T16:31:33.851033Z",
-     "start_time": "2026-02-12T16:31:33.821606Z"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "caught ValidationError on : [('chart_dpi', 'Input should be greater than or equal to 72')]\n"
+     ]
     }
-   },
-   "outputs": [],
+   ],
    "source": [
-    "# Create custom branding for a client\n",
-    "client_branding = BrandingConfig(\n",
-    "    primary_color=\"#1a4d2e\",      # Forest green\n",
-    "    secondary_color=\"#4a7c59\",    # Sage green\n",
-    "    accent_color=\"#f4a261\",       # Warm orange\n",
-    "    text_color=\"#2d3436\",         # Dark gray\n",
-    "    background_color=\"#ffffff\",   # White\n",
-    "    primary_font=\"Helvetica\",\n",
-    "    secondary_font=\"Georgia\",\n",
-    "    header_height=50,\n",
-    "    footer_height=25\n",
-    ")\n",
+    "from pydantic import ValidationError\n",
     "\n",
-    "su.log_info(\"Created BrandingConfig\")\n",
-    "su.log_info(f\"  Primary color: {client_branding.primary_color}\")\n",
-    "su.log_info(f\"  Secondary color: {client_branding.secondary_color}\")\n",
-    "su.log_info(f\"  Accent color: {client_branding.accent_color}\")\n",
-    "su.log_info(f\"  Primary font: {client_branding.primary_font}\")\n",
-    "\n",
-    "# Get the color scheme as a dict\n",
-    "colors = client_branding.get_color_scheme()\n",
-    "su.log_debug(f\"Color scheme dict: {colors}\")"
+    "try:\n",
+    "    # chart_dpi must be 72–600; 42 is rejected.\n",
+    "    ReportPreferences(chart_dpi=42)\n",
+    "except ValidationError as e:\n",
+    "    bad = [(err['loc'][0], err['msg']) for err in e.errors()]\n",
+    "    print(f'caught ValidationError on : {bad}')\n"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "cell-related",
    "metadata": {},
    "source": [
-    "## 5. Validation Examples\n",
+    "## Related\n",
     "\n",
-    "Pydantic validates all fields with clear error messages."
+    "- **Source**: `siege_utilities/config/` — `HydraConfigManager`, Pydantic models under `config/models/`\n",
+    "- **Tests**: `tests/test_config*.py`\n",
+    "- **Docs**: `docs/ARCHITECTURE.md` for the three-layer model; `docs/adr/0004-dataclass-vs-pydantic.md` for why we use Pydantic here\n",
+    "- **Next notebook**: `02_profiles_branding.ipynb` picks up from this config foundation to register ElectInfo + Masai Interactive as branded client profiles.\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-12T16:31:43.323293Z",
-     "start_time": "2026-02-12T16:31:43.291678Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# Validation example: Email format\n",
-    "su.log_info(\"Testing email validation...\")\n",
-    "try:\n",
-    "    valid_user = UserProfile(username=\"test\", email=\"valid@example.com\")\n",
-    "    su.log_info(f\"  Valid email accepted: {valid_user.email}\")\n",
-    "except ValueError as e:\n",
-    "    su.log_error(f\"  Unexpected error: {e}\")\n",
-    "\n",
-    "try:\n",
-    "    invalid_user = UserProfile(username=\"test\", email=\"not-an-email\")\n",
-    "    su.log_warning(\"  Invalid email was not rejected!\")\n",
-    "except ValueError as e:\n",
-    "    su.log_info(f\"  Invalid email correctly rejected\")\n",
-    "\n",
-    "# Validation example: Hex color format\n",
-    "su.log_info(\"Testing hex color validation...\")\n",
-    "try:\n",
-    "    valid_branding = BrandingConfig(\n",
-    "        primary_color=\"#FF5733\",\n",
-    "        secondary_color=\"#33FF57\",\n",
-    "        accent_color=\"#3357FF\",\n",
-    "        text_color=\"#000000\",\n",
-    "        background_color=\"#FFFFFF\",\n",
-    "        primary_font=\"Arial\",\n",
-    "        secondary_font=\"Times\"\n",
-    "    )\n",
-    "    su.log_info(f\"  Valid hex colors accepted: {valid_branding.primary_color}\")\n",
-    "except ValueError as e:\n",
-    "    su.log_error(f\"  Unexpected error: {e}\")\n",
-    "\n",
-    "try:\n",
-    "    invalid_branding = BrandingConfig(\n",
-    "        primary_color=\"red\",  # Not hex format\n",
-    "        secondary_color=\"#33FF57\",\n",
-    "        accent_color=\"#3357FF\",\n",
-    "        text_color=\"#000000\",\n",
-    "        background_color=\"#FFFFFF\",\n",
-    "        primary_font=\"Arial\",\n",
-    "        secondary_font=\"Times\"\n",
-    "    )\n",
-    "    su.log_warning(\"  Invalid color was not rejected!\")\n",
-    "except ValueError as e:\n",
-    "    su.log_info(\"  Invalid color 'red' correctly rejected (not hex format)\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 6. File System Utilities\n",
-    "\n",
-    "The `files/` module provides path management and file operations used throughout the library."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# --- Path utilities (siege_utilities.files.paths) ---\n",
-    "from siege_utilities.files.paths import (\n",
-    "    ensure_path_exists,\n",
-    "    normalize_path,\n",
-    "    find_files_by_pattern,\n",
-    "    create_backup_path,\n",
-    "    get_file_extension,\n",
-    "    get_file_name_without_extension,\n",
-    "    is_hidden_file,\n",
-    "    get_relative_path,\n",
-    ")\n",
-    "\n",
-    "# 6a. Ensure a directory exists (creates it if missing)\n",
-    "demo_dir = ensure_path_exists(OUTPUT_DIR / \"demo_files\")\n",
-    "su.log_info(f\"Ensured directory: {demo_dir}\")\n",
-    "\n",
-    "# 6b. Normalize a path (resolve ~, .., symlinks)\n",
-    "raw_path = \"~/Downloads/../Documents/./file.txt\"\n",
-    "norm = normalize_path(raw_path)\n",
-    "su.log_info(f\"normalize_path('{raw_path}') \u2192 {norm}\")\n",
-    "\n",
-    "# 6c. File extension helpers\n",
-    "for sample in [\"report.pdf\", \"archive.tar.gz\", \"README\"]:\n",
-    "    ext = get_file_extension(sample)\n",
-    "    stem = get_file_name_without_extension(sample)\n",
-    "    su.log_info(f\"  '{sample}' \u2192 stem='{stem}', ext='{ext}'\")\n",
-    "\n",
-    "# 6d. Hidden-file detection\n",
-    "for sample in [\".gitignore\", \"config.yaml\", \".env\"]:\n",
-    "    su.log_info(f\"  is_hidden_file('{sample}') \u2192 {is_hidden_file(sample)}\")\n",
-    "\n",
-    "# 6e. Create a backup path\n",
-    "backup = create_backup_path(OUTPUT_DIR / \"config.yaml\", backup_suffix=\".bak\")\n",
-    "su.log_info(f\"Backup path: {backup}\")\n",
-    "\n",
-    "# 6f. Relative path computation\n",
-    "rel = get_relative_path(OUTPUT_DIR, OUTPUT_DIR / \"demo_files\" / \"subdir\" / \"file.txt\")\n",
-    "su.log_info(f\"Relative path: {rel}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# --- File operations (siege_utilities.files.operations) ---\n",
-    "from siege_utilities.files.operations import (\n",
-    "    file_exists,\n",
-    "    touch_file,\n",
-    "    count_lines,\n",
-    "    copy_file,\n",
-    "    get_file_size,\n",
-    "    list_directory,\n",
-    ")\n",
-    "\n",
-    "# 6g. Touch a file (create if missing, update mtime if exists)\n",
-    "sample_file = OUTPUT_DIR / \"demo_files\" / \"sample.txt\"\n",
-    "touch_file(sample_file)\n",
-    "su.log_info(f\"Touched file: {sample_file}\")\n",
-    "\n",
-    "# Write some content so we can demo count_lines and get_file_size\n",
-    "sample_file.write_text(\"line 1\\nline 2\\nline 3\\nline 4\\nline 5\\n\")\n",
-    "\n",
-    "# 6h. Check file existence\n",
-    "su.log_info(f\"file_exists('{sample_file.name}') \u2192 {file_exists(sample_file)}\")\n",
-    "su.log_info(f\"file_exists('nonexistent.txt') \u2192 {file_exists(OUTPUT_DIR / 'nonexistent.txt')}\")\n",
-    "\n",
-    "# 6i. Count lines in a file\n",
-    "lines = count_lines(sample_file)\n",
-    "su.log_info(f\"count_lines('{sample_file.name}') \u2192 {lines}\")\n",
-    "\n",
-    "# 6j. Get file size in bytes\n",
-    "size = get_file_size(sample_file)\n",
-    "su.log_info(f\"get_file_size('{sample_file.name}') \u2192 {size} bytes\")\n",
-    "\n",
-    "# 6k. Copy a file\n",
-    "copy_dest = OUTPUT_DIR / \"demo_files\" / \"sample_copy.txt\"\n",
-    "copy_file(sample_file, copy_dest, overwrite=True)\n",
-    "su.log_info(f\"Copied \u2192 {copy_dest.name}\")\n",
-    "\n",
-    "# 6l. List directory contents\n",
-    "items = list_directory(OUTPUT_DIR / \"demo_files\")\n",
-    "su.log_info(f\"list_directory('demo_files') \u2192 {[p.name for p in items]}\")\n",
-    "\n",
-    "# 6m. Find files by pattern\n",
-    "found = find_files_by_pattern(OUTPUT_DIR / \"demo_files\", \"*.txt\")\n",
-    "su.log_info(f\"find_files_by_pattern('*.txt') \u2192 {[p.name for p in found]}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Summary\n",
-    "\n",
-    "This notebook demonstrated:\n",
-    "\n",
-    "| Feature | Description |\n",
-    "|---------|-------------|\n",
-    "| `HydraConfigManager` | Context manager for loading hierarchical configs |\n",
-    "| `UserProfile` | User preferences and API keys |\n",
-    "| `ClientProfile` | Client-specific settings |\n",
-    "| `BrandingConfig` | Colors, fonts, and layout |\n",
-    "| Validation | Automatic type and format validation |\n",
-    "| `files.paths` | Path normalization, extension helpers, backup paths, file search |\n",
-    "| `files.operations` | File existence, touch, copy, line count, size, directory listing |\n",
-    "\n",
-    "**Logging Functions Used:**\n",
-    "- `su.configure_shared_logging(level)` - Initialize logging\n",
-    "- `su.log_info(msg)` - Informational messages\n",
-    "- `su.log_debug(msg)` - Debug details\n",
-    "- `su.log_warning(msg)` - Warnings\n",
-    "- `su.log_error(msg)` - Errors\n",
-    "\n",
-    "**Next Steps:**\n",
-    "- See `02_Create_User_Client_Profiles.ipynb` for detailed profile creation\n",
-    "- See `03_Person_Actor_Architecture.ipynb` for the Person/Actor model\n",
-    "- See `10_Profile_Branding_Testing.ipynb` for 1Password integration"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "## Related\n- Source: `siege_utilities/config/`\n- Tests: `tests/test_config*.py`\n- Docs: `docs/ARCHITECTURE.md`\n"
   }
  ],
  "metadata": {
@@ -384,10 +307,18 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.11.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/notebooks/foundations/02_profiles_branding.ipynb
+++ b/notebooks/foundations/02_profiles_branding.ipynb
@@ -2,294 +2,46 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "cell-0",
-   "metadata": {},
-   "source": "# Create User and Client Profiles\n\nThis notebook demonstrates how to create user and client profiles using the modern Person/Actor architecture with Pydantic models, bidirectional User-Client assignment, and YAML persistence via HydraConfigManager.\n\n**Test case**: Hillcrest Children & Family Center as a Client of Masai Interactive, managed by Dheeraj Chand (Siege Analytics)."
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "## What this shows\nCreating, persisting, and branding user + client profiles (logos, fonts, colors).\n\n## Why it matters\nBranded output (PDF, PPTX, Slides) pulls style from the profile system.\n\n## Prereqs\n- `pip install 'siege-utilities[profiles,reporting]'`\n\n## Next\n- `06_Report_Generation.ipynb` and `12_PowerPoint_Generation.ipynb` consume these profiles.\n"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "> **See also:** Part 2 of this notebook (Person / Actor) covers the full Person/Actor architecture in depth (Organizations, Collaborations, credential management). This notebook focuses on the practical workflow of creating and managing profiles.\n"
-  },
-  {
-   "cell_type": "code",
-   "id": "cell-1",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-12T16:33:53.781336Z",
-     "start_time": "2026-02-12T16:33:40.560848Z"
-    }
-   },
-   "source": "# Import required modules \u2014 modern Person/Actor architecture\nfrom pathlib import Path\nfrom siege_utilities.config import User, Client, BrandingConfig, ReportPreferences\nfrom siege_utilities.config import HydraConfigManager\nimport siege_utilities as su\n\n# Initialize logging\nsu.configure_shared_logging(level=\"INFO\")\n\n# --- Output configuration ---\nOUTPUT_DIR = Path(\"output\") / \"notebook_02\"\nOUTPUT_DIR.mkdir(parents=True, exist_ok=True)\n\nsu.log_info(f\"Output directory: {OUTPUT_DIR}  (exists={OUTPUT_DIR.exists()})\")\nsu.log_info(\"Starting profile creation demo\")",
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cell-2",
-   "metadata": {},
-   "source": "## 1. Creating a User Profile\n\nLet's create a comprehensive user profile with all available options:"
-  },
-  {
-   "cell_type": "code",
-   "id": "cell-3",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-12T16:33:54.021172Z",
-     "start_time": "2026-02-12T16:33:53.782287Z"
-    }
-   },
-   "source": "import os\nfrom pathlib import Path\n\n# Define user identity variables up front\nusername = \"dheerajchand\"\nfull_name = \"Dheeraj Chand\"\nemail = \"dheeraj@siegeanalytics.com\"\n\n# Create a comprehensive user profile using the modern User model\nuser = User(\n    # Core Identity (from Person base)\n    person_id=username,\n    name=full_name,\n    email=email,\n    \n    # User-specific fields\n    username=username,\n    github_login=username,\n    role=\"admin\",\n    \n    # Preferences (cross-platform path)\n    preferred_download_directory=str(Path.home() / \"Downloads\" / \"siege_utilities\"),\n    default_output_format=\"pdf\",\n    preferred_map_style=\"carto-positron\",\n    default_color_scheme=\"viridis\",\n    \n    # Technical Preferences\n    default_dpi=300,\n    default_figure_size=(12, 8),\n    enable_logging=True,\n    log_level=\"INFO\",\n    \n    # API Keys (optional \u2014 will be populated from 1Password)\n    google_analytics_key=\"\",\n    facebook_business_key=\"\",\n    census_api_key=\"\",\n    \n    # Database Preferences\n    default_database=\"postgresql\",\n    postgresql_connection=\"\",\n    duckdb_path=\"\"\n)\n\nsu.log_info(\"User Created Successfully!\")\nsu.log_info(f\"Person ID: {user.person_id}\")\nsu.log_info(f\"Name: {user.name}\")\nsu.log_info(f\"Email: {user.email}\")\nsu.log_info(f\"Username: {user.username}\")\nsu.log_info(f\"Role: {user.role}\")\nsu.log_info(f\"Download Directory: {user.preferred_download_directory}\")\nsu.log_info(f\"Output Format: {user.default_output_format}\")\nsu.log_info(f\"Color Scheme: {user.default_color_scheme}\")\nsu.log_info(f\"Map Style: {user.preferred_map_style}\")\nsu.log_info(f\"DPI: {user.default_dpi}\")\nsu.log_info(f\"Figure Size: {user.default_figure_size}\")",
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cell-6",
-   "metadata": {},
-   "source": "## 2. Creating Branding Configuration\n\nNow let's create a branding configuration for Hillcrest Children & Family Center:"
-  },
-  {
-   "cell_type": "code",
-   "id": "cell-7",
-   "metadata": {},
-   "source": "# Create branding configuration for Hillcrest with hex color validation\nhillcrest_branding = BrandingConfig(\n    # Colors (must be valid hex codes) \u2014 Hillcrest brand palette\n    primary_color=\"#1a4d2e\",      # Forest green\n    secondary_color=\"#4a7c59\",    # Sage green\n    accent_color=\"#f4a261\",       # Warm orange\n    text_color=\"#2d3436\",         # Dark gray\n    background_color=\"#ffffff\",   # White\n    \n    # Typography\n    primary_font=\"Helvetica\",\n    secondary_font=\"Georgia\",\n    \n    # Logo (optional \u2014 will be set when logo file is available)\n    logo_path=None,\n    logo_width=None,\n    logo_height=None,\n    \n    # Layout dimensions\n    header_height=50,\n    footer_height=25,\n    margin_top=25,\n    margin_bottom=25,\n    \n    # Chart styling\n    chart_color_palette=\"viridis\"\n)\n\nsu.log_info(\"Hillcrest Branding Configuration Created!\")\nsu.log_info(f\"Primary Color: {hillcrest_branding.primary_color}\")\nsu.log_info(f\"Secondary Color: {hillcrest_branding.secondary_color}\")\nsu.log_info(f\"Accent Color: {hillcrest_branding.accent_color}\")\nsu.log_info(f\"Primary Font: {hillcrest_branding.primary_font}\")\nsu.log_info(f\"Secondary Font: {hillcrest_branding.secondary_font}\")\nsu.log_info(f\"Header Height: {hillcrest_branding.header_height}px\")\nsu.log_info(f\"Footer Height: {hillcrest_branding.footer_height}px\")",
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cell-8",
-   "metadata": {},
-   "source": "## 3. Creating a Client Profile\n\nNow let's create Hillcrest Children & Family Center as a Client of Masai Interactive, with Dheeraj as the assigned user:"
-  },
-  {
-   "cell_type": "code",
-   "id": "cell-9",
-   "metadata": {},
-   "source": "# Create Hillcrest as a Client using the modern Client model\nclient = Client(\n    # Core Identity (from Person base)\n    person_id=\"hillcrest_client\",\n    name=\"Hillcrest Children & Family Center\",\n    email=\"info@hillcrestchildren.org\",\n    website=\"https://www.hillcrestchildren.org\",\n    address=\"Washington, DC\",\n    \n    # Client-specific fields\n    client_code=\"HILL\",          # Must be uppercase, 2-10 characters\n    industry=\"Nonprofit - Children & Family Services\",\n    project_count=1,\n    client_status=\"active\",      # active, inactive, or archived\n    \n    # Organization context \u2014 Hillcrest is a client of Masai Interactive\n    organizations=[\"masai_interactive\"],\n    primary_organization=\"masai_interactive\",\n    \n    # Client-specific configurations\n    branding_config=hillcrest_branding,\n    report_preferences=ReportPreferences()  # Use defaults\n)\n\n# Demonstrate User-Client bidirectional assignment\nclient.assign_user(user.person_id)\nclient.set_primary_user(user.person_id)\nuser.assign_client(client.client_code)\nuser.set_primary_client(client.client_code)\n\nsu.log_info(\"Client Created Successfully!\")\nsu.log_info(f\"Person ID: {client.person_id}\")\nsu.log_info(f\"Name: {client.name}\")\nsu.log_info(f\"Client Code: {client.client_code}\")\nsu.log_info(f\"Industry: {client.industry}\")\nsu.log_info(f\"Project Count: {client.project_count}\")\nsu.log_info(f\"Status: {client.client_status}\")\nsu.log_info(f\"Email: {client.email}\")\nsu.log_info(f\"Website: {client.website}\")\nsu.log_info(f\"Address: {client.address}\")\nsu.log_info(f\"Organization: {client.primary_organization}\")\nsu.log_info(f\"Brand Primary Color: {client.branding_config.primary_color}\")\nsu.log_info(f\"Brand Primary Font: {client.branding_config.primary_font}\")\nsu.log_info(f\"Assigned Users: {client.get_assigned_users()}\")\nsu.log_info(f\"Primary User: {client.primary_user}\")\nsu.log_info(f\"User's Assigned Clients: {user.get_assigned_clients()}\")\nsu.log_info(f\"User's Primary Client: {user.primary_client}\")",
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cell-10",
-   "metadata": {},
-   "source": "## 4. Validation Examples\n\nLet's see how the validation system works with some examples:"
-  },
-  {
-   "cell_type": "code",
-   "id": "cell-11",
-   "metadata": {},
-   "source": "# Test email validation on modern User model\nsu.log_info(\"Testing Email Validation:\")\ntry:\n    valid_email_user = User(\n        person_id=\"test-user\", name=\"Test User\", email=\"valid@example.com\", username=\"testuser\"\n    )\n    su.log_info(\"   Valid email: valid@example.com\")\nexcept ValueError as e:\n    su.log_error(f\"   Error: {e}\")\n\ntry:\n    invalid_email_user = User(\n        person_id=\"test-user2\", name=\"Test User\", email=\"invalid-email\", username=\"testuser2\"\n    )\n    su.log_info(\"   Invalid email handled gracefully\")\nexcept ValueError as e:\n    su.log_error(f\"   Validation error: {e}\")\n\n# Test color validation\nsu.log_info(\"Testing Color Validation:\")\ntry:\n    valid_colors = BrandingConfig(\n        primary_color=\"#FF0000\",\n        secondary_color=\"#00FF00\",\n        accent_color=\"#0000FF\",\n        text_color=\"#000000\",\n        background_color=\"#FFFFFF\",\n        primary_font=\"Arial\",\n        secondary_font=\"Arial\"\n    )\n    su.log_info(\"   Valid hex colors accepted\")\nexcept ValueError as e:\n    su.log_error(f\"   Error: {e}\")\n\ntry:\n    invalid_colors = BrandingConfig(\n        primary_color=\"red\",  # Invalid hex format\n        secondary_color=\"#00FF00\",\n        accent_color=\"#0000FF\",\n        text_color=\"#000000\",\n        background_color=\"#FFFFFF\",\n        primary_font=\"Arial\",\n        secondary_font=\"Arial\"\n    )\nexcept ValueError as e:\n    su.log_error(f\"   Invalid color format correctly rejected: {e}\")",
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cell-12",
-   "metadata": {},
-   "source": "## 5. Loading Configurations with HydraConfigManager\n\nLet's see how to load configurations using the HydraConfigManager:"
-  },
-  {
-   "cell_type": "code",
-   "id": "cell-13",
-   "metadata": {},
-   "source": "# Save and load with modern HydraConfigManager methods\nimport tempfile\nfrom pathlib import Path\n\nwith HydraConfigManager() as manager:\n    # Use a temp directory for this demo\n    tmp_dir = Path(tempfile.mkdtemp())\n    \n    # Save the user we created above\n    saved = manager.save_user(user, profiles_dir=tmp_dir / \"users\")\n    su.log_info(f\"User saved: {saved}\")\n    \n    # Save the client we created above\n    saved = manager.save_client(client, profiles_dir=tmp_dir / \"clients\")\n    su.log_info(f\"Client saved: {saved}\")\n    \n    # Load them back\n    loaded_user = manager.load_user(\"dheerajchand\", profiles_dir=tmp_dir / \"users\")\n    if loaded_user:\n        su.log_info(\"Loaded User:\")\n        su.log_info(f\"   Person ID: {loaded_user.person_id}\")\n        su.log_info(f\"   Name: {loaded_user.name}\")\n        su.log_info(f\"   Email: {loaded_user.email}\")\n        su.log_info(f\"   Username: {loaded_user.username}\")\n        su.log_info(f\"   Role: {loaded_user.role}\")\n        su.log_info(f\"   Assigned Clients: {loaded_user.get_assigned_clients()}\")\n        su.log_info(f\"   Primary Client: {loaded_user.primary_client}\")\n    \n    loaded_client = manager.load_client(\"HILL\", profiles_dir=tmp_dir / \"clients\")\n    if loaded_client:\n        su.log_info(\"Loaded Client:\")\n        su.log_info(f\"   Person ID: {loaded_client.person_id}\")\n        su.log_info(f\"   Name: {loaded_client.name}\")\n        su.log_info(f\"   Client Code: {loaded_client.client_code}\")\n        su.log_info(f\"   Industry: {loaded_client.industry}\")\n        su.log_info(f\"   Organization: {loaded_client.primary_organization}\")\n        su.log_info(f\"   Brand Primary Color: {loaded_client.branding_config.primary_color}\")\n        su.log_info(f\"   Assigned Users: {loaded_client.get_assigned_users()}\")\n        su.log_info(f\"   Primary User: {loaded_client.primary_user}\")\n    \n    # Clean up temp directory\n    import shutil\n    shutil.rmtree(tmp_dir)",
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "---\n\n## Part 2: Person / Actor architecture\n\nThe underlying data model. Individuals become `Person` records, organizations become `Actor` records, and a `User` or `Client` profile is the projection of one of those into the reporting system.\n"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "> **See also:** `foundations/02_profiles_branding.ipynb` covers the practical workflow of creating User and Client profiles. This notebook provides the complete architectural reference for the Person/Actor model system.\n"
-  },
-  {
-   "cell_type": "code",
-   "id": "cell-1",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-03T20:06:39.502817Z",
-     "start_time": "2026-02-03T20:06:39.456980Z"
-    }
-   },
-   "source": "# Import Person/Actor architecture modules\nimport sys\nfrom pathlib import Path\nimport siege_utilities as su\n\n# Initialize logging\nsu.configure_shared_logging(level=\"INFO\")\n\n# Add parent directory to path for notebook imports\nnotebook_dir = Path.cwd()\nif notebook_dir.name == 'notebooks':\n    sys.path.insert(0, str(notebook_dir.parent))\n\n# Import Person-based models\nfrom siege_utilities.config import (\n    Person, User, Client, Collaborator, Organization, Collaboration,\n    Credential, OnePasswordCredential, OAuthIntegration, OAuthScope, DatabaseConnection\n)\n\n# Note: We'll use the Person/Actor models directly instead of the enhanced_config functions\n# which still use the old UserProfile/ClientProfile models\n\nsu.log_info(\"Person/Actor architecture modules imported successfully\")\n\n# --- Output configuration ---\nOUTPUT_DIR = Path(\"output\") / \"notebook_03\"\nOUTPUT_DIR.mkdir(parents=True, exist_ok=True)\n\nsu.log_info(f\"Output directory: {OUTPUT_DIR}  (exists={OUTPUT_DIR.exists()})\")",
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "cell-2",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-03T20:06:39.543361Z",
-     "start_time": "2026-02-03T20:06:39.504071Z"
-    }
-   },
-   "source": "# 1. Create Organizations\n#\n# Organization Field Constraints (Pydantic validated):\n#   org_id:        1-50 chars, pattern: [a-zA-Z0-9_-]+\n#   name:          1-100 chars\n#   org_type:      vendor | client | partner | internal\n#   primary_email: must match ^[^@]+@[^@]+\\.[^@]+$\n#   phone:         optional, 10-15 digits (extracted from string)\n#   website:       optional, must match ^https?://...\n#   address:       optional, max 200 chars\n#   status:        active | inactive | archived (default: active)\n\n# Siege Analytics organization\nsiege_org = Organization(\n    org_id='siege_analytics',              # 1-50 chars, [a-zA-Z0-9_-]+\n    name='Siege Analytics',                # 1-100 chars\n    org_type='internal',                   # vendor | client | partner | internal\n    primary_email='dheeraj@siegeanalytics.com',  # valid email format\n    phone='+1-512-850-5473',               # optional, 10-15 digits\n    website='https://siegeanalytics.com',  # optional, https?:// URL\n    address='Austin, TX'                   # optional, max 200 chars\n)\n\n# Masai Interactive organization  \nmasai_org = Organization(\n    org_id='masai_interactive',            # 1-50 chars, [a-zA-Z0-9_-]+\n    name='Masai Interactive',              # 1-100 chars\n    org_type='partner',                    # vendor | client | partner | internal\n    primary_email='info@masaiinteractive.com',\n    phone=None,\n    website='https://masaiinteractive.com',\n    address='Washington, DC'\n)\n\n# Hillcrest organization\nhillcrest_org = Organization(\n    org_id='hillcrest_children',           # 1-50 chars, [a-zA-Z0-9_-]+\n    name='Hillcrest Children & Family Center',\n    org_type='client',                     # vendor | client | partner | internal\n    primary_email='info@hillcrestchildren.org',\n    phone='+1-202-555-0123',\n    website='https://www.hillcrestchildren.org',\n    address='Washington, DC'\n)\n\nsu.log_info(\"Created organizations:\")\nsu.log_info(f\"   - {siege_org.name} ({siege_org.org_type})\")\nsu.log_info(f\"   - {masai_org.name} ({masai_org.org_type})\")\nsu.log_info(f\"   - {hillcrest_org.name} ({hillcrest_org.org_type})\")",
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "cell-3",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-03T20:06:39.572481Z",
-     "start_time": "2026-02-03T20:06:39.544282Z"
-    }
-   },
-   "source": "# 2. Create Users with Credentials\n#\n# Credential Field Constraints (Pydantic validated):\n#   name:            1-100 chars, pattern: [a-zA-Z0-9_-]+\n#   credential_type: api_key | oauth_token | username_password | ssh_key | certificate | secret\n#   service:         1-50 chars, pattern: [a-zA-Z0-9_-]+\n#   api_key:         min 10 chars (if provided)\n#   password:        min 8 chars (if provided)\n#   status:          active | expired | revoked | pending (default: active)\n#\n# DatabaseConnection Field Constraints (Pydantic validated):\n#   name:            1-50 chars, pattern: [a-zA-Z0-9_-]+\n#   connection_type: postgresql | mysql | sqlite | duckdb\n#   host:            1-255 chars, pattern: [a-zA-Z0-9.-]+\n#   port:            1-65535\n#   database:        1-50 chars, must start with letter, pattern: [a-zA-Z][a-zA-Z0-9_-]*\n#   username:        1-50 chars\n#   password:        8-100 chars, REQUIRES: uppercase + lowercase + number\n#\n# User Field Constraints (extends Person):\n#   username:        1-50 chars, pattern: [a-zA-Z0-9_-]+\n#   github_login:    optional, max 50 chars, pattern: [a-zA-Z0-9_-]+\n#   role:            analyst | manager | developer | admin | collaborator\n#\n# Collaborator Field Constraints (extends Person):\n#   external_organization: 1-100 chars (cannot be empty)\n#   collaboration_level:   read | write | admin (default: read)\n#   access_expires:        must be in the future (if provided)\n\nfrom datetime import datetime, timedelta\n\n# Dheeraj (Siege User) with credentials\ndheeraj_ga_cred = Credential(\n    name='dheeraj_google_analytics',       # 1-100 chars, [a-zA-Z0-9_-]+\n    credential_type='api_key',             # api_key | oauth_token | username_password | ...\n    service='google_analytics',            # 1-50 chars, [a-zA-Z0-9_-]+\n    api_key='GA-123456789-DHEERAJ',        # min 10 chars\n    username='dheeraj@siegeanalytics.com'\n)\n\ndheeraj_db_conn = DatabaseConnection(\n    name='dheeraj_localpostgis',           # 1-50 chars, [a-zA-Z0-9_-]+\n    connection_type='postgresql',          # postgresql | mysql | sqlite | duckdb\n    host='localhost',                      # 1-255 chars, [a-zA-Z0-9.-]+\n    port=5432,                             # 1-65535\n    database='postgres',                   # 1-50 chars, starts with letter\n    username='dheeraj',                    # 1-50 chars\n    password='Dessert123!'                 # 8-100 chars, uppercase + lowercase + number\n)\n\ndheeraj = User(\n    person_id='dheeraj_siege',             # 1-50 chars, [a-zA-Z0-9_-]+\n    name='Dheeraj Chand',                  # 1-100 chars\n    email='dheeraj@siegeanalytics.com',    # valid email format\n    username='dheerajchand',               # 1-50 chars, [a-zA-Z0-9_-]+\n    github_login='dheerajchand',           # optional, [a-zA-Z0-9_-]+\n    role='admin',                          # analyst | manager | developer | admin | collaborator\n    organizations=['siege_analytics'],\n    primary_organization='siege_analytics',\n    credentials=[dheeraj_ga_cred],\n    database_connections=[dheeraj_db_conn]\n)\n\n# Tony (Masai Collaborator) with limited access\ntony_oauth = OAuthIntegration(\n    name='google_analytics_oauth',         # 1-100 chars, [a-zA-Z0-9_-]+\n    provider='google',                     # google | microsoft | github | linkedin | ...\n    service='google_analytics',            # 1-50 chars, [a-zA-Z0-9_-]+\n    client_id='tony_google_client_123456789',    # 10-200 chars\n    client_secret='tony_secret_123456789',       # 10-200 chars\n    redirect_uri='https://masaiinteractive.com/oauth',  # must match https?://...\n    scopes=[OAuthScope.ANALYTICS]\n)\n\n# Use relative future date so this notebook doesn't rot\ntony_access_expiry = datetime.now() + timedelta(days=365)\n\ntony = Collaborator(\n    person_id='tony_masai',                # 1-50 chars, [a-zA-Z0-9_-]+\n    name='Tony Teat',                      # 1-100 chars\n    email='tony@masaiinteractive.com',     # valid email format\n    external_organization='Masai Interactive',  # 1-100 chars (required)\n    collaboration_level='write',           # read | write | admin\n    organizations=['masai_interactive'],\n    oauth_integrations=[tony_oauth],\n    allowed_services=['google_analytics', 'facebook_insights'],\n    access_expires=tony_access_expiry      # must be in the future\n)\n\nsu.log_info(\"Created users:\")\nsu.log_info(f\"   - {dheeraj.name} (User) - {dheeraj.role}\")\nsu.log_info(f\"   - {tony.name} (Collaborator) - {tony.collaboration_level}\")",
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "cell-4",
-   "metadata": {},
-   "source": "# 3. Create Client with Branding\n#\n# Client Field Constraints (extends Person):\n#   client_code:    2-10 chars, pattern: [A-Z0-9]+ (must be uppercase)\n#                   Reserved codes: DEFAULT, ADMIN, SYSTEM, TEST\n#   industry:       1-50 chars\n#   project_count:  >= 0\n#   client_status:  active | inactive | archived\n#   branding_config:    optional BrandingConfig (or Dict that matches BrandingConfig schema)\n#   report_preferences: optional ReportPreferences (or Dict that matches ReportPreferences schema)\n\nfrom siege_utilities.config.models.branding_config import BrandingConfig\nfrom siege_utilities.config.models.report_preferences import ReportPreferences\n\n# Hillcrest client with comprehensive branding using typed models\nhillcrest_branding = BrandingConfig(\n    primary_color='#2E8B57',               # Sea Green\n    secondary_color='#4169E1',             # Royal Blue\n    accent_color='#FFD700',                # Gold\n    text_color='#333333',                  # Dark gray text\n    background_color='#FAFAFA',            # Off-white background\n    primary_font='Georgia',                # Serif for headings\n    secondary_font='Arial',               # Sans-serif for body\n    logo_path='hillcrest_logo.png',        # Logo file path\n    chart_color_palette='YlGnBu',          # Blue-green palette for charts\n)\n\nhillcrest_report_prefs = ReportPreferences(\n    default_format='pdf',\n    chart_style='professional',\n    page_size='Letter',\n    include_executive_summary=True,\n    include_table_of_contents=True,\n)\n\nhillcrest_client = Client(\n    person_id='hillcrest_client',          # 1-50 chars, [a-zA-Z0-9_-]+\n    name='Hillcrest Children & Family Center',  # 1-100 chars\n    email='info@hillcrestchildren.org',    # valid email format\n    client_code='HILL',                    # 2-10 chars, [A-Z0-9]+, uppercase only\n    industry='Nonprofit - Children & Family Services',  # 1-50 chars\n    phone='+1-202-555-0123',               # optional, 10-15 digits\n    address='Washington, DC',              # optional, max 200 chars\n    website='https://www.hillcrestchildren.org',  # optional, https?://...\n    linkedin='https://linkedin.com/company/hillcrest-children-family-center',  # linkedin URL pattern\n    project_count=1,                       # >= 0\n    client_status='active',                # active | inactive | archived\n    organizations=['hillcrest_children'],\n    primary_organization='hillcrest_children',\n    branding_config=hillcrest_branding,    # Typed BrandingConfig model\n    report_preferences=hillcrest_report_prefs,  # Typed ReportPreferences model\n)\n\nsu.log_info(\"Created client:\")\nsu.log_info(f\"   - {hillcrest_client.name} ({hillcrest_client.industry})\")\nsu.log_info(f\"   - Website: {hillcrest_client.website}\")\nsu.log_info(f\"   - Location: {hillcrest_client.address}\")\nsu.log_info(f\"   - Branding: {type(hillcrest_client.branding_config).__name__}\")\nsu.log_info(f\"   - Primary color: {hillcrest_client.branding_config.primary_color}\")\nsu.log_info(f\"   - Report format: {hillcrest_client.report_preferences.default_format}\")",
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "cell-5",
-   "metadata": {},
-   "source": "# 4. Create Collaboration\n#\n# Collaboration Field Constraints (Pydantic validated):\n#   collab_id:      1-50 chars, pattern: [a-zA-Z0-9_-]+\n#   name:           1-100 chars\n#   description:    optional, max 500 chars\n#   organizations:  List[str], must be unique\n#   clients:        List[str], must be unique\n#   participants:   List[str], must be unique\n#   status:         planning | active | on_hold | completed | cancelled (default: planning)\n#   start_date:     datetime (default: now)\n#   end_date:       optional, must be in the future\n\n# Hillcrest Analytics Project - Joint project between Siege and Masai\ncollab_end_date = datetime.now() + timedelta(days=365)\n\nhillcrest_collaboration = Collaboration(\n    collab_id='hillcrest_analytics_2025',  # 1-50 chars, [a-zA-Z0-9_-]+\n    name='Hillcrest Analytics Project 2025',  # 1-100 chars\n    description='Marketing analytics project for Hillcrest Children & Family Center',  # max 500 chars\n    organizations=['siege_analytics', 'masai_interactive'],  # unique list\n    clients=['hillcrest_children'],        # unique list\n    participants=['dheeraj_siege', 'tony_masai'],  # unique list\n    status='active',                       # planning | active | on_hold | completed | cancelled\n    start_date=datetime(2025, 1, 1),\n    end_date=collab_end_date,              # must be in the future\n    shared_credentials=['hillcrest_google_analytics', 'hillcrest_facebook_insights'],\n    shared_databases=['hillcrest_analytics_db']\n)\n\nsu.log_info(\"Created collaboration:\")\nsu.log_info(f\"   - {hillcrest_collaboration.name}\")\nsu.log_info(f\"   - Organizations: {', '.join(hillcrest_collaboration.organizations)}\")\nsu.log_info(f\"   - Participants: {', '.join(hillcrest_collaboration.participants)}\")\nsu.log_info(f\"   - Status: {hillcrest_collaboration.status}\")",
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "cell-6",
+   "id": "cell-title",
    "metadata": {},
    "source": [
-    "# 5. Summary of Created Entities\n",
+    "# ElectInfo and Masai Interactive as branded client profiles\n",
     "\n",
-    "su.log_info(\"All entities created successfully!\")\n",
-    "su.log_info(f\"   Organizations: {len([siege_org, masai_org, hillcrest_org])} created\")\n",
-    "su.log_info(f\"   Users: {len([dheeraj])} created\")\n",
-    "su.log_info(f\"   Collaborators: {len([tony])} created\")\n",
-    "su.log_info(f\"   Clients: {len([hillcrest_client])} created\")\n",
-    "su.log_info(f\"   Collaborations: {len([hillcrest_collaboration])} created\")\n",
+    "## What this shows\n",
+    "How to register Siege Analytics' two partner firms — ElectInfo (political / civic) and Masai Interactive (web / social) — as branded client profiles, and prove the branding wire-up by rendering the same line chart twice: once for each brand. The same configuration flows into downstream PDF / PPTX / Google Slides pipelines.\n",
     "\n",
-    "su.log_info(\"Entity Summary:\")\n",
-    "su.log_info(f\"   - {siege_org.name} ({siege_org.org_type})\")\n",
-    "su.log_info(f\"   - {masai_org.name} ({masai_org.org_type})\")\n",
-    "su.log_info(f\"   - {hillcrest_org.name} ({hillcrest_org.org_type})\")\n",
-    "su.log_info(f\"   - {dheeraj.name} (User) - {dheeraj.role}\")\n",
-    "su.log_info(f\"   - {tony.name} (Collaborator) - {tony.collaboration_level}\")\n",
-    "su.log_info(f\"   - {hillcrest_client.name} (Client) - {hillcrest_client.industry}\")\n",
-    "su.log_info(f\"   - {hillcrest_collaboration.name} (Collaboration) - {hillcrest_collaboration.status}\")"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "cell-7",
-   "metadata": {},
-   "source": "# 6. Demonstrate Credential Management\n#\n# Credential Field Constraints (Pydantic validated):\n#   name:            1-100 chars, pattern: [a-zA-Z0-9_-]+\n#   credential_type: api_key | oauth_token | username_password | ssh_key | certificate | secret\n#   service:         1-50 chars, pattern: [a-zA-Z0-9_-]+\n#   api_key:         min 10 chars (if provided)\n#\n# OnePasswordCredential Field Constraints (Pydantic validated):\n#   vault_id:        1-50 chars, pattern: [a-zA-Z0-9_-]+\n#   item_id:         1-50 chars, pattern: [a-zA-Z0-9_-]+\n#   title:           1-100 chars\n#   credential_name: 1-100 chars\n#   service:         1-50 chars\n#   auto_sync:       bool (default: True)\n\n# Add shared credentials for the Hillcrest project\nhillcrest_ga_cred = Credential(\n    name='hillcrest_google_analytics',     # 1-100 chars, [a-zA-Z0-9_-]+\n    credential_type='api_key',             # api_key | oauth_token | ...\n    service='google_analytics',            # 1-50 chars, [a-zA-Z0-9_-]+\n    api_key='GA-987654321-HILLCREST',      # min 10 chars\n    username='hillcrest@analytics.com'\n)\n\n# Add credentials to both users\ndheeraj.add_credential(hillcrest_ga_cred)\ntony.add_credential(hillcrest_ga_cred)\n\n# Add 1Password credential reference\nonepassword_cred = OnePasswordCredential(\n    credential_name='hillcrest_facebook_token',  # 1-100 chars\n    vault_id='hillcrest_vault',            # 1-50 chars, [a-zA-Z0-9_-]+\n    item_id='item_123456789',              # 1-50 chars, [a-zA-Z0-9_-]+\n    title='Hillcrest Facebook Token',      # 1-100 chars\n    service='Facebook Business',           # 1-50 chars\n    auto_sync=True                         # bool\n)\n\ndheeraj.add_onepassword_credential(onepassword_cred)\n\nsu.log_info(\"Credential management demonstrated:\")\nsu.log_info(f\"   Dheeraj credentials: {len(dheeraj.credentials)}\")\nsu.log_info(f\"   Tony credentials: {len(tony.credentials)}\")\nsu.log_info(f\"   Dheeraj 1Password refs: {len(dheeraj.onepassword_credentials)}\")\n\n# Show credential details\nfor cred in dheeraj.credentials:\n    su.log_info(f\"   - {cred.name} ({cred.service})\")",
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "iszbbxptz",
-   "source": "# 6b. Demo: Pull real OAuth2 credential from 1Password\n#\n# This demonstrates get_google_oauth_from_1password() which retrieves\n# the actual GA4 OAuth2 client credentials from 1Password.\n# Falls back gracefully when 1Password is unavailable (headless, no op CLI, etc.)\n\ntry:\n    from siege_utilities.config import get_google_oauth_from_1password\n    real_creds = get_google_oauth_from_1password(\n        vault='Private', account='Dheeraj_Chand_Family'\n    )\n    if real_creds:\n        su.log_info(\"Real GA4 OAuth2 credential retrieved from 1Password\")\n        su.log_info(f\"  client_id: {real_creds['client_id'][:20]}...\")\n        su.log_info(f\"  project_id: {real_creds.get('project_id', 'N/A')}\")\n    else:\n        su.log_info(\"1Password not available \u2014 using demo credentials above\")\nexcept Exception as e:\n    su.log_info(f\"1Password not available ({e}) \u2014 using demo credentials above\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "id": "cell-8",
-   "metadata": {},
-   "source": "# 7. Demonstrate User\u2194Client Assignment, YAML I/O, and Organization Relationships\n\n# --- User\u2194Client Bidirectional Assignment ---\nsu.log_info(\"Testing User\u2194Client Assignment:\")\n\n# Assign Dheeraj to Hillcrest client\ndheeraj.assign_client('HILL')\nsu.log_info(f\"   Dheeraj assigned clients: {dheeraj.get_assigned_clients()}\")\nsu.log_info(f\"   Has HILL: {dheeraj.has_client('HILL')}\")\n\n# Set primary client\ndheeraj.set_primary_client('HILL')\nsu.log_info(f\"   Primary client: {dheeraj.primary_client}\")\n\n# Assign user to client (reverse direction)\nhillcrest_client.assign_user('dheeraj_siege')\nhillcrest_client.set_primary_user('dheeraj_siege')\nsu.log_info(f\"   Hillcrest users: {hillcrest_client.get_assigned_users()}\")\nsu.log_info(f\"   Hillcrest primary user: {hillcrest_client.primary_user}\")\n\n# --- YAML Serialization ---\nsu.log_info(\"\\nTesting YAML Serialization:\")\nyaml_str = dheeraj.to_yaml()\nsu.log_info(f\"   User YAML length: {len(yaml_str)} chars\")\n\n# Round-trip\nfrom siege_utilities.config.models.actor_types import User as UserModel\ndheeraj_copy = UserModel.from_yaml(yaml_str)\nsu.log_info(f\"   Round-trip: {dheeraj_copy.person_id} == {dheeraj.person_id}\")\n\n# Safe export (redact sensitive data) \u2014 for sharing, not for re-import\nsafe_yaml = dheeraj.to_yaml(exclude_sensitive=True)\nsu.log_info(f\"   Safe YAML (no secrets): {len(safe_yaml)} chars\")\nassert '***REDACTED***' in safe_yaml, \"Sensitive data should be redacted\"\nsu.log_info(\"   Credentials redacted in safe export: PASS\")\n\n# --- Bulk Export/Import ---\nsu.log_info(\"\\nTesting Bulk Export/Import:\")\nfrom siege_utilities.config.models.export import export_entities, import_entities\n\n# Full round-trip (no redaction \u2014 preserves all data for re-import)\nyaml_export = export_entities(\n    users=[dheeraj],\n    clients=[hillcrest_client],\n    organizations=[siege_org, masai_org, hillcrest_org],\n    collaborations=[hillcrest_collaboration],\n)\nsu.log_info(f\"   Exported {len(yaml_export)} chars of YAML\")\n\nresult = import_entities(yaml_export)\nsu.log_info(f\"   Imported: {len(result['users'])} users, {len(result['clients'])} clients, \"\n            f\"{len(result['organizations'])} orgs, {len(result['collaborations'])} collabs\")\nsu.log_info(f\"   Round-trip user: {result['users'][0].person_id}\")\n\n# Safe export for sharing (redacted \u2014 not for re-import)\nsafe_export = export_entities(users=[dheeraj], exclude_sensitive=True)\nsu.log_info(f\"   Safe export: {len(safe_export)} chars (credentials redacted)\")\n\n# --- 1Password and Organization Methods ---\nsu.log_info(\"\\nTesting 1Password Credential Methods:\")\nhas_fb_1p = dheeraj.has_onepassword_credential('hillcrest_facebook_token')\nsu.log_info(f\"   Has Facebook 1Password: {has_fb_1p}\")\n\nservices = dheeraj.get_onepassword_services()\nsu.log_info(f\"   1Password services: {services}\")\n\ncoverage = dheeraj.get_credential_coverage()\nsu.log_info(f\"   Total services covered: {coverage['summary']['total_services']}\")\n\nrecommendations = dheeraj.get_security_recommendations()\nsu.log_info(f\"   Security recommendations: {len(recommendations)}\")\nfor rec in recommendations:\n    su.log_info(f\"     - {rec}\")\n\nsu.log_info(\"\\nTesting Organization Relationships:\")\nsu.log_info(f\"   Has siege_analytics: {dheeraj.has_organization('siege_analytics')}\")\n\ndheeraj.add_collaboration('hillcrest_analytics_2025')\nsu.log_info(f\"   In Hillcrest project: {dheeraj.has_collaboration('hillcrest_analytics_2025')}\")\n\nsummary = dheeraj.get_summary()\nsu.log_info(f\"   User summary: {summary}\")\n\nsu.log_info(\"\\nAll Person/Actor functionality demonstrated successfully!\")",
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cell-9",
-   "metadata": {},
-   "source": "## Person/Actor Architecture Complete!\n\n### **What We Built:**\n\n#### **1. Organizations**\n- **Siege Analytics**: Internal organization\n- **Masai Interactive**: Partner organization  \n- **Hillcrest Children & Family Center**: Client organization\n\n#### **2. Users & Collaborators**\n- **Dheeraj (User)**: Siege admin with full credentials and database access\n- **Tony (Collaborator)**: Masai team member with limited access and expiration\n\n#### **3. Client Management with Typed Branding**\n- **Hillcrest Client**: Complete with **typed BrandingConfig** and **ReportPreferences** models\n- No more loose dicts \u2014 branding is validated at creation time (hex colors, font names, etc.)\n\n#### **4. User\u2194Client Bidirectional Assignment**\n- `dheeraj.assign_client('HILL')` / `dheeraj.set_primary_client('HILL')`\n- `hillcrest_client.assign_user('dheeraj_siege')` / `hillcrest_client.set_primary_user('dheeraj_siege')`\n\n#### **5. YAML Import/Export**\n- Individual entities: `user.to_yaml()` / `User.from_yaml(yaml_str)`\n- Bulk export/import: `export_entities(users=[...], clients=[...])` \u2192 `import_entities(yaml_str)`\n- Sensitive data redaction: `exclude_sensitive=True`\n\n#### **6. Collaboration**\n- **Hillcrest Analytics Project**: Joint project between Siege and Masai\n- **Shared Resources**: Credentials, databases, and access controls\n\n#### **7. Credential Management**\n- **API Keys**: Google Analytics credentials\n- **OAuth Integration**: Google OAuth for Tony\n- **1Password Integration**: Secure credential references\n- **Database Connections**: PostgreSQL access for Dheeraj\n- **Coverage Analysis**: Security recommendations based on credential audit\n\n### **Key Benefits:**\n- **Multi-Company Support**: Perfect for Siege + Masai collaborations\n- **Secure Credential Sharing**: Controlled access to sensitive data\n- **Flexible Relationships**: Users \u2194 Clients, Users \u2194 Organizations\n- **Type-Safe Configuration**: Pydantic validation catches errors at creation time\n- **YAML Round-Trip**: Export, share, and import entity configurations"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "---\n\n## Part 3: Branding \u2014 colors, fonts, logos, templates\n\nEverything the report / deck / PDF pipelines read when they ask \"how should this look for client X?\". Comes with predefined templates (Siege Analytics, Masai, Hillcrest) and validates unknown overrides.\n"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "cell-1",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-04T18:00:26.014943Z",
-     "iopub.status.busy": "2026-03-04T18:00:26.014707Z",
-     "iopub.status.idle": "2026-03-04T18:00:26.030467Z",
-     "shell.execute_reply": "2026-03-04T18:00:26.029421Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Python: 3.11.11 (main, Jan 23 2025, 20:04:51) [GCC 13.3.0]\n",
-      "Platform: linux\n",
-      "Output directory: output/notebook_10\n"
-     ]
-    }
-   ],
-   "source": [
-    "import os\n",
-    "import sys\n",
-    "from pathlib import Path\n",
-    "from datetime import datetime\n",
-    "from IPython.display import display\n",
+    "## Why it matters\n",
+    "Every report, deck, and digest the library emits consumes exactly one branding profile. Get this registration right once and every downstream capability renders in the right colors / fonts / logo automatically — no per-report manual styling.\n",
     "\n",
-    "import siege_utilities as su\n",
-    "su.configure_shared_logging(level=\"INFO\")\n",
+    "## Prereqs\n",
+    "- `pip install 'siege-utilities[reporting]'`\n",
+    "- No credentials.\n",
     "\n",
-    "sys.path.insert(0, str(Path.cwd().parent))\n",
-    "\n",
-    "print(f\"Python: {sys.version}\")\n",
-    "print(f\"Platform: {sys.platform}\")\n",
-    "\n",
-    "# --- Output configuration ---\n",
-    "OUTPUT_DIR = Path(\"output\") / \"notebook_10\"\n",
-    "OUTPUT_DIR.mkdir(parents=True, exist_ok=True)\n",
-    "print(f\"Output directory: {OUTPUT_DIR}\")"
+    "## Next\n",
+    "- Act 2 — data acquisition: `spatial/01_boundaries.ipynb` starts pulling TX boundaries for an ElectInfo engagement.\n",
+    "- `analytics/01_connectors.ipynb` switches context to Masai Interactive and its web / social data sources.\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "cell-2",
+   "id": "cell-sec1",
    "metadata": {},
-   "source": "## 1. Check Credential Backends\n\nCheck which credential storage backends are available."
+   "source": [
+    "## 1. Inspect the shipped branding templates\n",
+    "\n",
+    "`ClientBrandingManager` ships four predefined templates out of the box. The two we care about for the running example are `elect_info` (added in this epic) and `masai_interactive` (already shipped)."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "cell-3",
+   "execution_count": 1,
+   "id": "cell-code1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-04T18:00:26.032921Z",
-     "iopub.status.busy": "2026-03-04T18:00:26.032680Z",
-     "iopub.status.idle": "2026-03-04T18:00:26.378071Z",
-     "shell.execute_reply": "2026-03-04T18:00:26.377117Z"
+     "iopub.execute_input": "2026-04-24T22:11:56.607526Z",
+     "iopub.status.busy": "2026-04-24T22:11:56.607310Z",
+     "iopub.status.idle": "2026-04-24T22:11:56.625728Z",
+     "shell.execute_reply": "2026-04-24T22:11:56.625446Z"
     }
    },
    "outputs": [
@@ -297,61 +49,86 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[siege_utilities] 2026-03-04 12:00:26,360 INFO: Available credential backends: ['files', 'env', 'prompt', '1password']\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[siege_utilities] 2026-03-04 12:00:26,361 INFO: Credential manager initialized with backends: {'files': True, 'env': True, 'prompt': True, '1password': True, 'keychain': False}\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[siege_utilities] 2026-03-04 12:00:26,362 INFO: Credential search paths: [PosixPath('/home/dheerajchand/git/siege-analytics/siege_utilities/notebooks/credentials'), PosixPath('/home/dheerajchand/.siege_utilities/credentials')]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Credential Backend Status:\n",
-      "  [OK] env: Always available\n",
-      "         Environment variables\n",
-      "  [OK] 1password: Authenticated (6 accounts)\n",
-      "         1Password CLI\n",
-      "  [MISSING] keychain: Not available\n",
-      "         Apple Keychain (requires macOS)\n",
-      "  [OK] prompt: Available (fallback)\n",
-      "         Interactive prompts\n"
+      "predefined templates : ['elect_info', 'hillcrest', 'masai_interactive', 'siege_analytics']\n",
+      "\n",
+      "ElectInfo palette  : {'primary': '#0B3D91', 'secondary': '#D32F2F', 'accent': '#FFB300', 'text_color': '#1A1A1A', 'header_footer_text_color': '#555555', 'background': '#FFFFFF'}\n",
+      "Masai palette      : {'primary': '#0077CC', 'secondary': '#EEEEEE', 'accent': '#FF6B35', 'text_color': '#333333', 'header_footer_text_color': '#666666', 'background': '#FFFFFF'}\n"
      ]
     }
    ],
    "source": [
-    "from siege_utilities.config import CredentialManager, credential_status\n",
+    "from siege_utilities.reporting.client_branding import ClientBrandingManager\n",
     "\n",
-    "status = credential_status()\n",
+    "mgr = ClientBrandingManager()\n",
+    "print('predefined templates :', sorted(mgr.branding_templates.keys()))\n",
     "\n",
-    "print(\"Credential Backend Status:\")\n",
-    "for backend, info in status.items():\n",
-    "    symbol = \"OK\" if info['available'] else \"MISSING\"\n",
-    "    print(f\"  [{symbol}] {backend}: {info['status']}\")\n",
-    "    print(f\"         {info['description']}\")"
+    "ei = mgr.branding_templates['elect_info']\n",
+    "masai = mgr.branding_templates['masai_interactive']\n",
+    "print('\\nElectInfo palette  :', ei['colors'])\n",
+    "print('Masai palette      :', masai['colors'])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-sec2",
+   "metadata": {},
+   "source": [
+    "## 2. Validate a branding config before saving it\n",
+    "\n",
+    "`validate_branding_config` returns a list of errors rather than raising — handy in batch-import flows where you want to collect everything wrong at once, not just the first failure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "cell-code2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-24T22:11:56.627211Z",
+     "iopub.status.busy": "2026-04-24T22:11:56.627105Z",
+     "iopub.status.idle": "2026-04-24T22:11:56.629426Z",
+     "shell.execute_reply": "2026-04-24T22:11:56.629165Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "validation errors for ElectInfo template : none\n",
+      "validation errors for intentionally-bad cfg : ['Missing required field: fonts']\n"
+     ]
+    }
+   ],
+   "source": [
+    "errors = mgr.validate_branding_config(ei)\n",
+    "print('validation errors for ElectInfo template :', errors or 'none')\n",
+    "\n",
+    "# Show what a catch looks like — a config missing the required `fonts` section.\n",
+    "bad = {'name': 'Typo Client', 'colors': ei['colors']}\n",
+    "print('validation errors for intentionally-bad cfg :', mgr.validate_branding_config(bad))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-sec3",
+   "metadata": {},
+   "source": [
+    "## 3. Register a User / Client for ElectInfo\n",
+    "\n",
+    "User and Client are Pydantic actor types that extend a shared `Person` model. Each User is assigned to one or more clients so downstream reports know whose branding to apply. A short example — the full Person / Actor taxonomy lives in `siege_utilities.config.models.actor_types`."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "cell-4",
+   "id": "cell-code3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-04T18:00:26.379803Z",
-     "iopub.status.busy": "2026-03-04T18:00:26.379665Z",
-     "iopub.status.idle": "2026-03-04T18:00:26.397298Z",
-     "shell.execute_reply": "2026-03-04T18:00:26.396589Z"
+     "iopub.execute_input": "2026-04-24T22:11:56.630810Z",
+     "iopub.status.busy": "2026-04-24T22:11:56.630691Z",
+     "iopub.status.idle": "2026-04-24T22:11:56.766727Z",
+     "shell.execute_reply": "2026-04-24T22:11:56.766435Z"
     }
    },
    "outputs": [
@@ -359,58 +136,65 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[siege_utilities] 2026-03-04 12:00:26,394 INFO: Available credential backends: ['files', 'env', 'prompt', '1password']\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[siege_utilities] 2026-03-04 12:00:26,394 INFO: Credential manager initialized with backends: {'files': True, 'env': True, 'prompt': True, '1password': True, 'keychain': False}\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[siege_utilities] 2026-03-04 12:00:26,394 INFO: Credential search paths: [PosixPath('/home/dheerajchand/git/siege-analytics/siege_utilities/notebooks/credentials'), PosixPath('/home/dheerajchand/.siege_utilities/credentials')]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Backend priority: ['files', 'env', '1password', 'keychain', 'prompt']\n",
-      "Available backends: ['files', 'env', 'prompt', '1password']\n",
-      "Default vault: Private\n"
+      "pdoe assigned to: ['ELECTINFO', 'MASAI'] | primary = ELECTINFO\n"
      ]
     }
    ],
    "source": [
-    "# Initialize credential manager\n",
-    "cred_manager = CredentialManager()\n",
+    "from siege_utilities.config.models.actor_types import User, Client\n",
     "\n",
-    "print(f\"Backend priority: {cred_manager.backend_priority}\")\n",
-    "print(f\"Available backends: {[k for k,v in cred_manager.available_backends.items() if v]}\")\n",
-    "print(f\"Default vault: {cred_manager.default_vault}\")"
+    "electinfo_client = Client(\n",
+    "    person_id='electinfo',\n",
+    "    name='ElectInfo',\n",
+    "    email='hello@elect.info',\n",
+    "    client_code='ELECTINFO',\n",
+    "    industry='Political / civic analytics',\n",
+    "    project_count=0,\n",
+    "    client_status='active',\n",
+    "    website='https://elect.info',\n",
+    ")\n",
+    "masai_client = Client(\n",
+    "    person_id='masai_interactive',\n",
+    "    name='Masai Interactive',\n",
+    "    email='hello@masaiinteractive.com',\n",
+    "    client_code='MASAI',\n",
+    "    industry='Web / social analytics',\n",
+    "    project_count=0,\n",
+    "    client_status='active',\n",
+    "    website='https://masaiinteractive.com',\n",
+    ")\n",
+    "\n",
+    "analyst = User(\n",
+    "    person_id='analyst_01',\n",
+    "    name='Pat Doe',\n",
+    "    username='pdoe',\n",
+    "    email='pdoe@siegeanalytics.com',\n",
+    "    assigned_clients=['ELECTINFO', 'MASAI'],\n",
+    "    primary_client='ELECTINFO',\n",
+    ")\n",
+    "print(f'{analyst.username} assigned to: {analyst.assigned_clients} | primary = {analyst.primary_client}')\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "cell-5",
+   "id": "cell-sec4",
    "metadata": {},
-   "source": "## 2. Create User Profile\n\nCreate or load user profile with default preferences."
+   "source": [
+    "## 4. Summarize a branding config for a dashboard\n",
+    "\n",
+    "`get_branding_summary` extracts just the keys a UI / admin dashboard would surface (client name, color palette size, whether a logo is configured, footer text). Useful when you want to list all registered clients without dumping full template payloads."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "cell-6",
+   "id": "cell-code4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-04T18:00:26.399582Z",
-     "iopub.status.busy": "2026-03-04T18:00:26.399442Z",
-     "iopub.status.idle": "2026-03-04T18:00:26.404568Z",
-     "shell.execute_reply": "2026-03-04T18:00:26.403978Z"
+     "iopub.execute_input": "2026-04-24T22:11:56.768155Z",
+     "iopub.status.busy": "2026-04-24T22:11:56.768059Z",
+     "iopub.status.idle": "2026-04-24T22:11:56.770328Z",
+     "shell.execute_reply": "2026-04-24T22:11:56.770022Z"
     }
    },
    "outputs": [
@@ -418,713 +202,46 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[siege_utilities] 2026-03-04 12:00:26,401 INFO: Initialized HydraConfigManager with config directory: /home/dheerajchand/git/siege-analytics/siege_utilities/siege_utilities/configs\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Users dir:   /home/dheerajchand/.siege_utilities/profiles/users (exists: True)\n",
-      "Clients dir: /home/dheerajchand/.siege_utilities/profiles/clients (exists: True)\n",
-      "Existing user profiles: ['dheeraj']\n",
-      "Existing client profiles: ['HILL']\n"
+      "ElectInfo summary       : {'client_name': 'ElectInfo', 'colors': ['primary', 'secondary', 'accent', 'text_color', 'header_footer_text_color', 'background'], 'fonts': ['default_font', 'h1', 'h2', 'h3', 'BodyText'], 'has_logo': True, 'has_footer_logo': False, 'page_margins': {'top': 1.0, 'bottom': 1.0, 'left': 0.75, 'right': 0.75}, 'header_text': 'ElectInfo Analysis', 'footer_text': 'Prepared by: ElectInfo'}\n",
+      "Masai Interactive summary: {'client_name': 'Masai Interactive', 'colors': ['primary', 'secondary', 'accent', 'text_color', 'header_footer_text_color', 'background'], 'fonts': ['default_font', 'h1', 'h2', 'h3', 'BodyText'], 'has_logo': True, 'has_footer_logo': True, 'page_margins': {'top': 1.0, 'bottom': 1.0, 'left': 1.0, 'right': 1.0}, 'header_text': 'Masai Interactive Report', 'footer_text': 'Prepared by: Masai Interactive'}\n"
      ]
     }
    ],
    "source": [
-    "# Modern Person/Actor imports\n",
-    "from siege_utilities.config import User, Client, BrandingConfig, ReportPreferences, HydraConfigManager\n",
+    "summary_ei = mgr.get_branding_summary('elect_info')\n",
+    "summary_masai = mgr.get_branding_summary('masai_interactive')\n",
+    "print('ElectInfo summary       :', summary_ei)\n",
+    "print('Masai Interactive summary:', summary_masai)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-sec5",
+   "metadata": {},
+   "source": [
+    "## 5. Prove the wire-up — render the same chart under each brand\n",
     "\n",
-    "manager = HydraConfigManager()\n",
-    "\n",
-    "profiles_dir = Path.home() / \".siege_utilities\" / \"profiles\"\n",
-    "users_dir = profiles_dir / \"users\"\n",
-    "clients_dir = profiles_dir / \"clients\"\n",
-    "\n",
-    "print(f\"Users dir:   {users_dir} (exists: {users_dir.exists()})\")\n",
-    "print(f\"Clients dir: {clients_dir} (exists: {clients_dir.exists()})\")\n",
-    "\n",
-    "if users_dir.exists():\n",
-    "    existing_users = list(users_dir.glob(\"*.yaml\"))\n",
-    "    print(f\"Existing user profiles: {[f.stem for f in existing_users]}\")\n",
-    "\n",
-    "if clients_dir.exists():\n",
-    "    existing_clients = list(clients_dir.glob(\"*.yaml\"))\n",
-    "    print(f\"Existing client profiles: {[f.stem for f in existing_clients]}\")"
+    "Same synthetic monthly-engagement series, two brand palettes. In production this same `branding` dict is what flows into `reports/01_charts_and_pdf` and `reports/02_slides_pptx_and_google` downstream."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "cell-7",
+   "id": "cell-code5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-04T18:00:26.406606Z",
-     "iopub.status.busy": "2026-03-04T18:00:26.406480Z",
-     "iopub.status.idle": "2026-03-04T18:00:26.410343Z",
-     "shell.execute_reply": "2026-03-04T18:00:26.409732Z"
+     "iopub.execute_input": "2026-04-24T22:11:56.771507Z",
+     "iopub.status.busy": "2026-04-24T22:11:56.771430Z",
+     "iopub.status.idle": "2026-04-24T22:11:57.139817Z",
+     "shell.execute_reply": "2026-04-24T22:11:57.139582Z"
     }
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "User created: dheeraj (Dheeraj Chand)\n",
-      "  Username: dheeraj\n",
-      "  Default output: pdf\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Create user using modern User model\n",
-    "user = User(\n",
-    "    person_id=\"dheeraj\",\n",
-    "    name=\"Dheeraj Chand\",\n",
-    "    email=\"dheeraj@siegeanalytics.com\",\n",
-    "    username=\"dheeraj\",\n",
-    "    github_login=\"dheerajchand\",\n",
-    "    role=\"admin\",\n",
-    "    preferred_download_directory=str(Path.home() / \"Downloads\" / \"siege_utilities\"),\n",
-    "    default_output_format=\"pdf\",\n",
-    "    preferred_map_style=\"carto-positron\",\n",
-    "    default_color_scheme=\"viridis\",\n",
-    "    default_dpi=300,\n",
-    "    default_figure_size=(10, 8),\n",
-    "    enable_logging=True,\n",
-    "    log_level=\"INFO\"\n",
-    ")\n",
-    "\n",
-    "print(f\"User created: {user.person_id} ({user.name})\")\n",
-    "print(f\"  Username: {user.username}\")\n",
-    "print(f\"  Default output: {user.default_output_format}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "cell-8",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-04T18:00:26.412388Z",
-     "iopub.status.busy": "2026-03-04T18:00:26.412245Z",
-     "iopub.status.idle": "2026-03-04T18:00:26.421084Z",
-     "shell.execute_reply": "2026-03-04T18:00:26.420416Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[siege_utilities] 2026-03-04 12:00:26,415 INFO: Saved modern User: dheeraj\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "User profile saved: True\n",
-      "[siege_utilities] 2026-03-04 12:00:26,419 INFO: Loaded modern User: dheeraj\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Verified: loaded user dheeraj (Dheeraj Chand)\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Save and verify user profile\n",
-    "success = manager.save_user(user, profiles_dir=users_dir)\n",
-    "print(f\"User profile saved: {success}\")\n",
-    "\n",
-    "loaded_user = manager.load_user(\"dheeraj\", profiles_dir=users_dir)\n",
-    "if loaded_user:\n",
-    "    print(f\"Verified: loaded user {loaded_user.person_id} ({loaded_user.name})\")\n",
-    "else:\n",
-    "    print(\"WARNING: Could not load saved user profile\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cell-9",
-   "metadata": {},
-   "source": "## 3. Create Hillcrest Client Profile\n\nCreate a complete client profile with branding configuration."
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "cell-10",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-04T18:00:26.423021Z",
-     "iopub.status.busy": "2026-03-04T18:00:26.422899Z",
-     "iopub.status.idle": "2026-03-04T18:00:26.426962Z",
-     "shell.execute_reply": "2026-03-04T18:00:26.426285Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Branding: #1a4d2e / #4a7c59\n",
-      "Fonts: Helvetica / Georgia\n",
-      "Color scheme: {'primary': '#1a4d2e', 'secondary': '#4a7c59', 'accent': '#f4a261', 'text': '#2d3436', 'background': '#ffffff', 'chart_background': '#ffffff', 'chart_grid': '#e0e0e0'}\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Create Hillcrest branding config\n",
-    "hillcrest_branding = BrandingConfig(\n",
-    "    primary_color=\"#1a4d2e\",      # Forest green (placeholder)\n",
-    "    secondary_color=\"#4a7c59\",    # Sage green (placeholder)\n",
-    "    accent_color=\"#f4a261\",       # Warm accent (placeholder)\n",
-    "    text_color=\"#2d3436\",\n",
-    "    background_color=\"#ffffff\",\n",
-    "    primary_font=\"Helvetica\",\n",
-    "    secondary_font=\"Georgia\",\n",
-    "    logo_path=None,\n",
-    "    header_height=50, footer_height=25,\n",
-    "    margin_top=25, margin_bottom=25, margin_left=20, margin_right=20,\n",
-    "    title_font_size=28, subtitle_font_size=20, body_font_size=12, caption_font_size=10,\n",
-    "    chart_color_palette=\"viridis\",\n",
-    "    chart_background_color=\"#ffffff\",\n",
-    "    chart_grid_color=\"#e0e0e0\"\n",
-    ")\n",
-    "\n",
-    "print(f\"Branding: {hillcrest_branding.primary_color} / {hillcrest_branding.secondary_color}\")\n",
-    "print(f\"Fonts: {hillcrest_branding.primary_font} / {hillcrest_branding.secondary_font}\")\n",
-    "print(f\"Color scheme: {hillcrest_branding.get_color_scheme()}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "cell-11",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-04T18:00:26.429002Z",
-     "iopub.status.busy": "2026-03-04T18:00:26.428872Z",
-     "iopub.status.idle": "2026-03-04T18:00:26.432963Z",
-     "shell.execute_reply": "2026-03-04T18:00:26.432149Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Report: ReportFormat.PDF, Letter PageOrientation.LANDSCAPE\n",
-      "Sections: ['executive_summary', 'methodology', 'findings', 'recommendations']\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Create Hillcrest report preferences\n",
-    "hillcrest_reports = ReportPreferences(\n",
-    "    default_format=\"pdf\",\n",
-    "    include_executive_summary=True,\n",
-    "    chart_style=\"professional\",\n",
-    "    page_size=\"Letter\",\n",
-    "    orientation=\"landscape\",\n",
-    "    include_table_of_contents=True,\n",
-    "    include_page_numbers=True,\n",
-    "    chart_quality=\"high\",\n",
-    "    chart_dpi=300,\n",
-    "    include_chart_titles=True,\n",
-    "    include_chart_legends=True,\n",
-    "    sections=[\"executive_summary\", \"methodology\", \"findings\", \"recommendations\"]\n",
-    ")\n",
-    "\n",
-    "print(f\"Report: {hillcrest_reports.default_format}, {hillcrest_reports.page_size} {hillcrest_reports.orientation}\")\n",
-    "print(f\"Sections: {hillcrest_reports.sections}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "cell-12",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-04T18:00:26.434796Z",
-     "iopub.status.busy": "2026-03-04T18:00:26.434670Z",
-     "iopub.status.idle": "2026-03-04T18:00:26.438094Z",
-     "shell.execute_reply": "2026-03-04T18:00:26.437406Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Email:   contact@hillcrest.example.com\n",
-      "Phone:   (555) 123-4567\n",
-      "Website: https://www.hillcrest.example.com\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Hillcrest contact info\n",
-    "hillcrest_email = \"contact@hillcrest.example.com\"\n",
-    "hillcrest_phone = \"(555) 123-4567\"\n",
-    "hillcrest_website = \"https://www.hillcrest.example.com\"\n",
-    "\n",
-    "print(f\"Email:   {hillcrest_email}\")\n",
-    "print(f\"Phone:   {hillcrest_phone}\")\n",
-    "print(f\"Website: {hillcrest_website}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "cell-13",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-04T18:00:26.440233Z",
-     "iopub.status.busy": "2026-03-04T18:00:26.440103Z",
-     "iopub.status.idle": "2026-03-04T18:00:26.445036Z",
-     "shell.execute_reply": "2026-03-04T18:00:26.444286Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Client created: Hillcrest (HILL)\n",
-      "  Industry: Political Consulting\n",
-      "  Status: active\n",
-      "  Brand color: #1a4d2e\n",
-      "  Assigned users: ['dheeraj']\n",
-      "  Primary user: dheeraj\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Create the complete Hillcrest client\n",
-    "hillcrest = Client(\n",
-    "    person_id=\"hillcrest\",\n",
-    "    name=\"Hillcrest\",\n",
-    "    email=hillcrest_email,\n",
-    "    phone=hillcrest_phone,\n",
-    "    website=hillcrest_website,\n",
-    "    client_code=\"HILL\",\n",
-    "    industry=\"Political Consulting\",\n",
-    "    project_count=0,\n",
-    "    client_status=\"active\",\n",
-    "    branding_config=hillcrest_branding,\n",
-    "    report_preferences=hillcrest_reports,\n",
-    "    notes=\"Primary client for Siege Analytics\"\n",
-    ")\n",
-    "\n",
-    "# Bidirectional user-client assignment\n",
-    "hillcrest.assign_user(user.person_id)\n",
-    "hillcrest.set_primary_user(user.person_id)\n",
-    "user.assign_client(hillcrest.client_code)\n",
-    "user.set_primary_client(hillcrest.client_code)\n",
-    "\n",
-    "print(f\"Client created: {hillcrest.name} ({hillcrest.client_code})\")\n",
-    "print(f\"  Industry: {hillcrest.industry}\")\n",
-    "print(f\"  Status: {hillcrest.client_status}\")\n",
-    "print(f\"  Brand color: {hillcrest.branding_config.primary_color}\")\n",
-    "print(f\"  Assigned users: {hillcrest.get_assigned_users()}\")\n",
-    "print(f\"  Primary user: {hillcrest.primary_user}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "cell-14",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-04T18:00:26.447065Z",
-     "iopub.status.busy": "2026-03-04T18:00:26.446940Z",
-     "iopub.status.idle": "2026-03-04T18:00:26.462332Z",
-     "shell.execute_reply": "2026-03-04T18:00:26.461561Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[siege_utilities] 2026-03-04 12:00:26,451 INFO: Saved modern Client: HILL\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Hillcrest profile saved: True\n",
-      "[siege_utilities] 2026-03-04 12:00:26,454 INFO: Saved modern User: dheeraj\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[siege_utilities] 2026-03-04 12:00:26,459 INFO: Loaded modern Client: HILL\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Verified: loaded client Hillcrest\n",
-      "  Code: HILL\n",
-      "  Primary color: #1a4d2e\n",
-      "  Assigned users: ['dheeraj']\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Save and verify Hillcrest profile\n",
-    "success = manager.save_client(hillcrest, profiles_dir=clients_dir)\n",
-    "print(f\"Hillcrest profile saved: {success}\")\n",
-    "\n",
-    "manager.save_user(user, profiles_dir=users_dir)\n",
-    "\n",
-    "loaded_hillcrest = manager.load_client(\"HILL\", profiles_dir=clients_dir)\n",
-    "if loaded_hillcrest:\n",
-    "    print(f\"Verified: loaded client {loaded_hillcrest.name}\")\n",
-    "    print(f\"  Code: {loaded_hillcrest.client_code}\")\n",
-    "    print(f\"  Primary color: {loaded_hillcrest.branding_config.primary_color}\")\n",
-    "    print(f\"  Assigned users: {loaded_hillcrest.get_assigned_users()}\")\n",
-    "else:\n",
-    "    print(\"WARNING: Could not load saved client profile\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cell-15",
-   "metadata": {},
-   "source": "## 4. Test 1Password Integration\n\nRetrieve credentials from 1Password (if available)."
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "cell-16",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-04T18:00:26.464602Z",
-     "iopub.status.busy": "2026-03-04T18:00:26.464478Z",
-     "iopub.status.idle": "2026-03-04T18:00:26.494138Z",
-     "shell.execute_reply": "2026-03-04T18:00:26.493164Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== 1Password Available ===\n",
-      "[siege_utilities] 2026-03-04 12:00:26,489 INFO: 0 items tagged 'siege-utilities' in 1Password (0 total items in vault). Tag items with 'siege-utilities' to include them.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[siege_utilities] 2026-03-04 12:00:26,490 INFO: Found 0 stored credentials\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found 0 stored credentials (tagged 'siege-utilities'):\n",
-      "  (No items tagged 'siege-utilities' \u2014 tag items in 1Password to include them)\n"
-     ]
-    }
-   ],
-   "source": [
-    "from siege_utilities.config import get_google_service_account_from_1password\n",
-    "\n",
-    "# Check if 1Password is available\n",
-    "if cred_manager.available_backends.get('1password'):\n",
-    "    print(\"=== 1Password Available ===\")\n",
-    "    \n",
-    "    # List stored credentials with siege-utilities tag\n",
-    "    stored_creds = cred_manager.list_stored_credentials()\n",
-    "    print(f\"Found {len(stored_creds)} stored credentials (tagged 'siege-utilities'):\")\n",
-    "    for cred in stored_creds:\n",
-    "        print(f\"  - {cred.get('service', 'unknown')} ({cred.get('backend', 'unknown')})\")\n",
-    "    \n",
-    "    if not stored_creds:\n",
-    "        print(\"  (No items tagged 'siege-utilities' \u2014 tag items in 1Password to include them)\")\n",
-    "else:\n",
-    "    print(\"1Password not available - skipping 1Password tests\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "cell-17",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-04T18:00:26.496183Z",
-     "iopub.status.busy": "2026-03-04T18:00:26.496042Z",
-     "iopub.status.idle": "2026-03-04T18:00:26.546703Z",
-     "shell.execute_reply": "2026-03-04T18:00:26.546091Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Trying: Google Analytics Service Account - Multi-Client Reporter...\n",
-      "[siege_utilities] 2026-03-04 12:00:26,510 ERROR: Failed to get Google service account from 1Password: Command '['op', 'item', 'get', 'Google Analytics Service Account - Multi-Client Reporter', '--field=project_id', '--reveal']' returned non-zero exit status 1.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Trying: Google Analytics Service Account...\n",
-      "[siege_utilities] 2026-03-04 12:00:26,521 ERROR: Failed to get Google service account from 1Password: Command '['op', 'item', 'get', 'Google Analytics Service Account', '--field=project_id', '--reveal']' returned non-zero exit status 1.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Trying: GA4 Service Account...\n",
-      "[siege_utilities] 2026-03-04 12:00:26,533 ERROR: Failed to get Google service account from 1Password: Command '['op', 'item', 'get', 'GA4 Service Account', '--field=project_id', '--reveal']' returned non-zero exit status 1.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Trying: Hillcrest GA Service Account...\n",
-      "[siege_utilities] 2026-03-04 12:00:26,544 ERROR: Failed to get Google service account from 1Password: Command '['op', 'item', 'get', 'Hillcrest GA Service Account', '--field=project_id', '--reveal']' returned non-zero exit status 1.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "WARNING: No GA service account found in 1Password\n",
-      "To store one, use:\n",
-      "  from siege_utilities.config import store_ga_service_account_from_file\n",
-      "  store_ga_service_account_from_file('/path/to/service-account.json')\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Try to get Google Analytics service account from 1Password\n",
-    "# The item title should match what's stored in 1Password\n",
-    "\n",
-    "ga_service_account = None\n",
-    "\n",
-    "if cred_manager.available_backends.get('1password'):\n",
-    "    # Try common item titles\n",
-    "    item_titles = [\n",
-    "        \"Google Analytics Service Account - Multi-Client Reporter\",\n",
-    "        \"Google Analytics Service Account\",\n",
-    "        \"GA4 Service Account\",\n",
-    "        \"Hillcrest GA Service Account\"\n",
-    "    ]\n",
-    "    \n",
-    "    for title in item_titles:\n",
-    "        try:\n",
-    "            print(f\"Trying: {title}...\")\n",
-    "            ga_service_account = get_google_service_account_from_1password(title)\n",
-    "            if ga_service_account:\n",
-    "                print(\"Found service account!\")\n",
-    "                print(f\"   Project: {ga_service_account.get('project_id')}\")\n",
-    "                print(f\"   Email: {ga_service_account.get('client_email')}\")\n",
-    "                break\n",
-    "        except Exception as e:\n",
-    "            print(f\"   Not found or error: {str(e)[:50]}\")\n",
-    "            continue\n",
-    "    \n",
-    "    if not ga_service_account:\n",
-    "        print(\"WARNING: No GA service account found in 1Password\")\n",
-    "        print(\"To store one, use:\")\n",
-    "        print(\"  from siege_utilities.config import store_ga_service_account_from_file\")\n",
-    "        print(\"  store_ga_service_account_from_file('/path/to/service-account.json')\")\n",
-    "else:\n",
-    "    print(\"Skipping 1Password credential retrieval (not available)\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cell-18",
-   "metadata": {},
-   "source": "## 5. Generate Branded PDF Report\n\nCreate a sample report using Hillcrest branding."
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "cell-19",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-04T18:00:26.549152Z",
-     "iopub.status.busy": "2026-03-04T18:00:26.548871Z",
-     "iopub.status.idle": "2026-03-04T18:00:26.873946Z",
-     "shell.execute_reply": "2026-03-04T18:00:26.873053Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== Sample Polling Data ===\n"
-     ]
-    },
     {
      "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Candidate</th>\n",
-       "      <th>Support (%)</th>\n",
-       "      <th>Previous (%)</th>\n",
-       "      <th>Change</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>Smith</td>\n",
-       "      <td>42</td>\n",
-       "      <td>40</td>\n",
-       "      <td>+2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>Jones</td>\n",
-       "      <td>38</td>\n",
-       "      <td>39</td>\n",
-       "      <td>-1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>Williams</td>\n",
-       "      <td>12</td>\n",
-       "      <td>13</td>\n",
-       "      <td>-1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>Undecided</td>\n",
-       "      <td>8</td>\n",
-       "      <td>8</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAGGCAYAAACqvTJ0AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjYsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvq6yFwwAAAAlwSFlzAAAPYQAAD2EBqD+naQAAriVJREFUeJzs3QdUVEcbBuCX3nsRAVGx9957x6gxGrvGHtPUP4mxxIrdJPYaY6yxJ2qKBVvsvXdRsQFKk97rf2aQFRQMKHAX9n3O2QN39nJ3ltmFu9/95hutlJSUFBAREREREREREeUj7fx8MCIiIiIiIiIiIoFBKSIiIiIiIiIiyncMShERERERERERUb5jUIqIiIiIiIiIiPIdg1JERERERERERJTvGJQiIiIiIiIiIqJ8x6AUERERERERERHlOwaliIiIiIiIiIgo3zEoRURERERERERE+Y5BKSoQTJsuxsw1Z1HQ+AdHo++kPXDp+It8Dsu2X1G6S0Qa+54vqH9HiIjykta4S3A/+Ezpbqi9dReD5O/qcXAcNPk5N1/pKW+apMScG+i47gEKC/F+F+OqzrZfD4b11KuIjEtStYk+D//r6Vt/7rZ/DHTHX8JNv5h86CXlFt1cOxJRDm3cdxufzz6U5f3/ruiOupWK5nk/omMTsGDzJTSp4YymNZwz3Cc+wM5edx6P//4UtpZGOT72uKXHcfj8U3w/sB6K2BijRjl7qJvPZh3EJo87/7lfX7cKmP5FI9Tq9xuqlLbD3kVdM9yfkJiERkO2IjImHhfW94OJkV6mx7n96AVmrT2Hq54BMmhnZKiL8sWt8XXvmvigkatqv+TkFGzefwd/H/PCtfuBCImIRfGi5ujWsiz+16smDA3456sg+WXXdRgb6qJf+4pKd4WIKM8/yA/644n8/sTn5dC4hGmG+1NSUuAy5wZ8whLQobwFdg8sDXUnghIlf7yJnz5wwndNHXL888vPBMBYTxsDa9tC3c068hwV7Y3wUSVLpbuisU4/icSBe+H4urE9LI14vqdpkpJTMOXgc4xoaA9TA50c/WzFIkboUM4Ckw8+w85PSuVZHyl38V1Oips4pD5KFDV/o93VKX9OBqJjE2XgSXg9KPW+jl32QYfGrvhf75pQV4M/rIwWtYupth8/D8eM1WcxqFNlNKrmqGov6WgBeytjTPu8EUb89C827buDvu0rqO5fvPWKDDj9PqdTlgEpwdsvApHR8ejjVgFFbU3k7/+vYw/Q4/vdWPxdS9mftGChCFrWreSAIZ2rwM7KCOdv+WHm2nM4etkbexd2hZaWVp79Xih3rfrzOmwsjLIdlAo6+CV0dZjMS0QFl6GuFjZfDX4jKHXsYaQMSBnoqsf/sJjpNaCrnbd9WX42ELbGugUkKOWHbpWt3ghKfVLTBr2qWavNuCnlwJAy+RKUmnr4OQbWsmFQKg9MbFkU45rnPLicX/65EwbPoFgMq/tufy8+r2+HD9Y+gNeLOJSyMcj1/lHu47ucFNe2XnHULF8EhVFgSDQsTNX7j2G9ykXlLc3lu/4yKFWvsgN6tS3/xv4DO1bC5v13MX75Cbg1LCEDDY+fhWHO+vP4sGkptG9Y8q2P165BCXlL7/OuVdH4061Ysv2KKiilr6eDQ8u6o36VV30TgTIXBzPMXHMORy95o0Vtl1z4DZA6YiYcERV0H5SzwO83QrC4UzHo6rwKZGy+FoxaTsYIikqEOjDUK5gXABKTUpCckgJ93fzpv462lrxpuvz6fVPeEX+P0v9NUjdrLwahUXFTOFnov9PPty5tDisjHay/9ALT2r66wE7qi2f9VGA9C4zE9NVn4XHmEcIi42Rm1cieNdC/Q6UM+8XGJWLepov4/dA9eAdEwNLUQE4LnPllI+hoa6NSz3VyP5EtlZYx9f3AupgwuH6mj+s2cgdehMVgw9T2+HbBUVy87Q9LMwN82a06vulT642piWLakrgJkcdHyq+PnoVh0s+ncOySN2Ljk1C5lA3GDqgLtwZvD+ioA5GdtGhUCzQasgUTlp/Ez9+3wTcLjsp/bnP/1+ydjqmjow1ne1NcuhugahNBqfQBqTSdmpSSQam7T0KyFZTaeuAulm6/gruPg2FkoIuWdVww84vGcC5ilqMxTfPULxzfLTwms7WMDfXQs005tKlXHB9995ec0piWbXfqmi9W7LiGi7f9EBASDTtLY3zUvDTchzWU/Uhv55H7cqqoyFJzdbLApCENsOfkQ5y46oPb2wdlmNK44o+rWLv7lnwNmZvoo2PjUpj2eUNYmRmq9qvYYy0qlrTByF415RjdefRCvj/mft1M9k9kponfoZdvKCqUsMayMa1QrWzGqaWeT4Ix7dczOH7ZB9FxifJ44wbUlZl/adJe5weXdZPH3LL/LmLiEuXveMnolvI5p/XnqV+Eqq6T0Li6EzwWf5zluIn90r8P06bSXtvcHz9uuIDdJ72QkgIZCJ3/TXM5Fmni4hMxeeVpOfZx8UnyOS/4tvk7/R0Rz6fhkC3y+9Ore6vGLjg8FnX6b5RZngeWdpOvYSKi9HpXt8au26E4+CAc7ctZyLb4xGT8cSNEZiosPvXqf16aucf9sPNmqMwSiI5PllNRvm/ugG5VrDLsd/B+OKYeeoab/rFITE6Bk7kePq5shVluTqrHmfGvH/Z4huFBkNgHqOlkjGltHNGi1Kv/f2l1Wqa0Kgr3No7vNE3x5OflsONmCH67Eiz73LaMOX7p6gI7Uz1VPZ4nofGqxxKalTTF0c/Kye9DYxLhfui5PEZAZCKKWerj0zq2GN20CLRfBoHSTx8UWV1LTgfgcUg8Lo2ogIr2htl+ruL/qPjZXy8E4f6LOJgZ6MgA4Yy2jqjtbKLq3/rLL+RNGFDTBut6lFA930djKqOEtYGsMXQ7IAYPx1R543fTYPldJCSl4OKIVxnlG6+8wIKTAbLmjZGetvw9/fSBs3y+SrkbECunOR15GCFr97hY6svX2sx2qa+jzKTVk0obPyEuMVlmmG26Ggzv0HjYm+qidzVrTG/rCIN0QSzx+/2qgZ0MGkw84Iv7QXEobWOAeR2c4fbyPSLqHYksKUGMeZq03/vrxPvom93eeDG5miqrat5xf3y31wffNLbH/I7FVFPCLN2v4ssGdvihvbPq9bD4dABWnQ+CV3AcLAx18FFFS8xxc4KV8Zsfk8WUwjH7fHA3MBau1gbyddO1csb3Zma2XgvGT8f9cS8wFiLJv7ilPobWscX/Gr+6KJ+d90F2jiVed2IK6sYrwfAOi4eJvjYq2BliSmtHtCljnuF3nDKnVoYg7+yjflh3KUhmchY100Of6taY0rpohjEU7+fKDkYy0+rb3d647hcDR3M9uLdyRP9aNqr9stOPzMQmJMPjXjjGt8heJteMw88x+dAzLOpYDCMapZ7L6uloobmrGf66HcqgVAHBoBQpLiwqHkGhGYvRiT+yIgMnK6IWUYvPt8v9PutaTdZ7Onj2Mb784TAiouLxVY8acr+kpGR0G/ePzKrp1qosvuhWDZHRCfj34lPcfvhCBjUWjmqBr+cdkcGOzs1S5x5XLvX2dNHQiDh0+e4vfNi0NLq2KIM/jz6QQaZKrjZoW78EGlVzwq8T22LojANoWbuYnKqWvu+tvvwdMWJ62sfVYWNhKGs6ielrG6d9ID9kqzsRoBB1neZuvAhTY30cPPcEP45sCke7jFMU3iYqJkF+4A+PisPeU49w4NwTfNyi7H/+XEBwtPwqfm//RQQvpq8+I8doQMdK8nX2845raDdiB06t7i0DT9kd07Q+d/h6J/xeROPLbtVgb22C3w954vgVnzcee9fRB4iJTcTQj6rA2twIl+744eed1+AbGCnHOY0Ihgxw34dKrraYOqwhQiLi8NUPh1DU9s3f5ci5/2Ljvjvo90EFfPFxNTx5Ho6Vu67j+v1AHFreDXq6r+bde/mGYfC0/TLzrFebcli07TJ6jPtHBhTdV53Bpx+lnkSLgG3/KftwZVN/1UmPmIbZ5qvfZR++7Vtb1oISgbNeE3Zj0/QOb7xGRZBO/C5F7TQRtFv2x1WMWnBMBvmEH0Y0lfuIaZ1j+teRbWIq6LsQfRW1xURw79q9QKzbfUsGv0S9szRf/XgYWw94okfrcjLjT0yj/XjsP+/0d0QEoX4Z3watv/odU1edxpzhTeXPiuBleFQ8fh7fhgEpIspUCSt9NHAxwZarwaqg1D7PcITFJqFXNatMg1KLTgXgwwqW6FvDGvGJKdh6PRjdNz2UdadE/Snhln+MDIhULWokAy9iOtmDF3E49SRSdZzwuGQZeOldzUp+sI2IS8Lqi0Fot+Y+zn9VHtUd3+1vcGZG/P0UVka6MrAlAkULT/lj+N9a2NYn9SLGwk7F5D6m+jqY0DL1g2aRlwErEcRqtvIefMPj8Vk9OxkUEVO3vt/vi+cRCfJn01t78QViE5MxrK6dfN7Wxro5eq5DdjzBuksv0L6cufwgLwJYJx5H4OzTKBmU+q1nCQzd8QR1nU0wrF7quWCpTAIhQs+qVui/PQwXvKNQp5iJqv1JSJw8ngigpZn573NMOvgMPapYyccNjEzAkjOBaLrSE1dGVlBkitr159Fo8rOn/AAvfp/i9SoCM2Lq1NuCUq8TgZ0P13vh5ONIOd2qgr0hbvjFYMFJf9wLisWf/TPWTBP7icDrl/XtYGagLYNCH298iKfjqsDGRBddK1vKn9tyLQQLOjrD1iT1d2NnmvnvqEkJUySnpB63Y4XUKZdiTMUpzYnHr94TV55FIzI+GU1LvgpUfrbrqQzCDKpti5GN7PEoOA5LzwTKfU99UV7+btLcD4pFz80P5dQwEahce+mFfG96DC7z1iCLCCD33vIIrUqb4Yf2qb/XOwGxOPUkCv9rjBy9D7JzLPdDz2RwSbzOxOs4PC4JF32icNk3+q39FK97EYjtVsUSo5qY4Zx3lDyOOP6u/hnP+x68iEW3jV4YUscWA2rZYM3FFxj4x2PUcjZGpSJG79WPS77RiE9KQc1s/I2auN8Xs476YWUXF3xa1y7DfSLYLIJS4bFJMDfMWV0qyn8MSpHiOn2z6402A30dvDj0VZY/M23VaXnF49y6Pqrg1dDOVTBwqgdmrTuHwZ2ryA+TYpqZCEjNGd4Ew18GqoRR/WrLQqMi6+ejZqVlUEpkK2U2XS0zz4OisGpCG/RulxpsGtChEip0X4v1e27JAIaovyRuIihVuphVhuPO33RRBlZEdkXDqo6qKXH1B23G90tPoGNj1wxXRNSVyOza8e89GeQRBdw/61I1Rz///bITWPN36hUw8XxFoGPeN/+dabVgyyWZIdS2XsYpgK8TwZGZa89i8tAGGP1JaiBEEEEnkeUlahylb/+vMRXW/H0Dj56FY+vMDujYJPUf9JAPK6syadKb/nmjDBlRIjgksnDcV52Gt38Eir3M1Jqy8jQcbU1xaFk3GeATmtdyRvuRO+VUxTSnrz+TAZg1k9qhR5tXVyeb1nSWWVq7jjzI0H7/aQgOL++umppZvoQ1On/3F4b/9C8ub/xE9fiWZoYy2HXymq8qy2vM4uNwtjfD8V96wkA/9TkM61IVbb76A5N/PvVGUMrawhB/z/tIVeNLTKcQWWIi80hMXxUBX5F1Jd6r2X2PZaVaGTssH9datf0iLBbr995SBaVuPAiUASkRdFvwbQvZJgJOIkB30yvonf6O1KnogG9618L8zZfkcxGZb38cvieDbWWK/fcVUiLSXCLT4HsPX8QkJMvsGJFJ0qykGRzNM8+OufddZblfmuEN7VFz8W3MP+GvCkqJD6biQ9u+QWVUH9hfJ6auPB5bOcNUq0/r2qL8vFsyU2h1t7f/D80JG2NdWWco/f8AEWgQwTeZeVLJUmbFiJpS/Wq8yqQQxPMSgRARmCljm3qxSXwoF7+fn477YVSTIhkyiXzC4vFgdGVVFpYg/o5n57ke8YqQAamRDe2x6MNXwa5RTYvIc0JB9O/zXU9lFszrfX1d54qWMjC27XpIhqDU9ush8mJHj6rWqiDVlEPPZFbN+BavMsBFhk2Nxbdlva307fllxN/eEM/68siKMgiSZo5b6u8iu8R01EMPwnHss4xF/UU2jfhdiuBKw+Kv2kWQ4/a3lVS1fkQ2W7VFd7DlWrB8vVctaiwz3URQSmQtZZYdlV61okYwN9CWASgRlBJjKQJUInNw560QmQEmimWfeBQpA1WNiqeOldhHBDM39Sop36dpRH/c1jyQU2/Tt98LisOOfq6qzCgRkBGvsbH7fNCmTNb1MvfcDZP92z+4TJbTP7P7PsjOscQ+YurwL12LI7uuPYuWASkRQFr1cerPfdkAsDfVw9zj/vK9kz7r0DMwDsc/K4smLwN8IthabM4NGTSe28H5nfshiCw0oeR/jPt3e3xk4HNttxIyMPY68R4WwUpxvLrp3p+knnh5lxQnpt78M/+jDLedP36Y5f7in81fx7xk7SJxDiGyX9Jureu6ICwyHlfvpV59FFOKREbN512rvXGc9ymSbWqkl+HDtZhqVrtCETx+Fv6fP3vg7GO5b1pASh7PWF/WS3riF447j4NREIiTP3OT1H8YzWsWy3G2yFfdq8uxFlkooq5YUlIK4hOS3/ozP/12AUcuemPqZw0zZDll5u/jXvLqnch6Sv8aKWJtjFLOFm9kN2VnTEVGmKOdSYYpbKL20aBOGaeMCukDUiLDSjy2CBCJ1+y1l6/P50GRuPXwBXq7lVcFpIQm1Z1lhlZ6u47ch4WpPlrUKZbh+VQvay/7/vrzEUGo9LXCaldMvTrdrKazKiAl1KmYmu4t6oKlTUs7dtlb/t4iolP7LW4i+NOqrgse+ITKKW/piddu+vdTw6pOcjxF8C23iaL36Yli/MFhsTLjTth/9rH8+kW36m+83t7174gwflA9OdVRrFb5zfyjcvqhyJYjInob8WFNBKR23wmTGTy774Zm+KD7uvQBqZDoRBnYER/8RHZBGsuXV/1FFoD4P5cZ8YE1LUgj9gmOTpRZQSIbKP2xcoPIskn/P0BkriQlpwZj/ov44C/2F5lWosZW2q11aTN5jOOPMv4fEYGG9AGpnDxXMS1KdFNMR8qNc0KRfdG+rIVcuj4tqCWIIFX9YiaqQI/IChLDJF4L6Z+jg5meDECID/z5TWRqHX8UicG1bTMEpN7ld/H79RCZHVXezjDD82v5Mojx+vMTY5u++LQIQolAy8Pg/369ZEZc2BRBL/F80oJeL6KT5PQyMSxnnkbJdhG0qlzESJWVJvotgqZtSptl6HctJxOY6mu/0W8xRa1LuuL3Yvz717TGlWcx8ItIyLJ/4v0alZAsg8nv+z7IzrHEPiKbUmR2Zddez9RzwG+bZCzlIIJhaQGm9MSU2bSAlCDek+VsDTOM4bv0Q3gRnagKrGdGjOnwv55i0Sl/bOxZMtOAVPqfV5faffR2zJQixYkP/jkpdB4YGoPQyDis/eemvGW6T0jqdMCHvmEo62IF3Vwuyiimqb3+T1tknNz0Sq0/8DZP/SPQ9WWAIL1yxVOvvHj7h78RkEgjAgYJCUnv1Gcrc0MZaMkty/+4imv3A+VUvhU7rmJgp0oo5Wypmjb5+pTM1x+/XHFreRPE9MYPv90lp5cdXdkj0xMikZkism0GdKiITz/676wsETwR/7iq9dmQ6f3pp7pld0xFkEVkwL2+X2YrRYp9RcH4vaceyil56YlpX0JanaVSmfy8OOa1+6+CIl4+oTJQUvLDX7Msqp9e+sCTkFZw38k+Y3taYFFMXxQevvy9iTpL4pbVY6Wfqvn6Y6UFDEMicnYikh3OWTyW6L94LuJ3Kk5QXR1TMwrSlHGxfOe/I4J47a4Y1xpNh22Dob4Ofh7Xmqs/EtF/Eh/WRP0csQpfdEKy/IAppsdkZfedUFkf6erzaMQlvgp0pP9z07OatczwENNtxnn4olUpMznlSawYlz7TWhT5nXfCX2YKiPouaUpa524No9eDGuKDtRAS89/nK/dfxMqaNHbTr2V6v6itk15W2RPZea5iJS5HMz055S+39KxmhT9vh8rAhwiMiMcQ048Wdny1mrOoXSX+r5aZeyvTY+i9JTte1AYLzsbvMTP6OqnTGzPzMDj1PEQEad6XeH4iEJTdMXz99ZL2msnO6yUrTUqaynpMIgAsgk+iHpLIthJZVCJDSkwXE5lRPapaZXjtiaCv/YzrWfQ7Y6BJ1L56/f9+2ZdZTY9D4mSQMTOihtX2GyFov/aBrP0maomJfqTV0MrJ+yA7xxJTejtv8ELZubdQuYihvO+TGtYy+JcVUfNNvAxL22QsjSGekwguPQmNy8YY6iAkJvG9+pFeVvl6Gy6/kNMwV3zkIuv2/dfP81StYGBQigqclJdXBXu1LYe+6Wo1pVfpP2pCvS+dLFasSMnyT2ju6DNxD05e9X2nn01fhPt9+fhHyELZHZu4YuE3LVDzk99kjZ2/5n2Uen9ApKqAfHYf/6PmZeQ0svveoTKQmN6/F55i2KwDcGtQAotGtcxWH8XVUvGPaNdPnTNNcRb1jfJqTEVQTgTZRBBRFEoXz0c83rPAKHw2+6Cc2pBT4mfsrIzk9L3MiHpI6WWV1p1Ve1qX0vomaoaJjKHMuL4MPmb3mLkptx7rXf6OHDr/VH4VixOIIGGJ1wJfRESZEZlRn+58Ar/IBFnLKKv6QSceReDDDV5oWsIUyzu7oKi5ngxYiNo1IqiVPpvq+GflZHFqkcEgigKL7JyWpYLkNDrxd1IU1R74+2M5/UkUShaFp3W0tGSNFxE4yU1ZJUpn5++y+FPcpowZxjTNvKhxWbuMH5KN9N78H5Cfz/V1nSpYwFhPW07ZE0EpkTUl/k11Txf8EP9XxfnIvkGlZb9eZ2qQ9YXT00+i0GLVvXfqW/pi8nlJPL8qDkaY/3La1uteL+SeF+cMjYubymDkmSeRMgglglRCkxJmsr6UKOgeGJUos5Fe9VtMT9PFpp6ZLzJkl8XU2JwSU+CujqyA/ffCsU/cPMPke1pkWa3vUTJH74PsHKupqxm8xlSWmZQH7ofj1/NBcprbzx8Vx9C6b/98lN34TXbG8F37IaYDCyJI6ZzJaVajEqa4+iwaS88EyIBcVoHXtCCnmDZM6o+jRAWO+PBtZqwnawj81+prYiWzC7f9kJCY9EZmDBSKoLsUMZP1fl5372VbsSJZF/+b/VUThL5j9kmV0rkXqBu18Kj8OndkMzjYmsi6Td8tOobfD99D91Zl5RQ5MTUvJ48vip4L4ZEZTyDF+PWeuAc1yxXBhqkfZDvrTYy9+OcoimLnVt0fkRF090lqmn76q2UPfUMz7Cem5IngmpiamL7IvQiupZdWM0qsgve6148pMrSOXPJG/SqOb6zel5vSAi16utrZWt0wu7SyfarzfsTvVAQkHz5LzZJMc/9p6Dv/HRFEPao568/hkw8qysLyopj6uXV9VRloRERZEVN+Ptv1RBa/3tYn61V2d9wMhaGuFvYPKZNhtSvxofN1IiOqVWlzeZsPyFWuJux/JqcctS5jLlf4c7XWx85PXDP8vxK1jZSQ1X8AUUQ8Mi5Z9vldZfe5iilj+++Hy+l9b8uWysl/KxN9HXSsYCGnX4mgjAgOisBH+pph4jmK85GSVgZvBNn+i8j0OTikDN5FVtOfBPH7Em76Z8xqfxfi+V17HiOLb+dWBnFOzxlEzSCRGSaypMRNBCeFpiVNsepCIA57pU53S1/kXPRb1MISQY7002azIhYTeP38TxRkF0pYvf1cQEwv7VTRUt7EOcqXfz3FynNBmNSyKErbGuboffBfxxLE61sUbxc3UVNLFNQXhcezCgaJFfxEYExkbFWwf3WR0z8iAaGxSShu+W7nOjnthyCmgQqi6LwIdr5OZKz92N4JzX+5B7c193H407JyFc3XiZ8XsbOcvudIGawpRQWOqF3UuVlpWS9KfPh/XWDoq2lMYj9RC2flzjdTc9Pm/6ctJS+mRuUHUTT74h1/nLuZutxtWs0hMYWouIO5rFuTFVFQXHyAfpeblVnu/FEWtZr2nHqEiUPqq6ZSiSLYom+iULuo7SPqLGX1+KJI9OtE0HDL/jsy2CJqIaW5+zgYH4/9WwYafv+hU46CMaIYt8h+mr32fIZaD4LYfhGW8xOx1nWLy2ynPScfqtpi4xKx9p+MKflp0yfSP6x4TDHlMT2xup2Y/rjF4y4io1+9/k5c9Xnjtd21ZRlZp+mH9eff6FdiYrJq+t37EqviNanhJIvQ+wWl1mHI6v2VEyZGurLweV5LK4C/4rXf9bLfr77z3xHx+hS1pIramMpVJleObyNfx+OWnsiz50FEhYcosrzio+Jwb10UnV6uDpYZkbArPoyLKX5pHgfH4c9bGYPqIqjyuuovp8TEvZy6lpaRk/7/0LmnUar6OvlNBG/Eh9vXiUwH0af99zLWrBFCYxLlMvX/JbvPVdSjEvtMPfTq/CtN+vMEsXR9aGz269CIVfiehSfIKZUiOCOmV6YnCmOLbLKph59nfj7ylpo3Vsa6MlDxLrdaziZvnVYqAjZrLgbhaWjG89/X+/hfREF33/AErDqfcTERQUyni4rP+bQ8MQZCZq+ZzBjqaaOOsyiOHiyfT1pGlMiYiklIkStdiqCkyD581W8r+V6bfvjN14N43YnXX3pijHeley+KVd02XA5G9aJGWU7dE14fX3GOWPVlsCXt/Zrd90F2jvX6PuLvj5iWl3Z/ZkRBcmHhyYwrgs4/6S+/pi2ykBPv0o+0VfNEgPGiT9bnm2IK4N5BpeW00U7rHsjX2evENFqxEqCoG0bqj5lSpLgD556osoTSE0WaRXZIZqZ+1kgWdm7x+TYM7FhZBjJCwmNx9X4Ajl70hveez+R+fdqVx+b9d+SHRxEIEsXFo2MTZLFssTqXWEEtLRAiVpIrXcxS1j4SgYKs6jq9r2/71pYZRV3H/IXPP64OazMDbNp/B4+fh2PT9A5qvfJeRHQ8Ri86JldA++LjV0WeRZ8XjWqB5p9vx9RVZzDv6+ZZHkNM0YuIikejak6yaLj/i2hsO+gpXwOzv2qsKvgtHuuj7/6UwZave9XE/jOpBazTiNdG+kLemdVkmjykAab8clquxCemGopjP3kWjn9OeMni3P/rXTNHz1+soCcCnIOm7ZdFrovYmGD7QU8YvrxCk3bxTNQHE5la45efwLOgSJgZ6+Ov4w8yDRy5D2uAnuN3o/VXf+CT9hUQEhmHX3Zel69BEaxMX/xcPP7cjRdlpk6rOi4ya8zLJwy7jt6XwZIuzd/tampmiw+0/eoP1B20CYM6VpLZU2LFyPO3/OAbGImza/vk+JiiIPuvf92QQTUx/c/O0gjNa2Vc6js3VC1jh+6ty2LVnzdk7S7xGhErcIr6cu/6d+SHDRdw/UEgdi/oIseycilbjBtQT9Y4E6t3tmuQe6tYEVHhlFUx3vTEB7/5JwPk1X8x5U/UtFl2NlBmBoh6M2mmHX4uCx+L/UUGQ0BUApafCYSzhZ5q9TORvbPzVii6/OYl93sUEo+fzwbKAsUiIyO/iQ+aK84FYsbh5yhtawB7E120LG2O0U0d8PedMHRc9wADa9nK/aLik3HDLwZ/3AzB47FVslxhME12n6tYPUzUtBErA4qMELeyFnLqmZjuJe4TK7+l9fXQgwi5Ipoobi0ynOq5mLz1A72ZgTa+2+sjg08fV84YeBTBkBltneQqjKL2kJhmKDI7HoXEySDHsLq2+C6LaVt5aXGnYmj8s6dc3VEUqxf1tx6HxMspoVf/l/Vqcq8Tv1MxbfHzP5/KKaWNiotC9ymyvpeofyRWihNF53NCjIEwYb8velWzhp6OlpwqKYKbWRGFt+cc9ZNBiLQMGzHdrZydgVwtbuBr78Fmrmb4rJ6tnOYpariJ+kzice4HxcnMt0WdiqFblVcZ12VtDTDkjye44BONIqa6WHPxBfwjE7C2+9tXlxO134JjUgu/O1vo40lIvFwVUgSzKrzM4snu+yA7x6q44Baau5rJY1gb6eKib5Q8xvAGdln2sZqjMQbUtMEv54NkIFBM/Tzvnboin3i9pl95L7vepR9pAUYxFiKLbVrbV4tCva6+iyn+6l8KH6x7gG4bvfBn/9Jy/AQxlfPYowh8Wf/tj0Xqg0EpUpwoBp2Zn79vnWVQSkwPO7qyJ+asO4+/jz/Aqj+jYW1uiAolbTDt89Sl4dOyIXb+2Bk/briA3w95yqwIsV+Dqo4Z6sUsG9NKTj8bt/S4XAHu+4F18ywoJfp+eHl3TPr5FFbuuIbY+ET5Iff3OZ3g1iDrtH51MP3Xs3j+IgqbZ3R4Y7U9UaxeBPpEMKBf+4oycyozH7csiw17bskAhVg1TUyhql7OHtM/b5RhVTtxn6hNJUxeefqN44g6QG8LSgmj+tWWgcalv1/F7HWpGUZOdqZoWccFHzTO+e9aBLX2LOwiXyvL/7gm60SJwKfoR99Je2Gon/onVUwV3T67E0YvPoZ5Gy/CQF8HnZqWkqtA1h+0OcMxP2jkirWT3TBr7TlM/uW0LHouXvubPO7gzqOMKzEu/q6l/L2KLCb3VWegq6MFFwdz9GpTHg0qZ/2PO6cqlLDB8VW9MHvtOWzcd0fWxhL1rEQwctyAuu90zHED68ni7wu3XJKr+onV6/IiKCWsGNsathZG2HbIE7tPPkSzGs7Y8UMnlOu2Nsd/R656BmDubxfxWddqaFYz3RLifWvJjLnhPx3GhfX9/nM1SCKi/yKCNKs/Lo45x/zw9W5vGQz5wc1JBgrSB6U+rGAhgxviQ7FYWUp8WBUfIqe2cVRlBYgP4GJFMDGtR0xZEwGajb1KyhXHjj7M/9XeJrcqKosp/3jcDxFxybK/4vka62vj2LCymHXETwYCRBFjsaqZCABMbf3q+bxNTp7r2u4lULWoEVZfeIHRe33k8Ws7G8t6UGnmdyyGYTufYOIBX5llIz6svy0oJT5Ef1jBEpuuBsvV0kQg5HViJTjxnBacDJAZU0IxC3354Vv8rBJEIOLsV+Ux6cAzrDgbiNjEZBS30kePKlln7GdGXJgUAQFRL0iMnwi0iTpbrtYG+F9De1Ux8JyoU8wE09s44udzgfC491hOLXs0pjJMrN8SlCphijliBeDiJhku8Iq6UiIolb6eVJqfuxSXQRPx2hm/3xe62lpyKl6/GtYyuJaeWClxyYf28nXjGRQr35/b+riiXdm3ZxGJY4lgz/KzgQiNSZJZVaJAvntrR1U/s/s+yM6xRja0x993QnHgXjjikpJl4HpGW0cZ+HqbXz8uLqd1rns5hg6muvi+uUOmq1Vmx7v2Qxhc2wYfb3oI79D4N2qSpSf+hmzv44qPN3rhk22PsLlXSfl7OPxATNNNku9dKhi0UnKao0lERBks234FY5eewL0dgzOsSvc+GgzeLOse/TO/S64cj4iIiIhI3YlMu4rzb8lpjdPbOuX45z/a8EBOhd7Vv1Se9I9yH2tKERHlQFpB9vQ1pVb/fROlnS3fKSAl6hWJmlDpiSllNx4EySl7RERERESaQqzuN62NI5adCZQF0nPiTkAMdt8Nw/S3TP0j9cNMKSKiHOgy+i8425uhahlbhEfGY+vBu3Ka3ZpJ7dCjTc6XXn7yPBydvt2Fnm3KycLn954GY/VfN2Fuoo/z6/vCxuLNlUeIiIiIiIgKA9aUIiLKgdZ1XLBuzy1sP+SJpKRkWRx73RQ3dGtV9p2OJ2oRiSLg6/fcQlBoDEwM9WTh7GmfNWRAioiIiIiICjVmShERERERERERUb5jTSkiIiIiIiIiIsp3DEoREREREREREVG+U7uaUsnJyXj+/DlMTU2hpaWldHeIiIhIw4lKBxEREXB0dIS2tvpezxPnUH5+fjAxMeE5FBERERWI8ye1C0qJgJSzM5dBJyIiIvXi7e2t1ucoIiDl5OSkdDeIiIiIsn3+pHZBKTMzMzg4OODixYvy+7y6khgYGAg7Ozu1vuKpKTge6odjol44HuqF46F54xEeHo5ixYrl2XlJbhH9q169Ovbs2SMzzvMCX//qheOhXjge6oXjoV44HuolWY3On9QuKCXSzcUvxdzcPE+DUrGxsfIx+IZQHsdD/XBM1AvHQ71wPDR3PNR9Spzon46Ojvxd5GVQiq9/9cHxUC8cD/XC8VAvHA/1kqxG5098NRARERERERERUb5jUIqIiIiIiIiIiPIdg1JERERERERERJTvGJQiIiIiIiIiIqJ8x6AUERERERERERHlOwaliIiIiIiIiIgo3zEoRURERERERERE+U43/x+SiIiI6P0lJSXj5FUf3Hvkh7Il49G4ujN0dHi9jYiIiOh1T0PjERSVKL9PTk5GcEg8rBOioa2deu5ka6ILF0t9qHVQasmSJdi3bx8ePHgAQ0ND1K5dG+PHj0fp0qXf2DclJQWffPIJjhw5gtWrV8PNzS03+01EREQa7K9jDzBm8XH4Bkaq2pzsTPHjyKbo3OzN8xIiIiIiTQ5IlZt7E7GJKa/dE6j6zlBXC57fVc73wFSOLieePXsWAwYMwD///IMtW7YgISEBffr0QXR09Bv7rlq1ClpaWrnZVyIiIiIZkOo3aW+GgJTwLDBStov7iYiIiCiVyJB6MyCVkbg/LZNKbTOlNm3alGF74cKFqFq1Kq5fv4769eur2m/evImVK1fKrKoaNWrkXm+JiIgImj5lT2RIZXZaJdrE5bCxS46jY2NXTuUjIiIiKsw1pcLDw+VXS0tLVVtMTAyGDx+OWbNmwd7e/j+PERcXh/j4eNV2ZGSkao6juOUFcVwxvTCvjk85w/FQPxwT9cLxUC8cD2WJGlKvZ0i9HpjyCYiU+zWp4Zwrj8mxJiIiIlKzoJQ4QZsyZQrq1KmD8uXLq9pFm6g11a5du2wdZ+nSpZg/f/4b7YGBgTLAlRdE38PCwuSHirSiXqQcjof64ZioF46HeuF4KEsUNc/ufuWccqcmQkRERK4ch4iIiCi/paSk4NTjiMIXlBIFzj09PbFr1y5V24EDB3Dq1Cn5NbtEVtWwYcMyZEqJoJadnR3MzMyQVx8oRL0r8Rj8QKE8jof64ZioF46HeuF4KEusspe9/RyylbGdHWJxFyIiIqKCFoz6504Ypv/7HBd93qwDXqCDUhMmTMChQ4ewc+dOODo6qtpPnjyJJ0+eoEKFChn2//TTT1GvXj388ccfbxzLwMBA3l4nTvTz8mRffKDI68eg7ON4qB+OiXrheKgXjodyUv5jERVxr5O9KRpXd8618eE4ExERUUGRnJyCXbdCZTDq2vO8mX2mWFBKRNomTpwIDw8P/P7773BxcXkj60msxpdeq1at4O7ujjZt2uROj4mIiEgjPXkejgFT9mV5f1q46ocRTVnknIiIiDRKUnIKfr8Rghn/Psct/9gM95W1NcC9oDgU+KCUmLL3559/Ys2aNTA1NUVAQIBsF9PsjIyMZJp8ZqnyTk5ObwSwiIiIiLIrKiYBPcfvxouw1JOsqmXsEBQag2fpip6LDCkRkOrcrLSCPSUiIiLKP4lJKdh6PVgGozwDMwae6jgbY1LLoqha1Ajl591CbGJm6xenMtTVgq3Je62F905y9IgbNmyQX7t165ahXRQq79mzZ+72jIiIiOhlpvZnsw/ipleQ3C7tbIk9C7vA3FhfrrInipqLGlJiyh4zpIiIiEgTJCSlYOOVF5h5xA9eLzIGoxq4mGByq6JoV9Zclp0QPL+rjKCoRFWN1OCQYFhbWavKFIiAlItl7iwSk2dBKV9f3xw/wLv8DBEREVGaHzdcwJ9HH8jvzU30sW12R1iZpRYfb1LDWa6yJzK1WfuJiIiICrv4xGSsu/QCs4/64XFIxgVgmpY0lcGolqXMVMGoNCLglBZ0EkGpAL1I2NsbK37+lP+5WURERETZtPuEF6avPiu/F+dWaya3Q7ni1kp3i4iIiChfxSYkY/XFIPxw1A/eYQkZ7mtV2kxO02vmaoaChkEpIiIiUku3Hr7A0BkHVNvunzaEW4OSivaJiIiIKD9Fxyfjl/OB+PGYP55HZAxGuZU1x6RWRdGwuCkKKgaliIiISO0Eh8ei1/h/EBmTevLVvXVZfNu3ltLdIiIiIsoXkXFJ+PlcIH467o+AyNRaUGk6VbDAxJZFUbeYCQo6BqWIiIhIrSQmJmOA+z48ehYut6uXtcOyMa3eqI1AREREVNiExyZh2ZkAzD8ZoCpMnqZLJUsZjKrpZIzCgkEpIiIiUivjl5/EkYve8ns7KyNsndkRxoZ6SneLiIiIKM+ExiRiyelALDjpj5CYJFW7uCbXvYqVDEZVcTBCYcOgFBEREamN3/bexvI/rsrv9XS1sXlGBzgXKXhFO4mIiIiyIzg6EQtPBmDRKX+ExyWr2rW1gN7VrDGhpQMq2Be+YFQaBqWIiIhILZy7+Rz/m/evanv+N83RoIqjon0iIiIiyguBkQlyit7S0wGIjH8VjNLRBvpVt8H4Fg4oa2eIwo5BKSIiIlLcs8BI9Jm4B/EJqSdlw7pUxaBOlZXuFhEREVGu8otIwNzj/lhxNhDRL897BF1tYGAtW3zf3AGuNgbQFAxKERERkaJi4hLRa8Ju+AdHy+2mNZzxw4gmKEw6deqE58+fv9HevXt3jB07FnFxcVi4cCEOHDiA+Ph41K9fH+PGjYONjY0i/SUiIqLc5RsWL1fSW3kuELGJKap2fR0tDKlji7HNiqC4leYEo9IwKEVERESKSUlJwYifDuPy3QC5XdzBHBumtoeerg4Kkw0bNiAp6VXRUi8vL3z11Vdo1aqV3J4/fz5OnjyJOXPmwNTUFD/++CNGjx6NNWvWKNhrIiIiel9PQ+Pxw1E//HohCPFJr4JRhrpaGFbXDqObFYGzhT40FYNSREREpJjFW69g6wFP+b2JkR62ze4IW8vCV8zTysoqw/b69evh7OyMWrVqITIyEn/99RdmzJiBOnXqyPunTJmCbt264caNG6hSpYpCvSYiIqJ39Sg4DrOP+mHdpRdISBeMMtLTwhf17PBdUwcUNefqwgxKERERkSIOnnuMSStPqbZ/Gd8GlUvZorBLSEjA3r170bdvX2hpaeHOnTtITExEvXr1VPuUKFECDg4OuH79OoNSREREBcj9oFjMOuKH3668QNKrklEw0dfG8AZ2+LZJEdibMhiVhkEpIiIiynf3vUMwcKoHkpNTrxx+P7AuOjcrDU1w9OhRmR0l6kwJL168gJ6eHszMzDLsZ21tLe/Liqg9JW5poqKi5Nfk5GR5ywviuGLKZV4dn3KG46FeOB7qheOhXjRhPO4ExGLWUT9svRaCl6c3krmBNkY0tMP/GtnDxjg1BKP07yE5H8Yju8dmUIqIiIjyVVhkHHp8vxthkakBlU5NSuH7ga+yhAo7MVWvYcOGsLOze6/jrF27FqtWrXqjPSgoCNHRqUXj8+IEMywsTJ7Iamtr58ljUPZxPNQLx0O9cDzUS2Eej7tBCVh4PgJ/34tBulgULAy0MKyGKYZUN4WFoTaSIoMREAmNGY+IiIhs7cegFBEREeWbpKRkDJm+H/efhsjtiiVtsGpCG2hra0ETiBX4zp8/LwuZpxEr7IkpfeLkLX22VHBw8FtX3xs0aJCcApg+U6pDhw6wtbWVxdLz6iRWTDkUAbXC9qGiIOJ4qBeOh3rheKiXwjgeV59FY8YRP+y6FZah3cZYB980tsdX9e1gbqijseNhaGiYrf0YlCIiIqJ8M+3XM/A481h+b21uKAubmxprzoozf//9tyx63rhxY1VbhQoVoKurK4NVaavxPX78GH5+fqhatWqWx9LX15e314mTy7w84RcnsXn9GJR9HA/1wvFQLxwP9VJYxuOiTxSmH36Ov+9kDEbZm+riuyZF8EV9O5gaqGcwKj/HI7vHZVCKiIiI8sX2Q56Yt+mS/F5HRwsbprZHSUcLaApxVfKff/5Bx44dZRAqjchq6ty5MxYsWAALCwuYmJjgp59+kgEpFjknIiJSD2eeRGL6v8+xzzM8Q7uDmS7GNnPAsLp2MNYv2AE3JTAoRURERHnuimcAvpxzSLU9Z3hTNK9VDJpEZEKJ7KcPP/zwjfu+/fZbeUVxzJgxsnh5gwYNMHbsWEX6SURERK8cfxghg1GHHmSskeRsoSeDUUPq2MJIj8God8WgFBEREeUp/+Bo9Bq/G7HxSXJ7QIeK+Lxr1tPSCqv69evj4sWLmd5nYGAgg1AMRBERESlPFAA/4hWBaYef49ijjNXJi1vq4/sWDhhYywYGugxGvS8GpYiIiCjPxMUnot+kPfANTD2hq1+5KOZ/01zWMSAiIiJSt2DUgfvhsmbUqSdRGe5ztdbHhBZF8UlNG+jp8DwmtzAoRURERHl2Yjdq4TGcufFcbjvZmWLT9A9goM/TDyIiIlKvc5Y9d8PkNL3z3tEZ7itra4CJLYuidzVr6DIYlet4VkhERER54pdd17Fu9y35vaG+DrbM7IAiNiZKd4uIiIhISk5OkavoTTv8DFeexWS4r6K9oQxG9ahqBR1tBqPyCoNSRERElOuOXfbGmCXHVdvLx7ZGzfJFFO0TERERUVowasfNUJkZdcMvYzCqqoMRJrUqiq6VLKHNYFSeY1CKiIiIctXjZ2H4ZMo+JCWlyO1vetdCjzbllO4WERERabik5BRsux6CGf8+x52A2Az31XQyxuSWRdGpggWDUfmIQSkiIiLKNZHR8eg5fjeCw1JP9NrWKw73YQ2U7hYRERFpsMSkFGy+GoyZR57jXlBchvvqFTPB5FZF0b6cORdiUQCDUkRERJRrqfDDZh3ErYcv5HYZFyusmewGHR0ul0xERET5Lz4xGb9dCcasI8/xMDg+w32NiotglCPalDFjMEpBDEoRERFRrvhhw3n8fdxLfm9hqo9tszrC0sxA6W4RERGRholLTMbaiy8w+6gfnoZmDEY1dzWVwSjxlcEo5TEoRURERO9NBKNmrjknvxfnd2snu6Gsi5XS3SIiIiINEpOQjF/PB+GHY37wDU/IcJ/IiJrUsiialDRTrH/0JgaliIiI6L3c9ArCpzMPqLanfdYIbeuXULRPREREpDmi4pOw8lwQfjruB7+IxAz3fVDOXK6mV9/FVLH+UdYYlCIiIqJ39iIsBr3G70ZUTOrVyJ5tyuHr3jWV7hYRERFpgMi4JCw/G4i5x/0RGJUxGNW5ogUmtiyK2s4mivWP/huDUkRERPROEhKT0H/KPjx+Hi63a5Szx9IxrVifgYiIiPJUWGwSlp4OwIKT/ngRnZThvo8rW8pgVHVHY8X6R9nHoBQRERG9k++XncSxyz7ye3trY2yd2QFGBjy1ICIiorwREp2IRacC5C009lUwSlwP61nVChNaFEVlByNF+0g5wzNHIiIiyrH1u2/h5x3X5Pf6etrYPL0DnOxZOJSIiIhy34uoRJkVtfh0ACLiklXt2lpA3+rWGN+iKMrbGyraR3o3DEoRERFRjpy98Rxfzz+i2l74bQvUr1JU0T4RERFR4RMQmYB5J/yx7EwgouJfBaN0tYH+NW3wfXMHlLZlMKogY1CKiIiIss3HPwJ9Ju1BQmLqieHnH1dD/w6VlO4WERERFSLPwxPkSno/nwtETEKKql1PRwuDatlgXHMHlLQ2ULSPlDsYlCIiIqJsiYlLRO+JexAQHC23m9V0xuyvGivdLSIiIiokfMLi8eMxP/xyPghxia+CUfo6Wvi0ri3GNnNAMUt9RftIuYtBKSIiIvpPKSkp+OqHw7jiGSC3SxQ1x4ap7aGnq6N014iIiKiAexIShzlH/bDm4gvEJ70KRhnqauHzenYY3awIHM0ZjCqMGJQiIiKi/7Rwy2VsP+Qpvzcx0sPWWR1hY8HVbYiIiChzT0PjERSVKL9PTk5GcEg8rBOioa2tLdtsTXSRkJSC2UeeY/3lF3hZGUAy1tPGlw3sMKpJETiY6Sn1FEjdglJLlizBvn378ODBAxgaGqJ27doYP348SpcuLe8PCQnBvHnzcOzYMTx79gzW1tZwc3PD6NGjYW5unlfPgYiIiPLQ/jOPMXnlKdX2qgltUbmUraJ9IiIiIvUOSJWbexOx6abgpQrMsHKekJxuF1N9bYxoaI9vGtvDzpTBKE2Qo6DU2bNnMWDAAFSvXh2JiYmYM2cO+vTpg6NHj8LY2Bj+/v7yNmnSJJQtWxY+Pj4YN24c/Pz8sGrVqrx7FkRERJQn7j0NweDpHkh5ecI4YXA9fNi0lNLdIiIiIjUmMqTeDEhllD4YZWGog/81spc3a2NO6NIkORrtTZs2ZdheuHAhqlatiuvXr6N+/fooX758huBTiRIlMHbsWIwcOVIGsXR1+eIiIiIqKEIj4tDz+38QFhkvtzs3K4Wx/esq3S0iIiIqJMwMtDGmqQOGN7SDpRHjBZrovUY9PDxcfrW0tMxyn4iICJiammYZkIqLi0N8fOrJrhAZGamacypueUEcVxRszavjU85wPNQPx0S9cDzUi6aMR1JSMgZN88B971C5XbmUDVaMbSVKniM5/aVNDRiPwj7WREREStkzsDSalDRTuhtUEINS4gRtypQpqFOnjsyQykxwcLDMpurbt2+Wx1m6dCnmz5//RntgYCBiYmKQF0Tfw8LC5ElsWpE1Ug7HQ/1wTNQLx0O9aMp4/LjxGg6eeyK/tzLTx5Jv6iE6MhTRqdeONGo8xAU2IiIiyr7EdCvovY2JPlfx1XTvHJQSBc49PT2xa9euLE/g+vfvL2tLjRo1KsvjDB8+HMOGDcuQKSUKqNvZ2cHMzCzPTmC1tLTkYxTmDxQFBcdD/XBM1AvHQ71ownhsO+iJX/5OXWlPR1sLv037ALUqO0NTx0Ms7kJERETZc9QrAkN3PFa6G1SYg1ITJkzAoUOHsHPnTjg6Or5xvwgsiewoExMT/Prrr9DTy7pqvoGBgby9TpxY5uXJvjiBzevHoOzjeKgfjol64Xiol8I8Hpfv+mPET/+qtn8c2RTNa7lAk8ejMI4zERFRbvMOjcd3e32w/XqI0l2hwhqUEqnxEydOhIeHB37//Xe4uLhkmiElVuQTgaZ169bx6iIREVEB4f8iCr0m7EZsfJLcHtipEoZ1qap0t4iIiEiNxSYkY94Jf8w64ofoBNZhpDwMSokpe3/++SfWrFkji5cHBATIdjHNzsjISAakevfujdjYWCxZskRup9VhsLGxgY4O54sSERGpo7j4RPSZuAfPAqPkdoMqRTH/6+YyC4mIiIgos6SVf+6E4Zvd3ngY/GrxMlsTXXzXpAjcDz1DbGLWtaUMdbXkvqTZcvQK2LBhg/zarVu3DO2iUHnPnj1x48YNXLlyRbY1atQowz5nz55FsWLF3r/HRERElOsnld8uOIpzt/zktrO9KTZO7wB9PV5MIiIiojfdC4zF//7xhse9cFWbjjbwVX17uLcuCitjXfSubo2gqERVDcjgkGBYW1mrpsWLgJSLpb5iz4EKYFDK19f3rfc3bNjwP/chIiIi9fLzzutYv+e2/N5QXwdbZ3ZEEWtjpbtFREREaiYiLgkz/n2OBScDkJBuhb3mrqZY/KELqjgYqdpEwCkt6CSCUgF6kbC3N2atRsqAuXJEREQa7Mglb4xbely1vXxca1QvZ69on4iIiEj9sqo3XQ3GmL2+eB6RoGp3ttDDvA7O6F7FilP+6Z0wKEVERKShHj0Lw4Ap+5D08krnqL610KN1OaW7RURERGrksm80Rvz9FKefpNadFAx0tTC6aRGMa+4AE31O96d3x6AUERGRBoqIjkfP73cjODxWbrs1KIHJQxso3S0iIiJSEy+iEjHhgC9+OR+ElHT1yjtXtMD8DsXgamOgZPeokGBQioiISMMkJ6fg05kHcPvRC7ld1sUKqye1g46oUEpEREQaLTEpBb+cD8TEA88QEpOkai9ra4BFnYrBrZyFov2jwoVBKSIiIg0ze9057D7xUH5vYaqPbbM7wsKUVzuJiIg03fGHERj5jzeuPY9RtZnqa2Nyq6L4XyN76OvyAhblLgaliIiINMifRx9g9rrz8nttbS2sd2+PMsWslO4WERERKcg3LB6j9/pgy7WQDO2f1LDGnPZOcDRPXUWPKLcxKEVERKQhbnoFYdisA6rt6Z81Quu6xRXtExERESknLjEZC04GYMa/zxEVn6xqr+FohCUfuqBRCVNF+0eFH4NSREREGiAoNEYWNo+OTZTbvdqWw8heNZTuFhERESlkz90wfP2PNx68iFO12RjrYGY7JwytYwsdbS1F+0eagUEpIiKiQi4hMQmfTNmLJ37hcrtmeXssGd0KWlo82cxPAQEBWLJkCU6fPo3Y2Fg4OztjypQpqFixorzf3d0du3fvzvAzDRo0kD9DRESUW+4HxeKb3T4yKJVGxJ++qG+HaW0cYW3MMAHlH77aiIiICrmxS07gxBVf+X0Ra2NsndkRRgY8BchP4eHhGDJkCGrXro1FixbBysoK3t7eMDc3z7Bfw4YNMXnyZNW2vj5reBARUe6IjEvCzCN+mH/CH/FJKar2piVNsbhTMVRzNFa0f6SZeEZKRERUiK395yZ+2XVdfq+vp43NMzrA0Y71IfLb+vXrUaRIEZkZlcbJyemN/fT09GBra5vPvSMiosIsJSUFW6+FyELmvuEJqnYncz3M7eCMnlWtmD1NimFQioiIqJA6ff0Zvl1wVLW9aFRL1KtcVNE+aarjx4+jfv36GDt2LC5fvgw7Ozt0794dXbp0ybDfpUuX0KZNG5iZmaFOnTr44osvYGlpqVi/iYioYLv2LBoj/vbGiceRqjZ9HS2MalIE41s4wNRAR9H+ETEoRUREVAh5+0eg76Q9SEhMXUnny27V8ckHqbWLKP/5+vpix44d6Nu3LwYNGoTbt29j7ty5MjOqY8eOqvpRLVq0kBlUPj4+WLZsGUaOHIm1a9dCR+fNDw3x8fHyliYqKkp+TU5Olre8II4rrrjn1fEpZzge6oXjoV40fTyCoxMx+eBzrDwfhORXM/XQobw55ndwRmkbA7mdX78fTR8PdZOcD+OR3WMzKEVEpMaSkpJx8qoP7j3yQ9mS8Whc3Rk6OtpKd4vUXHRsAnpP2I3AkBi53bxWMcz6srHS3dJo4sRMFDT/6quv5Hb58uXh5eUlA1VpQal27dqp9i9durS8ffTRRzJ7qm7dum8cUwSrVq1a9UZ7UFAQoqOj8+x5hIWFyRNZbW3+LVIax0O9cDzUi6aOR1JyCjbejMYPp8MQEvsqGlXSUgfTm1miVUlDICkMAQH52y9NHQ91lZwP4xEREZGt/RiUIiJSU38de4Axi4/DN/BVurWTnSl+HNkUnZuVVrRvpL7EycWXPxzG1XuBcrukoznWu7tBV5cngEoSdaJKliyZoU1s//vvv1n+jFidT0zdEwXRMwtKiYwrkXmVPlOqQ4cO8rFMTU3z7CRW1B0R0w/5oUJ5HA/1wvFQL5o4HqeeROJ///jgyrPUi1KCib42JrQogq8b2cNAwXMBTRwPdZacD+NhaGiYrf0YlCIiUtOAVL9Je5Eu21p6Fhgp2zdO/4CBKcrU/E2X8Mfhe/J7UyM9bJvdCTYWRkp3S+NVq1YNT548ydAmtosWzbrGl7+/v7yKmVXhc7EyX2ar84mTy7w84RcnsXn9GJR9HA/1wvFQL5oyHs/C4zF2ny82XgnO0N6nujV+bO8EJwv1WMlVU8ajoNDK4/HI7nH5aiAiUsMpeyJD6vWAlJDWNnbJcbkfUXoeZx7BfdVp1favE9uiYkkbRftEqfr06YMbN25gzZo1MvPJw8MDu3btksXOBTHdbtGiRXKfZ8+e4fz58xg1ahSKFSsma00RERG9Lj4xGT8e80O5ubcyBKSqFTXC8c/KYlOvkmoTkCLKCjOliIjUzKnrzzJM2cssMOUTECn3a1rDOV/7Rurr7uNgDJ62HykvI5cTh9RHxyallO4WvVSpUiVZ2Hzp0qX49ddf4ejoKINO7du3V11NvH//Pnbv3i1rMIh0erFa3+eff55pNhQREWk2D88w/O8fb9wLilO1WRnpYEZbR3xWzw462lqK9o8ouxiUIiJSM9fvp9YC+i/eftkrHkiFX0hELHqN343wqNSV2D5qXhpj+9dRulv0miZNmshbVnUXRMCKiIjobbxexOHb3d74+06Yqk1LC/isri1mtHWCjQk/4lPBwlcsEZEa2X7IE1PTTb96m3FLjyM4PAaDP6wCEyO9PO8bqScxjXPQVA888AmV25VL2WLl921knQAiIiIqHKLikzD7iB/mnvBHXOKrIg+NiptgyYcuqOFkrGj/iN4Vg1JERGogKiYBoxcdw4a9t7P9MyERcfh+2UnM23QJI3vWwKddqsLMmNN8NM3kladx6PxT+b2NhSG2zerIICUREVEhWlV3+/UQfLfXBz5hCar2omZ6+OkDJ1nMnBeiqCBjoXMiIoXd9ApC02FbMwSkGlVzhDi9eP0UI227biUHVVtQaIwMTFTqsQ4/briAsMhXtQWocNt64C4Wbb0sv9fV0ZarMhYvaq50t4iIiCgX3PCLQctV99BryyNVQEpPRwtjmhWB53eV0LeGDQNSVOAxKEVEpOCVr9V/3UDzz7bB80mIbDM21JVTr/Yv6SYDDI52phl+xsneFJumf4B/V/TAuXV90a1VWVlHQAgOj8W0X8/I4NTMNWdlnSEqvC7d8cdXPx5Wbf/0v6ZoUp2F74mIiAq6kOhEjPz7KWosvo2jD18tfuNW1hw3vq6IH9o7w8xAR9E+EuUWTt8jIlJAaEQcRsw9jF1HHqjaqpS2xXr39ijrYiW3OzcrjY6NXXHyqg/uPfJD2ZIOaFzdGTo6qdcTKrnaYN0UN3w/sC7mbryIbQc9kZycgtDIOMxedx5Lt1/BZx9Xw/DuNWBraaTYc6Xc5xcUhV4TdiMuPkluD+pUGUM7V1G6W0RERPQekpJTsOZiEMbvf4agqERVu6u1PhZ2LIaOFSyYGUWFDoNSRET57MJtPwx098ATv3BV27AuVTHry8YwNMj4Z1kEoJrUcEY5J33Y29vLZeNfV664NVZNaItxA+pi3saL2Lz/LhKTkhERnYC5v13Eij+u4dOPqmBEz5ooYs0imAVdXHwi+kzag+dBUXK7YVVHzPu6GU9SiYiICrCzTyMx/C9vXPKNVrUZ62ljfAsHjGpSBIZ6nOREhRNf2URE+URkMS3YfAltvvpDFZCyNDXA5hkdMP+b5m8EpHKqlLMllo9rjaubPpGZM3q62qoi6gu3XEblnuvkin0iy4YK7pTPr+cfxflbfnLb2d5UTvPU12MKPxERUUHkF5GAgdsfo8FyzwwBqZ5VrXB3VCVMaFmUASkq1JgpRUSUDwJCojFs5gHVKmlCvUoOWDvFDS4OuVuYuoSjBZaMbomx/etg/uZLWL/nlpzmFROXiKXbr2LVnzcwsGMlfNunFpzszXL1sSlvLf/jGn57WRDfyEBXrrRnb8XsNyIiooImPjEZS04HYurhZ4iIS1a1V3EwwuJOxdC8FM/RSDMw5EpElMeOXPJGg0GbVQEpMcvqu3614bHk41wPSKXnXMRMZmDd3DoAX3WvDkP91GwaEaBaufM6qvRej5Fz/8WT56+mEZL6OnLxKcYvP6HaXjGuNaqVtVe0T0RERJRzB+6Fo9qiO/hur48qIGVpqCODUZdHVGBAijQKM6WIiPJIYmIyZq49h7kbLyAlJbXN3toYv05oi5Z1XPKtH0VtTfHDiKYyM2rxtitY9ed1RMcmIj4hGWv+vokNe26jT7vy+O6T2nB1ssy3flH2PfQNRf8p+5CUlPpCEmMlVl4kIiKiguNRcBy+3e2DP2+HqtrExcqhdWwxs60j7Ez1FO0fkRIYlCIiygPe/hEYPM0DZ248V7W1rF0Mqya2U6zYeBEbE8z8sjG+7lMTy7Zfxcqd12QxdFEUfcPe29i0/w56ti6H7z6po1oBkJQXER2PnuN3IyQiTm63b1gCk4c0ULpbRERElE3R8cn44Zgffjzmh9jEl1cqAdR3McGSD4uhtrOJov0jUhKDUkREueyfE174cs4hVRBBR0dLBhG+6VML2trKr5BmZ2kM92ENMbJXTSz/4ypW/HEVYZHxMgtHrNy39aAnPm5ZBqM/qYOKJW2U7i40vTj+pzMO4M6jYLldrrgVVk9qpxavIyIiIvrvBUp23AzFqD0+eBoar2ovYqqLH9s7o18Na/5PJ43HoBQRUS6Ji0/EhBWn8POOa6o2FwczrJ3shnqVi0LdWJsbYuLg+hjevYbMmlq6/YoMpIlAyO+H7uGPw/fQuVlpWTC9Smk7pburkcT0z90nH6pWatw2qxPMTQyU7hYRERH9h1v+MRj5tzf+9YpQtYmFkf/XqAgmtyoKc0OunEskMChFRJQL7nuHYKC7B67dD1S1fdi0FJaNbQUrM0OoM0szA4wdUBdfdq+OVbuuY9HWy3gRFivrYP159IG8dWzsKvepUY6FtfPLziP38cP68/J7cRV1vbsbShdjzS8iIiJ1FhqTCPdDz7H0TACSXi2qhzZlzLCoUzFUsDdSsntEaodBKSKi97Rl/x18Pf8oomIS5LaBvg7mDG+CoZ2rQEtUrywgzIz18W3f2visazWs/usGFm69jIDgaHmfyNYRN7cGJWRwqk5FB6W7W6jdeBCIz2cfVG3P/KIRWtUtrmifiIiIKGsi03zdpRf4fr8vAiITVe0lrPSxoGMxdK5oUaDOC4nyC4NSRETvKDI6HqMWHsMmjzuqtjIuVtjg7lagp7uZGOnJelOfdqmKtf/cxILNl/A8KEre53Hmsby1quMig1MNqzoq3d1CJzA0WhY2FyskCmJlxOE9aijdLSIiIsrCee8oDP/rKS74pF7MEwx1tfB9cweMbuYAIz1tRftHpM4YlCIiesdMlv7uHrj/NETV1q99Bcz7urkM6hQGRga6+LJbdQzuVBm/7buNeRsvwicgUt53+MJTeWtawxnjBtZFk+pOvPqXCxISk/DJ5H146pdaf6J2hSJY/F1L/m6JiIjUkH9EAr738MXaSy8ytHerYom5HzijuBXrQBL9FwaliIhyuIrKL7uuY/zyk4iLT5JtpkZ6WDiqBXq1LY/CyNBAF59+VBUDOlTC5v13MPe3i3j8PFzed/yKj7yJjKlxA+qiRe1iDKC8hzGLj+PkVV/5vYONCbbM7CB//0RERKQ+EpJSsOxMAKYcfIbwuFeFoyraG2Lxh8XQqrS5ov0jKkh4pktElE0hEbH4cs5h/HPCS9VWvawd1k1prxEFqPX1dDCwY2X0dauAbQc98dOGC/DyDZP3nb7+DB+O+hN1KzlgbP+6aFu/OINTObTm75tY9ecN+b2+nrYMSBW1NVW6W0RERJTO4QfhclW92wGxqjZzA21Ma+OILxvYQ0+H5z9EOZGjya1LlizBBx98gLJly6Jq1aoYPHgwHjx4kGGf2NhYjB8/HpUqVUKZMmXw6aefIjDw1WpUREQF0dkbz9Fw8JYMAakvPq6Gw8u7a0RAKj09XR30a18Rl377BKsntkVZFyvVfedv+eHjsX+j6bBt2HPyocwso/926povvl1wVLW95LtWLCZPRESkRp6ExKHbRi+0/vV+hoDU4No2uD+6Mv7XuAgDUkR5HZQ6e/YsBgwYgH/++QdbtmxBQkIC+vTpg+joVwXd3N3dcfDgQaxcuRI7duyAn58fhg4d+i59IyJSi5VU5m68gHYj/4C3f2qdH2tzQ2yb1RE//a8ZDPQ1N+FUV1cbPduWx4X1fbHe3Q0VS9qo7rviGSCLdTccsgV/Hn0gf4+UOfG66jtpLxJfrhs9vEd19G1fQeluEREREYCYhGRMPfQM5efdwo6boar2usWMce6r8ljdrQTsTQtHPVEiJeTo09SmTZsybC9cuFBmTF2/fh3169dHeHg4tm7diqVLl6Jx48ZynwULFqBZs2a4dOkSatWqlbu9JyLKQ/4vojB05gEcueitamtQ1RFrJ7WDcxEzRfumTnR0tPFxy7Lo0ryMzCT7YcN5XL8fJO+78SAI/SbvRYWS1hjTvy66Ni8t96dU0bEJ6DV+N4JCY+R2y9rFMOPz1P+fREREpByR7f3nrVB8u8cHj0PiVe32prqY4+aEATVtoK3NzCii9/Vel/hFEEqwtEyduiKCUyJ7qkmTJqp9SpcuDScnpyyDUnFxcYiPf/Umj4xMXdkpOTlZ3vKCOK74I5NXx6ec4XioH45J6upyw2YdRGBIarBAlEca/UkdjOtfR2YI5efvpiCNR6cmrujYuCQ8zjzGDxsu4PLdANl+51EwBk31wKw1lvL32K1lGfl7LIhyazzEMT6ffQjX7qdOcS/paIE1k9tBWzv1MUh93h8cDyIizXInIAb/+8cbB++nZskL4praiAb2cG/jCAtDHUX7R1SY6L7PCdqUKVNQp04dlC+fuuKUqB2lr68PCwuLDPva2dllWVdKZFXNnz//jXaxf0xM6ofB3Cb6HhYWJk9itcXZPymK46F+NHlMEhKTsXD7Taz8866qzd7KEPNG1EeDyvYIDk7NAMpPBXE8apU2wbapzXD8mh+W/nEbV+6lLpV83ztUBvtmrD6DL7tWQOcmxaFXwIJTuTUeK3bdwc4j9+X3Jka6WP5dfSTGhiMgNvWCD6nP+yMi4tWHEiIiKrzCY5PkVL3FpwOQmO56RKvSZljcqRgqFjFSsntEhdI7B6VEMXNPT0/s2rXrvTowfPhwDBs2LEOmVO3atWUgy8zMLM9OYMWqUOIxCsoHvMKM46F+NHVMnjwPx+AZ+3Hhtr+qrXVdF6z8vjXsrIwV61dBHo/ubYugW5uqOHbZR2ZOnbr2TLY/9Y/EuBUXsGLXXXzbtxb6tKsAA/2CcdUxN8Zj3+lHmL/1hioLb82kdmhUs2Qu91Qz5Mf7w9DQME+OS0RE6kHUvvztSjDG7vOBf2Siqt3FUh/zOzija2VLripMpE5BqQkTJuDQoUPYuXMnHB0dVe3ihFBMxRNXLNNnS4msJ3FfZgwMDOTtdeLEMi8/fIk/Knn9GJR9HA/1o2lj8texB/jqh8MIjYyT27o62pg6rCFG9KyhFvUCCvp4tKxTXN5OXPXBD+sv4Oil1DpdT/wi8L95R/HjhosyODWgQyUYGqh/8fj3GY87j19g6IwDSFuYcNKQBujQuFTud1KD5PX7o6C+74iI6L9d9InCiL+9cfZplKrNQFcLY5s5yJuxPv8HEOWlHL3DRGq8CEh5eHhg+/btcHFxyXC/KHqup6eHkydPqtoePHgAX19fFjknIrUUG5eIb+YfkaufpQWkShQ1x6Fl3fC/3jXVIiBVmDSp7ozdC7rg4LJuMgstjW9gJEYtPIbKvdZj2fYrsgB4YRQSEYte3+9GRHTq8+vaogxGf1Jb6W4RERFpnMDIBHy64wnqLrubISDVpZIl7nxbCVPbODIgRZQPdHM6Ze/PP//EmjVrYGpqioCA1AK2YpqdkZERzM3N0atXL0ydOlUWPxftEydOlAEpBqWISN14PgnGAHcP3PR6VSeqS4vSWDq6FSxM38zgpNzToIoj/pz7ES7e9pOr9e07/Vi2+72IwtilJzB300V83asWhnSuDFNjfRQGiYnJGOjuAS/fMLldtYwtVoxrzekARERE+SgxKQXLzwZi8sFnCItNUrWXtzPE4g+LoU0Zc0X7R6RpchSU2rBhg/zarVu3DO2iUHnPnj3l9+7u7jLNXdSJEivrNW/eHLNmzcrNPhMRvReR9bnJ4w6+XXAU0bGpdQMM9XXw48hmGNSpEoME+ah2RQf8PudDXPUMkDWn/jnhJdvFqocTVpzE/M0X5RTKYV2qwtykYAcKJ/18Sq7qKNhaGmHrzI4wMdJTultERESFxtPQeARFJapqDgaHxMM6IVo1Dft+UCxm/PscN/1jVT9jZqAN99aOGNHQHno6PAckUuuglJiGl51ioCIIxUAUEamjiOh4fD3vCLYd9FS1lS9hjfXu7VHJ1UbRvmmy6uXssWVmB5m19uOGC9h19L6sufQiLBbuv5zBoi2X8WX36vji4+qwNCt4wanNHnewZPsVVb2yTdM/gIsDr8QSERHlZkCq3NybiE18WbRRJfNV4IUBNW0wp70THMx4kYhIKZwkS0QaQ2TjNB6yJUNAamDHSjj+S08GpNRE5VK22DC1Pc6v74sercupanqFRMRh5ppzqNhjLaavPovg8FdXONWdmKI4Yu6/qu15XzdDo2pOivaJiIiosBEZUm8GpDJXy8kYp78oh3U9SjAgRaQwBqWISCOm6y3/4ypafrldVc/HzFgPa6e4YemYVjA25MmIuqlQwgZrJrfDpd/6oa9bBei8TKcPj4rHD+vPo2L3tZiy8hQCQ6Ohzp4HRaLXhD2Ii0+tWTGkcxV5IyIiImVMbOGA81+VR4Pipkp3hYgYlCKiwu5FWAx6fr8bYxYfR3xCsmyrWd4ep1b3RvdWZZXuHv2HMsWssHJ8G1zd1F9mtYmpb0JkTALmbbqESj3WYfyyE/B/8WrVHHVa2bHPxD2yeLvQqJojfhrZVOluERERFUoBkdlbubdLZSuurkykRhiUIqJC69Q1XzQcvAV7Tz9StY3oUQOHlnWHq5Olon2jnCnpaCGz2q5v6Y+hH1WBvl7qvy9RqH7xtiuo1HMdRi86hmeBkVCX7Lz/zTuCC7f95XaxImbYOP0D6OvpKN01IiKiQiE5OQXnnkZh0gFf1Fx8G+3XPlC6S0SU14XOiYgKgqSkZPy08SJmrT0nT1gEawtD/DK+DdwalFS6e/QeRHHwhd+2wOh+tbFgy2Ws++cmYuOT5G3FjmtY/fcNDOhQCd/2rS0DQUpZ9vtVucKjYGyoi22zOsLO0lix/hARERUGYbFJOHAvHLvvhmKfZzgCX660R0QFF4NSRFSoiBo+Q6YfwPErPqq2xtWdsGZSOzjasXZAYeFkb4a5/2uG7/rWxqKtl/HrXzcQE5cop2iu+vMG1u2+hb7tK8j7Szha5Gvf/r3wFOOXn1Rt//x9G1QtY5evfSAiIioMROaxZ2Ac9twNk4Gok48jkZhajeEN5e0McTew4CyEQkSpGJQiokLjwNnHGDbrIIJCY+S2qBfw/cC6GPNJHei8rEVEhYuDrQlmD2+Cb/rWwtJtV7By13VExSQgITEZ6/65hd/23kbvtuXxXb86KF0s76dsevmEYoD7PlWG3pj+ddC1RZk8f1wiIqLCIi4xGccfRWL3nTDs8QyD14u4TPcz0ddGm9Lm6FjBAu3LmcMvIhG1lqRmKRNRwcGgFBEVePEJSZi66ozMmElT1NZErt7WpLqzon2j/GFvZYxpnzfC/3rXlFPnft5xTa7Ul5SUgo377mDz/ruysP3oT+qgfAnrPOlDeFQcenz/D0IiUk+eOzQqiYmD6+fJYxERERUmz8MTsNczTAaiDj4IR1R85ulQrtb66FjeEh3KW6CZqykMdF9ddBQZVIa6WohNTL0wlBlxv60JPwITqRO+I4moQHv0LAyDpnrg4p3UgtKCW4MScsqUraWRon2j/GdjYYTJQxtgRM8aWPHHNSz//SpCI+Nk5tK2g57YfshTZi6N6V8XlVxtcu1xxfGHTj8AzychclsEvlZNbMvVfSiDgIAALFmyBKdPn0ZsbCycnZ0xZcoUVKxYUTVNZeXKldi1axciIyNRrVo1jBs3Di4uLkp3nYgoV4n/mxd9o19OywvDZd/oTPcTMacmJcxkEErcytkZQEsr8/+tLpb68PyuMoJe1plKTk5GcEgwrK2soa2dGrwSASmxHxGpDwaliKjA2vHvPYz46V+ZESPo6WpjxueN8GX36lmesJBmsDIzxPhB9TC8R3Ws3HkdS7ZfQXBYLFJSxOvmvrx92LQUxg2omyv1nqavPqta5dHKzADbZ3eEuYlBLjwTKizCw8MxZMgQ1K5dG4sWLYKVlRW8vb1hbm6u2mf9+vXYunUr3N3d4eTkhBUrVmDEiBHYvn07DAz4eiKigi1cFCm/Hy4DUSIrKiAy8yLldia6cjqeyIhqW9YcFobZX7lWBJzSgk4iKBWgFwl7e2NVUIqI1A+DUkRU4ETHJmDskhNY+89NVZurkwXWTXFDzfJFFO0bqRcRGBJT9r74uJoshr5wy2VVzbG/j3vJ2wcNS2LsgLqoVaHIOwdHf/rtgvxeZEatd28PV6e8r19FBYsIOBUpUkRmRqURgac0Iktqy5YtMnDVvHlz2TZt2jS0bdsWR48eRbt27RTpNxHR+7gXGCszoUQg6vijiCyLlNdwNJKZUCIQVdvZGDrMNCbSGAxKEVGBcvvRC1lI+s6jYFVb99ZlsWhUC2amUJZMjfXxde9aGNalKtb8fRMLNl+Cf3DqVAGR4SRubeoVl5lT9SoXzfZxr98PxOezD6m2Z3/ZGC3rcKoVven48eOoX78+xo4di8uXL8POzg7du3dHly5d5P2+vr548eIF6tatq/oZU1NTVK5cGTdu3GBQiogKhPiXRcrTpuU9yKJIubGeNtqUSZ2W90E5CzhZcEodkaZiUIqICgSRRbB+zy2MXnQcMXGp6d5GBrqY93UzfPJBRU7Xo2wxNtTD8B41MKRzFazffUsGp3wDI+V9B889kbcWtYthbP+6aFz9VRZLZgJDotFz/G7V67Ff+wpy6ihRZkTQaceOHejbty8GDRqE27dvY+7cudDT00PHjh1lQEqwsclY68za2lp13+vi4+PlLU1UVJRqyoq45QVxXPH3OK+OTznD8VAvmjoefhGiSHm4nJJ38H4EIrMoUl7SSv9lEMoczUqawlDv1ZS6vPidaep4qCuOh+aNR3I2j82gFBGpPbGqmagdJeoApalY0gbrp7qhQoncK1ZNmkMEND//uBoGdaokV+ebt+kinvpFyPuOXPSWNxGUEplTzWo6q4KeSUnJOHnVB7e9nmHdXi94+6f+TJ2KRbDw2xYMjtJbT8xEQfOvvvpKbpcvXx5eXl4yUCWCUu9i7dq1WLVq1RvtQUFBiI7OvGhwbjyPsLAweSLLGi3K43ioF00Zj+SUFFwPSMChh7E49DgW1/wTMt1PRwuo66iPNq6GaFXSEGWsdF/+n4xFeEgswvO6nxoyHgUFx0PzxiMiIvU8+b8wKEVEau3yXX85Xe/Rs1enLiLLZc7wJjKwQPQ+DPR15eupf4eK2LL/rqwNlfZaO3nVFx2v7kL9ykUxbmBdRMbEY+ziE6rMqjSWZgbYMqMjDPl6pLewtbVFyZIlM7SJ7X///TdDhpTIihL7pgkODkbZsmUzPabIuBKZV+kzpTp06CB/Xkz9y6uTWPGhUkw/5IcK5XE81EthHo+IuCSZBbXHMwz7PMPhn0WRchtjHVmkXEzJa1fGDJZGyv1vLMzjURBxPDRvPAwNDbO1H8+giUhtlwpe9vsVTF55Ggkvq2JamOpjyehW6NqijNLdo0JGT1cH/TtUQp92FfD7YU/8uOEC7nuHyvvO3nyOj777K8ufDY2Iw7lbz9G5Wel87DEVNNWqVcOTJ08ytIntokWLqoqei8DUhQsXUK5cOdkWGRmJmzdv4uOPP870mPr6+vL2OnFymZcn/OIkNq8fg7KP46FeCtN43A+KlbWhxO3Yo0gkJKVkul+1okboWN5CTs2rW8xErYqUF6bxKAw4Hpo1HtrZPC6DUkSkdgJDo/H5rEPYf/axqk1Mj1o72Q0lHC0U7RsVbrq62ujdrgJ6tC6HHUfuy+DU3ceviupnRpx6j11yHB0bu0JHhydZlLk+ffpg8ODBWLNmDdq0aYNbt25h165dmDBhgurEsHfv3li9ejWKFSsmg1QrVqyQVzDTVuMjIsrrIuUnH0eqVsu7F5R5kXIjPS20Lm0uA1EflLeAM4uUE9F7YFCKiNTK8Ss+GDJ9P54HpRbsFb7pXQuTP60vs1mI8oMILonAVLeWZTFn/TnMWns+y33FdWOfgEicuv4MTWs452s/qeCoVKmSLGy+dOlS/Prrr3B0dMSoUaPQvn171T4DBgxAbGwsZs2aJeswVK9eHYsXL4aBAVcWJaK84R+RgH2eqSvlHbgfjoi4zAsTl3hZpFzcmruawShdkXIiovfBoBQRqQVRQHr2+vP4Yf15pLzMDre1NMKqCW3Qpl4JpbtHGkpbWwuli1lla1+/F68CqUSZadKkibxlRWRLff755/JGRJRX5RGuPIuWmVAiEHXBJ/NFEUTib6PipqpAVEV7Qy7mQUR5gkEpIlKcb0AEBk/fj1PXnqnaxIpnqye2g4OtiaJ9I3KwMcnV/YiIiPK7SPmh++EyELXXMxzPIzJfLc9aFCkva4GOFUSRcnNYGfOjIhHlPf6lISJF7Tv9CJ/NPojgsFhVZsrEwfUxqm8t1uchtdCoqiOc7EzxLDBSTtV7nbhu7GRvKvcjIiJSB14v4rD7TqhcLe/Yw0jEZ1GkvKqDkcyEEoGoempWpJyINAODUkSkiLj4RLmy3rLfr6raxAf/tVPc0JAf7kmNiODojyObot+kvTIAlf60Pu3U/YcRTRlEJSIixYiV8USR8tRpeaHwDMy6SHmrUuYyECWKlLtYskg5ESmLQSkiyndePqEYONUDVzwDVG1i5bLl41rD2txQ0b4RZaZzs9LYOP0DjFl8HL6Bkap2kSElAlLifiIiovwUECmKlKdOy9t/LwzhWRQpF4EnsVKeCES1KMUi5USkXhiUIqJ8tf2QJ/43919ERKfWM9DX08bML5vg865VWUCT1JoIPIng6cmrPrj3yA9lSzqgcXVnZkgREVG+SElJwdVnMbJAuQhEnfeJUi0Ok56YgdewuKkqEFWpCIuUE5H6YlCKiPJFVEwCRi86hg17b6vaSjtbYr27G6qVtVe0b0TZJQJQTWo4o5yTPuzt7aGtzYAUERHlnci4JBx+ECEDUXs9w/AsPOsi5W5lU4NQbmXNYc0i5URUQPCvFRHluZteQRjgvg+eT0JUbb3blcf8b5rDzJi1DIiIiIjSPHwRJzOhRJHyI14RWRYpr/KySLm41S9mAl0dZkMRUcHDoBQR5Wma+eq/b2LckuOIjU+SbcaGuljwTQv0bV9B6e4RERERqUWR8lOiSLln6rS8OwGpKxK/zlBXCy1LmaFjBUt8UM4cxa0M8r2vRES5jUEpIsoToRFxGP7TYfx59IGqrUppW6x3b4+yLlaK9o2IiIgoNzwNjUdQVKL8Pjk5GcEh8bBOiFZN77Y10c10hTvxM/s8xUp5okh5OMJiUy/eva6YhZ7MhBKBqBauZjDW57RxIipcGJQiolx34bYfBrp74IlfuKptWJeqmPVlYxga8M8OERERFY6AVLm5NxGb+Pr0usAM2U2e31WWwaVrz2NkJpQIRJ3zzrpIeQMXE1UgqjKLlBNRIcdPh0SUa5KTU7Bo62VMXXUGiUmpyxJbmhpg+bjW+LBpKaW7R0RERJRrRLbTmwGpjMT93/zjLYNQvlkUKbc01EH7cuYvi5RbwMaEH9GISHPwLx4R5YqAkGgMm3kAh84/VbXVq+SAtVPc4OJgrmjfiIiIiJSy81boG22Vihii48si5Q1cTFmknIg0FoNSRPTejlzyxtDp++EfHC23RZb5qL61MWFwPejp6ijdPSIiIiJFGbwsUi5XyytngRLWLFJORCQwKEVE7ywxMRkz157D3I0XVHUR7K2N8euEtmhZx0Xp7hEREREpbkEHZ3xazxYm+rxQR0T0OgaliOidePtHYPA0D5y58VzV1qqOC36Z0BZFrI0V7RsRERFRXkt4WT/zvzR1NWNAiogoCwxKEVGO/XPCC1/OOYSQiDi5raOjhSlDG+Dr3rWgLZaNISIiIirEnoXHY9jOJ0p3g4iowGNQioiyLTYuERN/PoWfd1xTtbk4mGHtZDfUq1xU0b4RERER5YcTjyLQY/ND+EUkKt0VIqICj0EpIsqW+94hGOC+D9fvB6naPmxaCsvGtoKVmaGifSMiIiLKaykpKVh8KgDf7fVBYvZm7sFQVwu2JvzIRUSUFf6FJKIMkpKScfKqD+498kPZkvFoXN0Z2w954uv5RxEVkyD3MdDXwZzhTTC0cxVoiaX2iIiIiAqxqPgkDNv5FJuvBqvaWpU2w0/tnZCC1HOh5ORkBIcEw9rKGtra2rJNBKRcLPUV6zcRUaELSp09exYrVqzAjRs34O/vj9WrV8PNzU11f1RUFGbNmgUPDw+EhoaiWLFiGDx4MPr375/bfSeiXPbXsQcYs/g4fAMjVW3GBrqIjnuVnl7GxQob3N1QpbSdQr0kIiIiyj8PgmLRdeND3PCLUbWNbVYEM9o6QVfn1cU5EZQK0IuEvb2xKihFRES5HJSKjo5GxYoV0atXLwwdOvSN+6dOnYpTp05hyZIlMiB17NgxjB8/Hg4ODmjbtm1OH46I8jEg1W/SXqS81p4+INWvfQXM+7o5TIz08r1/RERERPlt951Q9Nv2GGGxSXLbVF8b63uUQNfKVkp3jYhIM4NSLVu2lLesXLx4Ed26dUPDhg3ldr9+/bBx40ZcuXKFQSkiNZ6yJzKkXg9IpWdlboBlY1pBR4dX/oiIiKhwS0pOwdRDzzH93+eqtvJ2htj1SSmUt2ctTSIita0pVbt2bRw8eFBmUonsqNOnT+Phw4dwd3fPdP+4uDjEx8ertiMjI1Xpr+KWF8RxRaHCvDo+5QzHQ3mihlT6KXuZCQmPk/s1qeGcb/2iVHyPqBeOh+aNB8eaSLMERyei79ZH8LgXrmr7uLIl1nYvATMDHUX7RkRU2OR6UGr69OkYM2aMDE7p6urK+dQ//vgj6tevn+n+S5cuxfz5899oDwwMREzMq3nbuX1yGRYWJk9iOd9beRwP5Ymi5tndr5wTi3XmN75H1AvHQ/PGIyIiIk+OS0Tq5+qzaHTd6IVHwakXzbW1gDluTviuaREu7kJEVBCCUmvXrsXly5flV2dnZ5w7dw4TJkxAkSJF0LRp0zf2Hz58OIYNG5YhU0oEtOzs7GBmZoa8OoEV/1TEY/ADhfI4HspKTk7BVa8b2dq3bEkH2Nvb53mfKCO+R9QLx0PzxsPQkFN1iDTBhksv8NmuJ4hNTC1oYGeii629S6JlaXOlu0ZEVGjlalBKZDbNmTMHv/76K1q3bi3bRFH0W7duYeXKlZkGpQwMDOTtdeLEMi9P9sUJbF4/BmUfx0MZ/i+iMHTmARy56P3W/cR1QSd7UzSu7swxUgjfI+qF46FZ48FxJirc4hOT8c1uHyw/G6hqq1vMGH/0LYVilswQJyIqMEGpxMREJCQkvHHyJrZZj4FIvRw+/0QGpAJDYt4IQKUveJ6WqP7DiKYsck5ERESFim9YPLpveogzT6NUbZ/Vs8WiTsVgoMvzHiIitQtKRUVF4dGjR6rtp0+f4ubNm7CysoKTkxMaNGiAGTNmyFR3MX3vzJkz2LFjByZPnpzbfSeid5CQmIQZq89i3qZLqjYHGxOsntQWoRFxchW+9EXPRYaUCEh1blZaoR4TERER5b7jDyPQY/ND+Ecmym0DXS2s+MgFg2rbKt01IiKNkeOg1LVr19C9e3fV9tSpU+VX0bZw4UIsX74cs2fPxogRIxAaGioDVaLwef/+/XO350SUY0+eh2PQNA+cv/WqsHmbesWxcnwb2FsZy+2OjV3lKnuiqLmoISWm7DFDioiIiAoLsTDColMB+G6vD5JeTuYobqmPHf1cUcvZROnuERFplBwHpRo2bAhfX98s7xdFkBcsWPC+/SKiXPbn0QcY/uNhhEbGyW1dHW1MHdYQI3rWgLZYWuYlEYBqUsNZrrIn3s+spUJERESFRVR8EobueIKt10JUbW3KmGFzL1fYmuT6GlBERPQf+JeXqJCLjUvEuGUn8Oufr1bYK1HUHOumuKF2RQdF+0ZERESUX+4HxaLrb1646R+rahvfwgHT2jhCJ90FOiIiyj8MShEVYp5PgjHA3QM3vYJUbV1alMbS0a1gYfrmqpdEREREhdHft0PxybZHCI9Lna9nZqCNDT1K4qNKlkp3jYhIozEoRVRIayVs8riDbxccRXRsavFOQ30d/DiyGQZ1qiSXTyciIiIq7JKSUzDl4DPMPPKqnmZFe0Ps/KQUytkZKto3IiJiUIqo0ImIjsfX845g20FPVVv5EtZY794elVxtFO0bERERUX55EZWIvtseYf+9cFVb9ypWWNOtOEwNdBTtGxERpWJQiqgQueoZgAHu++DlG6ZqG9ixEn4c2RTGhnqK9o2IiIgov1z2jcbHG73wOCRebouFhH9wc8a3TeyZMU5EpEYYlCIqJNP1Vuy4hokrTiI+4WWtBGM9LB7dCt1blVW6e0RERET5Zt3FIHzx51PEJqbIbTsTXWzv44rmpcyU7hoREb2GQSmiAu5FWAy+mH0Ie08/UrXVLG8vV9dzdWLxTiIiItIMcYnJ+Pofb/x87tUCL/WKmeCPfq5wttBXtG9ERJQ5BqWICrBT13wxeNp++AZGqtpG9KiBqZ81hL4eayUQERGRZvAJi0e3jQ9xzjtK1fZ5PVss7FQMBrraivaNiIiyxqAUUQGUlJSMnzZexKy155CcnJqabm1hiF/Gt4Fbg5JKd4+IiF6zcuVKrFq1KkNb8eLFsWPHDvn9sGHDcPny5Qz3d+3aFePHj8/XfhIVREe9ItBzy0MERKauOGygq4WfP3LBwNq2SneNiIj+A4NSRAXM86BIDJl+AMev+KjaGld3wppJ7eBoZ6po34iIKGuurq5Yvny5altXN+NpWJcuXfDZZ5+ptg0NuVw90X/V1Jx/IgBjPXyQlFpSE8Ut9bHzk1Ko6WSsdPeIiCgbGJQiKkAOnH2MYbMOIig0Rm5ra2vh+4F1MeaTOtARy8oQEZHaEkEoW9usMzdEEOpt9xPRK5FxSRiy4wm2Xw9RtbUtY47NvUrCxoQfcYiICgr+xSYqAOITkjB11Rks2vpqakdRWxOsmdwOTao7K9o3IiLKnqdPn8LNzQ0GBgaoUqUKhg8fDgcHB9X9+/btw969e2FjY4OmTZti6NChzJYiyoRnYCy6/uaF2wGxqrYJLRwwtY0jdLS1FO0bERHlDINSRGru0bMwDJrqgYt3/FVtbg1K4Ofv28DW0kjRvhERUfZUrlwZ7u7uso5UUFCQrC8lgk7btm2DiYmJDFYVLVoUdnZ2uH//PpYsWYInT57gp59+yvKY8fHx8pYmKiq1wHNycrK85QVxXDFlKq+OTzmjiePx5+1QDPz9CSLiUp+zuYE21nUvjs4VxYrDKapam0rQxPFQZxwP9cLx0LzxSM7msRmUIlJjO/69hxE//YvwqNQPHXq62pj+eSN81b06tLR4JZCIqKBo1KiR6vsyZcrIIFXHjh1x8OBBfPTRR7KoeZrSpUvLaXxffPEFfHx84OyceUbs2rVr3yieLoigV3R0dJ6dYIaFhckTWW1tThtXmiaNR1JyCn44E44lF16tOFzORherO1qjlFU8AgICoDRNGo+CgOOhXjgemjceERER2dqPQSkiNRQdm4CxS05g7T83VW2uThZYN8UNNcsXUbRvRET0/szMzGTWlAg6ZUYErQRvb+8sg1KDBg1C3759M2RKdejQQQa0TE1N8+wkVlwUERld/FChPE0Zj6CoRHyy7TEOPXgVkOpRxRKrurrA1EAH6kJTxqOg4HioF46H5o2HYTZLEDAoRaRmbj96gQHu+3DnUbCqrXvrslg0qgXMTQwU7RsREeUOkckkAlIffPBBpvd7enrKr28rfK6vry9vrxMnl3l5wi9OYvP6MSj7Cvt4XPKJwscbH+JJaGrWuFjX5af2zvi6sb1aZo0X9vEoaDge6oXjoVnjoZ3N4zIoRaQmROrk+j23MHrRccTEJco2IwNdzPu6GT75oKJanngREVH2LFy4EE2aNJF1owIDA7Fy5Up5stauXTsZnPLw8JBT/CwsLGRNqfnz56NmzZpyqh+RplpzIQhf/vUUcYmpdaLsTXWxvY8rmrmaKd01IiLKJQxKEamB8Kg4WTtqx7/3VW0VS9pg/VQ3VChho2jfiIjo/fn7+2PChAmyfoOVlRWqVauGdevWye/j4uJw/vx5bNmyBTExMShSpAhatmyJIUOGKN1tIkXEJSZj5N/e+OV8kKqtvosJ/ujrCieLN7MDiYio4GJQikhhl+/6y+l6j56Fq9qGdK6COcObyEwpIiIq+GbPnp3lfQ4ODvjll1/ytT9E6so7NB7dNnnhvPerYv1f1rfDgo7O0NfllB8iosKGn3iJFCKWLF72+xVMXnkaCYmpy2VamOpjyehW6NqC0zWIiIhIsxzxikDPzQ8RGJVaxsBQVwsruxRH/1rMGiciKqwYlCJSQGBoND6fdQj7zz5WtdWpWARrJ7uhhKOFon0jIiIiyu+6mnOP+2Ochy+SU8tHoYSVPnb2K4UaTsZKd4+IiPIQg1JE+ez4FR8Mmb4fz4OiVG3f9K6FyZ/Wh56u+ixrTERERJTXIuKSMPiPx/jjRqiqza2sOTb1KglrY35UISIq7PiXniifJCUlY8768/hhwwU5dU+wtTTCqglt0KZeCaW7R0RERJSv7gbEoutGL9wJiFW1TWpZFFNaF4WONlcdJiLSBAxKEeUD34AIDJ6+H6euPVO1NavpjNUT28HB1kTRvhERERHlt503QzDw98eIiHtZV9NQB7/1KIFOFS2V7hoREeUjBqWI8ti+04/w2eyDCA5LvQqoo6OFCYPqY1TfWtDR4SoyREREpDkSk1Iw8YAvfjjmr2qrXMQQOz8phTK2hor2jYiI8h+DUkR5JD4hCZN+PoVlv19VtTnbm2LNZDc0rOqoaN+IiIiI8ltgZAJ6b32Eww8iVG29q1lh1cfFYaLPuppERJqIQSmiPODlE4qBUz1wxTNA1daxsSuWj2sNa3NeBSQiIiLNcsE7Ch9v9IJ3WILcFsni8z5wxshG9tDSYv0oIiJNxaAUUS7bfsgT/5v7LyKiU0+69PW0MfPLJvi8a1WedBEREZHG+fV8EL766ynik1IXeiliqovtfVzR1NVM6a4REZHCGJQiyiVRMQkYvegYNuy9rWor7WyJ9e5uqFbWXtG+EREREeW32IRkjPjbG79eCFK1NXAxwR/9XOForq9o34iISD0wKEWUC256BWGA+z54PglRtfVuVx7zv2kOM2OedBEREZFmeRoaL6frXfSJVrV91cAO8zs4Q1+XC70QEVEqBqWI3kNKSgrW/H0TY5ccR2x8kmwzNtTFgm9aoG/7Ckp3j4iIiCjfHX4Qjl5bHiEoKlFuG+pq4ZeuxfFJTRulu0ZERGqGQSmidxQaEYcRcw9j15EHqrYqpW2x3r09yrpYKdo3IiIiIiUu1v14zB/j9/siObV8FEpa62Nnv1Ko7misdPeIiEgNMShF9A4u3PbDQHcPPPELV7UN61IVs75sDEMDvq2IiIhIs4THJmHQ74+x81aoqq19OXNs7FkS1sY8NyIioszxPwRRDiQnp2DR1suYuuoMEpOSZZulqQGWj2uND5uWUrp7RERERPnuTkAMuv72EHcDY1Vtk1sVxZRWRaGtzZWHiYgoawxKEWVTQEg0hs08gEPnn6ra6lcuijWT28HFwVzRvhEREREpYceNEAz8/TEi41Mv1lkY6mBjzxLoWMFS6a4REVEBwKAUUTYcueSNodP3wz84dQUZLS1gVN/amDC4HvR0dZTuHhEREVG+SkxKkbWjfjrur2qr4mCEnf1cUdrWUNG+ERFRwcGgFNFbJCYmY+bac5i78QJSXhbstLc2xq8T2qJlHRelu0dERESU7wIjE+Tqev96Raja+lS3xi9dXWCiz4t1RESUfQxKEWXB2z8Cg6d54MyN56q2VnVc8MuEtihizRVkiIiISPOc947Cxxu94BOWILd1tYH5HYpheEM7aIlUciIiohzQRg6dPXsWAwYMQM2aNeHk5AQPD4839rl//z4GDhyI8uXLo3Tp0vjggw/g6+ub04ciUszuE15oOHizKiClo6OFaZ81xK6fOjMgRURERBpp1flANPnZUxWQcjDTxZFh5TCikT0DUkRElD+ZUtHR0ahYsSJ69eqFoUOHvnH/48eP8dFHH6F379747rvvYGpqinv37sHAwODdekiUj+LiEzFhxSn8vOOaqs3FwQxrJ7uhXuWiivaNiIiISAmxCckY/tdTrL74QtXWuIQptvdxRVFzPUX7RkREGhaUatmypbxl5YcffpD3T5w4UdVWokSJd+8hUT657x2Cge4euHY/UNX2YdNSWDa2FazMWLCTiIiINM+TkDh02/QQF31SF3sRRja0x9wOztDTYXYUERGpUU2p5ORkHD58GF988QX69OmDmzdvwsXFBcOHD4ebm1umPxMXF4f4+HjVdmRkpOpY4pYXxHFTUlLy7PhU8MZjy4G7+Hb+MUTFpqajG+jpYPbwxhjyYWWZjq5prxV1GBN6heOhXjgemjceHGvSVAfvh6P3lod4EZ0kt430tLCqa3H0rWGjdNeIiKiQyNWgVFBQEKKiorBs2TKMGTMG48ePx9GjR+U0v99//x0NGjR442eWLl2K+fPnv9EeGBiImJgY5NXJZVhYmDyJ1dbOcVktKkTjIYJQU1dfwc5jj1VtpZzMsOjrBihf3FK+DjUR3yPqheOhXjgemjceERGvVhgj0gTi/TTnqB8mHniG5JerD5eyMcDOfq6oWpS1NYmISI0zpYR27dph2LBh8vvKlSvj4sWL+O233zINSoksqrR90zKlateuDTs7O5iZmeVm9zL0U2S/iMfgBwrlKTUeNx4EYeDUI7jvHapq6+tWHnP/1wwmRppdH4HvEfXC8VAvHA/NGw9DQ07hJs0RHpuEAdsf48/br86POpS3wG89SsDKmAt3ExFR7srV/yzW1tbQ1dVFmTJlMrSL7fPnz2f6M6IAemZF0MWJZV6e7IsT2Lx+DFLP8RBX/37ZdR3jl59EXHxqOrqpkR4WjmqBXm3L5/njFxR8j6gXjod64Xho1nhwnElT3PaPQZffvHAvKE5uiwX13FsVxcSWRaGtzfpRRESk5kEpfX19VKtWDV5eXhnaHz58CGdn59x8KKJ3EhIRiy/nHMY/J169RquXtcO6Ke1Rupilon0jIiIiUsrv10Mw6I/HiIpPnflgaaiDTb1K4oPyFkp3jYiICrEcB6VEzahHjx6ptp8+fSoLmltZWcHJyUkWORe3+vXro2HDhrKm1MGDB/HHH3/kdt+JcuTsjecYNM0D3v6vaoN82a06pn/eEAb6TEcnIiIizZOYlIJxHr6Yd8Jf1VatqBF29Csl60gRERHlpRx/Er927Rq6d++u2p46dar8KtoWLlyI9u3bY86cOViyZAkmT54MV1dXrFq1CnXr1s3dnhNlU3JyCuZvvojpq88iKSm1Wqe1uSFWjGuNDo1dle4eERERkSICIhPQc/NDHH2Yuvq10K+GNVZ2KQ5jfU5bJSIiNQxKiewnX1/ft+7Tq1cveSNSmv+LKAydeQBHLnqr2hpUdcTaSe3gXCRvCukTERERqbuzTyPRbeND+IYnyG1dbWBBx2L4qoGdrNNGRESUHzhniQqtw+efyIBUYEiM3BbnV2P618X3A+pCV5x5EREREWkYseDLynNBGPmPNxJeZpAXNdPD731d0aiEqdLdIyIiDcOgFBU6CYlJmLH6LOZtuqRqc7AxwepJbdGsZjFF+0ZERESklJiEZHz551Osu/RC1dakhCm293WFg5meon0jIiLNxKAUFSpP/cIxaKoHzt3yU7W1rVccP49vA3srY0X7RkRERKSUx8Fx+HjTQ1z2jVa1/a+RPX76wBl6OpyuR0REymBQigqNv449wFc/HEZoZJzc1tXRxtRhDTGiZw1oa/Nki4iIiDTTgXvh6L31IYKjk+S2sZ42fv24OHpXt1a6a0REpOEYlKICLzYuEd8vO4FVf95QtZUoao51U9xQu6KDon0jIiIiUnIF4tlH/TDp4DOkpJaPQikbA+z6pBSqOBgp3T0iIiIGpahg83wSjAHuHrjpFaRq69KiNJaObgULUwNF+0ZERESklLDYJAzY/gh/3Q5TtXUsb4HfepaApRE/AhARkXrgfyQqsCvHbPK4g28XHEV0bKJsM9TXwU//a4aBHStxKWMiIiLSWDf9YtB1oxfuB6WWNBCnRVNbO2JCCweWNCAiIrXCoBQVOBHR8fhm/hFsPeCpaitfwhrr3dujkquNon0jIiIiUtK2a8EY/McTRCcky20rIx1s6lUS7ctZKN01IiKiNzAoRQXKVc8ADHDfBy/fV6noIjPqx5FNYWzIpYyJiIiocHsaGo+gqNQs8eTkZASHxMM6IRrJKVpYdNofm6+GqPatXtQIO/qVgqsNSxoQEZF6YlCKCsx0vRU7rmHiipOIf3nlz8xYD4tHt0L3VmWV7h4REdFbrVy5EqtWrcrQVrx4cezYsUN+HxcXh4ULF+LAgQOIj49H/fr1MW7cONjYMAOYMgakys29idjEl1XLVQLf2Ld/TWus+Kg4jPW1861/REREOcWgFKm9F2Ex+HLOIew59UjVVrO8vVxdz9XJUtG+ERERZZerqyuWL1+u2tbVfXUaNn/+fJw8eRJz5syBqakpfvzxR4wePRpr1qxRqLekjkSG1JsBqTeNbVYEs92cWGOTiIjUHoNSpNZOXfPF4Gn74RsYqWob2bMG3Ic1hL6ejqJ9IyIiygkRhLK1tX2jPTIyEn/99RdmzJiBOnXqyLYpU6agW7duuHHjBqpUqaJAb6kg61HVmgEpIiIqEBiUIrWUlJSMuRsvYubac0hOTr0iaG1hiF/Gt4Fbg5JKd4+IiCjHnj59Cjc3NxgYGMhA0/Dhw+Hg4IA7d+4gMTER9erVU+1bokQJed/169ezDEqJaX7iliYqKkpVZ0jc8oI4rphSn1fHp7fL7u89L18DlDW+P9QLx0O9cDw0bzySs3lsBqVI8eDTyas+uPfID2VLxqNxdWcEhERjyPQDOH7FR7Vf4+pOWDOpHRztTBXtLxER0buoXLky3N3dZR2poKAgWV9q6NCh2LZtG168eAE9PT2YmZll+Blra2t5X1bWrl37Rp0qQRw/Ojo6z04ww8LC5ImstjZrFeU3UdQ8e/sFI0DvVZY55Q++P9QLx0O9cDw0bzwiIiKytR+DUqSYv449wJjFxzNMzbOxMJSFzCOiU0+6tLW1MG5AXYztXwc6OvzjRUREBVOjRo1U35cpU0YGqTp27IiDBw/C0NDwnY45aNAg9O3bN0OmVIcOHeQUQVGXKq9OYsW0MDs7O36oUMBdrzcLmmfG2soa9vbGed4fyojvD/XC8VAvHA/NGw/DbJ7fMChFigWk+k3ai9dLdb4Ii1V972hngtWT2qFJded87x8REVFeEllRImvKx8dHTttLSEiQVxTTZ0sFBwe/dfU9fX19eXudOLnMyxN+cRKb149BGYlSBjOP+GHywWfZ2p/joxy+P9QLx0O9cDw0azy0s3lcvhpIkSl7IkPqbWvHGOrr4MQvvRiQIiKiQklMrxMBKZHVVKFCBVkE/fz586r7Hz9+DD8/P1StWlXRfpLyQmMS8dFvXtkOSBERERUkzJSifHfq+rMMU/YyExufBM+nIShiY5Jv/SIiIsorCxcuRJMmTVC0aFEEBgZi5cqV8gpiu3bt5FS7zp07Y8GCBbCwsICJiQl++uknGZDiynua7YZfDLr+5oUHL+JUbbraQOJbasca6mrB1oSn+EREVDDwPxblO78XUbm6HxERkbrz9/fHhAkTZFFRKysrVKtWDevWrZPfC99++60MUo0ZM0auqNegQQOMHTtW6W6TgrZcDcbQHU8QnZAagbI21sHmXiVRwd4IQVGJqpogoqi5qCGVNk1CBKRcLN+c1klERKSOGJSifBefkJSt/RyYJUVERIXE7Nmz33q/gYGBDEIxEEUJSSkYvdcHi04FqNpqOBphR79SKGltILfTgk4iKCVW2RNFzVmjhYiICiIGpSjfiOUmN+y5jVELj751Py0ATvamaFTVMd/6RkRERKQ0v4gE9Nj0ECcevypzMLCWDZZ/5AIjPQadiIio8GFQivJFeFQcRs49gj8O3/vPgJTww4im0NHhyRcRERFphtNPItFt40M8j0iQ23o6WljcqRg+q2crV0giIiIqjBiUojx3+a4/Brjvw6Nn4aq2IZ2roHE1R0xccSpD0XORISUCUp2blVaot0RERET5m0m+7EwgvtntrSpg7mSuhz/6uaK+i6nS3SMiIspTDEpRnp5kLd1+BZNXnkbCy7MsC1N9LBndCl1blJHb4uvJqz6498gPZUs6oHF1Z2ZIERERkUaIjk/GZ7ueYOOVYFVbs5Km2NbHFUXM9BTtGxERUX5gUIryRFBoDD6ffRAeZx6r2upULIK1k91QwtFC1SYCUE1qOKOckz7s7e1ZpJOIiIg0wsMXcei60QvXnseo2kY1KYI5bk7Q1eF0PSIi0gwMSlGuO3HVB4On7cfzoChV2ze9a2Hyp/Whp6ujaN+IiIiIlLb3bhj6bn2E0NjUFYlN9LWxpltx9KhqrXTXiIiI8hWDUpRrkpKSMWf9efyw4QKSk1Nkm62lEVZNaIM29Uoo3T0iIiIiRYnzo+n/PsfUw8+RknqqhLK2Btj5SSlUKmKkdPeIiIjyHYNSlCueBUZi0DQPnLr2TNXWrKYzVk9sBwdbE0X7RkRERKS0kOhEfLL9MfbcDVO1fVTREut6lICFITPJiYhIMzEoRe/N48wjDJt1EMFhsXJbR0cLEwbVx6i+tVi0nIiIiDTe9efR6LrxIbxexMltbS1gRltHjG3mAG2xQUREpKEYlKJ3Fp+QhMkrT2Hp9quqNmd7U6yZ7IaGVR0V7RsRERGROth05QU+3fkEMQmp8/VsjHWwpbcr2pQxV7prREREimNQit6Jl08oBk71wBXPAFVbx8auWD6uNazNDRXtGxEREZHSEpJS8N0eHyw+/epcqZaTMXb0c0VxKwNF+0ZERKQuGJSiHNt+yBP/m/svIqIT5La+njZmftkEn3etCi0tpqATERGRZnsenoAemx/i5ONIVdvg2jZY1tkFhnosbUBERJSGQSnKtqiYBIxZfAzr99xWtZV2tsR6dzdUK2uvaN+IiIiI1MGpx5HotskLfhGJcltfRwtLPiyGT+va8uIdERHRaxiUomy56RWEAe774PkkRNXWu115zP+mOcyM9RXtGxEREZHSUlJSsPR0IL7d443E5NQ2Zws97OhXCnWLcSViIiKizDAoRf95grXm75sYu+Q4YuOTZJuJkR4WfNMcfdwqKN09IiIiIsVFxydj2M4n2HQ1WNXWwtUMW/uUhL2pnqJ9IyIiUmcMSlGWQiPiMGLuYew68kDVVqW0Lda7t0dZFytF+0ZERESkDrxexKHrb1647hejahvdtAhmtXOCrg6n6xEREb0Ng1KUqQu3/TDQ3QNP/MJVbcO6VMWsLxvD0IAvGyIiIqI9d8PQb+sjhMamZpOb6mtjbfcS6FaFF++IiIiyg9EFyiA5OQWLt12G+y9nkJiUWhDB0tQAy8e1xodNSyndPSIiIiK1OF+advg5ph5+rmorZ2eAXZ+UQgV7I0X7RkREVJDkeE3as2fPYsCAAahZsyacnJzg4eGR5b5jx46V+6xatep9+0n5ICAkGh+P/RsTV5xSBaTqVy6K02t6MyBFREREBCAkOhGd1j/IEJDqUskS57+qwIAUERFRXgeloqOjUbFiRcycOfOt++3btw+XL1+Gg4NDTh+CFHDkkjcaDNqMg+eeyG2xYvF3/Wpj3+KucHEwV7p7RERERIq79iwatZfewV7P1PIG2lrAHDcn7OjnCnNDHaW7R0REVPin77Vs2VLe3ub58+eYOHEiNm/ejP79+79P/yiPJSYmY+bac5i78QJSUlLb7K2N8euEtmhZx0Xp7hERERGphY1XXsgV9mISUk+YbIx1sLW3K1qX4cU7IiIitakplZycjJEjR+KLL75AuXLl/nP/uLg4xMfHq7YjIyNVxxG3vCCOm5KSkmfHLyh8AiIwZPoBnLnxKv28ZZ1i+OX7NjIwlV+/H46H+uGYqBeOh3rheGjeeHCsNVt8YjJG7fHB0jOBqrbazsbY0a8UXCz1Fe0bERFRQZfrQally5ZBV1cXQ4YMydb+S5cuxfz5899oDwwMREzMq6V1c/vkMiwsTJ7EamvneAZjoXDwgi/GLb+AsKjUgKCOtha+7VUZn35YHkiMREBAanAwP3A81A/HRL1wPNQLx0PzxiMiIiJPjkvq71l4PLpveojTT6JUbUPr2GLJh8VgqMf3PxERkVoFpa5fv47Vq1fL4udaoihRNgwfPhzDhg3LkClVu3Zt2NnZwczMDHl1Aiv6Jx5D0z5QxMUnYeLPp7By53VVm0sRM6ye3Bb1KhVVpE+aPB7qimOiXjge6oXjoXnjYWhomCfHJfV24lEEemx+CL+IRLmtr6OFpZ2L4dO6dkp3jYiIqNDI1aDUuXPnEBQUhLp166rakpKSMG3aNPz666/y/tcZGBjI2+vEiWVenuyLE9i8fgx1c987BAPdPXDt/qv0c7Gq3rKxrWBlpuwJtyaOh7rjmKgXjod64Xho1nhwnDWLyLpbfCoA3+31QeLLmZvFLPTwR79SqFvMROnuERERFSq5GpT6+OOP0aRJkwxtffv2le09evTIzYeiHNp64C6+nncEkTEJcttAXwdzhjfB0M5Vsp3VRkRERFSYRcUnYdjOp9h8NVjV1rKUGbb2Lgk7Uz1F+0ZERFQY5TgoFRUVhUePHqm2nz59ips3b8LKygpOTk6wtrbO+AC6ujKlvnTp0rnTY8qRyOh4jFp4DJs87qjayrpYYcPU9qhcylbRvhERERGpiwdBsei68SFu+L2qaTqmWRHMbOsEXR1ewCMiIlKLoNS1a9fQvXt31fbUqVPlV9G2cOHC3O0dvZcbDwLR390D95+GqNr6ta+AeV83h4kRr/YRERERCbvvhKLftscIi02S26b62ljXvQQ+rmKldNeIiIgKtRwHpRo2bAhfX99s759ZHSnK+1oIv+y6jvHLT8rC5oKpkR4WjmqBXm3LK909IiIiIrWQlJyCqYeeY/q/z1Vt5e0MsfMTV1SwN1K0b0RERJogV2tKkfJCImLx5ZzD+OeEl6qtelk7rJvSHqWLWSraNyIiIiJ1ERydiL5bH8HjXriq7ePKlljbvQTMDHQU7RsREZGmYFCqEDl74zkGTfOAt3+Equ3LbtUx/fOGMNDnUBMREREJV59Fo+tGLzwKjpfb2lrAHDcnfNe0CBeAISIiykeMVBQCyckpmL/5IqavPoukpBTZZm1uiBXjWqNDY1elu0dERESkNjZceoHPdj1BbGLqOZOtiS629S6JlqXNle4aERGRxmFQqoDzfxGFoTMP4MhFb1Vbg6qOWDupHZyLmCnaNyIiIiJ1EZ+YjG92+2D52UBVW91ixvijbykUs9RXtG9ERESaikGpAuzfC08xZMZ+BIakLl0sss3H9K+L7wfUha6uttLdIyIiIlILvmHx6L7pIc48jVK1Datri8UfFoMBz5mIiIgUw6BUAZSQmIQZq89i/uZLSEnNPIeDjQlWT2qLZjWLKd09IiIiIrVx/GEEemx+CP/IRLltoKuF5Z1dMLiOrdJdIyIi0ngMShUwT/3CMWiqB87d8lO1talXHCvHt4G9lbGifSMiIiJSFykpKVh0KgDf7fVBUnJqm4ulPnb0c0VtZxOlu0dEREQMShUsfx17gK9+OIzQyDi5raujjanDGmJEzxrQFsvGEBERERGi4pMwdMcTbL0WomprXdoMW3q7ysLmREREpB74X7kAiI1LxPfLTmDVnzdUbSWKmmPdFDfUruigaN+IiIiI1Mn9oFh0/c0LN/1jVW3fN3fA9LaO0OFFPCIiIrXCoJSa83wSjAHuHrjpFaRq69KiNJaObgULUwNF+0ZEREQ5t27dOixduhS9e/fGqFGjZNuwYcNw+fLlDPt17doV48ePV6iXBdM/t0PRb9sjhMelztczM9DG+u4l0KWyldJdIyIiokwwKKXGdRA2edzBtwuOIjo2tTCnob4OfvpfMwzsWAlaYqk9IiIiKlBu3bqFnTt3okyZMm/c16VLF3z22WeqbUNDw3zuXcGVlJwC90PPMOPfVzU3K9obYucnpVDOjr9HIiIidcWglBqKiI7HN/OPYOsBT1Vb+RLWWO/eHpVcbRTtGxEREb2b6OhoTJo0CRMmTMDq1avfuF8EoWxtuSJcTgVHJ6LP1kfYfy9c1da9ihXWdCsOUwMdRftGREREb8eglJq56hmAAe774OUbpmoTmVE/jmwKY0M9RftGRERE7+6HH35Ao0aNUK9evUyDUvv27cPevXthY2ODpk2bYujQoW/NloqPj5e3NFFRUfJrcnKyvOUFcVyRzZ1Xx8+pK8+i0W3TIzwOSf096GgDc9o54pvG9jKrXF36mVfUbTw0HcdDvXA81AvHQ/PGIzmbx2ZQSk2IF8SKHdcwccVJxCe8rINgrIfFo1uhe6uySnePiIiI3sP+/ftx9+5dbNiwIdP73dzcULRoUdjZ2eH+/ftYsmQJnjx5gp9++inLY65duxarVq16oz0oKEhmZeXVCWZYWJg8b9HW1oaStt+OwtjDoYhNSt22MdLGyg+s0aiYFgIDA6EJ1Gk8iOOhbjge6oXjoXnjERERka39GJRSAy/CYvDlnEPYc+qRqq1meXu5up6rk6WifSMiIqL34+fnh3nz5mHZsmUwMMh8kRJR1DxN6dKl5TS+L774Aj4+PnB2ds70ZwYNGoS+fftmyJTq0KGD/FlTU9M8O4kVGUgieKbUh4q4xGR8s9sXK8+HqtrqOhvj974l4WyhD02iDuNBr3A81AvHQ71wPDRvPAyzWRuTQSmFnbrmi8HT9sM3MFLVNqJHDUz9rCH09VgHgYiIqKATGVLBwcHo16+fqi0pKQlXrlzB9u3bcfr0aejoZPyfX7lyZfnV29s7y6CUvr6+vL1OnFzm5Qm/OInN68fIik9YPLptfIhz3qlTFYXP6tliUadiMNDVzA85So4HvYnjoV44HuqF46FZ46GdzeMyKKWQpKRkzN14ETPXnkNycopss7YwxC/j28CtQUmlu0dERES5pE6dOti6dWuGtmnTpqF48eIYMGDAGwEpwdMzdbETFj5/5ahXBHpueYiAyNRViQ10tbDiIxcMqs3fERERUUHFoJQC/IKiMGTGfhy77KNqa1zdCWsmtYOjXd6k2xMREZEyTExM5JS811PaLS0tZbuYoufh4SGLoFtYWMiaUvPnz0fNmjVRpkwZaDpR72L+iQCM9fBB0suaqcUt9bGjnytqOZso3T0iIiJ6DwxK5bOD5x7j05kHERQaI7e1tbXw/cC6GPNJHeiIJWOIiIhIo+jq6uL8+fPYsmULYmJiUKRIEbRs2RJDhgyBpouMS8KQHU+w/XqIqq1NGTNs6eUKGxOexhIRERV0/2/vXuBsrPY/jv+GMcb9zrjknkolSiVRUaLUqYiocFQcR1LSVYk64qTShVL8dSKnRKeLc0R0PTrVQaVDSoVci5H7MDOM+b++S3u3Z7tkLvt5HrM/79drv9jP3jPzzF6znrWe3/qttWjNPZK5N8se+r9P7clXvggfq165lL3wQHtr3fTQa0UAAIDCacKECeH/p6Sk5HiOA5anplunl1bYsk3p4WND2qTYQ+1qWNEiCb6eGwAAKBgEpTywasN26/3gHFv0zcbwsQ7n1LXn7m1nlcuX8PXcAAAAgubNr7dZz+mrbGfGgfl6ZYsXsSld69kVJ7MrMQAAhQlBqRh7/YPvbcDo92xHWqZ7XiyxiI3od67179LUrXYPAACAA7L2Z9vQuRts1Ic/h481rppsb/RoYI2qHN3W0gAA4NhBUCpG9mTss7vH/ttemLk0fKx+zXL24rAOdvqJ1Xw9NwAAgKDZnLbPrp220uZ9vzN8rGuTCjapcx0rXfzgHQoBAMCxj6BUDHzz4y/Wa9gcW7bql/CxLhc1sqcGt7GypYr7em4AAABB8/m6NOs8daWt3nYgs1x7v4y+pJYNalWVzHIAAAoxglIFvGXxlFnL7I6nPnKZUlKieKI9ftv51uPSxnSqAAAAorywcLP1f2uNZezLds+rlk60V7vXtwsalPH71AAAQIwRlCogO9IybOBjH9hr730XPta4XiWb/GAHO6luJV/PDQAAIGgy9u23gTPX2oQFm8PHWtQuZTOuq2+1yiX5em4AAMAbBKUKwBffbrRew2fbqg07wsduvOJU++uA1i5TCgAAAL9Zuy3Trv77Cluwdnf4WP8WVWzMZbWseGIRX88NAAB4h4hJPqfrPTNjsQ197j+2d9+BLYvLlU6ysXdeaJ3aHO/36QEAAATOByt22jUvr7TUtANLHSQnJtjzV9WxnmeQWQ4AQLwhKJVHm7ftsX6j5tmcT38MHzuzcTX72wMdrG6Ncr6eGwAAQBAH8x6fv9Hunr3e9h9YPsrqVkiy169vYM1qlvT79AAAgA8ISuXB/MXr7IaH3rGfNqeFjw3qfoY90KeFFUtky2IAAIBIOzOy7MbXVtuMJVvDxzo0Kmt/71bPKpakOwoAQLyiF5ALWVn77a+TF9gjUxba/l+H+CqXL2ET72tn7c6u6/fpAQAABM7y1HS76qUV9s2m9PCxoW2r27CLqlvRIuxMDABAPCModZQ2pO6yG/7yjn28eH342Pmn17JJ97e3lMqlfD03AACAIHpj6VbrNeNH25nx69qbyUXtpa517fLG5f0+NQAAEAAEpY7CnE9XWd+R82zL9gMjfEWKJNj9N7SwwdedYUWLskMMAABApKz92Xb/3A321w9/Dh87pVqyvd6jgR1fOdnXcwMAAMFBUOoIMvdm2QPP/8fGTV8cPlazSmn727AO1rJJDV/PDQAAIIg2p+2z7q+stHd/2Bk+1v20Cjaxcx0rlcTamwAA4DcEpQ5j5fpt1mv4HPty+abwscta1bdn77nIKpZlhA8AACDaonVp1nnqSluzLdM9V0L545fWsoHnVrWEBNaPAgAAORGUOoQZ731nAx99z3bu3uueJxUrYg/3b239OjWhQwUAAHAIkxZutpvfWmMZ+w5sBlOtdKJNv7a+nVe/jN+nBgAAAoqgVIS0PXvtrqc/ssmzloWPNaxV3iYP72CnNarq67kBAAAEUca+/XbLzLU2ccHm8LFzapey166vbzXKJvl6bgAAINgISv1q6YrN1mv4bFu+emv4WPf2J9qYQRdYmZJ0qAAAAKKt3ZZpnaeusIXrdoeP3XxOFRvTsZYlJbIZDAAAKOCg1GeffWbjx4+3JUuW2MaNG23SpEnWoUMH99revXtt9OjR9v7779vq1autbNmy1qpVKxsyZIilpKRYEGRl7bePF6+z71b9bI3qZdq5p9V0mVF3j/23pWdmufeUTE60Jwa1sesuOcnv0wUAAPCV1ofS4uWyf/9+27I10yru3W2L1u+2e+dssG3pB/pPyYkJNqFTHetxeiWfzxgAABTaoNTu3butcePG1q1bN7vppptyvLZnzx4XrLr11lvde7Zv327Dhg2z3r172+zZs81vb330g9319L9tfequ8LHk4kUtPeNAZ0pObVjZJg+/xBrVruDTWQIAAAQnIHXCY0st/dd1on6TmuPZceWK2cxeDa1pjZKenh8AAIizoFTbtm3d41CUGTVt2rQcx0aMGGEdO3a09evXW82aNc3PgNT1Q9+26C5VZECq71VNbGT/VpZcnFmNAAAAypA6OCB1sMld6xKQAgAAuRbz6MuOHTvcjnUKWPk5ZU8ZUkfqUlUql2yPDjzPimrvYgAAABy1cskM6AEAgNyLaQ8iPT3dRo4caVdeeaWVKXPo7YAzMjIsMzMz/HzXrl3hNQv0KAhaQypyyt6h/LI93b2vdbNaBfIzcfRUztnZ2QVW3sg/yiRYKI9goTzirzwoawAAgGMsKKVFz/v16+c6iqNGjTrs+8aNG2djxow56Hhqaqpbo6ogaFHzo33fCTXZac9r6uxr/TH9rRQpQqZaEFAmwUJ5BAvlEX/lsXPnzph8XwAAgHiXGMuA1Lp162z69OmHzZKSAQMGWN++fXNkSjVv3tyqVKlyxK/LDe2yd3TvS7GqVasWyM9E7m4oNMVTZc4NXjBQJsFCeQQL5RF/5ZGcnByT7wsAABDvEmMVkFq1apXNmDHDKlaseMT3Fy9e3D2iqWNZUJ3LVk1rWc0qpW1D6q5DriuVYGY1q5Z27+MGwx+6oSjIMkf+USbBQnkEC+URX+VBOQMAAMRGrntZaWlptnTpUveQNWvWuP9rdz0FpJT19NVXX9nYsWMtKyvLNm3a5B6R60Z5TYuXjx54XjgAFSn0/JFbWOQcAAAAAAAgsJlSCjh16dIl/PzBBx90/+rY4MGDbe7cue75xRdfnOPrlDXVsmVL88sV5ze0qX+51O3CF7nouTKkFJDS6wAAAPhN5VKJlpyYYOn7Dr+HsV7X+wAAAHIr1z0IBZaUFXU4R3rNbwo8XdaqvttlT4uaaw0pTdkjQwoAAOBgtcsn2fI7TrHNafvCa3ht2brFKlaoGJ7WqICU3gcAAJBbcTespQBU62a13C57WtScdSIAAAAOTwGnUNBJQalNxXZZ1aol6UMBAIB8ozcBAAAAAAAAzxGUAgAAAAAAgOcISgEAAAAAAMBzBKUAAAAAAADgOYJSAAAAAAAA8BxBKQAAAAAAAHgu0QImOzvb/btr166Y/QxtZ6zvX6JECbYzDgDKI3gok2ChPIKF8oi/8tD3T0hICPdRgip0fmlpaTH9vHfv3u0+E/7+/Ud5BAvlESyUR7BQHvFXHmlpae57/17/KXBBqVBHqnnz5n6fCgAAgFO9enXXRylXrpwFlTqX0rFjR79PBQAAwJo1a+b6J0fqPyVkB2zYTxG7jRs3WqlSpdyoZCwoGqig16JFi6x06dIx+Rk4epRH8FAmwUJ5BAvlEX/loa6Sfk5KSkqgR3fVh0pNTbWSJUvGrA+lwJyCXrNmzXJ9NfiL8ggWyiNYKI9goTzirzyyf+0/VatW7Yj9p8BlSulkNRrpBXVey5Qp48nPwu+jPIKHMgkWyiNYKI/4Ko+yZcta0KkPpY6fF9SBJSgbHJRHsFAewUJ5BAvlEV/lUeYo+mbBHe4DAAAAAABAoUVQCgAAAAAAAJ6Ly6BUUlKS3X777e5f+I/yCB7KJFgoj2ChPIKF8vCWPuc+ffrweQcE5REslEewUB7BQnkES1KAyiNwC50DAAAAAACg8IvLTCkAAAAAAAD4i6AUAAAAAAAAPEdQCgAAAAAAAJ4jKIXAqlmzps2ZM8fv0wAAADhmNG/e3D788EO/TwMAgPgNSt122212ww03+H0a+LUsFFyKfqxatcrvU4vbsrj77rsPem3IkCHuNb0H3lu0aJEdd9xx1qNHD79PJe5QL4KN9tx7w4cPt8GDB/t9GnFP5aDgUvRj7dq1fp9a3JbFyJEjD3rtkUceca/pPfDe//73PzvrrLPs1ltv9ftU4hJ1I9iGH0PteaEMSiFY2rRpY19++WWOR+3atf0+rbhUo0YNmzlzpu3Zsyd8LD093d588013850fe/fuLYAzjE/Tpk2z3r1723//+1/7+eef8/W9srKybP/+/QV2bvEglvUCAPKqZcuWLmM88qHrFbxXrVo1mzt3rmsbQjIyMlyZpKSk5Ot779u3rwDOMD699dZbds0117h7i9TU1Hx9L/pPwasbiB+FPij1wQcf2JVXXmknnXSSnXzyydazZ0/78ccfw69rxEk3HW+//bZdffXV1qBBA7voootc5gIKRlJSklWtWjXHo2jRovbOO+9Y+/btrX79+nbOOefYmDFjDmqYN27caNdff70rF73nX//6l2+/R2Fw6qmnug7t7Nmzw8f0fx075ZRTcl1v1Bno3LmzK8PXX3/d89+nMEhLS3MBEX3GF154oU2fPj382ieffOI+53fffdddl/Q5X3bZZfbtt9+G3/Pqq6+6clKH4IILLrB69erZ+vXrffpt4rtedOnSxe67774c3/uXX36xunXr2vz58z36bQqvs88+2yZOnJjjWLt27ezxxx8PP1d9efnll+3GG2907ca5557r6gbyRtcgfZa6tuj6pMy1devWhV/fsGGDGwl///337U9/+pP7vLt37+6yF5B/xYoVs8qVK+d4qP+kqXnXXXedC1pdccUVNmHChIP6T5s3b7aBAwe6MtF71I4g70488UR38612IET/1033CSeckOs6o+tS3759XRlGtj04ert377Z58+a5fqj+zv/5z3+GX9N9nD7njz/+2Lp16+Y+5z/+8Y/2ww8/hN+j96ucPvroI9d+6z35HRiMRwVVN/r16+eyqyJt3brVWrRoYQsWLPDotym8Lr/8ctc/inTttdfa888/H36uOqMB2TvuuMPVqauuusrVDy8UiYcLli76Cjrp5q1IkSJ20003HRQJVyVQZVAjoRu/m2++mZGLGFJGiFJtdXHShUufv27Gn3766Rzve/TRR+3SSy915aKK0b9/f/v+++99O+/CQCNKqguRWTo6lpd6M2rUKFeG6iCrkUHuqVPUsGFD9+jUqZP7vLOzs3O8Z8SIEfbAAw/YrFmzrFKlSq5jFZmZpgyfZ555xtUX3RzqxgXe1ws17mrMNUIY8o9//MN1zFq1auXhbxPfNMChzpduwtXxHTBggOvYIvd0bVHw46WXXrJnn33WEhISXGc1ui3Qa5p+rA6vMqEVnKUPFRvKCBk2bJgL/qnfdO+997oBuxdeeCHH+8aPH29t27Z1ZdKhQwdXJiydkD9/+MMfcgQ+NKCka01e6sy4ceNcsGTGjBlu0BW5p4CUBn300L2CyiO6//TUU0+54MeUKVOsQoUKdvvtt+e4Nim7Z/LkyXb//fe7dr1ixYo+/CbHvoKoGxr0U8JCZmZm+GvU31Iyw5lnnunhbxPfJk6c6AbC1Q9WYGro0KG2ffv2mP/cQh+U6tixo7tQKXtAI97qrH7zzTf23Xff5XifAlIqAI2sqoIochs5Ao68043B8ccfH37opk7loMBf165drU6dOnbeeefZnXfeaVOnTs3xtcoK0Y2eyuWuu+6yJk2aHNTxQu5oRGnhwoXub1wPjSbpWF7qjW7I9T7dhGiUBLn3yiuvuGBUaKrrjh077NNPP83xnkGDBrk6ogydJ5980qWoR46sKkCl+fxqtBXcKlGihOe/x7GuIOrFJZdc4v5VpypEN426zqnzBW/o81bnVuV0zz33uGzExYsX+31axyQF9RTY0Jp3GvFWMESZBitXrszxPmU0K/Cq9lwZUz/99FOOEXDkjbI8WrduHX5o7TvdMGhgQv2jWrVquSwC9WGjs5XVp1U9UJn8+c9/du1HZOAduafrv64l+vvW46uvvnLH8lJnFFTU+5TdyUBS3ihbP9TuKrC3a9cu+/zzz3O8p0+fPq6OqG+k9XWUvRyZ0aMAldqJ0047zQW3kpOTPf89CoOCqBvqA0tkZo4C7rrW0Yfyjj5vDWSonHSvrgHZr7/+OuY/N9EKOf2hP/bYY25kacuWLeForKa3KN0wRI11iCKyodRnXcSQP0qHVUZNSMmSJcNTJCMzo1Q2GrFQJD10U33GGWfk+F567kXFKMyUaROaJqYRJTUQ0SNDR1tv1Igj79QYqxGfNGmSe56YmOhGmxSoUr2JTKcN0UifgrSRKeiaItu4cWOPz75wKYh6oc6sAlm68VM5LlmyxJYvX24vvviiT79VfIpsz9XelClTxrXnyL01a9bYc88959rdbdu2hf/mNcUlsn+kAaeQ0A226ohu8pB36vMoEypEfSNl1+iGL3KATuWiDE31oUI31ZqWHEnPoweWkDtqf0PTxNRO6P/ly5fPU52JvE4h95Q4oM9YbXKo/6Tp3ApURfaZNJgdUq5cORekjcwY1BTZyOsX/KsbxYsXD2e8qSy1VMWKFSvcACC8E1kf1OaUKlXKteexVuiDUhpN0kjS6NGj3RQKVQDdbEQvyqyLWUgoGstidwVDNwUasY6kqKt2AwiNcETSRQmxpWlJSlWWhx9+OM/1hoyc/FFqrEbpTj/99PAxNeYKMh2qXA5HNyGMIgWjXmj0++KLL3brhig4pY6Zvgb5p+mS0VMzDjVFTDcZkVQ3aM/zRlma1atXd1O/qlSp4j5H1ZPoz50+VGyojdVodSQN3CnjXNeeaGo7EFtan0ttgCiDP691hv5T/ij4pIXJI+8j1D7o+n+o3XQPR/cc9J+CUzeU3akZMlpTWMEpBRj1NfCuDxXZnovqR/TXxUKhDkopqqcIq9ZZ0QKpwkJpwaCpLyqb6GBVtC+++MItPhj5PHLhYeSNUmRDN9LRa0FRb7yhhuC1115za0Wdf/75OV7TOl1amyg0qqp09NAucBpdUsYOWZzBrBca/VYGodZxeeONN3IVXMTvZ7Nt2rQp/Hznzp1u5BWxoWvN6tWrXaC2WbNm7hjTIP2naS8ql+hgVbSlS5e6aRiRzyMXHUbeaJqY2gndqEWvBUWd8a7/pLWGtFaUpuZF0hIs2vUtlKWpjOXQDnBaHkFtxu/de8C/uqG+rfpR6gNrKQQt7YKCocy1yKxxTXcN0sZIiYX9w1c6odYp0pQ8ffCR08jgH0XLe/Xq5W60tU6LorfLli1zqZqRIxyaS6wbPK2Voxs8XcAid1pC3oR27wn9PxL1xru11rRwoDJrypYtm+M1pS8riyqUtaN1pFQmGlnSpgCaVqb53ghmvVCZquyUJUo5FRxlnWl6pdL6VWc0bSO6nFBw9BlruovWKtKUPE2xGDt2rN+nFfe0Ro5uxnWjrSnH6j9pWp6C5toMJrKN0c1d06ZN3U26psxowVrkj645Wpw89P9I1Bnv1lpTgElZNaVLl87xmjIIlWGjnSdFa7CpTNRv0uLaasvZmCfYdUPlqowrZROG1plC/uleWtMrtUatljXQVMog9aEK5ULnSgfUh6yGWhcgRcnVcGuBu9BNHvylBkG7XWgxO92Aa4cGNRzR01w0xU8puroJUVaJdhhr1KiRb+ddmOiCpEc06o03tG6UFgaODkiJ6oTWDNEi2qI1RbQgpNLUtci51ihimkZw64U6VGqDlMrOoqkF056LdtHTqLgGNHr27Gnt27d364Mgdn0obaCgwSJNsdC6Hto1F/5SBoIGKj777DNXDzStWJmZ0VNctOC8di5WkFw7typrU7tLI/8UCIkOhgh1xhu6LzjrrLMOWQYKSmmQO7Tu5i233OIGMLQ7qBY5f+KJJw6a4o1g1Q217WqD9C9LuhRcH0pthZYL0aCGPnvdiwdpeYmEbC8mCXpM200qbZNpEwCOZZ988ombvqoOlkaYcGxYu3atW6he0wuiFxtG7tCee083ceqo5mZdFgAIEm2mpF0ptdPeoQaaEFxak1ODe1OmTMmxuRIKd3teqDKlNF913rx5bjt1bZ0LAIBXtJaC1jxS2rlGowhI5R3tufc0HWb+/PluDbvQumkAAHi1VpjWPBo/frxbP5iAVHy154VqTSlN9dKaQ9qVRCl/AAB4ZeHChS6zTVNkJkyY4PfpHNNoz7330EMPuaxMZadFb74AAEAsqc1Xdlvt2rXDu/ghftrzQjl9DwAAAAAAAMFWqKbvAQAAAAAA4NhAUAoAAAAAAACeIygFAAAAAAAAzxGUAgAAAAAAgOcISgEAAAAAAMBzBKUAAAAAAADgOYJSAAAAAAAA8BxBKQAAAAAAAHiOoBQAAAAAAADMa/8Pm6lL6m5H/6cAAAAASUVORK5CYII=",
       "text/plain": [
-       "   Candidate  Support (%)  Previous (%) Change\n",
-       "0      Smith           42            40     +2\n",
-       "1      Jones           38            39     -1\n",
-       "2   Williams           12            13     -1\n",
-       "3  Undecided            8             8      0"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "=== Demographic Breakdown ===\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Age Group</th>\n",
-       "      <th>Smith</th>\n",
-       "      <th>Jones</th>\n",
-       "      <th>Williams</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>18-29</td>\n",
-       "      <td>35</td>\n",
-       "      <td>45</td>\n",
-       "      <td>15</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>30-44</td>\n",
-       "      <td>40</td>\n",
-       "      <td>42</td>\n",
-       "      <td>12</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>45-59</td>\n",
-       "      <td>45</td>\n",
-       "      <td>35</td>\n",
-       "      <td>12</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>60+</td>\n",
-       "      <td>48</td>\n",
-       "      <td>32</td>\n",
-       "      <td>10</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "  Age Group  Smith  Jones  Williams\n",
-       "0     18-29     35     45        15\n",
-       "1     30-44     40     42        12\n",
-       "2     45-59     45     35        12\n",
-       "3       60+     48     32        10"
+       "<Figure size 1200x400 with 2 Axes>"
       ]
      },
      "metadata": {},
@@ -1132,420 +249,50 @@
     }
    ],
    "source": [
-    "import pandas as pd\n",
-    "import numpy as np\n",
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
     "\n",
-    "# Create sample data for the report\n",
-    "np.random.seed(42)\n",
+    "months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun']\n",
+    "electinfo_series = [12, 15, 18, 21, 19, 24]     # TX-32 engagement index\n",
+    "masai_series = [42, 50, 58, 61, 67, 72]        # Masai client web sessions (k)\n",
     "\n",
-    "# Sample polling data\n",
-    "poll_data = pd.DataFrame({\n",
-    "    'Candidate': ['Smith', 'Jones', 'Williams', 'Undecided'],\n",
-    "    'Support (%)': [42, 38, 12, 8],\n",
-    "    'Previous (%)': [40, 39, 13, 8],\n",
-    "    'Change': ['+2', '-1', '-1', '0']\n",
-    "})\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 4))\n",
     "\n",
-    "# Sample demographic breakdown\n",
-    "demo_data = pd.DataFrame({\n",
-    "    'Age Group': ['18-29', '30-44', '45-59', '60+'],\n",
-    "    'Smith': [35, 40, 45, 48],\n",
-    "    'Jones': [45, 42, 35, 32],\n",
-    "    'Williams': [15, 12, 12, 10]\n",
-    "})\n",
+    "# --- ElectInfo ---\n",
+    "ax1 = axes[0]\n",
+    "ax1.plot(months, electinfo_series, marker='o', color=ei['colors']['primary'], linewidth=2)\n",
+    "ax1.set_title('ElectInfo — TX-32 engagement index', color=ei['colors']['primary'])\n",
+    "ax1.set_facecolor(ei['colors']['background'])\n",
+    "ax1.tick_params(colors=ei['colors']['text_color'])\n",
+    "ax1.spines['bottom'].set_color(ei['colors']['text_color'])\n",
+    "ax1.spines['left'].set_color(ei['colors']['text_color'])\n",
     "\n",
-    "print(\"=== Sample Polling Data ===\")\n",
-    "display(poll_data)\n",
-    "print(\"\\n=== Demographic Breakdown ===\")\n",
-    "display(demo_data)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "id": "cell-20",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-04T18:00:26.876124Z",
-     "iopub.status.busy": "2026-03-04T18:00:26.875906Z",
-     "iopub.status.idle": "2026-03-04T18:00:28.416517Z",
-     "shell.execute_reply": "2026-03-04T18:00:28.415441Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== ReportGenerator Initialized ===\n",
-      "Client: Hillcrest\n",
-      "Output directory: output/notebook_10\n"
-     ]
-    }
-   ],
-   "source": [
-    "from siege_utilities.reporting.report_generator import ReportGenerator\n",
+    "# --- Masai Interactive ---\n",
+    "ax2 = axes[1]\n",
+    "ax2.plot(months, masai_series, marker='s', color=masai['colors']['primary'], linewidth=2)\n",
+    "ax2.set_title('Masai Interactive — client web sessions (k)', color=masai['colors']['primary'])\n",
+    "ax2.set_facecolor(masai['colors']['background'])\n",
+    "ax2.tick_params(colors=masai['colors']['text_color'])\n",
+    "ax2.spines['bottom'].set_color(masai['colors']['text_color'])\n",
+    "ax2.spines['left'].set_color(masai['colors']['text_color'])\n",
     "\n",
-    "# Initialize ReportGenerator with Hillcrest branding \u2014 output goes to OUTPUT_DIR\n",
-    "rg = ReportGenerator(\n",
-    "    client_name=\"Hillcrest\",\n",
-    "    output_dir=OUTPUT_DIR\n",
-    ")\n",
-    "\n",
-    "print(\"=== ReportGenerator Initialized ===\")\n",
-    "print(f\"Client: {rg.client_name}\")\n",
-    "print(f\"Output directory: {rg.output_dir}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "id": "cell-21",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-04T18:00:28.418792Z",
-     "iopub.status.busy": "2026-03-04T18:00:28.418539Z",
-     "iopub.status.idle": "2026-03-04T18:00:28.423062Z",
-     "shell.execute_reply": "2026-03-04T18:00:28.422308Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Added executive summary\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Build report content\n",
-    "report_content = {\n",
-    "    'sections': [],\n",
-    "    'metadata': {\n",
-    "        'title': 'Sample Polling Report',\n",
-    "        'subtitle': 'Q1 2026 Survey Results',\n",
-    "        'author': 'Siege Analytics',\n",
-    "        'date': datetime.now().strftime('%B %d, %Y'),\n",
-    "        'client': 'Hillcrest'\n",
-    "    }\n",
-    "}\n",
-    "\n",
-    "# Add executive summary\n",
-    "executive_summary = \"\"\"\n",
-    "This polling report presents findings from a survey of 1,200 likely voters \n",
-    "conducted January 10-15, 2026. Key findings include:\n",
-    "\n",
-    "- Smith leads with 42% support, up 2 points from previous poll\n",
-    "- Jones at 38%, down 1 point\n",
-    "- Williams at 12%, essentially unchanged\n",
-    "- 8% remain undecided with 3 weeks until election\n",
-    "\n",
-    "Margin of error: +/-2.8 percentage points (95% confidence)\n",
-    "\"\"\"\n",
-    "\n",
-    "report_content = rg.add_text_section(\n",
-    "    report_content, \n",
-    "    'Executive Summary', \n",
-    "    executive_summary\n",
-    ")\n",
-    "\n",
-    "print(\"Added executive summary\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "id": "cell-22",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-04T18:00:28.425271Z",
-     "iopub.status.busy": "2026-03-04T18:00:28.425136Z",
-     "iopub.status.idle": "2026-03-04T18:00:28.428564Z",
-     "shell.execute_reply": "2026-03-04T18:00:28.427765Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Added polling data table\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Add polling data table\n",
-    "report_content = rg.add_table_section(\n",
-    "    report_content,\n",
-    "    'Current Poll Results',\n",
-    "    poll_data\n",
-    ")\n",
-    "\n",
-    "print(\"Added polling data table\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "id": "cell-23",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-04T18:00:28.430650Z",
-     "iopub.status.busy": "2026-03-04T18:00:28.430525Z",
-     "iopub.status.idle": "2026-03-04T18:00:28.433897Z",
-     "shell.execute_reply": "2026-03-04T18:00:28.433044Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Added demographic breakdown table\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Add demographic breakdown table\n",
-    "report_content = rg.add_table_section(\n",
-    "    report_content,\n",
-    "    'Support by Age Group',\n",
-    "    demo_data\n",
-    ")\n",
-    "\n",
-    "print(\"Added demographic breakdown table\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "id": "cell-24",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-04T18:00:28.435803Z",
-     "iopub.status.busy": "2026-03-04T18:00:28.435679Z",
-     "iopub.status.idle": "2026-03-04T18:00:28.439106Z",
-     "shell.execute_reply": "2026-03-04T18:00:28.438391Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Added methodology section\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Add methodology section\n",
-    "methodology = \"\"\"\n",
-    "Survey Methodology:\n",
-    "\n",
-    "- Sample Size: 1,200 likely voters\n",
-    "- Mode: Mixed (60% cell, 40% landline)\n",
-    "- Field Dates: January 10-15, 2026\n",
-    "- Weighting: Age, gender, education, party registration\n",
-    "- Margin of Error: +/-2.8 percentage points\n",
-    "\n",
-    "The survey was conducted by Siege Analytics using live interviewers. \n",
-    "Respondents were selected using stratified random sampling from \n",
-    "voter file records.\n",
-    "\"\"\"\n",
-    "\n",
-    "report_content = rg.add_text_section(\n",
-    "    report_content,\n",
-    "    'Methodology',\n",
-    "    methodology\n",
-    ")\n",
-    "\n",
-    "print(\"Added methodology section\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cell-25",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-04T18:00:28.441570Z",
-     "iopub.status.busy": "2026-03-04T18:00:28.441448Z",
-     "iopub.status.idle": "2026-03-04T18:00:28.473425Z",
-     "shell.execute_reply": "2026-03-04T18:00:28.472509Z"
-    }
-   },
-   "outputs": [],
-   "source": "from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, Table, TableStyle, PageBreak, HRFlowable\nfrom reportlab.lib.pagesizes import letter\nfrom reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle\nfrom reportlab.lib import colors\nfrom reportlab.lib.units import inch\nfrom reportlab.lib.enums import TA_CENTER, TA_LEFT\nfrom siege_utilities.reporting.chart_generator import ChartGenerator\nfrom siege_utilities.reporting.image_utils import save_rl_image\nimport matplotlib\nmatplotlib.use('Agg')\n\ntimestamp = datetime.now().strftime('%Y%m%d_%H%M%S')\noutput_path = OUTPUT_DIR / f\"hillcrest_poll_report_{timestamp}.pdf\"\n\n# --- Hillcrest branding colors ---\nhc_primary = colors.HexColor(hillcrest_branding.primary_color)      # #1a4d2e forest green\nhc_secondary = colors.HexColor(hillcrest_branding.secondary_color)   # #4a7c59 sage green\nhc_accent = colors.HexColor(hillcrest_branding.accent_color)         # #f4a261 warm accent\nhc_text = colors.HexColor(hillcrest_branding.text_color)             # #2d3436\nhc_white = colors.white\nhc_light_bg = colors.HexColor('#f0f7f2')\n\n# Chart generator with Hillcrest palette\nhc_branding = {\n    'name': 'Hillcrest',\n    'colors': {\n        'primary': hillcrest_branding.primary_color,\n        'secondary': hillcrest_branding.secondary_color,\n        'accent': hillcrest_branding.accent_color,\n    }\n}\nchart_gen_hc = ChartGenerator(\n    branding_config=hc_branding, output_dir=OUTPUT_DIR,\n    max_chart_width=5.5, max_chart_height=3.5,\n)\nchart_gen_hc.default_dpi = 200\n\n# Chart dimensions for ReportLab\nCHART_W = 5.5 * inch\nCHART_H = 3.5 * inch\n\n# --- Branded styles ---\nstyles = getSampleStyleSheet()\nstyles.add(ParagraphStyle('HC_Title', parent=styles['Title'],\n    fontSize=32, textColor=hc_primary, spaceAfter=4))\nstyles.add(ParagraphStyle('HC_Subtitle', parent=styles['Normal'],\n    fontSize=16, textColor=hc_secondary, alignment=TA_CENTER, spaceBefore=8, spaceAfter=20))\nstyles.add(ParagraphStyle('HC_Heading', parent=styles['Heading1'],\n    fontSize=18, textColor=hc_primary, spaceBefore=12, spaceAfter=8))\nstyles.add(ParagraphStyle('HC_SubHeading', parent=styles['Heading2'],\n    fontSize=14, textColor=hc_secondary, spaceBefore=8, spaceAfter=6))\nstyles.add(ParagraphStyle('HC_Body', parent=styles['Normal'],\n    fontSize=11, textColor=hc_text, leading=15, spaceAfter=4))\nstyles.add(ParagraphStyle('HC_Bullet', parent=styles['Normal'],\n    fontSize=11, textColor=hc_text, leading=15, leftIndent=20, spaceAfter=2))\nstyles.add(ParagraphStyle('HC_Meta', parent=styles['Normal'],\n    fontSize=10, textColor=colors.HexColor('#666666'), alignment=TA_CENTER))\nstyles.add(ParagraphStyle('HC_Caption', parent=styles['Normal'],\n    fontSize=9, textColor=colors.HexColor('#888888'), italic=True,\n    alignment=TA_CENTER, spaceBefore=4, spaceAfter=8))\nstyles.add(ParagraphStyle('HC_Callout', parent=styles['Normal'],\n    fontSize=12, textColor=hc_primary, bold=True, alignment=TA_CENTER,\n    spaceBefore=8, spaceAfter=8))\n\n# =================================================================\n# Generate charts\n# =================================================================\n\n# 1. Horse race bar chart \u2014 current support\nimport matplotlib.pyplot as plt\n\nfig, ax = plt.subplots(figsize=(6, 3.5), dpi=200)\ncandidates = poll_data['Candidate'].tolist()\nsupport = poll_data['Support (%)'].tolist()\nbar_colors = [hillcrest_branding.primary_color, hillcrest_branding.secondary_color,\n              hillcrest_branding.accent_color, '#cccccc']\nbars = ax.barh(candidates[::-1], support[::-1], color=bar_colors[::-1], edgecolor='white', height=0.6)\nfor bar, val in zip(bars, support[::-1]):\n    ax.text(bar.get_width() + 0.8, bar.get_y() + bar.get_height()/2,\n            f'{val}%', va='center', fontsize=11, fontweight='bold')\nax.set_xlim(0, 55)\nax.set_xlabel('Support (%)')\nax.set_title('Current Candidate Support', fontsize=14, fontweight='bold',\n             color=hillcrest_branding.primary_color)\nax.spines['top'].set_visible(False)\nax.spines['right'].set_visible(False)\nplt.tight_layout()\nhorse_race_img = chart_gen_hc._matplotlib_to_reportlab_image(fig, width=CHART_W, height=CHART_H)\nsave_rl_image(horse_race_img, OUTPUT_DIR / 'poll_horse_race.png')\nplt.close(fig)\n\n# 2. Change from previous poll \u2014 grouped bar\nfig, ax = plt.subplots(figsize=(6, 3.5), dpi=200)\nx = np.arange(len(candidates))\nwidth = 0.35\nbars1 = ax.bar(x - width/2, poll_data['Previous (%)'].tolist(), width,\n               label='Previous', color=hillcrest_branding.secondary_color, alpha=0.7)\nbars2 = ax.bar(x + width/2, support, width,\n               label='Current', color=hillcrest_branding.primary_color)\nax.set_xticks(x)\nax.set_xticklabels(candidates)\nax.set_ylabel('Support (%)')\nax.set_title('Movement Since Last Poll', fontsize=14, fontweight='bold',\n             color=hillcrest_branding.primary_color)\nax.legend(loc='upper right')\nax.spines['top'].set_visible(False)\nax.spines['right'].set_visible(False)\nfor bar in bars2:\n    ax.text(bar.get_x() + bar.get_width()/2, bar.get_height() + 0.5,\n            f'{bar.get_height():.0f}%', ha='center', fontsize=9, fontweight='bold')\nplt.tight_layout()\nmovement_img = chart_gen_hc._matplotlib_to_reportlab_image(fig, width=CHART_W, height=CHART_H)\nsave_rl_image(movement_img, OUTPUT_DIR / 'poll_movement.png')\nplt.close(fig)\n\n# 3. Demographic breakdown \u2014 grouped bar by age\nfig, ax = plt.subplots(figsize=(6, 3.5), dpi=200)\nage_groups = demo_data['Age Group'].tolist()\nx = np.arange(len(age_groups))\nwidth = 0.25\nax.bar(x - width, demo_data['Smith'].tolist(), width, label='Smith',\n       color=hillcrest_branding.primary_color)\nax.bar(x, demo_data['Jones'].tolist(), width, label='Jones',\n       color=hillcrest_branding.secondary_color)\nax.bar(x + width, demo_data['Williams'].tolist(), width, label='Williams',\n       color=hillcrest_branding.accent_color)\nax.set_xticks(x)\nax.set_xticklabels(age_groups)\nax.set_ylabel('Support (%)')\nax.set_title('Support by Age Group', fontsize=14, fontweight='bold',\n             color=hillcrest_branding.primary_color)\nax.legend(loc='upper right')\nax.spines['top'].set_visible(False)\nax.spines['right'].set_visible(False)\nplt.tight_layout()\ndemo_chart_img = chart_gen_hc._matplotlib_to_reportlab_image(fig, width=CHART_W, height=CHART_H)\nsave_rl_image(demo_chart_img, OUTPUT_DIR / 'poll_demographics.png')\nplt.close(fig)\n\n# 4. Pie chart \u2014 current share (excluding undecided)\ndecided = poll_data[poll_data['Candidate'] != 'Undecided'].copy()\ndecided_pct = decided['Support (%)'].tolist()\ndecided_names = decided['Candidate'].tolist()\nfig, ax = plt.subplots(figsize=(5, 3.5), dpi=200)\nwedges, texts, autotexts = ax.pie(\n    decided_pct, labels=decided_names, autopct='%1.0f%%',\n    colors=[hillcrest_branding.primary_color, hillcrest_branding.secondary_color,\n            hillcrest_branding.accent_color],\n    startangle=90, textprops={'fontsize': 10},\n)\nfor at in autotexts:\n    at.set_color('white')\n    at.set_fontweight('bold')\nax.set_title('Decided Voter Share', fontsize=14, fontweight='bold',\n             color=hillcrest_branding.primary_color)\nplt.tight_layout()\npie_img = chart_gen_hc._matplotlib_to_reportlab_image(fig, width=CHART_W, height=CHART_H)\nsave_rl_image(pie_img, OUTPUT_DIR / 'poll_decided_share.png')\nplt.close(fig)\n\nprint(f\"Generated 4 polling charts at 200 DPI\")\n\n# =================================================================\n# Helper: styled table\n# =================================================================\ndef make_table(df, col_widths=None):\n    data = [df.columns.tolist()] + df.values.tolist()\n    tbl = Table(data, colWidths=col_widths)\n    tbl.setStyle(TableStyle([\n        ('BACKGROUND', (0, 0), (-1, 0), hc_primary),\n        ('TEXTCOLOR', (0, 0), (-1, 0), hc_white),\n        ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),\n        ('FONTSIZE', (0, 0), (-1, 0), 11),\n        ('FONTNAME', (0, 1), (-1, -1), 'Helvetica'),\n        ('FONTSIZE', (0, 1), (-1, -1), 10),\n        ('ALIGN', (0, 0), (-1, -1), 'CENTER'),\n        ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),\n        ('BOTTOMPADDING', (0, 0), (-1, 0), 10),\n        ('TOPPADDING', (0, 0), (-1, 0), 8),\n        ('BOTTOMPADDING', (0, 1), (-1, -1), 6),\n        ('TOPPADDING', (0, 1), (-1, -1), 6),\n        ('GRID', (0, 0), (-1, -1), 0.5, colors.HexColor('#cccccc')),\n        ('ROWBACKGROUNDS', (0, 1), (-1, -1), [hc_white, hc_light_bg]),\n    ]))\n    return tbl\n\n# =================================================================\n# Build the PDF\n# =================================================================\nstory = []\n\n# --- Title page ---\nstory.append(Spacer(1, 2.0 * inch))\nstory.append(HRFlowable(width='70%', thickness=3, color=hc_primary, spaceAfter=16))\nstory.append(Paragraph('Hillcrest District Poll', styles['HC_Title']))\nstory.append(Paragraph('Q1 2026 Likely Voter Survey', styles['HC_Subtitle']))\nstory.append(HRFlowable(width='70%', thickness=1, color=hc_secondary, spaceBefore=4, spaceAfter=30))\nstory.append(Paragraph('n = 1,200 Likely Voters | MOE +/-2.8%', styles['HC_Meta']))\nstory.append(Spacer(1, 8))\nstory.append(Paragraph('Prepared for: Hillcrest', styles['HC_Meta']))\nstory.append(Spacer(1, 4))\nstory.append(Paragraph('Prepared by: Siege Analytics', styles['HC_Meta']))\nstory.append(Spacer(1, 4))\nstory.append(Paragraph(f'{datetime.now().strftime(\"%B %d, %Y\")}', styles['HC_Meta']))\n\n# --- Page 2: Top-line findings (chart + table + argument) ---\nstory.append(PageBreak())\nstory.append(HRFlowable(width='100%', thickness=2, color=hc_primary, spaceAfter=8))\nstory.append(Paragraph('The Horse Race', styles['HC_Heading']))\nstory.append(Spacer(1, 4))\n\nstory.append(Paragraph(\n    'Smith holds a <b>4-point lead</b> over Jones among likely voters, '\n    'outside the margin of error. This represents a net 3-point swing '\n    'toward Smith since the previous survey.',\n    styles['HC_Body']))\nstory.append(Spacer(1, 8))\n\n# Horse race chart\nstory.extend(chart_gen_hc.create_chart_with_caption(\n    horse_race_img,\n    'Figure 1: Current candidate support among likely voters (n=1,200)'))\nstory.append(Spacer(1, 12))\n\n# Table\nstory.append(Paragraph('Detailed Results', styles['HC_SubHeading']))\nstory.append(Spacer(1, 4))\nstory.append(make_table(poll_data, [1.5*inch, 1.2*inch, 1.2*inch, 1.0*inch]))\n\n# --- Page 3: Movement + argument ---\nstory.append(PageBreak())\nstory.append(HRFlowable(width='100%', thickness=2, color=hc_primary, spaceAfter=8))\nstory.append(Paragraph('Movement', styles['HC_Heading']))\nstory.append(Spacer(1, 4))\n\nstory.append(Paragraph(\n    'Smith gained 2 points while Jones lost 1 point since the previous poll. '\n    'Williams is flat at 12%. The undecided pool (8%) is small enough that '\n    'even a complete break toward Jones would not close the gap.',\n    styles['HC_Body']))\nstory.append(Spacer(1, 8))\n\nstory.extend(chart_gen_hc.create_chart_with_caption(\n    movement_img,\n    'Figure 2: Previous vs current support \u2014 net 3-point swing toward Smith'))\nstory.append(Spacer(1, 12))\n\nstory.append(Paragraph(\n    'Among decided voters, Smith commands <b>46%</b> of the share '\n    'vs Jones at <b>41%</b> and Williams at <b>13%</b>.',\n    styles['HC_Body']))\nstory.append(Spacer(1, 8))\nstory.extend(chart_gen_hc.create_chart_with_caption(\n    pie_img,\n    'Figure 3: Share among decided voters (undecided excluded)'))\n\n# --- Page 4: Demographics + argument ---\nstory.append(PageBreak())\nstory.append(HRFlowable(width='100%', thickness=2, color=hc_primary, spaceAfter=8))\nstory.append(Paragraph('The Demographic Picture', styles['HC_Heading']))\nstory.append(Spacer(1, 4))\n\nstory.append(Paragraph(\n    'Smith dominates with voters 45 and older, leading Jones by <b>10+ points</b> '\n    'in both the 45-59 and 60+ cohorts. Jones leads among younger voters '\n    '(18-29) by 10 points, but this group has historically lower turnout. '\n    'The 30-44 cohort is the most competitive, with just 2 points separating '\n    'the top two candidates.',\n    styles['HC_Body']))\nstory.append(Spacer(1, 8))\n\nstory.extend(chart_gen_hc.create_chart_with_caption(\n    demo_chart_img,\n    'Figure 4: Support by age group \u2014 Smith strongest with 45+, Jones leads 18-29'))\nstory.append(Spacer(1, 12))\n\nstory.append(Paragraph('Breakdown by Age Cohort', styles['HC_SubHeading']))\nstory.append(Spacer(1, 4))\nstory.append(make_table(demo_data, [1.2*inch, 1.0*inch, 1.0*inch, 1.0*inch]))\n\n# --- Page 5: Methodology ---\nstory.append(PageBreak())\nstory.append(HRFlowable(width='100%', thickness=2, color=hc_primary, spaceAfter=8))\nstory.append(Paragraph('Methodology', styles['HC_Heading']))\nstory.append(Spacer(1, 8))\n\nfor b in [\n    '<b>Sample Size:</b> 1,200 likely voters',\n    '<b>Mode:</b> Mixed (60% cell phone, 40% landline)',\n    '<b>Field Dates:</b> January 10-15, 2026',\n    '<b>Weighting:</b> Age, gender, education, party registration',\n    '<b>Margin of Error:</b> +/-2.8 percentage points (95% CI)',\n    '<b>Sampling Frame:</b> Voter file, stratified random',\n    '<b>Interviewing:</b> Live interviewers',\n]:\n    story.append(Paragraph(f'&bull; {b}', styles['HC_Bullet']))\n\nstory.append(Spacer(1, 12))\nstory.append(Paragraph(\n    'The survey was conducted by Siege Analytics using live interviewers. '\n    'Respondents were selected using stratified random sampling from '\n    'voter file records. Results are weighted to match the demographic '\n    'composition of the likely electorate based on past turnout models.',\n    styles['HC_Body']))\nstory.append(Spacer(1, 12))\nstory.append(HRFlowable(width='40%', thickness=0.5, color=hc_secondary))\nstory.append(Spacer(1, 8))\nstory.append(Paragraph(\n    'Siege Analytics | contact@siegeanalytics.com | siegeanalytics.com',\n    styles['HC_Meta']))\n\n# --- Build ---\ndoc = SimpleDocTemplate(\n    str(output_path), pagesize=letter,\n    topMargin=1*inch, bottomMargin=1*inch,\n    leftMargin=1*inch, rightMargin=1*inch,\n)\ndoc.build(story)\n\nsize_kb = output_path.stat().st_size / 1024\nprint(f\"Polling report generated: {output_path}\")\nprint(f\"Size: {size_kb:.1f} KB, 5 pages\")\nprint(f\"Contents: 4 charts, 2 tables, narrative argument per section\")"
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cell-26",
-   "metadata": {},
-   "source": "## 6. Verify Profile Persistence\n\nVerify that profiles are correctly saved and can be reloaded."
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "id": "cell-27",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-04T18:00:28.475457Z",
-     "iopub.status.busy": "2026-03-04T18:00:28.475332Z",
-     "iopub.status.idle": "2026-03-04T18:00:28.489171Z",
-     "shell.execute_reply": "2026-03-04T18:00:28.488305Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== Verification: Reload All Profiles ===\n",
-      "[siege_utilities] 2026-03-04 12:00:28,480 INFO: Loaded modern User: dheeraj\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[OK] User: dheeraj (Dheeraj Chand)\n",
-      "   Username: dheeraj\n",
-      "   Default format: pdf\n",
-      "   Assigned clients: ['HILL']\n",
-      "[siege_utilities] 2026-03-04 12:00:28,486 INFO: Loaded modern Client: HILL\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[OK] Client: Hillcrest\n",
-      "   Code: HILL\n",
-      "   Industry: Political Consulting\n",
-      "   Primary color: #1a4d2e\n",
-      "   Primary font: Helvetica\n",
-      "   Assigned users: ['dheeraj']\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Reload and verify all profiles using modern API\n",
-    "print(\"=== Verification: Reload All Profiles ===\")\n",
-    "\n",
-    "# User profile\n",
-    "loaded_user = manager.load_user(\"dheeraj\", profiles_dir=users_dir)\n",
-    "if loaded_user:\n",
-    "    print(f\"[OK] User: {loaded_user.person_id} ({loaded_user.name})\")\n",
-    "    print(f\"   Username: {loaded_user.username}\")\n",
-    "    print(f\"   Default format: {loaded_user.default_output_format}\")\n",
-    "    print(f\"   Assigned clients: {loaded_user.get_assigned_clients()}\")\n",
-    "else:\n",
-    "    print(\"ERROR: User profile not found\")\n",
-    "\n",
-    "# Client profile\n",
-    "loaded_client = manager.load_client(\"HILL\", profiles_dir=clients_dir)\n",
-    "if loaded_client:\n",
-    "    print(f\"[OK] Client: {loaded_client.name}\")\n",
-    "    print(f\"   Code: {loaded_client.client_code}\")\n",
-    "    print(f\"   Industry: {loaded_client.industry}\")\n",
-    "    print(f\"   Primary color: {loaded_client.branding_config.primary_color}\")\n",
-    "    print(f\"   Primary font: {loaded_client.branding_config.primary_font}\")\n",
-    "    print(f\"   Assigned users: {loaded_client.get_assigned_users()}\")\n",
-    "else:\n",
-    "    print(\"ERROR: Client profile not found\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "id": "cell-28",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-04T18:00:28.491074Z",
-     "iopub.status.busy": "2026-03-04T18:00:28.490953Z",
-     "iopub.status.idle": "2026-03-04T18:00:28.495335Z",
-     "shell.execute_reply": "2026-03-04T18:00:28.494520Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== Profile Files ===\n",
-      "Users:\n",
-      "  - dheeraj.yaml (961 bytes)\n",
-      "Clients:\n",
-      "  - HILL.yaml (1756 bytes)\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Check saved profile files\n",
-    "print(\"=== Profile Files ===\")\n",
-    "\n",
-    "profiles_base = Path.home() / \".siege_utilities\" / \"profiles\"\n",
-    "\n",
-    "for profile_type in [\"users\", \"clients\"]:\n",
-    "    profile_dir = profiles_base / profile_type\n",
-    "    if profile_dir.exists():\n",
-    "        files = list(profile_dir.glob(\"*.yaml\"))\n",
-    "        print(f\"{profile_type.title()}:\")\n",
-    "        for f in files:\n",
-    "            size = f.stat().st_size\n",
-    "            print(f\"  - {f.name} ({size} bytes)\")\n",
-    "    else:\n",
-    "        print(f\"WARNING: {profile_type.title()}: Directory not found\")"
+    "for ax in axes:\n",
+    "    ax.grid(True, alpha=0.3)\n",
+    "fig.tight_layout()\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "fot9vgnt754",
-   "source": "## 7. Design Kit Export\n\nExport a complete design kit from the Hillcrest report data using `export_design_kit()`.\nThis produces a folder structure with separated assets for InDesign/Illustrator handoff:\n\n```\noutput_dir/\n    charts/          SVG vector chart files\n    charts-png/      High-resolution PNG chart files (300 DPI)\n    tables/          CSV exports of all data tables\n    text/            report_text.md with narrative sections\n    metadata.yaml    Client name, dates, KPIs, summary stats\n```\n\nThis is useful when handing off analytics results to a graphic designer who\nneeds editable vector charts and raw data tables alongside the narrative text.",
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "id": "6vdyljg3fe3",
-   "source": "import tempfile\nfrom datetime import datetime, timedelta\n\ntry:\n    from siege_utilities.reporting.examples.google_analytics_report_example import (\n        export_design_kit,\n        generate_sample_ga_data,\n    )\n    HAS_DESIGN_KIT = True\nexcept ImportError as e:\n    HAS_DESIGN_KIT = False\n    print(f\"Design kit import failed ({e}) \u2014 skipping.\")\n\nif HAS_DESIGN_KIT:\n    # Generate sample GA data to demonstrate the export\n    end_date = datetime.now()\n    start_date = end_date - timedelta(days=30)\n    ga_data = generate_sample_ga_data(start_date, end_date)\n    print(\"=== Sample GA Data ===\")\n    print(f\"  Total users   : {ga_data['totals']['users']:,}\")\n    print(f\"  Total sessions: {ga_data['totals']['sessions']:,}\")\n    print(f\"  Date range    : {ga_data['date_range']}\")\n    print(f\"  Daily records : {len(ga_data['daily_data'])}\")\n    print(f\"  Sources       : {len(ga_data['traffic_sources'])}\")\n    print()\n\n    # Export the design kit\n    with tempfile.TemporaryDirectory() as tmpdir:\n        export_path = export_design_kit(\n            ga_data=ga_data,\n            output_dir=tmpdir,\n        )\n        print(f\"Design kit exported to: {export_path}\")\n        if export_path:\n            import os\n            for f in os.listdir(tmpdir):\n                fpath = os.path.join(tmpdir, f)\n                size = os.path.getsize(fpath)\n                print(f\"  {f}: {size:,} bytes\")",
+   "id": "cell-related",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "id": "c9swfnypyoe",
-   "source": "if HAS_DESIGN_KIT:\n    # Export the design kit to the notebook output directory\n    kit_dir = OUTPUT_DIR / \"design_kit\"\n\n    success = export_design_kit(\n        ga_data,\n        output_dir=str(kit_dir),\n        client_name=\"Hillcrest\",\n        prepared_by=\"Siege Analytics\",\n    )\n    print(f\"Design kit export success: {success}\")\n\n    if success:\n        print(f\"\\n=== Design Kit Contents ===\")\n        for item in sorted(kit_dir.rglob(\"*\")):\n            rel = item.relative_to(kit_dir)\n            if item.is_file():\n                print(f\"  {rel}  ({item.stat().st_size:,} bytes)\")\n            else:\n                print(f\"  {rel}/\")\nelse:\n    print(\"Skipping design kit export (import not available).\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cell-30",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-04T18:00:28.497322Z",
-     "iopub.status.busy": "2026-03-04T18:00:28.497196Z",
-     "iopub.status.idle": "2026-03-04T18:00:28.511712Z",
-     "shell.execute_reply": "2026-03-04T18:00:28.510912Z"
-    }
-   },
-   "outputs": [],
-   "source": "# Summary of all tests\nprint(\"=\" * 50)\nprint(\"PROFILE & BRANDING SYSTEM TEST RESULTS\")\nprint(\"=\" * 50)\n\nresults = {\n    \"Credential Backends\": \"1password\" in [k for k,v in cred_manager.available_backends.items() if v],\n    \"User Profile Created\": manager.load_user(\"dheeraj\", profiles_dir=users_dir) is not None,\n    \"Client Profile Created\": manager.load_client(\"HILL\", profiles_dir=clients_dir) is not None,\n    \"1Password Integration\": cred_manager.available_backends.get('1password', False),\n    \"PDF Generation\": output_path.exists() if 'output_path' in dir() else False,\n    \"Design Kit Export\": HAS_DESIGN_KIT and kit_dir.exists() if 'kit_dir' in dir() else False,\n}\n\nfor test, passed in results.items():\n    symbol = \"PASS\" if passed else \"FAIL\"\n    print(f\"  {symbol}  {test}\")\n\npassed = sum(results.values())\ntotal = len(results)\nprint(f\"\\n{passed}/{total} tests passed.\")\n\nif passed == total:\n    print(\"\\nAll Profile/Branding tests passed!\")\nelse:\n    print(\"\\nSome tests need attention.\")\n\n# Clean up HydraConfigManager\nmanager.cleanup()"
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cell-31",
-   "metadata": {},
-   "source": "## Next Steps\n\nIf all tests pass:\n\n1. **Update Hillcrest branding colors** - Edit the BrandingConfig with actual Hillcrest colors\n2. **Add logo** - Set `logo_path` to actual Hillcrest logo file\n3. **Store GA credentials** - If you have GA service account, store it:\n   ```python\n   from siege_utilities.config import store_ga_service_account_from_file\n   store_ga_service_account_from_file('/path/to/service-account.json', \n                                       item_title='Hillcrest GA Service Account')\n   ```\n4. **Test with real data** - Use actual polling data from Hillcrest projects"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "## Related\n- Source: `siege_utilities/admin/profile_manager.py`, `siege_utilities/reporting/client_branding.py`\n- Tests: `tests/test_admin_profile_manager.py`, `tests/test_client_branding*.py`\n- Consolidates: previous `03_Person_Actor_Architecture` and `10_Profile_Branding_Testing`\n"
+   "source": [
+    "## Related\n",
+    "\n",
+    "- **Source**: `siege_utilities/reporting/client_branding.py` for the manager; `siege_utilities/config/models/actor_types.py` for User / Client / Person.\n",
+    "- **Tests**: `tests/test_client_branding*.py`, `tests/test_admin_profile_manager.py`.\n",
+    "- **Downstream consumers**: every notebook under `reports/` reads a branding profile by client code; the first cell loads it the same way we loaded it here.\n",
+    "- **Next notebook**: `spatial/01_boundaries.ipynb` shifts into data acquisition for the ElectInfo TX-32 engagement.\n"
+   ]
   }
  ],
  "metadata": {
@@ -1555,8 +302,16 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.11.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
   }
  },
  "nbformat": 4,

--- a/siege_utilities/cache.py
+++ b/siege_utilities/cache.py
@@ -1,0 +1,110 @@
+"""Cache helpers — on-disk caching for sample datasets used by notebooks.
+
+The notebooks under ``notebooks/`` deliberately do not commit spatial or
+large tabular fixtures to the repo. Instead, each notebook that needs a
+dataset calls :func:`ensure_sample_dataset`, which downloads the file on
+first run into a user-scoped cache directory and returns a local path on
+every subsequent run.
+
+Default cache root: ``~/.cache/siege_utilities/notebooks/``. Override per
+call via the ``cache_dir`` argument or globally with the
+``SIEGE_UTILITIES_CACHE_DIR`` environment variable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import urllib.request
+from pathlib import Path
+from typing import Optional
+
+
+class SampleDatasetError(RuntimeError):
+    """Raised when a sample dataset cannot be fetched or fails verification."""
+
+
+def _default_cache_dir() -> Path:
+    override = os.environ.get("SIEGE_UTILITIES_CACHE_DIR")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".cache" / "siege_utilities" / "notebooks"
+
+
+def ensure_sample_dataset(
+    name: str,
+    url: str,
+    *,
+    cache_dir: Optional[Path] = None,
+    sha256: Optional[str] = None,
+) -> Path:
+    """Return a local path to ``name``, downloading from ``url`` on first use.
+
+    Parameters
+    ----------
+    name:
+        Filename to use in the cache (e.g. ``"tx_counties_2020.geojson"``).
+        Not treated as a directory — must be a single filename. Cache
+        layout is flat by design; if you need hierarchy, encode it in the
+        name.
+    url:
+        HTTPS URL to download from on cache miss.
+    cache_dir:
+        Override the cache directory. Defaults to
+        :func:`_default_cache_dir` (``~/.cache/siege_utilities/notebooks``
+        or the value of ``SIEGE_UTILITIES_CACHE_DIR``).
+    sha256:
+        Optional hex digest. When provided, a freshly-downloaded file is
+        verified against it and :class:`SampleDatasetError` is raised on
+        mismatch (the corrupt file is removed).
+
+    Returns
+    -------
+    Path
+        Absolute path to the cached file.
+
+    Raises
+    ------
+    SampleDatasetError
+        On HTTP failure or SHA-256 mismatch.
+    ValueError
+        If ``name`` contains a path separator.
+    """
+    if "/" in name or os.sep in name:
+        raise ValueError(
+            f"name {name!r} must be a single filename, not a path"
+        )
+
+    root = (cache_dir or _default_cache_dir()).expanduser()
+    root.mkdir(parents=True, exist_ok=True)
+    target = root / name
+
+    if target.exists():
+        return target
+
+    tmp = target.with_suffix(target.suffix + ".part")
+    try:
+        with urllib.request.urlopen(url) as resp, open(tmp, "wb") as f:
+            while chunk := resp.read(1 << 16):
+                f.write(chunk)
+    except Exception as e:
+        if tmp.exists():
+            tmp.unlink()
+        raise SampleDatasetError(
+            f"failed to download sample dataset {name!r} from {url}: {e}"
+        ) from e
+
+    if sha256 is not None:
+        h = hashlib.sha256()
+        with open(tmp, "rb") as f:
+            while chunk := f.read(1 << 16):
+                h.update(chunk)
+        got = h.hexdigest()
+        if got != sha256.lower():
+            tmp.unlink()
+            raise SampleDatasetError(
+                f"sha256 mismatch for {name!r}: expected {sha256}, got {got}"
+            )
+
+    tmp.rename(target)
+    return target

--- a/siege_utilities/reporting/client_branding.py
+++ b/siege_utilities/reporting/client_branding.py
@@ -163,7 +163,48 @@ class ClientBrandingManager:
                     'left': 0.75,
                     'right': 0.75
                 }
-            }
+            },
+            # elect.info was unreachable when this template was seeded
+            # (2026-04-24). Colors / fonts / logo are civic-tech placeholders —
+            # swap in real brand assets when the site is up.
+            'elect_info': {
+                'name': 'ElectInfo',
+                'colors': {
+                    'primary': '#0B3D91',
+                    'secondary': '#D32F2F',
+                    'accent': '#FFB300',
+                    'text_color': '#1A1A1A',
+                    'header_footer_text_color': '#555555',
+                    'background': '#FFFFFF',
+                },
+                'fonts': {
+                    'default_font': 'Helvetica',
+                    'h1': {'font_size': 24, 'leading': 28},
+                    'h2': {'font_size': 18, 'leading': 22},
+                    'h3': {'font_size': 14, 'leading': 18},
+                    'BodyText': {'font_size': 11, 'leading': 14},
+                },
+                'logo': {
+                    'image_url': 'https://elect.info/logo.png',
+                    'width': 1.5,
+                    'height': 0.6,
+                },
+                'header': {
+                    'left_text': 'ElectInfo Analysis',
+                    'right_text': 'Political & Civic Analytics',
+                },
+                'footer': {
+                    'left_text': 'Prepared by: ElectInfo',
+                    'right_text': 'elect.info',
+                    'page_number_format': 'Page %s',
+                },
+                'page_margins': {
+                    'top': 1.0,
+                    'bottom': 1.0,
+                    'left': 0.75,
+                    'right': 0.75,
+                },
+            },
         }
 
     def create_client_branding(self, client_name: str, branding_config: Dict[str, Any]) -> Path:

--- a/tests/test_cache_sample_dataset.py
+++ b/tests/test_cache_sample_dataset.py
@@ -1,0 +1,100 @@
+"""Tests for siege_utilities.cache.ensure_sample_dataset."""
+
+from __future__ import annotations
+
+import hashlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from siege_utilities.cache import SampleDatasetError, ensure_sample_dataset
+
+
+PAYLOAD = b"synthetic,dataset,payload\n1,2,3\n"
+PAYLOAD_SHA = hashlib.sha256(PAYLOAD).hexdigest()
+
+
+def _mock_urlopen(payload: bytes):
+    """Return a context-manager mock that yields a fake HTTP response."""
+    response = MagicMock()
+    response.read.side_effect = [payload, b""]
+    cm = MagicMock()
+    cm.__enter__.return_value = response
+    cm.__exit__.return_value = False
+    return cm
+
+
+class TestFirstRunDownload:
+    def test_downloads_and_caches(self, tmp_path):
+        with patch("urllib.request.urlopen", return_value=_mock_urlopen(PAYLOAD)):
+            path = ensure_sample_dataset(
+                "sample.csv",
+                "https://example.invalid/sample.csv",
+                cache_dir=tmp_path,
+            )
+        assert path == tmp_path / "sample.csv"
+        assert path.read_bytes() == PAYLOAD
+
+    def test_second_call_does_not_fetch(self, tmp_path):
+        with patch("urllib.request.urlopen", return_value=_mock_urlopen(PAYLOAD)) as m:
+            ensure_sample_dataset(
+                "sample.csv", "https://example.invalid/sample.csv", cache_dir=tmp_path,
+            )
+            assert m.call_count == 1
+            ensure_sample_dataset(
+                "sample.csv", "https://example.invalid/sample.csv", cache_dir=tmp_path,
+            )
+            assert m.call_count == 1  # cache hit, no second fetch
+
+
+class TestSha256Verification:
+    def test_matching_sha_accepts(self, tmp_path):
+        with patch("urllib.request.urlopen", return_value=_mock_urlopen(PAYLOAD)):
+            path = ensure_sample_dataset(
+                "sample.csv",
+                "https://example.invalid/sample.csv",
+                cache_dir=tmp_path,
+                sha256=PAYLOAD_SHA,
+            )
+        assert path.exists()
+
+    def test_mismatched_sha_raises_and_removes(self, tmp_path):
+        with patch("urllib.request.urlopen", return_value=_mock_urlopen(PAYLOAD)):
+            with pytest.raises(SampleDatasetError, match="sha256 mismatch"):
+                ensure_sample_dataset(
+                    "sample.csv",
+                    "https://example.invalid/sample.csv",
+                    cache_dir=tmp_path,
+                    sha256="0" * 64,
+                )
+        # Corrupt file should not linger in cache
+        assert not (tmp_path / "sample.csv").exists()
+
+
+class TestErrorHandling:
+    def test_network_failure_wrapped(self, tmp_path):
+        with patch("urllib.request.urlopen", side_effect=OSError("network down")):
+            with pytest.raises(SampleDatasetError, match="failed to download"):
+                ensure_sample_dataset(
+                    "sample.csv",
+                    "https://example.invalid/sample.csv",
+                    cache_dir=tmp_path,
+                )
+
+    def test_rejects_path_in_name(self, tmp_path):
+        with pytest.raises(ValueError, match="single filename"):
+            ensure_sample_dataset(
+                "sub/sample.csv",
+                "https://example.invalid/sample.csv",
+                cache_dir=tmp_path,
+            )
+
+
+class TestEnvOverride:
+    def test_env_var_used_when_cache_dir_not_given(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SIEGE_UTILITIES_CACHE_DIR", str(tmp_path))
+        with patch("urllib.request.urlopen", return_value=_mock_urlopen(PAYLOAD)):
+            path = ensure_sample_dataset(
+                "sample.csv", "https://example.invalid/sample.csv",
+            )
+        assert path == tmp_path / "sample.csv"

--- a/tests/test_notebook_hygiene.py
+++ b/tests/test_notebook_hygiene.py
@@ -1,0 +1,129 @@
+"""Structural hygiene checks for canonical notebooks.
+
+Enforces the contract each rewritten notebook in ELE-2456 must follow:
+
+- Opens with a ``# Title`` markdown cell
+- Has a ``## What this shows`` cell in the first two cells
+- Has exactly one ``## Related`` cell, at the end
+- Contains no stale ``NB0\\d`` / ``NB1\\d`` / ``NB2\\d`` cross-references
+- Has no ``try: import X; HAS_X = True`` guards at cell top level
+- Has no ``if HAS_[A-Z_]+:`` guards wrapping main content
+
+Notebooks that have been rewritten against the ELE-2456 template are listed
+in :data:`RE_WRITTEN`. Everything else is skipped until its rewrite PR lands
+— we don't want to fail CI on notebooks we haven't gotten to yet.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+NOTEBOOK_ROOT = REPO_ROOT / "notebooks"
+
+
+RE_WRITTEN: list[str] = [
+    # PR 1 (ELE-2457): foundations
+    "foundations/01_configuration.ipynb",
+    "foundations/02_profiles_branding.ipynb",
+    # Already in the ELE-2456 template shape from prior work:
+    "reports/03_polling_survey_analysis.ipynb",
+]
+
+
+def _load(rel: str):
+    path = NOTEBOOK_ROOT / rel
+    if not path.exists():
+        pytest.skip(f"{rel} not present")
+    return json.loads(path.read_text())
+
+
+def _markdown(cell):
+    return "".join(cell.get("source", [])) if cell["cell_type"] == "markdown" else ""
+
+
+def _code(cell):
+    return "".join(cell.get("source", [])) if cell["cell_type"] == "code" else ""
+
+
+@pytest.mark.parametrize("rel", RE_WRITTEN)
+class TestCanonicalHygiene:
+    """Per-notebook structural checks."""
+
+    def test_opens_with_title(self, rel):
+        nb = _load(rel)
+        assert nb["cells"], f"{rel}: notebook is empty"
+        first = _markdown(nb["cells"][0]).lstrip()
+        assert first.startswith("# "), (
+            f"{rel}: first cell must be a markdown `# Title`, got: {first[:60]!r}"
+        )
+
+    def test_has_what_this_shows_near_top(self, rel):
+        nb = _load(rel)
+        head = "\n".join(_markdown(c) for c in nb["cells"][:2])
+        assert "## What this shows" in head, (
+            f"{rel}: must contain `## What this shows` in one of the first two cells"
+        )
+
+    def test_exactly_one_related_at_end(self, rel):
+        nb = _load(rel)
+        related_positions = [
+            i
+            for i, c in enumerate(nb["cells"])
+            if _markdown(c).lstrip().startswith("## Related")
+        ]
+        assert len(related_positions) == 1, (
+            f"{rel}: expected exactly one `## Related` cell, got {len(related_positions)}"
+        )
+        n = len(nb["cells"])
+        assert related_positions[0] >= n - 2, (
+            f"{rel}: `## Related` must be at (or very near) the end; "
+            f"found at index {related_positions[0]} of {n}"
+        )
+
+    def test_no_stale_nb_refs(self, rel):
+        nb = _load(rel)
+        pat = re.compile(r"\bNB0\d\b|\bNB1\d\b|\bNB2\d\b")
+        offenders = []
+        for i, c in enumerate(nb["cells"]):
+            if c["cell_type"] != "markdown":
+                continue
+            if pat.search(_markdown(c)):
+                offenders.append(i)
+        assert not offenders, (
+            f"{rel}: cells {offenders} still contain stale NB## refs"
+        )
+
+    def test_no_top_level_try_import_guards(self, rel):
+        nb = _load(rel)
+        offenders = []
+        for i, c in enumerate(nb["cells"]):
+            src = _code(c).lstrip()
+            if src.startswith("try:") and "import" in src[: src.find("except") or len(src)]:
+                offenders.append(i)
+        assert not offenders, (
+            f"{rel}: cells {offenders} open with `try: import X` guards; "
+            "assume extras are installed and let it error loudly if not"
+        )
+
+    def test_no_has_x_guards_wrapping_main_content(self, rel):
+        """Blocks `if HAS_SOMETHING:` around a notebook's main capability cell."""
+        nb = _load(rel)
+        pat = re.compile(r"^\s*if\s+HAS_[A-Z_]+\b")
+        offenders = []
+        for i, c in enumerate(nb["cells"]):
+            src = _code(c)
+            if not src:
+                continue
+            first_line = src.lstrip().split("\n", 1)[0]
+            if pat.match(first_line):
+                offenders.append(i)
+        assert not offenders, (
+            f"{rel}: cells {offenders} use `if HAS_X:` guards — "
+            "inline the capability and let missing extras raise at import"
+        )


### PR DESCRIPTION
Parent: [ELE-2456](https://linear.app/elect-info/issue/ELE-2456). Validates the 10–15-cell user-intent-driven template on two Act 1 notebooks before committing to the pattern across 14 more.

## Scaffolding
- `elect_info` branding template (sibling to `masai_interactive`)
- `siege_utilities.cache.ensure_sample_dataset` + `SampleDatasetError` — download-on-first-run helper, honors `SIEGE_UTILITIES_CACHE_DIR`
- `tests/test_notebook_hygiene.py` — structural rules (title opener, `## What this shows`, exactly one trailing `## Related`, no stale `NB##` refs, no `try:import` / `HAS_X` guards)

## Notebooks rewritten
- `foundations/01_configuration` — "ElectInfo bootstraps its reporting environment"
- `foundations/02_profiles_branding` — "ElectInfo + Masai Interactive as branded client profiles", renders the same chart under each brand

## Test plan
- [x] 68 tests pass (hygiene + cache helper + full existing branding suite)
- [x] Both rewritten notebooks execute end-to-end against the project venv with embedded outputs

## Open item
elect.info was unreachable at authoring (ECONNREFUSED 2026-04-24). Branding colors / logo URL are civic-tech placeholders flagged in a code comment for later update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic sample dataset caching with support for custom cache directories and integrity verification
  * Added ElectInfo branding template with predefined visual configuration

* **Documentation**
  * Updated setup documentation with improved end-to-end workflow narrative
  * Streamlined configuration tutorial for clearer guidance on system setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->