### PR TITLE
fix(geo): correct Census TIGER URL patterns + census geocoder test mock paths

### DIFF
--- a/siege_utilities/geo/spatial_data.py
+++ b/siege_utilities/geo/spatial_data.py
@@ -71,6 +71,30 @@ FilePath = Union[str, Path]
 GeoDataFrame = gpd.GeoDataFrame
 
 # ---------------------------------------------------------------------------
+# Congressional District number by TIGER year
+# ---------------------------------------------------------------------------
+# All values verified by direct URL probing against Census FTP (2026-04-26).
+# cd117 (117th Congress) is entirely absent from TIGER — Census held on
+# the pre-redistricting 116th boundaries for 2020 and 2021, then jumped
+# directly to cd118 when per-state files appeared for 2022.
+YEAR_TO_CONGRESS: Dict[int, int] = {
+    2011: 112,
+    2012: 112,  # 113th elected Nov 2012 but TIGER 2012 still uses seated 112th
+    2013: 113,  # 113th seated Jan 2013; direct URL confirmed 200
+    2014: 114,
+    2015: 114,
+    2016: 115,
+    2017: 115,
+    2018: 116,
+    2019: 116,
+    2020: 116,  # pre-redistricting hold; 117th elected but old districts kept
+    2021: 116,  # still pre-redistricting; cd117 entirely absent from TIGER
+    2022: 118,  # post-redistricting; per-state files only (national = 404)
+    2023: 118,
+    2024: 119,
+}
+
+# ---------------------------------------------------------------------------
 # Boundary Type Catalog
 # ---------------------------------------------------------------------------
 # Reference data for Census TIGER/Line boundary types.
@@ -90,7 +114,6 @@ BOUNDARY_TYPE_CATALOG = {
     'place':        {'category': 'redistricting', 'abbrev': 'PLACE',      'name': 'Places (cities/towns)',              'geometry_type': 'MultiPolygon'},
     'cd':           {'category': 'redistricting', 'abbrev': 'CD',         'name': 'Congressional Districts',            'geometry_type': 'MultiPolygon'},
     'cd116':        {'category': 'redistricting', 'abbrev': 'CD116',      'name': 'Congressional Districts (116th)',    'geometry_type': 'MultiPolygon'},
-    'cd117':        {'category': 'redistricting', 'abbrev': 'CD117',      'name': 'Congressional Districts (117th)',    'geometry_type': 'MultiPolygon'},
     'cd118':        {'category': 'redistricting', 'abbrev': 'CD118',      'name': 'Congressional Districts (118th)',    'geometry_type': 'MultiPolygon'},
     'cd119':        {'category': 'redistricting', 'abbrev': 'CD119',      'name': 'Congressional Districts (119th)',    'geometry_type': 'MultiPolygon'},
     'sldu':         {'category': 'redistricting', 'abbrev': 'SLDU',       'name': 'State Legislative Upper (Senate)',   'geometry_type': 'MultiPolygon'},
@@ -355,7 +378,8 @@ class CensusDirectoryDiscovery:
             'TABBLOCK10': 'tabblock10',  # 2010 naming
             'PLACE': 'place',
             'ZCTA5': 'zcta',
-            'ZCTA': 'zcta',  # Alternative naming
+            'ZCTA': 'zcta',    # Alternative naming
+            'ZCTA520': 'zcta', # 2020+ directory name (Census renamed from ZCTA5)
             
             # Legislative boundaries
             'SLDU': 'sldu',  # State Legislative District Upper
@@ -370,7 +394,6 @@ class CensusDirectoryDiscovery:
             'CD114': 'cd114', # 114th Congress
             'CD115': 'cd115', # 115th Congress
             'CD116': 'cd116', # 116th Congress
-            'CD117': 'cd117', # 117th Congress
             'CD118': 'cd118', # 118th Congress
             'CD119': 'cd119', # 119th Congress
             
@@ -439,7 +462,9 @@ class CensusDirectoryDiscovery:
                 # State-specific files (state FIPS required)
                 'state': 'tl_{year}_{state_fips}_{boundary_type}.zip',
                 # Congressional districts with number
-                'congress': 'tl_{year}_us_cd{congress_num}.zip'
+                'congress': 'tl_{year}_us_cd{congress_num}.zip',
+                # Per-state congressional districts (2022+, Census dropped the national file)
+                'congress_state': 'tl_{year}_{state_fips}_cd{congress_num}.zip'
             },
             'directory_mappings': {}
         }
@@ -624,21 +649,22 @@ class CensusDirectoryDiscovery:
         }
 
         # Define flexible types (can be national or state-specific)
-        flexible_types = {'place', 'zcta', 'anrc', 'concity'}
-        
+        flexible_types = {'place', 'anrc', 'concity'}
+
+        # Census uses short abbreviations in filenames that differ from the canonical type name.
+        _FILENAME_ABBREVS = {'block_group': 'bg'}
+
         # Handle congressional districts specially
         if boundary_type.startswith('cd'):
             if len(boundary_type) > 2:
                 # Specific congress number in boundary type (cd118, cd119, etc.)
                 congress_num = boundary_type[2:]
-                return patterns['filename_patterns']['congress'].format(
-                    year=year, congress_num=congress_num
-                )
             elif congress_number:
-                # Congress number provided separately
-                return patterns['filename_patterns']['congress'].format(
-                    year=year, congress_num=congress_number
-                )
+                # Congress number provided separately — zero-pad to 3 digits
+                congress_num = f"{congress_number:03d}"
+            elif year in YEAR_TO_CONGRESS:
+                # Auto-lookup from verified year→congress mapping
+                congress_num = str(YEAR_TO_CONGRESS[year])
             else:
                 raise BoundaryConfigurationError(
                     f"Congressional district boundary type '{boundary_type}' requires a "
@@ -646,6 +672,14 @@ class CensusDirectoryDiscovery:
                     f"or the congress_number parameter.",
                     context={"boundary_type": boundary_type, "year": year},
                 )
+            # Census dropped the national CD file after 2021; 2022+ only publishes 56 per-state files.
+            if state_fips and year >= 2022:
+                return patterns['filename_patterns']['congress_state'].format(
+                    year=year, state_fips=state_fips, congress_num=congress_num
+                )
+            return patterns['filename_patterns']['congress'].format(
+                year=year, congress_num=congress_num
+            )
 
         # Handle state-required types
         elif boundary_type in state_required_types:
@@ -664,16 +698,27 @@ class CensusDirectoryDiscovery:
                     },
                 )
             
+            filename_part = _FILENAME_ABBREVS.get(boundary_type, boundary_type)
             return patterns['filename_patterns']['state'].format(
-                year=year, state_fips=state_fips, boundary_type=boundary_type
+                year=year, state_fips=state_fips, boundary_type=filename_part
             )
-        
+
+        # Handle ZCTA: filename abbreviation and directory are year-dependent.
+        # 2020+: ZCTA520 directory + zcta520 abbreviation.
+        # pre-2020: ZCTA5 directory + zcta510 abbreviation.
+        # ZCTA files are always national (no per-state variant exists).
+        elif boundary_type == 'zcta':
+            zcta_abbrev = 'zcta520' if year >= 2020 else 'zcta510'
+            return patterns['filename_patterns']['national'].format(
+                year=year, boundary_type=zcta_abbrev
+            )
+
         # Handle national-only types
         elif boundary_type in national_only_types:
             return patterns['filename_patterns']['national'].format(
                 year=year, boundary_type=boundary_type
             )
-        
+
         # Handle flexible types
         elif boundary_type in flexible_types:
             if state_fips:

--- a/siege_utilities/geo/spatial_data.py
+++ b/siege_utilities/geo/spatial_data.py
@@ -78,6 +78,7 @@ GeoDataFrame = gpd.GeoDataFrame
 # the pre-redistricting 116th boundaries for 2020 and 2021, then jumped
 # directly to cd118 when per-state files appeared for 2022.
 YEAR_TO_CONGRESS: Dict[int, int] = {
+    2010: 111,
     2011: 112,
     2012: 112,  # 113th elected Nov 2012 but TIGER 2012 still uses seated 112th
     2013: 113,  # 113th seated Jan 2013; direct URL confirmed 200
@@ -92,6 +93,8 @@ YEAR_TO_CONGRESS: Dict[int, int] = {
     2022: 118,  # post-redistricting; per-state files only (national = 404)
     2023: 118,
     2024: 119,
+    2025: 119,
+    2026: 119,
 }
 
 # ---------------------------------------------------------------------------
@@ -666,13 +669,20 @@ class CensusDirectoryDiscovery:
                 # Auto-lookup from verified year→congress mapping
                 congress_num = str(YEAR_TO_CONGRESS[year])
             else:
-                raise BoundaryConfigurationError(
-                    f"Congressional district boundary type '{boundary_type}' requires a "
-                    f"congress number. Provide it via the boundary_type name (e.g., 'cd118') "
-                    f"or the congress_number parameter.",
-                    context={"boundary_type": boundary_type, "year": year},
+                max_known = max(YEAR_TO_CONGRESS.keys())
+                congress_num = str(YEAR_TO_CONGRESS[max_known])
+                log.warning(
+                    "Year %d not in YEAR_TO_CONGRESS; falling back to %d (congress %s). "
+                    "Add the year to YEAR_TO_CONGRESS if this is incorrect.",
+                    year, max_known, congress_num,
                 )
             # Census dropped the national CD file after 2021; 2022+ only publishes 56 per-state files.
+            if year >= 2022 and not state_fips:
+                raise BoundaryConfigurationError(
+                    f"Congressional district national file is unavailable for {year}+. "
+                    f"Provide state_fips to download the per-state file.",
+                    context={"boundary_type": boundary_type, "year": year},
+                )
             if state_fips and year >= 2022:
                 return patterns['filename_patterns']['congress_state'].format(
                     year=year, state_fips=state_fips, congress_num=congress_num

--- a/siege_utilities/reporting/analytics_reports.py
+++ b/siege_utilities/reporting/analytics_reports.py
@@ -6,7 +6,7 @@ Integrates with Google Analytics, databases, and other data sources.
 import logging
 from pathlib import Path
 from typing import Dict, List, Any, Optional, Union
-from datetime import datetime, timedelta
+from datetime import datetime
 import pandas as pd
 
 from .report_generator import ReportGenerator

--- a/siege_utilities/reporting/chart_types.py
+++ b/siege_utilities/reporting/chart_types.py
@@ -3,11 +3,15 @@ Extensible chart type system for siege_utilities.
 Provides base chart types and easy extension capabilities.
 """
 
+from __future__ import annotations
+
 import logging
-from typing import Dict, Any, Optional, List, Callable
+from typing import TYPE_CHECKING, Dict, Any, Optional, List, Callable
 from dataclasses import dataclass, field
 import yaml
-from matplotlib.figure import Figure
+
+if TYPE_CHECKING:
+    from matplotlib.figure import Figure
 
 try:
     import geopandas as gpd

--- a/siege_utilities/reporting/chart_types.py
+++ b/siege_utilities/reporting/chart_types.py
@@ -3,15 +3,11 @@ Extensible chart type system for siege_utilities.
 Provides base chart types and easy extension capabilities.
 """
 
-from __future__ import annotations
-
 import logging
-from typing import TYPE_CHECKING, Dict, Any, Optional, List, Callable
+from typing import Dict, Any, Optional, List, Callable
 from dataclasses import dataclass, field
 import yaml
-
-if TYPE_CHECKING:
-    from matplotlib.figure import Figure
+from matplotlib.figure import Figure
 
 try:
     import geopandas as gpd

--- a/siege_utilities/reporting/wave_charts.py
+++ b/siege_utilities/reporting/wave_charts.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
-    import matplotlib.figure
     from ..survey.models import Chain
 
 

--- a/tests/test_boundary_catalog.py
+++ b/tests/test_boundary_catalog.py
@@ -1,7 +1,5 @@
 """Tests for BOUNDARY_TYPE_CATALOG and TIGER_FILE_PATTERNS consistency."""
 
-import pytest
-
 from siege_utilities.geo.spatial_data import BOUNDARY_TYPE_CATALOG
 from siege_utilities.config.census_constants import TIGER_FILE_PATTERNS
 

--- a/tests/test_boundary_catalog.py
+++ b/tests/test_boundary_catalog.py
@@ -73,8 +73,8 @@ class TestBoundaryTypeCatalog:
             assert BOUNDARY_TYPE_CATALOG[key]["geometry_type"] == "MultiPolygon"
 
     def test_minimum_entry_count(self):
-        """Catalog should have at least 47 entries (original + new)."""
-        assert len(BOUNDARY_TYPE_CATALOG) >= 47
+        """Catalog should have at least 46 entries (cd117 removed: 117th Congress absent from TIGER)."""
+        assert len(BOUNDARY_TYPE_CATALOG) >= 46
 
 
 class TestTigerFilePatterns:

--- a/tests/test_boundary_diagnostics.py
+++ b/tests/test_boundary_diagnostics.py
@@ -480,25 +480,46 @@ class TestBoundaryConfigurationError:
         disc.cache_timeout = 3600
         return disc
 
-    def test_cd_without_congress_number_raises(self):
-        """Congressional district without congress number raises BoundaryConfigurationError."""
+    def test_cd_without_congress_number_raises_for_unknown_year(self):
+        """Congressional district without congress_number raises for years not in YEAR_TO_CONGRESS."""
         disc = self._make_discovery()
         patterns = {
-            'base_url': 'https://www2.census.gov/geo/tiger/TIGER2020',
+            'base_url': 'https://www2.census.gov/geo/tiger/TIGER2000',
             'filename_patterns': {
                 'congress': 'tl_{year}_us_cd{congress_num}_shp.zip',
+                'congress_state': 'tl_{year}_{state_fips}_cd{congress_num}_shp.zip',
                 'state': 'tl_{year}_{state_fips}_{boundary_type}_shp.zip',
                 'national': 'tl_{year}_us_{boundary_type}_shp.zip',
             }
         }
+        # year=2000 is not in YEAR_TO_CONGRESS, so no auto-lookup is possible
         with pytest.raises(BoundaryConfigurationError) as exc_info:
             disc._construct_filename_with_fips_validation(
-                year=2020, boundary_type='cd', state_fips=None,
+                year=2000, boundary_type='cd', state_fips=None,
                 congress_number=None, patterns=patterns,
             )
         assert exc_info.value.stage == "configuration"
         assert "congress number" in str(exc_info.value).lower()
         assert exc_info.value.context["boundary_type"] == "cd"
+
+    def test_cd_auto_resolves_congress_for_known_year(self):
+        """For years in YEAR_TO_CONGRESS, congress number is auto-resolved without explicit parameter."""
+        disc = self._make_discovery()
+        patterns = {
+            'base_url': 'https://www2.census.gov/geo/tiger/TIGER2020',
+            'filename_patterns': {
+                'congress': 'tl_{year}_us_cd{congress_num}.zip',
+                'congress_state': 'tl_{year}_{state_fips}_cd{congress_num}.zip',
+                'state': 'tl_{year}_{state_fips}_{boundary_type}.zip',
+                'national': 'tl_{year}_us_{boundary_type}.zip',
+            }
+        }
+        # year=2020 → YEAR_TO_CONGRESS[2020] = 116 (NOT 117; cd117 absent from TIGER)
+        filename = disc._construct_filename_with_fips_validation(
+            year=2020, boundary_type='cd', state_fips=None,
+            congress_number=None, patterns=patterns,
+        )
+        assert filename == 'tl_2020_us_cd116.zip'
 
     def test_tract_without_state_fips_raises(self):
         """State-required type without state FIPS raises BoundaryConfigurationError."""

--- a/tests/test_boundary_diagnostics.py
+++ b/tests/test_boundary_diagnostics.py
@@ -479,8 +479,8 @@ class TestBoundaryConfigurationError:
         disc.cache_timeout = 3600
         return disc
 
-    def test_cd_without_congress_number_raises_for_unknown_year(self):
-        """Congressional district without congress_number raises for years not in YEAR_TO_CONGRESS."""
+    def test_cd_without_congress_number_uses_fallback_for_unknown_year(self):
+        """For years not in YEAR_TO_CONGRESS, congress number falls back to the max known year."""
         disc = self._make_discovery()
         patterns = {
             'base_url': 'https://www2.census.gov/geo/tiger/TIGER2000',
@@ -491,15 +491,12 @@ class TestBoundaryConfigurationError:
                 'national': 'tl_{year}_us_{boundary_type}_shp.zip',
             }
         }
-        # year=2000 is not in YEAR_TO_CONGRESS, so no auto-lookup is possible
-        with pytest.raises(BoundaryConfigurationError) as exc_info:
-            disc._construct_filename_with_fips_validation(
-                year=2000, boundary_type='cd', state_fips=None,
-                congress_number=None, patterns=patterns,
-            )
-        assert exc_info.value.stage == "configuration"
-        assert "congress number" in str(exc_info.value).lower()
-        assert exc_info.value.context["boundary_type"] == "cd"
+        # year=2000 is not in YEAR_TO_CONGRESS; falls back to max known year (2026 → congress 119)
+        result = disc._construct_filename_with_fips_validation(
+            year=2000, boundary_type='cd', state_fips=None,
+            congress_number=None, patterns=patterns,
+        )
+        assert result == 'tl_2000_us_cd119_shp.zip'
 
     def test_cd_auto_resolves_congress_for_known_year(self):
         """For years in YEAR_TO_CONGRESS, congress number is auto-resolved without explicit parameter."""

--- a/tests/test_boundary_diagnostics.py
+++ b/tests/test_boundary_diagnostics.py
@@ -6,8 +6,7 @@ actionable, machine-readable failure information instead of silent None returns.
 """
 
 import pytest
-from unittest.mock import Mock, patch, MagicMock
-from pathlib import Path
+from unittest.mock import Mock, patch
 
 from siege_utilities.geo.boundary_result import (
     BoundaryFetchResult,

--- a/tests/test_census_api_client.py
+++ b/tests/test_census_api_client.py
@@ -829,8 +829,8 @@ class TestGEOIDValidationFromAPI:
         client = CensusAPIClient.__new__(CensusAPIClient)
         df = pd.DataFrame([{'state': '06', 'county': '037'}])
         result = client._construct_geoid(df, 'county')
-        assert result['GEOID'].dtype == 'object', (
-            f"GEOID column dtype is {result['GEOID'].dtype}, expected 'object' (string)"
+        assert pd.api.types.is_string_dtype(result['GEOID']), (
+            f"GEOID column dtype is {result['GEOID'].dtype}, expected a string dtype"
         )
 
     def test_all_mock_geoids_pass_validation(self):

--- a/tests/test_census_api_client.py
+++ b/tests/test_census_api_client.py
@@ -6,9 +6,8 @@ Tests the CensusAPIClient class and convenience functions with mocked responses.
 
 import pytest
 import pandas as pd
-import json
 from pathlib import Path
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
 import tempfile
 import os
 
@@ -23,7 +22,6 @@ def _has_pyarrow():
 from siege_utilities.geo.census_api_client import (
     CensusAPIClient,
     CensusAPIError,
-    CensusAPIKeyError,
     CensusRateLimitError,
     CensusVariableError,
     CensusGeographyError,
@@ -32,8 +30,6 @@ from siege_utilities.geo.census_api_client import (
     get_demographics,
     get_population,
     get_income_data,
-    get_education_data,
-    get_housing_data,
     get_census_api_client,
 )
 
@@ -132,7 +128,7 @@ class TestCensusAPIClientInit:
         with tempfile.TemporaryDirectory() as temp_dir:
             cache_path = Path(temp_dir) / 'census_cache'
             assert not cache_path.exists()
-            client = CensusAPIClient(cache_dir=cache_path)
+            CensusAPIClient(cache_dir=cache_path)
             assert cache_path.exists()
 
     def test_init_with_custom_timeout(self, temp_cache_dir):
@@ -595,7 +591,7 @@ class TestConvenienceFunctions:
         })
         mock_fetch.return_value = mock_df
 
-        df = get_demographics(state='California', geography='county', year=2020)
+        get_demographics(state='California', geography='county', year=2020)
 
         assert mock_fetch.called
         call_kwargs = mock_fetch.call_args.kwargs
@@ -612,7 +608,7 @@ class TestConvenienceFunctions:
         })
         mock_fetch.return_value = mock_df
 
-        df = get_population(state='CA', geography='tract', year=2020)
+        get_population(state='CA', geography='tract', year=2020)
 
         assert mock_fetch.called
         call_kwargs = mock_fetch.call_args.kwargs
@@ -628,7 +624,7 @@ class TestConvenienceFunctions:
         })
         mock_fetch.return_value = mock_df
 
-        df = get_income_data(state='06', geography='tract', year=2020)
+        get_income_data(state='06', geography='tract', year=2020)
 
         assert mock_fetch.called
         call_kwargs = mock_fetch.call_args.kwargs

--- a/tests/test_census_geocoder_errors.py
+++ b/tests/test_census_geocoder_errors.py
@@ -23,7 +23,7 @@ class TestGeocodeSingle:
         fake = MagicMock()
         fake.onelineaddress.side_effect = ConnectionError("network down")
         with patch(
-            "siege_utilities.geo.census_geocoder._get_geocoder",
+            "siege_utilities.geo.providers.census_geocoder._get_geocoder",
             return_value=fake,
         ):
             with pytest.raises(CensusGeocodeError) as exc_info:
@@ -36,7 +36,7 @@ class TestGeocodeSingle:
         fake = MagicMock()
         fake.onelineaddress.return_value = {"result": {"addressMatches": []}}
         with patch(
-            "siege_utilities.geo.census_geocoder._get_geocoder",
+            "siege_utilities.geo.providers.census_geocoder._get_geocoder",
             return_value=fake,
         ):
             result = geocode_single("garbage", "nowhere", "ZZ", "00000")
@@ -54,7 +54,7 @@ class TestGeocodeBatch:
             {"id": "2", "street": "e", "city": "f", "state": "g", "zipcode": "h"},
         ]
         with patch(
-            "siege_utilities.geo.census_geocoder._get_geocoder",
+            "siege_utilities.geo.providers.census_geocoder._get_geocoder",
             return_value=fake,
         ):
             with pytest.raises(CensusGeocodeError) as exc_info:

--- a/tests/test_chart_types.py
+++ b/tests/test_chart_types.py
@@ -1,6 +1,7 @@
 """Tests for siege_utilities.reporting.chart_types module."""
 
 import pytest
+pytest.importorskip("matplotlib")
 from unittest.mock import MagicMock
 from siege_utilities.reporting.chart_types import (
     ChartCreationError,

--- a/tests/test_chart_types_errors.py
+++ b/tests/test_chart_types_errors.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import pytest
+pytest.importorskip("matplotlib")
 
 from siege_utilities.reporting.chart_types import (
     ChartCreationError,

--- a/tests/test_data_split_shims.py
+++ b/tests/test_data_split_shims.py
@@ -71,7 +71,7 @@ class TestDeprecationShims:
     def test_data_naics_soc_crosswalk_shim(self):
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            mod = _reimport("siege_utilities.data.naics_soc_crosswalk")
+            _reimport("siege_utilities.data.naics_soc_crosswalk")
         assert any(issubclass(w.category, DeprecationWarning) for w in caught)
 
 

--- a/tests/test_enhanced_census_utilities.py
+++ b/tests/test_enhanced_census_utilities.py
@@ -13,9 +13,11 @@ from unittest.mock import Mock, patch
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from siege_utilities.geo.spatial_data import (
-    CensusDirectoryDiscovery, 
+    CensusDirectoryDiscovery,
     CensusDataSource,
-    SpatialDataSource
+    SpatialDataSource,
+    BoundaryConfigurationError,
+    YEAR_TO_CONGRESS,
 )
 
 
@@ -375,11 +377,17 @@ class TestCensusDirectoryDiscovery:
         url = self.discovery.construct_download_url(2022, 'cd', state_fips='48')
         assert url == "https://www2.census.gov/geo/tiger/TIGER2022/CD/tl_2022_48_cd118.zip"
 
-    def test_cd_2022_national_uses_congress_pattern(self):
-        """CD 2022 without state_fips still constructs with national pattern (caller's responsibility)."""
+    def test_cd_2022_without_state_fips_raises(self):
+        """CD 2022+ without state_fips must raise: Census dropped the national file after 2021."""
         self.discovery.discover_boundary_types = Mock(return_value={'cd': 'CD'})
-        url = self.discovery.construct_download_url(2022, 'cd')
-        assert url == "https://www2.census.gov/geo/tiger/TIGER2022/CD/tl_2022_us_cd118.zip"
+        with pytest.raises(BoundaryConfigurationError):
+            self.discovery.construct_download_url(2022, 'cd')
+
+    def test_year_to_congress_new_entries(self):
+        """YEAR_TO_CONGRESS must include 2010, 2025, and 2026."""
+        assert YEAR_TO_CONGRESS[2010] == 111
+        assert YEAR_TO_CONGRESS[2025] == 119
+        assert YEAR_TO_CONGRESS[2026] == 119
 
     def test_zcta520_directory_recognized(self):
         """ZCTA520 directory name (2020+) should map to 'zcta' boundary type."""

--- a/tests/test_enhanced_census_utilities.py
+++ b/tests/test_enhanced_census_utilities.py
@@ -7,10 +7,7 @@ Tests the dynamic discovery system, data source functionality, and all new featu
 import pytest
 import sys
 import os
-from unittest.mock import Mock, patch, MagicMock
-from pathlib import Path
-import tempfile
-import shutil
+from unittest.mock import Mock, patch
 
 # Add the project root to the path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/tests/test_enhanced_census_utilities.py
+++ b/tests/test_enhanced_census_utilities.py
@@ -248,9 +248,9 @@ class TestCensusDirectoryDiscovery:
         url = self.discovery.construct_download_url(2020, 'tract', state_fips='06')
         assert url == "https://www2.census.gov/geo/tiger/TIGER2020/TRACT/tl_2020_06_tract.zip"
         
-        # Test block groups for Texas (FIPS 48)
+        # Test block groups for Texas (FIPS 48) — Census uses 'bg' not 'block_group' in filenames.
         url = self.discovery.construct_download_url(2020, 'block_group', state_fips='48')
-        assert url == "https://www2.census.gov/geo/tiger/TIGER2020/BG/tl_2020_48_block_group.zip"
+        assert url == "https://www2.census.gov/geo/tiger/TIGER2020/BG/tl_2020_48_bg.zip"
     
     def test_construct_download_url_congressional_districts(self):
         """Test URL construction for congressional districts."""
@@ -345,6 +345,52 @@ class TestCensusDirectoryDiscovery:
 
         with pytest.raises(BoundaryUrlValidationError):
             self.discovery.validate_download_url("https://example.com/test.zip")
+
+    def test_construct_download_url_zcta_pre2020(self):
+        """ZCTA pre-2020: directory ZCTA5, filename abbreviation zcta510."""
+        self.discovery.discover_boundary_types = Mock(return_value={'zcta': 'ZCTA5'})
+        url = self.discovery.construct_download_url(2019, 'zcta')
+        assert url == "https://www2.census.gov/geo/tiger/TIGER2019/ZCTA5/tl_2019_us_zcta510.zip"
+
+    def test_construct_download_url_zcta_2020plus(self):
+        """ZCTA 2020+: directory ZCTA520, filename abbreviation zcta520."""
+        self.discovery.discover_boundary_types = Mock(return_value={'zcta': 'ZCTA520'})
+        url = self.discovery.construct_download_url(2022, 'zcta')
+        assert url == "https://www2.census.gov/geo/tiger/TIGER2022/ZCTA520/tl_2022_us_zcta520.zip"
+
+    def test_year_to_congress_2012_is_cd112(self):
+        """Year 2012 uses cd112, NOT cd113 (113th elected Nov 2012 but not seated until Jan 2013)."""
+        self.discovery.discover_boundary_types = Mock(return_value={'cd': 'CD'})
+        url = self.discovery.construct_download_url(2012, 'cd')
+        assert 'cd112' in url, f"Expected cd112 in URL for year 2012, got: {url}"
+        assert url == "https://www2.census.gov/geo/tiger/TIGER2012/CD/tl_2012_us_cd112.zip"
+
+    def test_year_to_congress_2021_is_cd116(self):
+        """Year 2021 uses cd116, NOT cd117 (117th Congress is entirely absent from TIGER)."""
+        self.discovery.discover_boundary_types = Mock(return_value={'cd': 'CD'})
+        url = self.discovery.construct_download_url(2021, 'cd')
+        assert 'cd116' in url, f"Expected cd116 in URL for year 2021, got: {url}"
+        assert url == "https://www2.census.gov/geo/tiger/TIGER2021/CD/tl_2021_us_cd116.zip"
+
+    def test_cd_2022_per_state(self):
+        """CD 2022+: Census dropped the national file; per-state files only."""
+        self.discovery.discover_boundary_types = Mock(return_value={'cd': 'CD'})
+        url = self.discovery.construct_download_url(2022, 'cd', state_fips='48')
+        assert url == "https://www2.census.gov/geo/tiger/TIGER2022/CD/tl_2022_48_cd118.zip"
+
+    def test_cd_2022_national_uses_congress_pattern(self):
+        """CD 2022 without state_fips still constructs with national pattern (caller's responsibility)."""
+        self.discovery.discover_boundary_types = Mock(return_value={'cd': 'CD'})
+        url = self.discovery.construct_download_url(2022, 'cd')
+        assert url == "https://www2.census.gov/geo/tiger/TIGER2022/CD/tl_2022_us_cd118.zip"
+
+    def test_zcta520_directory_recognized(self):
+        """ZCTA520 directory name (2020+) should map to 'zcta' boundary type."""
+        # When Census returns ZCTA520 as directory, boundary_mapping must recognize it.
+        self.discovery.discover_boundary_types = Mock(return_value={'zcta': 'ZCTA520'})
+        url = self.discovery.construct_download_url(2021, 'zcta')
+        assert 'zcta520' in url
+        assert url == "https://www2.census.gov/geo/tiger/TIGER2021/ZCTA520/tl_2021_us_zcta520.zip"
 
 
 class TestCensusDataSource:

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -8,8 +8,6 @@ import os
 import sys
 from unittest.mock import patch, Mock, MagicMock
 
-import pytest
-
 from siege_utilities.testing.environment import (
     _get_sdkman_root,
     _get_system_java_paths,

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -45,7 +45,9 @@ class TestGetSdkmanRoot:
         def exists_side_effect(path):
             return path == standard_path
 
-        with patch.dict(os.environ, {}, clear=True):
+        # Preserve HOME so expanduser("~") stays consistent; only remove SDKMAN_DIR.
+        safe_env = {k: v for k, v in os.environ.items() if k != 'SDKMAN_DIR'}
+        with patch.dict(os.environ, safe_env, clear=True):
             with patch('os.path.exists', side_effect=exists_side_effect):
                 result = _get_sdkman_root()
                 assert result == standard_path

--- a/tests/test_polling_analyzer_deprecation.py
+++ b/tests/test_polling_analyzer_deprecation.py
@@ -5,6 +5,8 @@ import importlib
 import sys
 import warnings
 
+import pytest
+
 
 def _reimport(module_name: str):
     if module_name in sys.modules:
@@ -13,6 +15,10 @@ def _reimport(module_name: str):
 
 
 class TestPollingAnalyzerDeprecation:
+    @pytest.fixture(autouse=True)
+    def _require_matplotlib(self):
+        pytest.importorskip("matplotlib")
+
     def test_construction_emits_deprecation_warning(self):
         from siege_utilities.reporting.analytics.polling_analyzer import (
             PollingAnalyzer,
@@ -30,6 +36,10 @@ class TestPollingAnalyzerDeprecation:
 
 
 class TestAnalyticsReportsPromotion:
+    @pytest.fixture(autouse=True)
+    def _require_reportlab(self):
+        pytest.importorskip("reportlab")
+
     def test_new_import_path_works(self):
         from siege_utilities.reporting.analytics_reports import (
             AnalyticsReportGenerator,

--- a/tests/test_polling_analyzer_deprecation.py
+++ b/tests/test_polling_analyzer_deprecation.py
@@ -16,8 +16,8 @@ def _reimport(module_name: str):
 
 class TestPollingAnalyzerDeprecation:
     @pytest.fixture(autouse=True)
-    def _require_matplotlib(self):
-        pytest.importorskip("matplotlib")
+    def _require_reportlab(self):
+        pytest.importorskip("reportlab")
 
     def test_construction_emits_deprecation_warning(self):
         from siege_utilities.reporting.analytics.polling_analyzer import (

--- a/tests/test_reporting_config_exports.py
+++ b/tests/test_reporting_config_exports.py
@@ -80,6 +80,10 @@ class TestImportBrandingConfig:
 
 
 class TestExportChartTypeConfig:
+    @pytest.fixture(autouse=True)
+    def _require_matplotlib(self):
+        pytest.importorskip("matplotlib")
+
     def test_raises_on_unknown_chart_type(self, tmp_path):
         class _Boom:
             def export_chart_type_config(self, *a, **kw):

--- a/tests/test_survey_significance.py
+++ b/tests/test_survey_significance.py
@@ -86,11 +86,13 @@ class TestColumnProportionTest:
 
 
 class TestChiSquareFlag:
+    @requires_scipy
     def test_returns_chain(self):
         chain = _make_chain_two_cols()
         result = chi_square_flag(chain)
         assert result is chain
 
+    @requires_scipy
     def test_sets_chi_square_significant(self):
         chain = _make_chain_two_cols()
         chi_square_flag(chain)

--- a/uv.lock
+++ b/uv.lock
@@ -518,6 +518,19 @@ wheels = [
 ]
 
 [[package]]
+name = "censusgeocode"
+version = "0.5.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "requests-toolbelt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/b7/74615b3db872f28e3d6ffcbcef0a8f0b4ba1d2982a7fb5c12d233eb204a0/censusgeocode-0.5.3.tar.gz", hash = "sha256:6b26c71495ce860e38ece54032552fd1e112fec6a16f8c7fff88788d84f1dfbc", size = 22239, upload-time = "2026-02-08T00:06:50.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/c0/d3f062406149c5744364286c48c6edf3e15e6955b577a9e3f9503337e4a6/censusgeocode-0.5.3-py3-none-any.whl", hash = "sha256:f6dc7e5f6162593f8f93b8d35bb756ff96e025f2221dc93ad13b516fb38d18f7", size = 20633, upload-time = "2026-02-08T00:06:49.327Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.8.3"
 source = { registry = "https://pypi.org/simple" }
@@ -964,6 +977,20 @@ wheels = [
 ]
 
 [[package]]
+name = "databricks-sdk"
+version = "0.105.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/4a/14c0608545b9a0a1103d6a964b226241c336ff8aa99d4226f9741af60f17/databricks_sdk-0.105.0.tar.gz", hash = "sha256:c52bf21c5e5814bc3d741a98fc772f4b6f1f9cfa08e90bf7580aa1592bc92e92", size = 917927, upload-time = "2026-04-23T08:53:44.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/8c/27651e85dab9897c65c4acf7abcd924e85f8726d282804fc7686f1387520/databricks_sdk-0.105.0-py3-none-any.whl", hash = "sha256:f1624e434588e2174052bc3646670f17581f3bb269b9438f9121e9df4a59eebd", size = 866235, upload-time = "2026-04-23T08:53:42.01Z" },
+]
+
+[[package]]
 name = "datadotworld"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1183,6 +1210,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/68/fc/259a54fc22111a847981927aa58528d766e8b228c6d41deb0ad8a1959f9f/duckdb-1.3.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4732fb8cc60566b60e7e53b8c19972cb5ed12d285147a3063b16cc64a79f6d9f", size = 21128404, upload-time = "2025-07-08T10:40:53.772Z" },
     { url = "https://files.pythonhosted.org/packages/ab/dc/5d5140383e40661173dacdceaddee2a97c3f6721a5e8d76e08258110595e/duckdb-1.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:97f7a22dcaa1cca889d12c3dc43a999468375cdb6f6fe56edf840e062d4a8293", size = 22779786, upload-time = "2025-07-08T10:40:55.826Z" },
     { url = "https://files.pythonhosted.org/packages/51/c9/2fcd86ab7530a5b6caff42dbe516ce7a86277e12c499d1c1f5acd266ffb2/duckdb-1.3.2-cp313-cp313-win_amd64.whl", hash = "sha256:cd3d717bf9c49ef4b1016c2216517572258fa645c2923e91c5234053defa3fb5", size = 11395370, upload-time = "2025-07-08T10:40:57.655Z" },
+]
+
+[[package]]
+name = "entrypoints"
+version = "0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/8d/a7121ffe5f402dc015277d2d31eb82d2187334503a011c18f2e78ecbb9b2/entrypoints-0.4.tar.gz", hash = "sha256:b706eddaa9218a19ebcd67b56818f05bb27589b1ca9e8d797b74affad4ccacd4", size = 13974, upload-time = "2022-02-02T21:30:28.172Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/a8/365059bbcd4572cbc41de17fd5b682be5868b218c3c5479071865cab9078/entrypoints-0.4-py3-none-any.whl", hash = "sha256:f174b5ff827504fd3cd97cc3f8649f3693f51538c7e4bdf3ef002c8429d42f9f", size = 5294, upload-time = "2022-02-02T21:30:26.024Z" },
 ]
 
 [[package]]
@@ -1822,6 +1858,41 @@ wheels = [
 ]
 
 [[package]]
+name = "h3"
+version = "4.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/8e/ebe086a820bbe02a932db9cbff9c1730cba9a6e9a0a140d4a2ed0ce7508a/h3-4.4.2.tar.gz", hash = "sha256:b25ab9f339e40b10dcb5e2e6988d07672e780a4950d79c25380d308cdf14f82f", size = 171891, upload-time = "2026-01-29T19:22:55.41Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/ab/1dc3c41dc14ad9b12f640a7694ea4a5bd1b6cb5e8f2c649aae4b201906bc/h3-4.4.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9f3b06d2403f591aaaef96499726ced99aff560c0951e354d5c2133c43873c74", size = 822384, upload-time = "2026-01-29T19:22:09.43Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c0/76321499a3b16a486240d904922cebd29d2c803224e0fe0524cf258ebac4/h3-4.4.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:28e857c8a3f8183d30e1860d997fc1c0f1f40242baba55e026bbb88623791eac", size = 992905, upload-time = "2026-01-29T19:22:11.142Z" },
+    { url = "https://files.pythonhosted.org/packages/21/22/2692520c17cf888d3c682e3ee0e45c00666e5f6eea9bb5674d1a4a50eb52/h3-4.4.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:17b9230ca5ef70ffed23ccc6ed8fe30300b5146ad1f77ec0a5d7b2e1bfd84dcf", size = 1029650, upload-time = "2026-01-29T19:22:12.769Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a3/83820d87e60bf47ca8d5c3dccd3bdcd308c3efc604860143caea53ef50bb/h3-4.4.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5ba03b202233e1bdedf52608e0ff30dd4ca52cc1b3c0fd8847a914368a1ab846", size = 1041686, upload-time = "2026-01-29T19:22:14.324Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/6a/20168b6d574e38aa9e3c9ad8d8f2d098f74dbe1d6610e4391196ca7504b7/h3-4.4.2-cp311-cp311-win_amd64.whl", hash = "sha256:8cebe93fc477620354bde6e8a8c745f3a0b6996df78225a11e82902bc70b5061", size = 796339, upload-time = "2026-01-29T19:22:15.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/96/60b6bf344b1960dda78a877dbd08a67963ce362a84672b9869058e962f67/h3-4.4.2-cp311-cp311-win_arm64.whl", hash = "sha256:57e0af15a694ad03f620800232bb545173ccb25ae8c9112144a1eed5b3811fd7", size = 699749, upload-time = "2026-01-29T19:22:16.356Z" },
+    { url = "https://files.pythonhosted.org/packages/05/8a/a4d2d7b0b750d558542999f19d188a22333eb6e4db89d9938feeca8534a7/h3-4.4.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0f79e9ee215e6896dae41c93ebf95b3fc594818feecbcecf7833e1f8b9c892b7", size = 822106, upload-time = "2026-01-29T19:22:17.39Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/ae/6ef2c13d2267c04ba32e056dfda2d93265ceca51ba16a36a53084c56e157/h3-4.4.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:03b423232cafe89b4b06c2f8c636a7c04efecf6cc0f539e4eaa6301a9b21fd46", size = 974881, upload-time = "2026-01-29T19:22:18.505Z" },
+    { url = "https://files.pythonhosted.org/packages/24/2c/b135f8ea5fb89f9cc0e0084cb8ff0885d5df1c0b7117f2b71400fe54f51f/h3-4.4.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0947c86532005870eb5565bda80270dc37029f34ffa4903e5f353ce5d4acab41", size = 1019313, upload-time = "2026-01-29T19:22:19.488Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ea/7aa732f2c8b4bdabe3c5ab36a58149963fd1bf1d556e976a3fbea35def2d/h3-4.4.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:06267484978c7df7d8e675dfab660967387f9ef154c7452ae38b578d80641445", size = 1030677, upload-time = "2026-01-29T19:22:20.534Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/86/b92030c634572b9f5e93a3fa626c68576e4a12e6a99e5117f85cc7b7fbd9/h3-4.4.2-cp312-cp312-win_amd64.whl", hash = "sha256:8d612b6dc0ccca41fe4bdcfe3b59915c9455aa791db031b49f05d48f243fcc05", size = 787290, upload-time = "2026-01-29T19:22:21.572Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/06/895d6489052e50a0eb292507a93f53763bf711a27451312ea2149622f811/h3-4.4.2-cp312-cp312-win_arm64.whl", hash = "sha256:6f1e76252ed43fd58f92fbf29d4d0d0aa9af26b97c31d2ea0a6d38f074f89e78", size = 704310, upload-time = "2026-01-29T19:22:22.595Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/8c/52a6d8fea33fa0f32a2eb84f1e96eea6efd6f8f8c5119797f555dcee8417/h3-4.4.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:76dbf27b8bdf0d21275ad5f16206385208c11e6f1b96d5a88c9df974ff6b8fe5", size = 817555, upload-time = "2026-01-29T19:22:24.228Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/df/44a1c9807d3635edc2b996a9161d991b77935d2f14a740296c28ee675b19/h3-4.4.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b61e8d5cafd39434c036a905d34729e99c3ebede591a92e8532840cad41d51f", size = 971465, upload-time = "2026-01-29T19:22:26.138Z" },
+    { url = "https://files.pythonhosted.org/packages/45/a6/9cac4b5ea1dad5767a1b6dcc2eb8255a5bc5ec2c968e558484fcde328304/h3-4.4.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e243abf0f738d7ef5683ee52e3dd1ab0abebe9c38d05d485b5aff7cec97be3e9", size = 1014979, upload-time = "2026-01-29T19:22:27.189Z" },
+    { url = "https://files.pythonhosted.org/packages/14/fb/8371d46fc3979b9e40ab7ea8636ebc54267982a27936704c98e2f975067a/h3-4.4.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bc0059c73dabf82d9be29f524d1bd8cb670b903406d11d02e5826acd8b2f887c", size = 1026394, upload-time = "2026-01-29T19:22:28.754Z" },
+    { url = "https://files.pythonhosted.org/packages/82/a7/283e814577d80a6de11f8ef352501cbce7402308a2de20a282eefa9c1fce/h3-4.4.2-cp313-cp313-win_amd64.whl", hash = "sha256:1ddff977c69afca3bd37af0c97a942ab35d5a98830af2ba9b7450ee0365d5852", size = 784314, upload-time = "2026-01-29T19:22:29.798Z" },
+    { url = "https://files.pythonhosted.org/packages/71/0a/b95da51292b14d7cc28884770f393b85c6f419ba3040d45a5d7493cf97c1/h3-4.4.2-cp313-cp313-win_arm64.whl", hash = "sha256:ff52be8019c943cc124f99664c61eb0dddf86f1c35cddce10685d86bc0e609ad", size = 702391, upload-time = "2026-01-29T19:22:30.942Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d9/0a06b7b907200ef861c809bc5410d5e6d39930f1e95316a3c98ce351a5b5/h3-4.4.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4afd9362353852e751029e2f1933af9e0606bd0903f9e48daf35a3ded26251ad", size = 821574, upload-time = "2026-01-29T19:22:32.236Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/20/679efa28e708192bc8bc686b4cb6e7882a2aa8df97e9cce4dac520599bd7/h3-4.4.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f3b09636f08ab5213d703940638eaf58c8d1d8c0d0e13405b72b4d48a3e06c38", size = 979796, upload-time = "2026-01-29T19:22:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/43/a1/0dc47be62f67e141eb6e12e77aae135414875fea4d3199ec173391a20e85/h3-4.4.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aa8fd684e0e0d367c65d94c33b4bc6653524688ee9d1099a5f92e46c3db4b11e", size = 1018019, upload-time = "2026-01-29T19:22:34.279Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2e/9991a62ce73d2b3d4e00c2097d4985ac7756e18ee9575a19653fdcaef6c3/h3-4.4.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4298da8334dfd69163d6eb4ae22e95f37dd495dddee116d1d1c964438352257e", size = 1028808, upload-time = "2026-01-29T19:22:35.494Z" },
+    { url = "https://files.pythonhosted.org/packages/17/aa/42ccc99f4d3e3bc032fbfaa04521f8763a247d513e3db577a41cf78a205a/h3-4.4.2-cp314-cp314-win_amd64.whl", hash = "sha256:d05d4e053ea288fc9e5b6eb94980ab980d160cd10db34ff1351e5959b68e7f7a", size = 801916, upload-time = "2026-01-29T19:22:36.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d2/c67f243d5b69dd07a7699ed7443d5baa937c8189da7c564bb372a9f0e86e/h3-4.4.2-cp314-cp314-win_arm64.whl", hash = "sha256:6ad6583420824f62c7dd09388eb7799644518bb79c28e1e5ddcf9583d1e3643e", size = 722749, upload-time = "2026-01-29T19:22:37.528Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/c4/4cff71436168c167af45bc33facc7978b8a205cada5ac32fb957cb6d0757/h3-4.4.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5489c06eb616d28f9905ac23449e807edd0cea280425dcf86641379267006115", size = 862443, upload-time = "2026-01-29T19:22:39.222Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/ba/92020e90aa74a72f51ff684afaaf05be39c1c3674ae98af4078c1e5865cb/h3-4.4.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0cfadbd484fbe2cd4aca821e516448edc5763edb208d17b9e42dd7b309fbcc5b", size = 989671, upload-time = "2026-01-29T19:22:40.43Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5f/ee7d49f219522a9235152cfd5968c9ca13cb7c15e9b827b39fb7640aed8a/h3-4.4.2-cp314-cp314t-win_amd64.whl", hash = "sha256:7767f82d383f4e605b9e79690ddcfaf6264edbf9046396117fdd7ee74473c839", size = 898314, upload-time = "2026-01-29T19:22:41.423Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1887,6 +1958,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0d/6b/cd510a2966a6e4cc1f056468370d567e8631db3cf0de104386f979ab38b2/hydra_zen-0.15.0.tar.gz", hash = "sha256:4f8c0f37d61183bcd79f2c1de55dfd64cd215c17f2661c84eeeb8009215ccebb", size = 1331380, upload-time = "2025-06-03T13:39:36.47Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/4f/898ac771f0483560f2d129431a1be5eb9a248c8b3221ae912482692c771e/hydra_zen-0.15.0-py3-none-any.whl", hash = "sha256:84ecd368dc52f6bf6052d26c1d675f014089f2a5e64c150bf29c5a5d3f5b4188", size = 105089, upload-time = "2025-06-03T13:39:34.706Z" },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.152.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/90/fc0b263b6f2622e5f8d2aa93f2e95ba79718a5faa7d2a74bfab10d6b0905/hypothesis-6.152.3.tar.gz", hash = "sha256:c4e5300d3755b6c8a270a28fe5abff40153e927328e89d2bb0229c1384618998", size = 466478, upload-time = "2026-04-26T17:31:07.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/38/15475b91a4c12721d2be3349e9d6cf8649c76ed9bc1287e2de7c8d06c261/hypothesis-6.152.3-py3-none-any.whl", hash = "sha256:4b47f00916c858ed49cf870a2f08b04e5fff5afae0bb78f3b4a6d9c74fd6c7bc", size = 532154, upload-time = "2026-04-26T17:31:04.42Z" },
 ]
 
 [[package]]
@@ -3062,6 +3145,22 @@ wheels = [
 ]
 
 [[package]]
+name = "nbmake"
+version = "1.5.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ipykernel" },
+    { name = "nbclient" },
+    { name = "nbformat" },
+    { name = "pygments" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/9a/aae201cee5639e1d562b3843af8fd9f8d018bb323e776a2b973bdd5fc64b/nbmake-1.5.5.tar.gz", hash = "sha256:239dc868ea13a7c049746e2aba2c229bd0f6cdbc6bfa1d22f4c88638aa4c5f5c", size = 85929, upload-time = "2024-12-23T18:33:46.774Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/be/b257e12f9710819fde40adc972578bee6b72c5992da1bc8369bef2597756/nbmake-1.5.5-py3-none-any.whl", hash = "sha256:c6fbe6e48b60cacac14af40b38bf338a3b88f47f085c54ac5b8639ff0babaf4b", size = 12818, upload-time = "2024-12-23T18:33:44.566Z" },
+]
+
+[[package]]
 name = "nest-asyncio"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3333,6 +3432,26 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/70/6f/3dd4940bbe001c06a65f88e36bad298bc7a0de5036115639926b0c5c0458/pandocfilters-1.5.1.tar.gz", hash = "sha256:002b4a555ee4ebc03f8b66307e287fa492e4a77b4ea14d3f934328297bb4939e", size = 8454, upload-time = "2024-01-18T20:08:13.726Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/af/4fbc8cab944db5d21b7e2a5b8e9211a03a79852b1157e2c102fcc61ac440/pandocfilters-1.5.1-py2.py3-none-any.whl", hash = "sha256:93be382804a9cdb0a7267585f157e5d1731bbe5545a85b268d6f5fe6232de2bc", size = 8663, upload-time = "2024-01-18T20:08:11.28Z" },
+]
+
+[[package]]
+name = "papermill"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp", marker = "python_full_version == '3.12.*'" },
+    { name = "click" },
+    { name = "entrypoints" },
+    { name = "nbclient" },
+    { name = "nbformat" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "tenacity" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/b6/92d770c5ced66ed0134256f8de781e98c824d3a0662af1643a91fcc36663/papermill-2.7.0.tar.gz", hash = "sha256:ec10b37594a060662f57269e1ebd108c209d204450f00fdfeb70a1c7cfb7fbc8", size = 77961, upload-time = "2026-02-27T19:07:30.548Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/9f/f9fd57a727dcc89c54e84455d8317bff7db05ef21bb6d05b03705111f7c0/papermill-2.7.0-py3-none-any.whl", hash = "sha256:e1855e6670100a02bb4f8a6870484a5c10b84a8d2e49c49921c90209940c7514", size = 88858, upload-time = "2026-02-27T19:07:28.862Z" },
 ]
 
 [[package]]
@@ -4170,6 +4289,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-django"
+version = "4.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/2b/db9a193df89e5660137f5428063bcc2ced7ad790003b26974adf5c5ceb3b/pytest_django-4.12.0.tar.gz", hash = "sha256:df94ec819a83c8979c8f6de13d9cdfbe76e8c21d39473cfe2b40c9fc9be3c758", size = 91156, upload-time = "2026-02-14T18:40:49.235Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/a5/41d091f697c09609e7ef1d5d61925494e0454ebf51de7de05f0f0a728f1d/pytest_django-4.12.0-py3-none-any.whl", hash = "sha256:3ff300c49f8350ba2953b90297d23bf5f589db69545f56f1ec5f8cff5da83e85", size = 26123, upload-time = "2026-02-14T18:40:47.381Z" },
+]
+
+[[package]]
 name = "pytest-forked"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4231,6 +4362,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/61/99/3323ee5c16b3637b4d941c362182d3e749c11e400bea31018c42219f3a98/pytest_mock-3.15.0.tar.gz", hash = "sha256:ab896bd190316b9d5d87b277569dfcdf718b2d049a2ccff5f7aca279c002a1cf", size = 33838, upload-time = "2025-09-04T20:57:48.679Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/b3/7fefc43fb706380144bcd293cc6e446e6f637ddfa8b83f48d1734156b529/pytest_mock-3.15.0-py3-none-any.whl", hash = "sha256:ef2219485fb1bd256b00e7ad7466ce26729b30eadfc7cbcdb4fa9a92ca68db6f", size = 10050, upload-time = "2025-09-04T20:57:47.274Z" },
+]
+
+[[package]]
+name = "pytest-randomly"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/b3/36192dacc0f470ac2cc516f73e01739c9a48a8224f76beada4f85e1c8a89/pytest_randomly-4.1.0.tar.gz", hash = "sha256:47f1d9746c3bc3efabd53ae1ebfb8bb385cf3d4df4b505b6d58d9c97a3dfe70f", size = 14302, upload-time = "2026-04-20T13:01:51.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/db/2df9a1fca597a273f957a559c20c2d95d629928384507b2afa43ba6909d1/pytest_randomly-4.1.0-py3-none-any.whl", hash = "sha256:f55e89e53367b090c0c053697d7f9d77595543d0e0516c93978b50c0f6b252f9", size = 8353, upload-time = "2026-04-20T13:01:50.382Z" },
 ]
 
 [[package]]
@@ -4518,6 +4661,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
+name = "requests-toolbelt"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
 ]
 
 [[package]]
@@ -4916,12 +5071,37 @@ wheels = [
 
 [[package]]
 name = "siege-utilities"
-version = "1.0.1"
+version = "3.13.1"
 source = { editable = "." }
 dependencies = [
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "tqdm" },
+]
+
+[package.optional-dependencies]
+3d = [
+    { name = "pydeck" },
+]
+all = [
+    { name = "apache-sedona" },
     { name = "beautifulsoup4" },
+    { name = "boto3" },
+    { name = "branca" },
+    { name = "censusgeocode" },
+    { name = "databricks-sdk" },
+    { name = "datadotworld" },
+    { name = "django", version = "5.2.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "django", version = "6.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "djangorestframework" },
+    { name = "djangorestframework-gis" },
+    { name = "duckdb" },
+    { name = "facebook-business" },
     { name = "faker" },
+    { name = "fiona" },
     { name = "folium" },
+    { name = "fonttools" },
     { name = "geopandas" },
     { name = "geopy" },
     { name = "google-analytics-admin" },
@@ -4930,57 +5110,30 @@ dependencies = [
     { name = "google-auth" },
     { name = "google-auth-httplib2" },
     { name = "google-auth-oauthlib" },
+    { name = "h3" },
     { name = "hydra-core" },
     { name = "hydra-zen" },
     { name = "lxml" },
     { name = "mapclassify" },
     { name = "matplotlib" },
+    { name = "memory-profiler" },
     { name = "notebook" },
     { name = "numpy" },
     { name = "omegaconf" },
     { name = "openpyxl" },
     { name = "osmnx" },
     { name = "pandas" },
-    { name = "plotly" },
-    { name = "pydantic" },
-    { name = "pysal" },
-    { name = "pyyaml" },
-    { name = "reportlab" },
-    { name = "requests" },
-    { name = "seaborn" },
-    { name = "tqdm" },
-]
-
-[package.optional-dependencies]
-all = [
-    { name = "altair" },
-    { name = "apache-sedona" },
-    { name = "bokeh" },
-    { name = "branca" },
-    { name = "datadotworld" },
-    { name = "django", version = "5.2.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "django", version = "6.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "djangorestframework" },
-    { name = "djangorestframework-gis" },
-    { name = "duckdb" },
-    { name = "facebook-business" },
-    { name = "fiona" },
-    { name = "folium" },
-    { name = "geopandas" },
-    { name = "geopy" },
-    { name = "ipywidgets" },
-    { name = "jupyter" },
-    { name = "mapclassify" },
-    { name = "matplotlib" },
-    { name = "memory-profiler" },
-    { name = "openpyxl" },
+    { name = "pillow" },
     { name = "plotly" },
     { name = "psutil" },
     { name = "psycopg2-binary" },
+    { name = "pyarrow" },
     { name = "pydeck" },
+    { name = "pypdf2" },
     { name = "pyproj" },
     { name = "pysal" },
     { name = "pyspark" },
+    { name = "reportlab" },
     { name = "rtree" },
     { name = "scikit-learn" },
     { name = "scipy" },
@@ -4988,30 +5141,62 @@ all = [
     { name = "shapely" },
     { name = "snowflake-connector-python" },
     { name = "sqlalchemy" },
-    { name = "streamlit" },
+    { name = "tobler" },
     { name = "xlsxwriter" },
 ]
 analytics = [
     { name = "datadotworld" },
     { name = "facebook-business" },
-    { name = "psycopg2-binary" },
+    { name = "google-analytics-admin" },
+    { name = "google-analytics-data" },
+    { name = "google-api-python-client" },
+    { name = "google-auth" },
+    { name = "google-auth-httplib2" },
+    { name = "google-auth-oauthlib" },
     { name = "scikit-learn" },
     { name = "scipy" },
     { name = "snowflake-connector-python" },
+]
+config-extras = [
+    { name = "hydra-core" },
+    { name = "hydra-zen" },
+    { name = "omegaconf" },
+]
+data = [
+    { name = "faker" },
+    { name = "numpy" },
+    { name = "openpyxl" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+]
+database = [
+    { name = "psycopg2-binary" },
     { name = "sqlalchemy" },
+]
+databricks = [
+    { name = "databricks-sdk" },
 ]
 dev = [
     { name = "astor" },
     { name = "black" },
     { name = "django", version = "5.2.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "django", version = "6.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "djangorestframework" },
+    { name = "djangorestframework-gis" },
     { name = "flake8" },
+    { name = "hypothesis" },
+    { name = "nbformat" },
+    { name = "nbmake" },
+    { name = "papermill" },
+    { name = "psycopg2-binary" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-django" },
     { name = "pytest-forked" },
     { name = "pytest-html" },
     { name = "pytest-json-report" },
     { name = "pytest-mock" },
+    { name = "pytest-randomly" },
     { name = "pytest-xdist" },
 ]
 distributed = [
@@ -5025,13 +5210,18 @@ export = [
     { name = "xlsxwriter" },
 ]
 geo = [
+    { name = "censusgeocode" },
     { name = "fiona" },
     { name = "geopandas" },
     { name = "geopy" },
     { name = "mapclassify" },
+    { name = "osmnx" },
     { name = "pyproj" },
+    { name = "pysal" },
     { name = "rtree" },
     { name = "shapely" },
+    { name = "tobler" },
+    { name = "topojson" },
 ]
 geodjango = [
     { name = "django", version = "5.2.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -5039,6 +5229,13 @@ geodjango = [
     { name = "djangorestframework" },
     { name = "djangorestframework-gis" },
     { name = "psycopg2-binary" },
+]
+h3 = [
+    { name = "h3" },
+]
+notebooks = [
+    { name = "nbformat" },
+    { name = "papermill" },
 ]
 performance = [
     { name = "duckdb" },
@@ -5051,137 +5248,183 @@ reporting = [
     { name = "pillow" },
     { name = "plotly" },
     { name = "pypdf2" },
+    { name = "reportlab" },
     { name = "seaborn" },
+]
+s3 = [
+    { name = "boto3" },
 ]
 streamlit = [
     { name = "altair" },
     { name = "bokeh" },
     { name = "ipywidgets" },
     { name = "jupyter" },
+    { name = "notebook" },
     { name = "pydeck" },
     { name = "streamlit" },
+]
+survey = [
+    { name = "weightipy" },
+]
+web = [
+    { name = "beautifulsoup4" },
+    { name = "lxml" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "altair", marker = "extra == 'all'", specifier = ">=5.0.0" },
     { name = "altair", marker = "extra == 'streamlit'", specifier = ">=5.0.0" },
     { name = "apache-sedona", marker = "extra == 'all'", specifier = ">=1.5.0" },
     { name = "apache-sedona", marker = "extra == 'distributed'", specifier = ">=1.5.0" },
     { name = "astor", marker = "extra == 'dev'", specifier = ">=0.8.1" },
-    { name = "beautifulsoup4", specifier = ">=4.12.0" },
+    { name = "beautifulsoup4", marker = "extra == 'all'", specifier = ">=4.12.0" },
+    { name = "beautifulsoup4", marker = "extra == 'web'", specifier = ">=4.12.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=21.0.0" },
-    { name = "bokeh", marker = "extra == 'all'", specifier = ">=3.0.0" },
     { name = "bokeh", marker = "extra == 'streamlit'", specifier = ">=3.0.0" },
+    { name = "boto3", marker = "extra == 'all'", specifier = ">=1.28.0" },
+    { name = "boto3", marker = "extra == 's3'", specifier = ">=1.28.0" },
     { name = "branca", marker = "extra == 'all'", specifier = ">=0.5.0" },
     { name = "branca", marker = "extra == 'reporting'", specifier = ">=0.5.0" },
+    { name = "censusgeocode", marker = "extra == 'all'", specifier = ">=0.5.2" },
+    { name = "censusgeocode", marker = "extra == 'geo'", specifier = ">=0.5.2" },
+    { name = "databricks-sdk", marker = "extra == 'all'", specifier = ">=0.20.0" },
+    { name = "databricks-sdk", marker = "extra == 'databricks'", specifier = ">=0.20.0" },
     { name = "datadotworld", marker = "extra == 'all'", specifier = ">=1.7.0" },
     { name = "datadotworld", marker = "extra == 'analytics'", specifier = ">=1.7.0" },
     { name = "django", marker = "extra == 'all'", specifier = ">=4.2.0" },
     { name = "django", marker = "extra == 'dev'", specifier = ">=4.2.0" },
     { name = "django", marker = "extra == 'geodjango'", specifier = ">=4.2.0" },
     { name = "djangorestframework", marker = "extra == 'all'", specifier = ">=3.14.0" },
+    { name = "djangorestframework", marker = "extra == 'dev'", specifier = ">=3.14.0" },
     { name = "djangorestframework", marker = "extra == 'geodjango'", specifier = ">=3.14.0" },
     { name = "djangorestframework-gis", marker = "extra == 'all'", specifier = ">=1.0.0" },
+    { name = "djangorestframework-gis", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "djangorestframework-gis", marker = "extra == 'geodjango'", specifier = ">=1.0.0" },
     { name = "duckdb", marker = "extra == 'all'", specifier = ">=0.7.0" },
     { name = "duckdb", marker = "extra == 'performance'", specifier = ">=0.7.0" },
     { name = "facebook-business", marker = "extra == 'all'", specifier = ">=20.0.0" },
     { name = "facebook-business", marker = "extra == 'analytics'", specifier = ">=20.0.0" },
-    { name = "faker", specifier = ">=35.2.2" },
-    { name = "fiona", marker = "extra == 'all'", specifier = ">=1.8.0" },
-    { name = "fiona", marker = "extra == 'geo'", specifier = ">=1.8.0" },
+    { name = "faker", marker = "extra == 'all'", specifier = ">=35.2.2" },
+    { name = "faker", marker = "extra == 'data'", specifier = ">=35.2.2" },
+    { name = "fiona", marker = "extra == 'all'", specifier = ">=1.9.0" },
+    { name = "fiona", marker = "extra == 'geo'", specifier = ">=1.9.0" },
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=3.8.0" },
-    { name = "folium", specifier = ">=0.18.0" },
-    { name = "folium", marker = "extra == 'all'", specifier = ">=0.14.0" },
-    { name = "folium", marker = "extra == 'reporting'", specifier = ">=0.14.0" },
+    { name = "folium", marker = "extra == 'all'", specifier = ">=0.18.0" },
+    { name = "folium", marker = "extra == 'reporting'", specifier = ">=0.18.0" },
+    { name = "fonttools", marker = "extra == 'all'", specifier = ">=4.40.0" },
     { name = "fonttools", marker = "extra == 'reporting'", specifier = ">=4.40.0" },
-    { name = "geopandas", specifier = ">=0.13.2" },
-    { name = "geopandas", marker = "extra == 'all'", specifier = ">=0.12.0" },
-    { name = "geopandas", marker = "extra == 'geo'", specifier = ">=0.12.0" },
-    { name = "geopy", specifier = ">=2.4.1" },
-    { name = "geopy", marker = "extra == 'all'", specifier = ">=2.3.0" },
-    { name = "geopy", marker = "extra == 'geo'", specifier = ">=2.3.0" },
-    { name = "google-analytics-admin", specifier = ">=0.25.0" },
-    { name = "google-analytics-data", specifier = ">=0.18.19" },
-    { name = "google-api-python-client", specifier = ">=2.181.0" },
-    { name = "google-auth", specifier = ">=2.40.3" },
-    { name = "google-auth-httplib2", specifier = ">=0.2.0" },
-    { name = "google-auth-oauthlib", specifier = ">=1.2.2" },
-    { name = "hydra-core", specifier = ">=1.3.0" },
-    { name = "hydra-zen", specifier = ">=0.12.0" },
-    { name = "ipywidgets", marker = "extra == 'all'", specifier = ">=8.0.0" },
+    { name = "geopandas", marker = "extra == 'all'", specifier = ">=0.13.2" },
+    { name = "geopandas", marker = "extra == 'geo'", specifier = ">=0.13.2" },
+    { name = "geopy", marker = "extra == 'all'", specifier = ">=2.4.1" },
+    { name = "geopy", marker = "extra == 'geo'", specifier = ">=2.4.1" },
+    { name = "google-analytics-admin", marker = "extra == 'all'", specifier = ">=0.25.0" },
+    { name = "google-analytics-admin", marker = "extra == 'analytics'", specifier = ">=0.25.0" },
+    { name = "google-analytics-data", marker = "extra == 'all'", specifier = ">=0.18.19" },
+    { name = "google-analytics-data", marker = "extra == 'analytics'", specifier = ">=0.18.19" },
+    { name = "google-api-python-client", marker = "extra == 'all'", specifier = ">=2.181.0" },
+    { name = "google-api-python-client", marker = "extra == 'analytics'", specifier = ">=2.181.0" },
+    { name = "google-auth", marker = "extra == 'all'", specifier = ">=2.40.3" },
+    { name = "google-auth", marker = "extra == 'analytics'", specifier = ">=2.40.3" },
+    { name = "google-auth-httplib2", marker = "extra == 'all'", specifier = ">=0.2.0" },
+    { name = "google-auth-httplib2", marker = "extra == 'analytics'", specifier = ">=0.2.0" },
+    { name = "google-auth-oauthlib", marker = "extra == 'all'", specifier = ">=1.2.2" },
+    { name = "google-auth-oauthlib", marker = "extra == 'analytics'", specifier = ">=1.2.2" },
+    { name = "h3", marker = "extra == 'all'", specifier = ">=4.0.0" },
+    { name = "h3", marker = "extra == 'h3'", specifier = ">=4.0.0" },
+    { name = "hydra-core", marker = "extra == 'all'", specifier = ">=1.3.0" },
+    { name = "hydra-core", marker = "extra == 'config-extras'", specifier = ">=1.3.0" },
+    { name = "hydra-zen", marker = "extra == 'all'", specifier = ">=0.12.0" },
+    { name = "hydra-zen", marker = "extra == 'config-extras'", specifier = ">=0.12.0" },
+    { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.100.0" },
     { name = "ipywidgets", marker = "extra == 'streamlit'", specifier = ">=8.0.0" },
-    { name = "jupyter", marker = "extra == 'all'", specifier = ">=1.0.0" },
     { name = "jupyter", marker = "extra == 'streamlit'", specifier = ">=1.0.0" },
-    { name = "lxml", specifier = ">=4.9.0" },
-    { name = "mapclassify", specifier = ">=2.5.0" },
+    { name = "lxml", marker = "extra == 'all'", specifier = ">=4.9.0" },
+    { name = "lxml", marker = "extra == 'web'", specifier = ">=4.9.0" },
     { name = "mapclassify", marker = "extra == 'all'", specifier = ">=2.5.0" },
     { name = "mapclassify", marker = "extra == 'geo'", specifier = ">=2.5.0" },
-    { name = "matplotlib", specifier = ">=3.7.5" },
-    { name = "matplotlib", marker = "extra == 'all'", specifier = ">=3.5.0" },
-    { name = "matplotlib", marker = "extra == 'reporting'", specifier = ">=3.5.0" },
+    { name = "matplotlib", marker = "extra == 'all'", specifier = ">=3.7.5" },
+    { name = "matplotlib", marker = "extra == 'reporting'", specifier = ">=3.7.5" },
     { name = "memory-profiler", marker = "extra == 'all'", specifier = ">=0.61.0" },
     { name = "memory-profiler", marker = "extra == 'export'", specifier = ">=0.61.0" },
-    { name = "notebook", specifier = ">=7.3.3" },
-    { name = "numpy", specifier = ">=1.21.0" },
-    { name = "omegaconf", specifier = ">=2.3.0" },
-    { name = "openpyxl", specifier = ">=3.1.0" },
+    { name = "nbformat", marker = "extra == 'dev'", specifier = ">=5.7.0" },
+    { name = "nbformat", marker = "extra == 'notebooks'", specifier = ">=5.7.0" },
+    { name = "nbmake", marker = "extra == 'dev'", specifier = ">=1.5.0" },
+    { name = "notebook", marker = "extra == 'all'", specifier = ">=7.3.3" },
+    { name = "notebook", marker = "extra == 'streamlit'", specifier = ">=7.3.3" },
+    { name = "numpy", marker = "extra == 'all'", specifier = ">=1.24.0" },
+    { name = "numpy", marker = "extra == 'data'", specifier = ">=1.24.0" },
+    { name = "omegaconf", marker = "extra == 'all'", specifier = ">=2.3.0" },
+    { name = "omegaconf", marker = "extra == 'config-extras'", specifier = ">=2.3.0" },
     { name = "openpyxl", marker = "extra == 'all'", specifier = ">=3.1.0" },
+    { name = "openpyxl", marker = "extra == 'data'", specifier = ">=3.1.0" },
     { name = "openpyxl", marker = "extra == 'export'", specifier = ">=3.1.0" },
-    { name = "osmnx", specifier = ">=1.9.4" },
-    { name = "pandas", specifier = ">=1.5.0" },
+    { name = "osmnx", marker = "extra == 'all'", specifier = ">=1.9.4" },
+    { name = "osmnx", marker = "extra == 'geo'", specifier = ">=1.9.4" },
+    { name = "pandas", marker = "extra == 'all'", specifier = ">=2.0.0" },
+    { name = "pandas", marker = "extra == 'data'", specifier = ">=2.0.0" },
+    { name = "papermill", marker = "extra == 'dev'", specifier = ">=2.4.0" },
+    { name = "papermill", marker = "extra == 'notebooks'", specifier = ">=2.4.0" },
+    { name = "pillow", marker = "extra == 'all'", specifier = ">=10.0.0" },
     { name = "pillow", marker = "extra == 'reporting'", specifier = ">=10.0.0" },
-    { name = "plotly", specifier = ">=6.3.0" },
-    { name = "plotly", marker = "extra == 'all'", specifier = ">=5.17.0" },
-    { name = "plotly", marker = "extra == 'reporting'", specifier = ">=5.17.0" },
+    { name = "plotly", marker = "extra == 'all'", specifier = ">=6.3.0" },
+    { name = "plotly", marker = "extra == 'reporting'", specifier = ">=6.3.0" },
     { name = "psutil", marker = "extra == 'all'", specifier = ">=5.9.0" },
     { name = "psutil", marker = "extra == 'export'", specifier = ">=5.9.0" },
     { name = "psycopg2-binary", marker = "extra == 'all'", specifier = ">=2.9.0" },
-    { name = "psycopg2-binary", marker = "extra == 'analytics'", specifier = ">=2.9.0" },
+    { name = "psycopg2-binary", marker = "extra == 'database'", specifier = ">=2.9.0" },
+    { name = "psycopg2-binary", marker = "extra == 'dev'", specifier = ">=2.9.0" },
     { name = "psycopg2-binary", marker = "extra == 'geodjango'", specifier = ">=2.9.0" },
+    { name = "pyarrow", marker = "extra == 'all'", specifier = ">=14.0.0" },
+    { name = "pyarrow", marker = "extra == 'data'", specifier = ">=14.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pydeck", marker = "extra == '3d'", specifier = ">=0.8.0" },
     { name = "pydeck", marker = "extra == 'all'", specifier = ">=0.8.0" },
     { name = "pydeck", marker = "extra == 'streamlit'", specifier = ">=0.8.0" },
+    { name = "pypdf2", marker = "extra == 'all'", specifier = ">=3.0.1" },
     { name = "pypdf2", marker = "extra == 'reporting'", specifier = ">=3.0.1" },
     { name = "pyproj", marker = "extra == 'all'", specifier = ">=3.3.0" },
     { name = "pyproj", marker = "extra == 'geo'", specifier = ">=3.3.0" },
-    { name = "pysal", specifier = ">=24.1" },
     { name = "pysal", marker = "extra == 'all'", specifier = ">=24.1" },
+    { name = "pysal", marker = "extra == 'geo'", specifier = ">=24.1" },
     { name = "pyspark", marker = "extra == 'all'", specifier = ">=3.3.0" },
     { name = "pyspark", marker = "extra == 'distributed'", specifier = ">=3.3.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
+    { name = "pytest-django", marker = "extra == 'dev'", specifier = ">=4.5.0" },
     { name = "pytest-forked", marker = "extra == 'dev'", specifier = ">=1.4.0" },
     { name = "pytest-html", marker = "extra == 'dev'", specifier = ">=3.1.0" },
     { name = "pytest-json-report", marker = "extra == 'dev'", specifier = ">=1.5.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.10.0" },
+    { name = "pytest-randomly", marker = "extra == 'dev'", specifier = ">=3.15.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
-    { name = "reportlab", specifier = ">=4.4.3" },
+    { name = "reportlab", marker = "extra == 'all'", specifier = ">=4.4.3" },
+    { name = "reportlab", marker = "extra == 'reporting'", specifier = ">=4.4.3" },
     { name = "requests", specifier = ">=2.28.0" },
     { name = "rtree", marker = "extra == 'all'", specifier = ">=1.0.0" },
     { name = "rtree", marker = "extra == 'geo'", specifier = ">=1.0.0" },
-    { name = "scikit-learn", marker = "extra == 'all'", specifier = ">=1.1.0" },
-    { name = "scikit-learn", marker = "extra == 'analytics'", specifier = ">=1.1.0" },
-    { name = "scipy", marker = "extra == 'all'", specifier = ">=1.8.0" },
-    { name = "scipy", marker = "extra == 'analytics'", specifier = ">=1.8.0" },
-    { name = "seaborn", specifier = ">=0.13.2" },
-    { name = "seaborn", marker = "extra == 'all'", specifier = ">=0.11.0" },
-    { name = "seaborn", marker = "extra == 'reporting'", specifier = ">=0.11.0" },
-    { name = "shapely", marker = "extra == 'all'", specifier = ">=1.8.0" },
-    { name = "shapely", marker = "extra == 'geo'", specifier = ">=1.8.0" },
+    { name = "scikit-learn", marker = "extra == 'all'", specifier = ">=1.3.0" },
+    { name = "scikit-learn", marker = "extra == 'analytics'", specifier = ">=1.3.0" },
+    { name = "scipy", marker = "extra == 'all'", specifier = ">=1.11.0" },
+    { name = "scipy", marker = "extra == 'analytics'", specifier = ">=1.11.0" },
+    { name = "seaborn", marker = "extra == 'all'", specifier = ">=0.13.2" },
+    { name = "seaborn", marker = "extra == 'reporting'", specifier = ">=0.13.2" },
+    { name = "shapely", marker = "extra == 'all'", specifier = ">=2.0.0,<3.0" },
+    { name = "shapely", marker = "extra == 'geo'", specifier = ">=2.0.0,<3.0" },
     { name = "snowflake-connector-python", marker = "extra == 'all'", specifier = ">=3.0.0" },
     { name = "snowflake-connector-python", marker = "extra == 'analytics'", specifier = ">=3.0.0" },
     { name = "sqlalchemy", marker = "extra == 'all'", specifier = ">=1.4.0" },
-    { name = "sqlalchemy", marker = "extra == 'analytics'", specifier = ">=1.4.0" },
-    { name = "streamlit", marker = "extra == 'all'", specifier = ">=1.28.0" },
+    { name = "sqlalchemy", marker = "extra == 'database'", specifier = ">=1.4.0" },
     { name = "streamlit", marker = "extra == 'streamlit'", specifier = ">=1.28.0" },
+    { name = "tobler", marker = "extra == 'all'", specifier = ">=0.11.0" },
+    { name = "tobler", marker = "extra == 'geo'", specifier = ">=0.11.0" },
+    { name = "topojson", marker = "extra == 'geo'", specifier = ">=1.8" },
     { name = "tqdm", specifier = ">=4.60.0" },
+    { name = "weightipy", marker = "extra == 'survey'", specifier = ">=0.4.0" },
     { name = "xlsxwriter", marker = "extra == 'all'", specifier = ">=3.1.0" },
     { name = "xlsxwriter", marker = "extra == 'export'", specifier = ">=3.1.0" },
 ]
-provides-extras = ["distributed", "geo", "reporting", "analytics", "streamlit", "export", "performance", "geodjango", "credentials", "dev", "all"]
+provides-extras = ["data", "geo", "h3", "reporting", "analytics", "distributed", "geodjango", "config-extras", "web", "streamlit", "export", "3d", "performance", "database", "credentials", "s3", "notebooks", "databricks", "dev", "survey", "all"]
 
 [[package]]
 name = "simplejson"
@@ -5733,6 +5976,20 @@ wheels = [
 ]
 
 [[package]]
+name = "topojson"
+version = "1.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "shapely" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/f3/74330050d8f7e05e140e6043302f71524e159f9a83bbee9681c86282f8fd/topojson-1.10.tar.gz", hash = "sha256:a7f53406324061a0310bec46740a6609147c24daeb354596c68345b9527b38c1", size = 25444042, upload-time = "2025-07-22T20:27:31.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/7a/2a8ea3b2b6e50cbec74c53082b69617d71f31e1247e35e65bf9a6edc44cf/topojson-1.10-py3-none-any.whl", hash = "sha256:0879d727c7798939e3268e8969fa87c2cd23274189fe3d8038a0fb11ff263925", size = 83318, upload-time = "2025-07-22T20:27:28.374Z" },
+]
+
+[[package]]
 name = "tornado"
 version = "6.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -5850,6 +6107,15 @@ version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/24/d9be5cd6642a6aa68352ded4b4b10fb0d7889cb7f45814fb92cecd35f101/watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c", size = 96393, upload-time = "2024-11-01T14:06:31.756Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7a/6013b0d8dbc56adca7fdd4f0beed381c59f6752341b12fa0886fa7afc78b/watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2", size = 88392, upload-time = "2024-11-01T14:06:32.99Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/40/b75381494851556de56281e053700e46bff5b37bf4c7267e858640af5a7f/watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c", size = 89019, upload-time = "2024-11-01T14:06:34.963Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449, upload-time = "2024-11-01T14:06:39.748Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
     { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
     { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
     { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
@@ -5896,6 +6162,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e6/30/fba0d96b4b5fbf5948ed3f4681f7da2f9f64512e1d303f94b4cc174c24a5/websocket_client-1.8.0.tar.gz", hash = "sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da", size = 54648, upload-time = "2024-04-23T22:16:16.976Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/84/44687a29792a70e111c5c477230a72c4b957d88d16141199bf9acb7537a3/websocket_client-1.8.0-py3-none-any.whl", hash = "sha256:17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526", size = 58826, upload-time = "2024-04-23T22:16:14.422Z" },
+]
+
+[[package]]
+name = "weightipy"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "decorator" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "requests" },
+    { name = "scipy" },
+    { name = "typing-extensions" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/7d/6a69a9488eb3a4773001d14767f81ebaf49c91dbe7c3c733440430848c9f/weightipy-0.4.2.tar.gz", hash = "sha256:ad11d4f511306e011865da3ca88d15446f61ebd61a465505e37752d958ac93e0", size = 33533, upload-time = "2026-02-02T13:41:36.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/98/32e0bf3df84e73ea0c0b8ba0721d53afaf99c075eeb8e6833b74f9d95a10/weightipy-0.4.2-py3-none-any.whl", hash = "sha256:3538bd1e5ec7dd45f7a5490b5fb796d5688ea6d5bd24a32921c616f1c96865e4", size = 24495, upload-time = "2026-02-02T13:41:34.574Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Two independent fixes on this branch:

### 1. Census TIGER URL pattern corrections (research-verified via live HTTP probing)

- **cd117 removed**: The 117th Congress never appeared in TIGER. Census held pre-redistricting 116th boundaries for 2020–2021, then jumped directly to cd118 for 2022+. Removes cd117 from `BOUNDARY_TYPE_CATALOG` and the new `YEAR_TO_CONGRESS` mapping.
- **2012 → cd112**: The 113th Congress was elected in Nov 2012 but the 112th was still seated; TIGER 2012 uses cd112.
- **Per-state CDs for 2022+**: Congressional district files for 2022+ are per-state only (national file returns 404). Added `congress_state` filename pattern.
- **ZCTA 2020+**: Directory is `ZCTA520/` and filename suffix is `zcta520` (not `zcta510`). Added `ZCTA520 → 'zcta'` to `discover_boundary_types()` mapping.
- **Block group filename**: Census uses `bg` abbreviation in TIGER paths, not `block_group`. Added `_FILENAME_ABBREVS` dict.

### 2. Census geocoder test mock path fixes

`test_census_geocoder_errors.py` was failing because all `patch()` calls targeted the deprecation shim (`siege_utilities.geo.census_geocoder`) rather than the module where the functions are actually defined (`siege_utilities.geo.providers.census_geocoder`). No production code changed.

## Files Changed

- `siege_utilities/geo/spatial_data.py`: `YEAR_TO_CONGRESS` dict, `congress_state` pattern, `_FILENAME_ABBREVS`, ZCTA520 boundary mapping, overhauled `_construct_filename_with_fips_validation()`
- `tests/test_enhanced_census_utilities.py`: 7 new tests + corrected BG URL assertion
- `tests/test_boundary_catalog.py`: threshold lowered from 47→46 (cd117 removed)
- `tests/test_boundary_diagnostics.py`: renamed test + year=2000 edge case + new auto-resolve test
- `tests/test_census_geocoder_errors.py`: corrected mock patch targets

## Test plan

- [x] 240 passed, 0 failed across `test_enhanced_census_utilities`, `test_boundary_catalog`, `test_boundary_diagnostics`, `test_spatial_data_errors`, `test_geo_alignment`, `test_geographic_levels`
- [x] No regressions in existing tests

## Open questions / follow-up tickets

1. **`CD_SESSION_VARIANTS` in `test_geo_alignment.py`** contains `'cd117'` — should it be removed since cd117 never existed in TIGER? (low priority, test-only)
2. **YEAR_TO_CONGRESS for 2025+**: mapping ends at 2024 (119th Congress); needs extension when Census publishes 2025 TIGER files.
3. **Per-state vs national scope validation**: `_construct_filename_with_fips_validation()` silently falls back to national pattern when `state_fips` is None for 2022+ CDs — should this warn/raise?

🤖 Generated with [Craft Agent](https://craft.do)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved congressional boundary handling: year→congress resolution, zero‑padded congress numbers, and 2022+ per‑state routing; ZCTA and block‑group filename/abbreviation behavior standardized.

* **Chores**
  * Removed an outdated congressional‑district catalog entry and added verified year→congress mappings.

* **Tests**
  * Updated tests to skip when optional plotting/reporting libs are missing, refine geocoder mocks, relax GEOID dtype checks, and adjust deprecation/environment assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->