### PR TITLE
docs(lint): add lint policy + fix CONTRIBUTING pre-PR checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ flake8 siege_utilities --count --select=E9,F63,F7,F82 --show-source --statistics
 #    common reason a PR passes locally but fails CI lint.
 python scripts/check_lint_ratchet.py --phase all
 
-# 4. API contract check (if you changed public API)
+# 5. API contract check (if you changed public API)
 python -m venv /tmp/.venv_baseline
 /tmp/.venv_baseline/bin/pip install siege-utilities==3.8.0
 /tmp/.venv_baseline/bin/python scripts/contracts/generate_public_api_contract.py \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,8 +110,9 @@ python scripts/check_test_file_hygiene.py
 flake8 siege_utilities --count --select=E9,F63,F7,F82 --show-source --statistics
 
 # 4. Lint — phases 2-4 (hygiene + module ratchet + full-repo fingerprint)
-#    This is what CI's "lint ratchet phases2-4" job runs. Skipping it is the
-#    most common reason a PR passes locally but fails CI lint.
+#    Local aggregate equivalent; CI runs phase2, phase3, phase4 as separate
+#    steps with explicit --base-sha/--head-sha. Skipping this is the most
+#    common reason a PR passes locally but fails CI lint.
 python scripts/check_lint_ratchet.py --phase all
 
 # 4. API contract check (if you changed public API)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,8 +106,13 @@ python -m pytest tests/ -v --no-cov
 # 2. Test file hygiene (naming/location conventions)
 python scripts/check_test_file_hygiene.py
 
-# 3. Lint check (flake8 — at minimum, no syntax errors)
+# 3. Lint — phase 1 (runtime-safety errors)
 flake8 siege_utilities --count --select=E9,F63,F7,F82 --show-source --statistics
+
+# 4. Lint — phases 2-4 (hygiene + module ratchet + full-repo fingerprint)
+#    This is what CI's "lint ratchet phases2-4" job runs. Skipping it is the
+#    most common reason a PR passes locally but fails CI lint.
+python scripts/check_lint_ratchet.py --phase all
 
 # 4. API contract check (if you changed public API)
 python -m venv /tmp/.venv_baseline
@@ -174,6 +179,8 @@ The impact level is **inferred automatically** from the version delta between th
 ### Lint Ratchet
 
 The lint ratchet is a one-way quality gate — the total violation count can only go **down**, never up. If you touch a file, clean up any existing lint violations in that file before submitting.
+
+See [docs/policies/LINT_POLICY.md](docs/policies/LINT_POLICY.md) for root-cause analysis of common CI lint failures, baseline update procedures, and the full rule reference.
 
 ## Pull Request Guidelines
 

--- a/docs/policies/LINT_POLICY.md
+++ b/docs/policies/LINT_POLICY.md
@@ -89,13 +89,14 @@ Run these in order. Stop and fix before continuing if any step fails.
 # Phase 1 — runtime-safety errors on changed files (matches CI lint-ratchet-phase1)
 flake8 siege_utilities --count --select=E9,F63,F7,F82 --show-source --statistics
 
-# Phases 2-4 — hygiene + module ratchet + full-repo fingerprint (matches CI lint-ratchet-phases2-4)
+# Phases 2-4 — hygiene + module ratchet + full-repo fingerprint
+# (local aggregate; CI runs each phase separately with explicit --base-sha/--head-sha)
 python scripts/check_lint_ratchet.py --phase phase2
 python scripts/check_lint_ratchet.py --phase phase3
 python scripts/check_lint_ratchet.py --phase phase4
 ```
 
-Or run all phases in one call (the script accepts `all`):
+Or run all phases in one call:
 
 ```bash
 python scripts/check_lint_ratchet.py --phase all
@@ -139,7 +140,7 @@ easy to identify in git history.
 
 | Phase | Rules enforced | Scope |
 |-------|---------------|-------|
-| 1 | `E722, F601, F403, F405` | Files touched by the PR |
+| 1 | `E9, F63, F7, F82` | Full package (`flake8 siege_utilities --select=E9,F63,F7,F82`) |
 | 2 | `F401, F841, F541` | Files touched by the PR |
-| 3 | All of phase 1 + 2 | Entire domain (`siege_utilities/geo/`, `config/`, `files/`) if any file in domain is touched |
-| 4 | All of phase 1 + 2 | Full repo, fingerprint-matched against baseline |
+| 3 | `E722, F601, F403, F405` + phase 2 | Entire domain (`siege_utilities/geo/`, `config/`, `files/`) if any file in domain is touched |
+| 4 | `E722, F601, F403, F405` + phase 2 | Full repo, fingerprint-matched against baseline |

--- a/docs/policies/LINT_POLICY.md
+++ b/docs/policies/LINT_POLICY.md
@@ -9,7 +9,7 @@ See [LINT_RATCHET_PLAN.md](LINT_RATCHET_PLAN.md) for the phased rollout strategy
 
 ## Why CI Lint Keeps Failing When Local Checks Pass
 
-Four root causes account for nearly every "passed locally, failed in CI" lint or release incident:
+Five root causes account for nearly every "passed locally, failed in CI" lint or release incident:
 
 ### 1. The CONTRIBUTING.md pre-PR checklist was incomplete
 
@@ -53,6 +53,31 @@ Checklist addition for release PRs:
 # Confirm version in pyproject.toml matches the intended tag before merging
 grep '^version' pyproject.toml
 ```
+
+### 5. Bypassing the canonical release script
+
+`scripts/release_manager.py` atomically updates all six version-bearing files
+(`pyproject.toml`, `setup.py`, `siege_utilities/__init__.py`, `docs/conf.py`,
+`docs/source/conf.py`, `docs/source/conf_fast.py`) in a single `--set-version` or
+`--bump` call. When version bumps are done file-by-file across multiple PRs instead,
+at least one file is always missed. CI's "Verify version consistency" step then fails
+every release attempt until all six are aligned.
+
+**Fix:** always use the release script for version management:
+
+```bash
+# Check current consistency
+python scripts/release_manager.py --check
+
+# Bump (updates all 6 files at once)
+python scripts/release_manager.py --bump patch
+
+# Or set an explicit version
+python scripts/release_manager.py --set-version 3.13.2
+```
+
+The `--release` workflow does the full 12-step dance (version bump → tests → build →
+merge develop → tag → PyPI → GitHub Release). Use `--dry-run` to preview.
 
 ---
 

--- a/docs/policies/LINT_POLICY.md
+++ b/docs/policies/LINT_POLICY.md
@@ -1,0 +1,104 @@
+# Lint Policy
+
+This document explains why CI lint checks fail, what commands to run locally before
+pushing, and how to keep the phase4 baseline from drifting.
+
+See [LINT_RATCHET_PLAN.md](LINT_RATCHET_PLAN.md) for the phased rollout strategy.
+
+---
+
+## Why CI Lint Keeps Failing When Local Checks Pass
+
+Three root causes account for nearly every "passed locally, failed in CI" lint incident:
+
+### 1. The CONTRIBUTING.md pre-PR checklist was incomplete
+
+The checklist showed only the phase-1 `flake8 --select=E9,F63,F7,F82` command.
+CI runs phases 2–4 via `scripts/check_lint_ratchet.py`, which enforces
+`F401` (unused imports), `F841` (unused variables), and `F541` (f-strings without
+placeholders) on every file touched by the PR. Those rules were invisible to developers
+following the documented checklist.
+
+**Fix:** run the full ratchet script locally (see commands below).
+
+### 2. No pre-commit hook enforces lint before commit
+
+There is no `.pre-commit-config.yaml` in the repo. Nothing stops a commit that
+introduces new F401/F841 violations. The first time a developer sees the failure is
+when CI runs on their push.
+
+**Fix:** install the pre-commit hook shown below.
+
+### 3. Phase-4 baseline can drift from the codebase
+
+`lint_baselines/phase4_flake8_fingerprints.txt` is hand-maintained. If a PR is merged
+that cleans up violations without regenerating the baseline, subsequent PRs fail phase 4
+because the baseline references fingerprints that no longer exist.
+
+**Fix:** regenerate the baseline in a dedicated debt-cleanup PR using
+`python scripts/check_lint_ratchet.py --phase phase4 --update-baseline`.
+
+---
+
+## Commands to Run Before Every Push
+
+Run these in order. Stop and fix before continuing if any step fails.
+
+```bash
+# Phase 1 — runtime-safety errors on changed files (matches CI lint-ratchet-phase1)
+flake8 siege_utilities --count --select=E9,F63,F7,F82 --show-source --statistics
+
+# Phases 2-4 — hygiene + module ratchet + full-repo fingerprint (matches CI lint-ratchet-phases2-4)
+python scripts/check_lint_ratchet.py --phase phase2
+python scripts/check_lint_ratchet.py --phase phase3
+python scripts/check_lint_ratchet.py --phase phase4
+```
+
+Or run all phases in one call (the script accepts `all`):
+
+```bash
+python scripts/check_lint_ratchet.py --phase all
+```
+
+---
+
+## Optional: Pre-commit Hook
+
+Installing pre-commit runs the phase-1 check automatically on every `git commit`,
+so violations are caught at the source before they reach CI.
+
+```bash
+pip install pre-commit
+# From repo root:
+pre-commit install
+```
+
+If the repo gains a `.pre-commit-config.yaml`, the full ratchet can be wired in there.
+Until then, the manual commands above are the authoritative gate.
+
+---
+
+## Updating the Phase-4 Baseline
+
+The baseline (`lint_baselines/phase4_flake8_fingerprints.txt`) must only be updated in
+a dedicated lint-debt cleanup PR — **never** as a side effect of a feature PR.
+
+```bash
+python scripts/check_lint_ratchet.py --phase phase4 --update-baseline
+git add lint_baselines/phase4_flake8_fingerprints.txt
+git commit -m "chore(lint): regenerate phase4 baseline after debt cleanup"
+```
+
+Include the PR title `chore(lint): phase4 baseline refresh — <brief reason>` so it is
+easy to identify in git history.
+
+---
+
+## Rule Reference
+
+| Phase | Rules enforced | Scope |
+|-------|---------------|-------|
+| 1 | `E722, F601, F403, F405` | Files touched by the PR |
+| 2 | `F401, F841, F541` | Files touched by the PR |
+| 3 | All of phase 1 + 2 | Entire domain (`siege_utilities/geo/`, `config/`, `files/`) if any file in domain is touched |
+| 4 | All of phase 1 + 2 | Full repo, fingerprint-matched against baseline |

--- a/docs/policies/LINT_POLICY.md
+++ b/docs/policies/LINT_POLICY.md
@@ -9,7 +9,7 @@ See [LINT_RATCHET_PLAN.md](LINT_RATCHET_PLAN.md) for the phased rollout strategy
 
 ## Why CI Lint Keeps Failing When Local Checks Pass
 
-Three root causes account for nearly every "passed locally, failed in CI" lint incident:
+Four root causes account for nearly every "passed locally, failed in CI" lint or release incident:
 
 ### 1. The CONTRIBUTING.md pre-PR checklist was incomplete
 
@@ -37,6 +37,22 @@ because the baseline references fingerprints that no longer exist.
 
 **Fix:** regenerate the baseline in a dedicated debt-cleanup PR using
 `python scripts/check_lint_ratchet.py --phase phase4 --update-baseline`.
+
+### 4. Version bump omitted from the release PR (release-mechanics gap)
+
+CI's "Verify release tag matches package version" step runs only on the `release` event —
+it never fires on a normal PR push. This means a PR that forgets to bump
+`pyproject.toml` passes all pre-merge checks, the tag gets created, and only then does
+the release job fail before PyPI upload.
+
+**Fix:** the version bump (`pyproject.toml` + any `__version__` literals) belongs in the
+**same PR** as the code being released, committed before the GitHub Release is created.
+Checklist addition for release PRs:
+
+```bash
+# Confirm version in pyproject.toml matches the intended tag before merging
+grep '^version' pyproject.toml
+```
 
 ---
 

--- a/scripts/check_lint_ratchet.py
+++ b/scripts/check_lint_ratchet.py
@@ -179,7 +179,7 @@ def check_phase4(update_baseline: bool) -> int:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Lint ratchet checks for phases 2-4")
-    parser.add_argument("--phase", required=True, choices=["phase2", "phase3", "phase4"])
+    parser.add_argument("--phase", required=True, choices=["phase2", "phase3", "phase4", "all"])
     parser.add_argument("--base-sha", default="")
     parser.add_argument("--head-sha", default="")
     parser.add_argument("--base-ref", default="origin/main")
@@ -195,6 +195,15 @@ def main() -> int:
         return check_phase2(base, head)
     if args.phase == "phase3":
         return check_phase3(base, head)
+
+    if args.phase == "all":
+        rc = check_phase2(base, head)
+        if rc != 0:
+            return rc
+        rc = check_phase3(base, head)
+        if rc != 0:
+            return rc
+        return check_phase4(update_baseline=args.update_baseline)
 
     print(f"Unknown phase: {args.phase}")
     return 2


### PR DESCRIPTION
## Summary

- Adds `docs/policies/LINT_POLICY.md` — canonical reference for why CI lint keeps failing when local checks pass, with five root causes, exact commands to run before every push, baseline update procedure, and a rule reference table
- Updates `CONTRIBUTING.md` pre-PR checklist to include `python scripts/check_lint_ratchet.py --phase all` (phases 2–4) — the missing command responsible for every "passed locally, failed CI lint" incident
- Adds a link from the Lint Ratchet section in CONTRIBUTING to the new policy doc
- Fixes `scripts/check_lint_ratchet.py` to accept `--phase all` (was missing from argparse choices)

## Root causes documented

1. CONTRIBUTING.md showed only the phase-1 flake8 command; phases 2–4 were invisible to developers
2. No pre-commit hook to catch F401/F841/F541 violations before push
3. Phase-4 baseline (`lint_baselines/phase4_flake8_fingerprints.txt`) is hand-maintained and can drift
4. Version bump omitted from release PR — CI's release-tag consistency check fires only on the `release` event, not on PR pushes
5. Bypassing `scripts/release_manager.py` — the canonical script updates all six version files atomically; per-file PRs always miss at least one

## Test plan

- [x] `scripts/check_lint_ratchet.py --phase all` now works (argparse choices fixed)
- [ ] Confirm CI passes (lint ratchet should be clean; no touched source files)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded lint policy with two additional root causes for CI lint failures and clearer phase-to-rule mapping.
  * Updated contribution guidance to reference the lint policy and clarified local lint verification steps.

* **Chores**
  * Added an option to run all lint phases in one local invocation.
  * Clarified pre-PR lint validation and local workflow for consistent baseline updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->