### PR TITLE
chore: bump version to 3.13.2 in all version files

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,7 +5,7 @@ sys.path.insert(0, os.path.abspath('../'))
 project = 'Siege Utilities'
 copyright = '2025-2026, Dheeraj Chand'
 author = 'Dheeraj Chand'
-release = '3.13.1'
+release = '3.13.2'
 
 extensions = [
     'sphinx.ext.autodoc',

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,7 +5,7 @@ sys.path.insert(0, os.path.abspath('../../'))
 project = 'Siege Utilities'
 copyright = '2025-2026, Dheeraj Chand'
 author = 'Dheeraj Chand'
-release = '3.13.1'
+release = '3.13.2'
 
 extensions = [
     'sphinx.ext.autodoc',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="siege-utilities",
-    version="3.13.1",
+    version="3.13.2",
     author="Dheeraj Chand",
     author_email="dheeraj@siegeanalytics.com",
     description="A comprehensive Python utilities package with enhanced auto-discovery",

--- a/siege_utilities/__init__.py
+++ b/siege_utilities/__init__.py
@@ -29,7 +29,7 @@ try:
     from importlib.metadata import version as _meta_version
     __version__ = _meta_version("siege-utilities")
 except Exception:
-    __version__ = "3.13.1"  # fallback for editable installs without metadata
+    __version__ = "3.13.2"  # fallback for editable installs without metadata
 __author__ = "Siege Analytics"
 __description__ = "Comprehensive utilities for data engineering, analytics, and distributed computing"
 


### PR DESCRIPTION
## Summary

PR #426 only updated `pyproject.toml`. The build job's "Verify version consistency" step checks **five** locations and requires all to match:

| File | Before | After |
|------|--------|-------|
| `pyproject.toml` | ✅ 3.13.2 (done in #426) | 3.13.2 |
| `setup.py` | ❌ 3.13.1 | 3.13.2 |
| `siege_utilities/__init__.py` (`__version__`) | ❌ 3.13.1 | 3.13.2 |
| `docs/conf.py` | ❌ 3.13.1 | 3.13.2 |
| `docs/source/conf.py` | ❌ 3.13.1 | 3.13.2 |

## Why

The build job failed on the release CI run (25060302435) with `"consistent": false`. The release job was skipped as a result, blocking PyPI publish.

## After merge

Delete and recreate the v3.13.2 release tag (pointing at this new main HEAD) to re-trigger release CI and PyPI publish.

## Test plan

- [ ] Only version string changes — all CI should pass
- [ ] Build job "Verify version consistency" should show `"consistent": true`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 3.13.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->