### PR TITLE
chore: bump version to 3.13.2 in docs/source/conf_fast.py

### DIFF
--- a/docs/source/conf_fast.py
+++ b/docs/source/conf_fast.py
@@ -5,7 +5,7 @@ sys.path.insert(0, os.path.abspath('../../'))
 project = 'Siege Utilities'
 copyright = '2025, Dheeraj Chand'
 author = 'Dheeraj Chand'
-release = '3.13.1'
+release = '3.13.2'
 
 # Minimal extensions for fast builds
 extensions = [


### PR DESCRIPTION
Final missing version file from the 3.13.2 bump. Build CI checks all conf*.py files — docs/source/conf_fast.py was not caught in PR #427 because it does not follow the standard conf.py naming pattern.

After merge: delete + recreate v3.13.2 release tag to re-trigger release CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project documentation release version from 3.13.1 to 3.13.2, ensuring docs reflect the latest release number and build metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->