### PR TITLE
feat(notebooks): reports/04 — exercise BANNER (all 7 TableTypes)

### DIFF
--- a/notebooks/reports/04_survey_full_showcase.ipynb
+++ b/notebooks/reports/04_survey_full_showcase.ipynb
@@ -8,7 +8,7 @@
     "# ElectInfo: full Q1 survey deliverable for Acme Campaign\n",
     "\n",
     "## What this shows\n",
-    "How the survey module and the reporting module compose into one coherent deliverable. We exercise **six of the seven `TableType`s** (single-response, multiple-response, cross-tab, ranking, mean-scale, longitudinal), render each as an `Argument` with the right rendering hint, generate trend / heatmap charts off a `WaveSet`, hit the `ChartTypeRegistry` for a registry-based chart, and assemble the whole thing into a multi-section branded PDF via `ReportGenerator`.\n",
+    "How the survey module and the reporting module compose into one coherent deliverable. We exercise **all seven `TableType`s** (single-response, multiple-response, cross-tab, ranking, mean-scale, banner, longitudinal), render each as an `Argument` with the right rendering hint, generate trend / heatmap charts off a `WaveSet`, hit the `ChartTypeRegistry` for a registry-based chart, and assemble the whole thing into a multi-section branded PDF via `ReportGenerator`.\n",
     "\n",
     "## Why it matters\n",
     "`reports/03_polling_survey_analysis` shows the survey pipeline in isolation. `reports/01_charts_and_pdf` shows the report builder in isolation. This notebook is the **integration showcase** — every TableType ElectInfo uses in a real client deliverable, every reporting surface they ship, all in the order an actual quarterly report would be assembled. If you're trying to understand 'what does this library actually let me build end-to-end', this is the answer.\n",
@@ -47,10 +47,10 @@
    "id": "c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T23:28:29.015002Z",
-     "iopub.status.busy": "2026-04-28T23:28:29.014934Z",
-     "iopub.status.idle": "2026-04-28T23:28:29.371569Z",
-     "shell.execute_reply": "2026-04-28T23:28:29.371133Z"
+     "iopub.execute_input": "2026-04-29T05:45:14.505786Z",
+     "iopub.status.busy": "2026-04-29T05:45:14.505704Z",
+     "iopub.status.idle": "2026-04-29T05:45:16.574305Z",
+     "shell.execute_reply": "2026-04-29T05:45:16.573884Z"
     }
    },
    "outputs": [
@@ -245,10 +245,10 @@
    "id": "c2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T23:28:29.372785Z",
-     "iopub.status.busy": "2026-04-28T23:28:29.372682Z",
-     "iopub.status.idle": "2026-04-28T23:28:29.649655Z",
-     "shell.execute_reply": "2026-04-28T23:28:29.649190Z"
+     "iopub.execute_input": "2026-04-29T05:45:16.575604Z",
+     "iopub.status.busy": "2026-04-29T05:45:16.575490Z",
+     "iopub.status.idle": "2026-04-29T05:45:17.083119Z",
+     "shell.execute_reply": "2026-04-29T05:45:17.082693Z"
     }
    },
    "outputs": [
@@ -364,10 +364,10 @@
    "id": "c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T23:28:29.650838Z",
-     "iopub.status.busy": "2026-04-28T23:28:29.650732Z",
-     "iopub.status.idle": "2026-04-28T23:28:29.680790Z",
-     "shell.execute_reply": "2026-04-28T23:28:29.680345Z"
+     "iopub.execute_input": "2026-04-29T05:45:17.084326Z",
+     "iopub.status.busy": "2026-04-29T05:45:17.084222Z",
+     "iopub.status.idle": "2026-04-29T05:45:17.113869Z",
+     "shell.execute_reply": "2026-04-29T05:45:17.113500Z"
     }
    },
    "outputs": [
@@ -497,10 +497,10 @@
    "id": "c4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T23:28:29.681989Z",
-     "iopub.status.busy": "2026-04-28T23:28:29.681915Z",
-     "iopub.status.idle": "2026-04-28T23:28:29.702581Z",
-     "shell.execute_reply": "2026-04-28T23:28:29.702139Z"
+     "iopub.execute_input": "2026-04-29T05:45:17.115304Z",
+     "iopub.status.busy": "2026-04-29T05:45:17.115218Z",
+     "iopub.status.idle": "2026-04-29T05:45:17.137031Z",
+     "shell.execute_reply": "2026-04-29T05:45:17.136687Z"
     }
    },
    "outputs": [
@@ -604,10 +604,10 @@
    "id": "c5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T23:28:29.703769Z",
-     "iopub.status.busy": "2026-04-28T23:28:29.703710Z",
-     "iopub.status.idle": "2026-04-28T23:28:29.727439Z",
-     "shell.execute_reply": "2026-04-28T23:28:29.726964Z"
+     "iopub.execute_input": "2026-04-29T05:45:17.138448Z",
+     "iopub.status.busy": "2026-04-29T05:45:17.138383Z",
+     "iopub.status.idle": "2026-04-29T05:45:17.162421Z",
+     "shell.execute_reply": "2026-04-29T05:45:17.161964Z"
     }
    },
    "outputs": [
@@ -697,24 +697,186 @@
   },
   {
    "cell_type": "markdown",
+   "id": "s_banner",
+   "metadata": {},
+   "source": [
+    "## 6. BANNER — party × multi-banner break (county and top_issue)\n",
+    "\n",
+    "BANNER is shape-equivalent to CROSS_TAB but signals to the renderer that **multiple break variables share one slide / page** as side-by-side banner columns. ElectInfo uses this for OSCAR-style executive summary slides where one row variable (party ID) needs to be cross-tabbed against several breaks at once — demographics on the left, issue salience on the right — without forcing a slide per break."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c_banner",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-29T05:45:17.163614Z",
+     "iopub.status.busy": "2026-04-29T05:45:17.163551Z",
+     "iopub.status.idle": "2026-04-29T05:45:17.195738Z",
+     "shell.execute_reply": "2026-04-29T05:45:17.195189Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "view keys (one column per break value):\n",
+      "   county=Dallas\n",
+      "   county=Travis\n",
+      "   county=Harris\n",
+      "   top_issue=public_safety\n",
+      "   top_issue=economy\n",
+      "   top_issue=education\n",
+      "   top_issue=healthcare\n",
+      "   top_issue=immigration\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>county=Dallas</th>\n",
+       "      <th>county=Travis</th>\n",
+       "      <th>county=Harris</th>\n",
+       "      <th>top_issue=public_safety</th>\n",
+       "      <th>top_issue=economy</th>\n",
+       "      <th>top_issue=education</th>\n",
+       "      <th>top_issue=healthcare</th>\n",
+       "      <th>top_issue=immigration</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>party</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>D</th>\n",
+       "      <td>44.149</td>\n",
+       "      <td>47.716</td>\n",
+       "      <td>52.558</td>\n",
+       "      <td>42.667</td>\n",
+       "      <td>48.684</td>\n",
+       "      <td>56.250</td>\n",
+       "      <td>47.321</td>\n",
+       "      <td>47.934</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>I</th>\n",
+       "      <td>11.170</td>\n",
+       "      <td>12.183</td>\n",
+       "      <td>7.907</td>\n",
+       "      <td>13.333</td>\n",
+       "      <td>10.088</td>\n",
+       "      <td>9.375</td>\n",
+       "      <td>10.714</td>\n",
+       "      <td>9.091</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>R</th>\n",
+       "      <td>44.681</td>\n",
+       "      <td>40.102</td>\n",
+       "      <td>39.535</td>\n",
+       "      <td>44.000</td>\n",
+       "      <td>41.228</td>\n",
+       "      <td>34.375</td>\n",
+       "      <td>41.964</td>\n",
+       "      <td>42.975</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       county=Dallas  county=Travis  county=Harris  top_issue=public_safety  \\\n",
+       "party                                                                         \n",
+       "D             44.149         47.716         52.558                   42.667   \n",
+       "I             11.170         12.183          7.907                   13.333   \n",
+       "R             44.681         40.102         39.535                   44.000   \n",
+       "\n",
+       "       top_issue=economy  top_issue=education  top_issue=healthcare  \\\n",
+       "party                                                                 \n",
+       "D                 48.684               56.250                47.321   \n",
+       "I                 10.088                9.375                10.714   \n",
+       "R                 41.228               34.375                41.964   \n",
+       "\n",
+       "       top_issue=immigration  \n",
+       "party                         \n",
+       "D                     47.934  \n",
+       "I                      9.091  \n",
+       "R                     42.975  "
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chain_banner = build_chain(\n",
+    "    df_sept,\n",
+    "    row_var='party',\n",
+    "    break_vars=['county', 'top_issue'],\n",
+    "    table_type=TableType.BANNER,\n",
+    ")\n",
+    "arg_banner = chain_to_argument(\n",
+    "    chain_banner,\n",
+    "    headline='Party ID — banner: by county and top issue (September)',\n",
+    "    narrative='Two banners side by side: party × county on the left, '\n",
+    "              'party × top_issue on the right. Single executive slide.',\n",
+    ")\n",
+    "print('view keys (one column per break value):')\n",
+    "for k in list(chain_banner.views.keys()):\n",
+    "    print('  ', k)\n",
+    "arg_banner.table.round(3)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "s6",
    "metadata": {},
    "source": [
-    "## 6. LONGITUDINAL — WaveSet.compare_chain\n",
+    "## 7. LONGITUDINAL — WaveSet.compare_chain\n",
     "\n",
     "Now the multi-wave story: the same row variable (`party`) compared across all three fielding dates. `WaveSet.compare_chain` returns a LONGITUDINAL `Chain` whose columns are wave ids in date order, with a trailing Δ column."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T23:28:29.728676Z",
-     "iopub.status.busy": "2026-04-28T23:28:29.728607Z",
-     "iopub.status.idle": "2026-04-28T23:28:29.754664Z",
-     "shell.execute_reply": "2026-04-28T23:28:29.754142Z"
+     "iopub.execute_input": "2026-04-29T05:45:17.196854Z",
+     "iopub.status.busy": "2026-04-29T05:45:17.196785Z",
+     "iopub.status.idle": "2026-04-29T05:45:17.222690Z",
+     "shell.execute_reply": "2026-04-29T05:45:17.222287Z"
     }
    },
    "outputs": [
@@ -793,7 +955,7 @@
        "R      36.666667  42.0  41.333333          4.666667"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -814,21 +976,21 @@
    "id": "s7",
    "metadata": {},
    "source": [
-    "## 7. Render the longitudinal chain — trend chart + heatmap\n",
+    "## 8. Render the longitudinal chain — trend chart + heatmap\n",
     "\n",
     "`reporting.wave_charts` consumes a LONGITUDINAL chain directly. Both helpers return matplotlib `Figure`s, so we can save them as PNGs and feed them straight into the PDF builder later."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "c7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T23:28:29.755849Z",
-     "iopub.status.busy": "2026-04-28T23:28:29.755779Z",
-     "iopub.status.idle": "2026-04-28T23:28:33.651921Z",
-     "shell.execute_reply": "2026-04-28T23:28:33.651387Z"
+     "iopub.execute_input": "2026-04-29T05:45:17.223846Z",
+     "iopub.status.busy": "2026-04-29T05:45:17.223771Z",
+     "iopub.status.idle": "2026-04-29T05:45:17.742764Z",
+     "shell.execute_reply": "2026-04-29T05:45:17.742128Z"
     }
    },
    "outputs": [
@@ -846,7 +1008,7 @@
        "<Figure size 1000x600 with 1 Axes>"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -883,6 +1045,16 @@
     {
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxYAAAGGCAYAAADmRxfNAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAANNRJREFUeJzt3Qu8FVW9OPCFD8AX+AZFVEpT8QGKL7AEDUVTk2uZ2QM0tWtJaXrzE1Y+8hZ2DcXSRK8PUjPNUixTjDC0FB+glvgq0wQLUFNBSdFg/z+/+d/ZzTns82IOnAff7+czn3P27Nl7r5lZs2Z+a61Z06VSqVQSAABACWuU+TAAAEAQWAAAAKUJLAAAgNIEFgAAQGkCCwAAoDSBBQAAUJrAAgAAKE1gAQAAlCawAAAAShNYQErpuOOOS126dMmm6dOnt3VyWEGLFy9OvXr1yvbjt7/97dQe3H///dW89cgjj7R1clYLkyZNqm7zc889t62TA6wkw4YNqx7rf/3rX9s6OQgs2r84KeYHTa1pww03bOsk0s5Nnjw5y0cxdfaC9wc/+EF6+eWXU/fu3dN//ud/Vue/9tpraezYsWno0KFp3XXXrR4/EVCujOOyGJzut99+aa+99sr+P/vss1thLaGuOK7zYzyOd1rfG2+8Ud3GEbiuSk899VT61Kc+lbbccsu09tprp4033jjtsMMO6WMf+1i69NJLV4ttQMexVlsnANqDr3/96+nEE0/M/t91111TZxIXGj/60Y+qtTvbbrtt6oz+9a9/pQkTJmT/jxw5Mm266abV9+bMmZMuuOCCNktb5K1orZgyZUqaPXt22mWXXdosLXTOwOK8887L/h89enSW/2n9i+p8G0cFxYpWSrTUk08+mfbdd9/01ltvVee9/vrr2fSnP/0p/eEPf0hjxozp1NuAjkVg0YEceuih6ayzzqozb6217MLWsP3222dTZ+sWtN5666XVxV133ZUWLFiQ/R81eUVdu3ZN+++/fxoyZEjWonHNNde02u/+7ne/W25e/eA0LvS+8IUvpGXLlmU1fd/73vda7fdZfa3qY/zuu+9Of//739Pxxx+/3Hv33XdfeuKJJ9Ipp5yyytKzOvjOd75TDSo+8YlPpM9+9rPZef+FF15Iv//977OKClatKMfffffdrGWcGiq0a+ecc04ldlNMo0ePbtZnbrzxxsqwYcMqG264YaVr166VbbbZpvKZz3ym8sYbb1SXWbJkSeWCCy6oDBgwoLLuuutW1llnncpuu+1WGTduXPZeUXw+T8O8efOy74rvXn/99Suf+MQnKv/4xz+WS8Mtt9ySpaFnz55ZGvr161c55ZRTKn//+9/rLBfrlH/3nXfeWfnSl75U2XjjjSsbbbRRtvw777xTefHFFytHHHFEZb311qv06tWr8vWvf72ydOnS7PO/+c1vqp8fNWpUne9+/PHHq+8dfvjhjW6zYjp++9vfVufn82Ib/OEPf6h86EMfyrbVDjvskK1jvq79+/fP1jO24bRp0xr87l//+teVb3zjG5Utt9yy0r179+z7Zs2atVx6/vznP1eOO+64ylZbbVVZe+21s21y6KGHZutbFGkt5o+f//zn2T6NtBR/t9aUr2fs86FDh1b69OmTpSnWb6eddsq28+LFi0vnhbvuuitL+6abbpqtS6z7xz72scpf//rX6jLLli2rXHPNNZUhQ4ZUNthggywdsS0nTJhQ3ddNOf7447N0denSpU5er+/yyy9v8THV2HHZXAMHDsyWf9/73ldpS7Gv87TPnDmz8ulPfzrbf3FsxXrFvoi8Hsdv7Ie+fftWLrnkkuW+5913362MHz++sscee2RlSEx777135frrr19u2ZWdx+q79tprq98R63TzzTdXdtlll0q3bt2y3/3xj39cXTaOx3zZyINFkf/y9773ve81+pvFdM+fP7/yqU99Kiv/evTokf2/YMGCVtkmUR4eddRR2fduu+22dfZn/Snyd2y//PU999xT53tPO+206ns/+9nPGl2/2BdRBq+55prLLRtlWKQnjr377ruv0hz/+te/Kpdddlll3333zT4b22C77barfP7zn6+z3MKFCytnnXVWZccdd8yWiXwQ+WzixIlZXs298MIL1XWJbdLQ9muo7JwyZUplzz33zPJI/TzfWFkav9VaeaiWWO/884sWLVru/fp5JTz//POVE088sbL11ltn54LNNtssO3aeeuqpRo+TOHbjXFbrOGlqG+TefPPN7Lt23nnnbH9FeR7vx/m9qP7+irwZZUl8Zvfdd6+en374wx9m1w+Rpjg/xHm9qJj/n3zyycqXv/zlbH2jPDrssMMqzz333HLbJ8q3T37yk5XevXtXz0knnHBCZe7cuQ2W81dffXXl/PPPz7bpGmusUec6gboEFp0ssPjc5z7X4MEfB3KIi/X999+/weXivWJwUSyU46Ko/vJxYVJ05plnNvjdcSBHoVersHr/+9+/3PKf/exns0Kl/vz//d//zT4fJ5b8/SjA/vnPf1a/+1vf+lZ1+Qi2ygQWcWGzySab1ElDnESLJ5R8inS89tprNb87ApL6y8dJ9dlnn60u/9BDD2XfUWv7xW9GQVvr5BjbId4v5peG9kNxPWulKZ8OOOCAOtuppXnhvPPOa/L3QwSFDS13zDHHVJrjAx/4QDUfNaa1A4u4CImT0xZbbJGt/5/+9Kcmj824SGsrxRNxrWMugvvI7/XnT506tU5Q8eEPf7jBfRZlQNHKzGO1FC+Ydt1115q/m5cJf/nLX6rHTaxT0YEHHpjNjwuJl156qdHfLKa71vpGoBxlb2tuk5jfVGBRLCPi4qko3/9RBr399ttNbtf//u//zpaPi9W77747m/fMM89kF3L5sdqcioDIPyNGjGgw3bkoR4sX1vWnuDhsjcAi3o993FCeb+qiurXyUC177bVX9beiDHnkkUcq7733XoPLR5BX6/iNKYKyOL/UOk4ayo/5cdKcwCIqdBo63mKKQLLW/sqD6+KyEWj/13/913LfEcF0cf2L+T+OsfrLx3e/+uqr1eUjwIkgpTnXJ8Vyvn5ZJLBomMCinStm7IZOHLmoRcrnR61SHJRxEF133XWVgw46qFpDHC0VxYuiKDh+8pOfZJF4Pj+WqVUox8XTDTfckF3cxskl/628hvjBBx+sLhsFRdTQ/OIXv8hOlPn8Qw45pPrdxcIqasOuvPLKylVXXVWnkI+D/aabbqqce+651XlRs1QrgIjlcrFMzIuai7feeqtUYBFT1KzFusTJrDj/yCOPrNxxxx2VD37wg9V5l156ac3vjrRETdjkyZOr6YspaiDzQClqjPL5H//4xyu/+tWvKt/85jer2yS2+5w5c5Y7OcYUJ6FoQYnvjxq43/3ud1lrQf7+97///WxeTPk+u/jii7Oaqsgr06dPz9bxIx/5SPUz999//wrlhTgBFtMWFzW//OUvs7x29NFHV+69995suUhv8eQW78dysb1r7dda4kSTn9jjgmVVBhb1p7hI++Mf/7jcZ77zne9Ul6nfqrUqFU/Em2++eba9i2mLKS7mbrvttsoXvvCFOnkxd+GFF9Y5LmLZKH+KFydRFuRWVh5rSPGCKaZTTz01O46KtfdRrsQFbv2Lv7/97W/ZvNdffz0LGIsXTo2pf/EfrSSTJk3KWuqKx1/ZbRLl5EUXXZS1fl5xxRVZXovvzd+P4z0/xiPIjTIlDyDigjMPbmbPnr1Cx8EZZ5xRTUesY5xD8t/Nt2dT4rxQLBOjJjjKq6gwijIsd/LJJ1eXiwvWW2+9NTs/RIt2/bKhTGCRl+NR7hTL9zzPx3YsllPR+phv4/xYb408VMvYsWOXK2Nimw0fPjw7Xxa3eezraJnLl4t9Ffnku9/9bnbcxLw4v+QtPS05TpqzDaKXQf5+5OX4rrj+iO+of+4q7q+8V0Esn2/HfIqWlzi/FgPMeF2rPItjLdYp0lkMBE4//fRq604eBK+11lqVb3/729n2KVaGFq9P6pfzUamRr1NDFUgILDpVYBEFYz4/CqOGFKP6KEhz8X8+P7rT1CqU4wIiFwdgPj9vnoxmyGKhlnvllVeqtQRxAZh3ZyhedEdzdy6aUYtNkCEKw7wmP06QuSio8ovu6DIVostVfqFZrNUqE1jkBUnxgjkK+Lx5uljoRheDWt8d3Rxy8X3FICwK70cffbTmhU+I7kP5e3FRUv/kGLVRtbqJNLRuubjAiG2Ud7uqn8eKXQJakhfiJJXPO/bYYxvc9sV8Wwx84iKjeNJpTHQzyZdtan83FVjEfsnTUJxiv+fiRB3rFCexODFFTVx+8qxVa1n/d+OCrDENpaE5U1MX3cUTcVyY5CL/1A984rgtXkjkonzI5//0pz+t/nYxyB8zZsxKz2MNKV4w7bfffnW63xQrUPJuO9HlI58X3btCBFz5vOh205RiuoutO8V8HBdNZbdJcZ811K2nvriAyt+P7pJ5V6x8XlzUt0RUEhTTGl06i63FTSnmnwiOaomWj2IA8cQTT1Tf+8EPflCdH+VH2cAiAuw84IpubLXyfGPf31p5qJY4v0TFYP38kU/77LNP9Tzx2GOP1Ul7sVwYPHhwnS6QK3KcNLYNivsrAojotpv/9he/+MXluoMVvytaJ6LLW/3zaKQhD4KKlRnRvaxWeZb3ZAhxDObz8+6nUZ7UCsBjipaQmB/XDVHu1b/+Km4fGufO3w5+83aM2Z+LESJyhx9+eIPfU1xun332qf6/995711ymKEaCyG2yySZ1Roto7LtjhJ73ve996emnn46SPT333HN1fq/+78dwerk999wz+xvDeMb8N998s/p7oW/fvunggw/ORtyJ6R//+Ef65S9/mf1OOPbYY1NZMaxvfnN3MW0x5N8GG2xQXcf626O+4jaJ79too42y0T3eeeed7KbI4vbbY489sqEFi9vn5z//eYP7J4Y1LaatOV588cXshuZFixY1uExD69KSvNDc/PjlL3+55jKRb5or3+8rKp5/kY+iVbTNNttUh+s988wz67x30EEHpZ122ikdeOCB2esYbvbtt99O66yzzgqlq6E0NMdvf/vbbPSv5igec5EX85tE82OuoTxd3GdxQ2lj+2xl5rHmKB5za665Zho0aFA2Slh4/vnn04c+9KF01FFHZcd4fO+Pf/zjdPrpp6df/OIX2TJxDH784x9v9u/V/83iNo7fK7tNjjjiiNRSMXpPDHW8dOnSbP1iffP123zzzdOHP/zhFn3fhRdemG655ZZq+mM0tmJeb0pzyoZXXnklKxtDDBFdHEmtOeeqlohRl7p161Yqn7V2HsrF+SVumr/nnnuy8j/KlmJ5+NBDD6Vrr702ff7zn6+zLR5//PEsb9cSn4/joKXHSWNeffXV6v6KG5uHDx/e4G/XF+fRHj16ZP8Xz2GRhjjvr8j5tZhHotyO8re4fWKwj5jqi+WeeeaZ9MEPfrDO/MbOYdTlORYdSJwAIrMXp9YcySg/gBsTFx+1RqRqzkVTU9/fs2fP6v9rrPHvrJkXOI054YQTsr/vvfde+ulPf1ot0CO9hxxySCqrpWlr7kVkc7Z5c5ctBpnNFRev+cXB4MGDs6FpY5Sj4oVzjIDR2nlhRUa/aUycjPLtk5/cVrXiiSwu4Oqno/i6eJJsSy3J1y3dr/k+a295rNZxFKO7fPrTn87+f/TRR7PRjfKLjqi0KF5stsbvldkmK3Kcx/MP8nLwV7/6VXaBFRek4eijj27R6IIRMMcoZ5H+uAANcdEcFSMrS/1tWGubFufF8Vf/orcxrZHPVnYeiuDvhz/8YfZMixgRqnjhG7/XmuVp/psrQ63fXhnn1zLpr5XGFTnuVlcCi07kAx/4QPX/OHk0Z7mHH364+n9+oqm/zIqmofjd0Yrwl7/8pXrAb7fddqk1ffSjH61erF199dVp2rRp1WFHY6jR9qK4TaLVJh7clp+U4uRf3H6PPfZY9myG5u6fhgrSYkFd/2Llb3/7W/X/aA078sgjsxPWwoULU1vkx6ht/78umnWmPO80JC4G8iA7tmsZMRxsrTQUHy44c+bM5T5X3D+RnvqtR8V09e/ff4XS0Jypua0VZRT3WdRm1kpHfgyuzDzW0mMuLjiL+y5aUetXToQYGjivFV2RFs+GytX898psk1rHeWPHeP31W7JkSfrc5z5XXa4l6xcVNxFExNCy0VL8xz/+MavtjwvdaLWLcr61yobNNtus+gDYuNCL5zk0VhYWL07nz59f/T+GZG3OhXRTWrKNWyMP5X7zm99kLQBF8SyiCAjrB1LF7RqtfbWOy9gWxYeHtuQ4aWwbxPk3D9DWX3/9rGdB/d+O743WlZWloeMutlccN8XtE897aWj7jBgxYpUFWp2RrlAdSIy/H4VkffFU32jG/cxnPpNuv/32bN7//M//ZBelBxxwQFbY33DDDWnixIlZd454gmecEEKMOR4FQBw0X/va16rfuaIFYXzu+9//fvZ/PBE0Lpbjgi+ayuOEFuKgbWmXnaZE8BDje1988cVp1qxZddLTnkT6ouZj6623zrq7FLu5RXP5wIEDsy410Vw8b968rAYsujFEIXnbbbdV17X+cxqaWxsX+SBqGWOKC5nID7nYb/Hd8VsRnJUVab/kkkuy/2+88cZsvP24gIqCO/JpnNzi2RKxXJ5vYx/Gwwojz0RXiD//+c/ZhUdsn3POOafR34uuYFETGxc5cYFWvND45z//me68885qwJaLLik/+9nPqsdRcXs01ToRaYr9EJ959tln0/nnn199P/J4/THO89+Nk3Tv3r1TRxb7LB7MlXcRiJr2rbbaKsuz0Y0g9ucZZ5yR5d2VmceaI8rM6JYSF7433XRTtXtHHIdxUZzbfffdsyn20/3335/Ni+49kWdbKvL2uHHjsi6OkZ9z+Xe19jYpHuOxvlFTHl1o4kIqWrrz/RT/x3kkX78oh6JLVnPEhWQcn3EcxUX/1KlTsy4s8TouYqOGPlpFostO3j20IXGuyvPPV77ylSxNcfxFwHXllVemGTNmZBexn/zkJ7PzVp7nogyIlr9iWZCX8RGERKtAnO8iiD/55JOz9LXWM2OK2zjWNVqZ4mI6tmFMzc1D8dTq/CFzcZHd1EPmYvmoWDnmmGOyMi5+M8qt8ePHV5eJbRcGDBiQdRmLZ1vce++9adSoUVkAEueWqBiJC+84j9Rq1W3OcdLUNoh9Ea0q0aUyWmmia2u8/9JLL2VpuvXWW7NnCK2syo+xY8dmlTpxron/c/n2j3WLvBvnluuuuy67Dol5EfDE9ol9FvkyWoUooYl7MGjnN28Xh5Ftaki44nCzcbPdigw325ybgld0uNnidxRvyCquX0NpqT/KST6iTHOfgdCc51jkGrqBraEbKIvfXWs4vLhp9umnny493GxDI7sUb8ovTiHGxI8b0Ou/Fzeq5f9HHmxq+ze0/c4+++zSw83WT0NDiutZf5z9+iOQ1JriRsbmaux74nkQ9cdOj5vL8wEGYrS2ttTSY6vWMRDlQ2PDzRa358rOY7UUb0qNZyPUSl+t523EaG7FZWLs/+YqprvWcR6j9eRDurbWNimOilYcPKChPF1/+M76wwI35uWXX85upo1nc8QgE0UxfHKMPBUjRdV/r5a42ThGNWoo7+RiMIqmhpstPsui1ghKcR4oDr/anLKzVp4PgwYNarJsaioPFc/pzSlzinmi1hSjPBVvnG9suNn626A5wzLXP04a2wYxClZjw80Wj92WnkfrP3OjVnm2/fbb19z/kXdzMapTQ8PN1t/nLd1X/H+6QnUy0YXi+uuvz2qQosY2asKiJiFqe/LahmjdiNqmCy64IO22225ZjUrUrsbTgqOW7de//nWp7kPf/e53s/scIg3RRzJqS6IpMlpHoi9ov3790sqw884717l5K24qLTbdtgdRyxQ1UH369Mn2Q7QaRPefHXfcsU5teLS6RFNtLBc1MPm9IrFvoom9JaKmMmrt3v/+9y/XlzryRnxn/Gbkg1gmapxOPPHEVlnfqJmLFodIe9QmRl6IVqy40bGYD6LPedQg1c+30a84anS/+MUvNvlb8Rt5S0DUjK1M8f1R6xo1wlE7G/syWllOO+20rMYrtmNR1OzlXQeaqqHsCGL/xEAJsW8i78Q2iDIk9ulhhx2W1bz/x3/8xyrJY02Jsi9qhuMYi3RHLXaUkbH/ai1bbGla0RbP6AYWtfuRl2PbRM17dGnJv7u1t0kc13FfWZQnjbUWFLvqtHT9oqY30hwtFFErXxTHXZxTYtCM+u/VEuVAtKrk+Se6zsS2iS6yJ510UnW5qFF+8MEHs9rn2G9xnEVtdNTQX3755VlLaLGLStygHjcxR+tF3kIatdDF1ssyfvKTn2TlTLHmvqV5qNiFKL9hvDHR8h/laJSN0dIV3x15Jlq2o6Uw1q9443wM+hE3bkeLTbSORp6P7REtGTEv76JYX5TJN998c3Yebew4aWwbxO9Ea1O03kbrSaQrbryPsjG60MVni62ErS0GFIj9H+ea+O1oVY5ue5F3cx/5yEeybl5xfEYra+TFaFWJ3gLRYhPfQUn/F2BAp1B8IFvxQUBtqSU1rZSTP6Mlhi8sPhSpreUPuYohDmnf8mfuRK1vseW2KU21KrQX+QNF48nKrPo8FEOi50OgNuehhCtTQ60AUEb7qs6FFRR9OqNfbfQNDVE7WX84Wzq/MWPGZP3IY+SavG92W4saxUceeST7P+9bTfsSfazjXrPolx41riH6tLengR/KiPvtYhSnuJ8o7kEK0f+eVZuHorUiRv8Kcf9Z/fuwoDNw8zadQv3m/29+85ttlhbaTnR/WLBgQWpP4obLlTEEL60nLvZioItcXPB99atfTZ1FDNpw/PHHV19H8B3dYli1eSgGTYmRoqK7oOci0FlpsaDTiL620Qc1aoJi5CuAlshHZot7BerfJ9MZxMVu3IcR9zfkQ7my6vJQzI9KhjvuuKPN0gcrW5foD7XSfwUAAOjUtFgAAAClCSwAAIDV4+btGEnh73//e3aDrseqAwDAqhF3TcSoZ/EcqqaeD9YhAosIKvr27dvWyQAAgNXS3LlzswcLdvjAIh9KNFYonuQMAACsfPEcnKjgrz+0f4cNLPLuTxFUCCwAAGDVas7tCG7eBgAAShNYAAAApQksAACA0gQWAABAaQILAACgNIEFAABQmsACAAAoTWABAACUJrAAAABKE1gAAACrNrC4/PLL02677ZZ69OiRTYMHD0533XVXo5+55ZZb0o477pi6d++edt1113TnnXeWTTMAANCRA4utttoqXXDBBWnWrFlp5syZ6cADD0xHHnlkevLJJ2su/8ADD6Rjjz02nXDCCemxxx5LI0eOzKbZs2e3VvoBAIB2oEulUqmU+YKNN944XXjhhVnwUN8xxxyTFi9enO64447qvH333TcNHDgwTZw4sdm/sWjRotSzZ8+0cOHCrKUEoKPa7ZRJbZ0EVpE/XnZcWycBoLSWXIev8D0WS5cuTTfddFMWOESXqFpmzJiRhg8fXmfeiBEjsvmNWbJkSbYSxQkAAGi/WhxYPPHEE2n99ddP3bp1SyeffHK67bbbUv/+/WsuO3/+/NSrV6868+J1zG/MuHHjssgon/r27dvSZAIAAO05sNhhhx3S448/nh566KH0hS98IY0ePTo99dRTrZqosWPHZs0t+TR37txW/X4AAKB1rdXSD3Tt2jVtt9122f+DBg1KjzzySLrkkkvSFVdcsdyyvXv3TgsWLKgzL17H/MZEa0hMAADAavIci2XLlmX3RNQS915MmzatzrypU6c2eE8GAACwGrRYRBelQw89NG299dbpzTffTDfeeGOaPn16uvvuu7P3R40alfr06ZPdIxFOPfXUNHTo0DR+/Ph02GGHZTd7xzC1V1555cpZGwAAoP0HFi+//HIWPMybNy+7qToelhdBxUEHHZS9P2fOnLTGGv9uBBkyZEgWfHzjG99IZ511Vtp+++3T5MmT0y677NL6awIAAHTc51isCp5jAXQWnmOx+vAcC6AzWCXPsQAAAMgJLAAAgNIEFgAAQGkCCwAAoDSBBQAAUJrAAgAAKE1gAQAArNoH5AEAUJfn06w+PJ+mcVosAACA0gQWAABAaQILAACgNPdYtGP6bK4+9NkEADo6LRYAAEBpAgsAAKA0gQUAAFCawAIAAChNYAEAAJQmsAAAAEoTWAAAAKUJLAAAgNIEFgAAQGkCCwAAoDSBBQAAUJrAAgAAKE1gAQAAlCawAAAAShNYAAAApQksAACA0gQWAABAaQILAACgNIEFAABQmsACAAAoTWABAACUJrAAAABKE1gAAAClCSwAAIDSBBYAAMCqDSzGjRuX9tprr7TBBhukzTffPI0cOTI9++yzjX5m0qRJqUuXLnWm7t27l003AADQUQOLe++9N51yyinpwQcfTFOnTk3vvfdeOvjgg9PixYsb/VyPHj3SvHnzqtOLL75YNt0AAEA7slZLFp4yZcpyrRHRcjFr1qy0//77N/i5aKXo3bv3iqcSAADovPdYLFy4MPu78cYbN7rcW2+9lbbZZpvUt2/fdOSRR6Ynn3yyzM8CAACdJbBYtmxZOu2009J+++2XdtlllwaX22GHHdI111yTbr/99nTDDTdknxsyZEh66aWXGvzMkiVL0qJFi+pMAABAJ+kKVRT3WsyePTv9/ve/b3S5wYMHZ1MugoqddtopXXHFFen8889v8Cbx8847b0WTBgAAdIQWizFjxqQ77rgj/fa3v01bbbVViz679tprp9133z0999xzDS4zduzYrJtVPs2dO3dFkgkAALTHFotKpZK+9KUvpdtuuy1Nnz499evXr8U/uHTp0vTEE0+kj3zkIw0u061bt2wCAAA6YWAR3Z9uvPHG7H6JeJbF/Pnzs/k9e/ZM66yzTvb/qFGjUp8+fbLuTOFb3/pW2nfffdN2222X3njjjXThhRdmw82eeOKJK2N9AACA9h5YXH755dnfYcOG1Zl/7bXXpuOOOy77f86cOWmNNf7dw+r1119PJ510UhaEbLTRRmnQoEHpgQceSP3792+dNQAAADpeV6imRBepoosvvjibAACAzqvUcywAAACCwAIAAChNYAEAAJQmsAAAAEoTWAAAAKUJLAAAgNIEFgAAQGkCCwAAoDSBBQAAUJrAAgAAKE1gAQAAlCawAAAAShNYAAAApQksAACA0gQWAABAaQILAACgNIEFAABQmsACAAAoTWABAACUJrAAAABKE1gAAAClCSwAAIDSBBYAAEBpAgsAAKA0gQUAAFCawAIAAChNYAEAAJQmsAAAAEoTWAAAAKUJLAAAgNIEFgAAQGkCCwAAoDSBBQAAUJrAAgAAKE1gAQAAlCawAAAAShNYAAAApQksAACAVRtYjBs3Lu21115pgw02SJtvvnkaOXJkevbZZ5v83C233JJ23HHH1L1797TrrrumO++8s0yaAQCAjhxY3HvvvemUU05JDz74YJo6dWp677330sEHH5wWL17c4GceeOCBdOyxx6YTTjghPfbYY1kwEtPs2bNbI/0AAEA7sFZLFp4yZUqd15MmTcpaLmbNmpX233//mp+55JJL0iGHHJK++tWvZq/PP//8LCi59NJL08SJE8ukHQAA6Az3WCxcuDD7u/HGGze4zIwZM9Lw4cPrzBsxYkQ2vyFLlixJixYtqjMBAACdMLBYtmxZOu2009J+++2XdtlllwaXmz9/furVq1edefE65jd2L0fPnj2rU9++fVc0mQAAQHsOLOJei7hP4qabbmrdFKWUxo4dm7WG5NPcuXNb/TcAAIA2usciN2bMmHTHHXek++67L2211VaNLtu7d++0YMGCOvPidcxvSLdu3bIJAADohC0WlUolCypuu+22dM8996R+/fo1+ZnBgwenadOm1ZkXN2/HfAAAYDVssYjuTzfeeGO6/fbbs2dZ5PdJxH0Q66yzTvb/qFGjUp8+fbL7JMKpp56ahg4dmsaPH58OO+ywrOvUzJkz05VXXrky1gcAAGjvLRaXX355ds/DsGHD0hZbbFGdbr755uoyc+bMSfPmzau+HjJkSBaMRCAxYMCA9LOf/SxNnjy50Ru+AQCATtxiEV2hmjJ9+vTl5h199NHZBAAAdE6lnmMBAAAQBBYAAEBpAgsAAKA0gQUAAFCawAIAAChNYAEAAJQmsAAAAEoTWAAAAKUJLAAAgNIEFgAAQGkCCwAAoDSBBQAAUJrAAgAAKE1gAQAAlCawAAAAShNYAAAApQksAACA0gQWAABAaQILAACgNIEFAABQmsACAAAoTWABAACUJrAAAABKE1gAAAClCSwAAIDSBBYAAEBpAgsAAKA0gQUAAFCawAIAAChNYAEAAJQmsAAAAEoTWAAAAKUJLAAAgNIEFgAAQGkCCwAAoDSBBQAAUJrAAgAAWPWBxX333ZeOOOKItOWWW6YuXbqkyZMnN7r89OnTs+XqT/Pnzy+TbgAAoCMHFosXL04DBgxIl112WYs+9+yzz6Z58+ZVp80337ylPw0AALRTa7X0A4ceemg2tVQEEhtuuGGLPwcAALR/q+wei4EDB6YtttgiHXTQQen+++9fVT8LAAC0xxaLlopgYuLEiWnPPfdMS5YsSVdddVUaNmxYeuihh9Iee+xR8zOxXEy5RYsWrexkAgAA7Tmw2GGHHbIpN2TIkPSXv/wlXXzxxen666+v+Zlx48al8847b2UnDQAA6MjDze69997pueeea/D9sWPHpoULF1anuXPnrtL0AQAA7azFopbHH3886yLVkG7dumUTAADQSQOLt956q05rwwsvvJAFChtvvHHaeuuts9aGv/3tb+m6667L3p8wYULq169f2nnnndM777yT3WNxzz33pF//+tetuyYAAEDHCSxmzpyZDjjggOrr008/Pfs7evToNGnSpOwZFXPmzKm+/+6776YzzjgjCzbWXXfdtNtuu6Xf/OY3db4DAABYzQKLGNGpUqk0+H4EF0VnnnlmNgEAAJ1Xm9y8DQAAdC4CCwAAoDSBBQAAUJrAAgAAKE1gAQAAlCawAAAAShNYAAAApQksAACA0gQWAABAaQILAACgNIEFAABQmsACAAAoTWABAACUJrAAAABKE1gAAAClCSwAAIDSBBYAAEBpAgsAAKA0gQUAAFCawAIAAChNYAEAAJQmsAAAAEoTWAAAAKUJLAAAgNIEFgAAQGkCCwAAoDSBBQAAUJrAAgAAKE1gAQAAlCawAAAAShNYAAAApQksAACA0gQWAABAaQILAACgNIEFAABQmsACAAAoTWABAACUJrAAAABWfWBx3333pSOOOCJtueWWqUuXLmny5MlNfmb69Olpjz32SN26dUvbbbddmjRp0oqmFwAA6AyBxeLFi9OAAQPSZZdd1qzlX3jhhXTYYYelAw44ID3++OPptNNOSyeeeGK6++67VyS9AABAO7RWSz9w6KGHZlNzTZw4MfXr1y+NHz8+e73TTjul3//+9+niiy9OI0aMaOnPAwAAq+M9FjNmzEjDhw+vMy8CipjfkCVLlqRFixbVmQAAgNU4sJg/f37q1atXnXnxOoKFt99+u+Znxo0bl3r27Fmd+vbtu7KTCQAAdLZRocaOHZsWLlxYnebOndvWSQIAAFrzHouW6t27d1qwYEGdefG6R48eaZ111qn5mRg9KiYAAKBjWOktFoMHD07Tpk2rM2/q1KnZfAAAYDUNLN56661s2NiY8uFk4/85c+ZUuzGNGjWquvzJJ5+cnn/++XTmmWemZ555Jv3whz9MP/3pT9NXvvKV1lwPAACgIwUWM2fOTLvvvns2hdNPPz37/+yzz85ez5s3rxpkhBhq9le/+lXWShHPv4hhZ6+66ipDzQIAwOp8j8WwYcNSpVJp8P1aT9WOzzz22GMtTx0AANAhtMtRoQAAgI5FYAEAAJQmsAAAAEoTWAAAAKUJLAAAgNIEFgAAQGkCCwAAoDSBBQAAUJrAAgAAKE1gAQAAlCawAAAAShNYAAAApQksAACA0gQWAABAaQILAACgNIEFAABQmsACAAAoTWABAACUJrAAAABKE1gAAAClCSwAAIDSBBYAAEBpAgsAAKA0gQUAAFCawAIAAChNYAEAAJQmsAAAAEoTWAAAAKUJLAAAgNIEFgAAQGkCCwAAoDSBBQAAUJrAAgAAKE1gAQAAlCawAAAAShNYAAAApQksAACAtgksLrvssrTtttum7t27p3322Sc9/PDDDS47adKk1KVLlzpTfA4AAFiNA4ubb745nX766emcc85Jjz76aBowYEAaMWJEevnllxv8TI8ePdK8efOq04svvlg23QAAQEcOLC666KJ00kknpeOPPz71798/TZw4Ma277rrpmmuuafAz0UrRu3fv6tSrV6+y6QYAADpqYPHuu++mWbNmpeHDh//7C9ZYI3s9Y8aMBj/31ltvpW222Sb17ds3HXnkkenJJ58sl2oAAKDjBhavvvpqWrp06XItDvF6/vz5NT+zww47ZK0Zt99+e7rhhhvSsmXL0pAhQ9JLL73U4O8sWbIkLVq0qM4EAACsxqNCDR48OI0aNSoNHDgwDR06NN16661ps802S1dccUWDnxk3blzq2bNndYqWDgAAoJMEFptuumlac80104IFC+rMj9dx70RzrL322mn33XdPzz33XIPLjB07Ni1cuLA6zZ07tyXJBAAA2nNg0bVr1zRo0KA0bdq06rzo2hSvo2WiOaIr1RNPPJG22GKLBpfp1q1bNpJUcQIAANqvtVr6gRhqdvTo0WnPPfdMe++9d5owYUJavHhxNkpUiG5Pffr0ybozhW9961tp3333Tdttt11644030oUXXpgNN3viiSe2/toAAAAdI7A45phj0iuvvJLOPvvs7IbtuHdiypQp1Ru658yZk40UlXv99dez4Wlj2Y022ihr8XjggQeyoWoBAIDVNLAIY8aMyaZapk+fXuf1xRdfnE0AAEDntdJHhQIAADo/gQUAAFCawAIAAChNYAEAAJQmsAAAAEoTWAAAAKUJLAAAgNIEFgAAQGkCCwAAoDSBBQAAUJrAAgAAKE1gAQAAlCawAAAAShNYAAAApQksAACA0gQWAABAaQILAACgNIEFAABQmsACAAAoTWABAACUJrAAAABKE1gAAAClCSwAAIDSBBYAAEBpAgsAAKA0gQUAAFCawAIAAChNYAEAAJQmsAAAAEoTWAAAAKUJLAAAgNIEFgAAQGkCCwAAoDSBBQAAUJrAAgAAKE1gAQAAlCawAAAA2iawuOyyy9K2226bunfvnvbZZ5/08MMPN7r8Lbfcknbcccds+V133TXdeeedK5peAACgMwQWN998czr99NPTOeeckx599NE0YMCANGLEiPTyyy/XXP6BBx5Ixx57bDrhhBPSY489lkaOHJlNs2fPbo30AwAAHTGwuOiii9JJJ52Ujj/++NS/f/80ceLEtO6666Zrrrmm5vKXXHJJOuSQQ9JXv/rVtNNOO6Xzzz8/7bHHHunSSy9tjfQDAAAdLbB4991306xZs9Lw4cP//QVrrJG9njFjRs3PxPzi8iFaOBpaHgAA6HjWasnCr776alq6dGnq1atXnfnx+plnnqn5mfnz59dcPuY3ZMmSJdmUW7hwYfZ30aJFaXWy9N232zoJrCKrW95enTmuVx+O69WH43r1sToe14v+b50rlUrrBharyrhx49J555233Py+ffu2SXpgZet51RfbOglAK3NcQ+ezOh/Xb775ZurZs2frBRabbrppWnPNNdOCBQvqzI/XvXv3rvmZmN+S5cPYsWOzG8Rzy5YtS6+99lraZJNNUpcuXVqSZDpgVBwB5Ny5c1OPHj3aOjlAK3BcQ+fjuF59VCqVLKjYcsstm1y2RYFF165d06BBg9K0adOykZ3yi/54PWbMmJqfGTx4cPb+aaedVp03derUbH5DunXrlk1FG264YUuSSgcXhZSCCjoXxzV0Po7r1UPPJloqVrgrVLQkjB49Ou25555p7733ThMmTEiLFy/ORokKo0aNSn369Mm6M4VTTz01DR06NI0fPz4ddthh6aabbkozZ85MV155ZUt/GgAAaKdaHFgcc8wx6ZVXXklnn312dgP2wIED05QpU6o3aM+ZMycbKSo3ZMiQdOONN6ZvfOMb6ayzzkrbb799mjx5ctpll11ad00AAIA206XSnFu8YRWJ0cCitSvus6nfHQ7omBzX0Pk4rqlFYAEAAKz6J28DAADUJ7AAAABKE1gAAAClCSwAAIDSBBa0a2+//XZbJwEAgGYQWNBuh7GLhyr269evrZMCtNCyZcvSNddckw4//PDsmUW77rpr+uhHP5quu+66ZCBCgM6rxQ/Ig9YMHs4999w0derU1LVr13TmmWemkSNHpmuvvTZ9/etfT2uuuWb6yle+0tbJBFogAocIIu688840YMCALKiIeU8//XQ67rjj0q233po9JBXoOI466qhmLRfHN6s3gQVtJp7efsUVV6Thw4enBx54IB199NHp+OOPTw8++GC66KKLstcRXAAdx6RJk9J9992Xpk2blg444IA6791zzz1Z5UG0XIwaNarN0gi0TM+ePds6CXQQHpBHm3nf+96XJkyYkNVuzp49O+22225ZjebVV1+dunTp0tbJA1bAwQcfnA488MD0ta99reb73/nOd9K9996b7r777lWeNgBWLoEFbSa6P73wwgupT58+2et11lknPfzww1nXCaBj6t27d5oyZUoaOHBgzfcfe+yxdOihh6b58+ev8rQBsHK5eZs2s3Tp0iy4yK211lpp/fXXb9M0AeW89tprqVevXg2+H++9/vrrqzRNAKwa7rGgzURjWXR96tatW/b6nXfeSSeffHJab7316iznZjDoWBUGUUnQkLhv6l//+tcqTRMAq4bAgjYzevToOq8/85nPtFlagJVTYVBrNDgAOif3WADQamJkt+aIYaUB6FwEFgAAQGlu3gYAAEoTWAAAAKUJLAAAgNIEFgAAQGkCCwAAoDSBBQBt4txzz00DBw5s62QA0Eo8IA+AVSpGOY8ndAPQuWixAKBRw4YNS2PGjMmmnj17pk033TR985vfzAKEcP3116c999wzbbDBBql3797pU5/6VHr55Zern58+fXrq0qVLuuuuu9KgQYOyp3LfcMMN6bzzzkt/+MMfsvdimjRpUvrc5z6XDj/88Dq//95776XNN988XX311at83QFoPoEFAE360Y9+lNZaa6308MMPp0suuSRddNFF6aqrrqpe+J9//vlZkDB58uT017/+NR133HHLfcfXvva1dMEFF6Snn346HXTQQemMM85IO++8c5o3b142HXPMMenEE09MU6ZMyV7n7rjjjvTPf/4zex+A9suTtwFossUiWiCefPLJrGUhDxJ+8YtfpKeeemq55WfOnJn22muv9Oabb6b1118/a7E44IADsqDjyCOPrHOPRcx7/PHH63w+go3Ro0enM888M3v90Y9+NG2yySbp2muvXenrCsCK02IBQJP23XffalARBg8enP785z9n90rMmjUrHXHEEWnrrbfOukMNHTo0W2bOnDl1viO6SzVHtFrkQcSCBQuyLlTRRQqA9k1gAcAKe+edd9KIESNSjx490o9//OP0yCOPpNtuuy177913362z7Hrrrdes7xw1alR6/vnn04wZM7J7Mfr165c+9KEPrZT0A9B6jAoFQJMeeuihOq8ffPDBtP3226dnnnkm/eMf/8junejbt2+1K1RzdO3ateboUNHtaeTIkVmrRQQXxx9/fCutBQArkxYLAJoU3ZpOP/309Oyzz6af/OQn6Qc/+EE69dRTs+5PESDE62hliPsu4kbu5th2223TCy+8kN1j8eqrr6YlS5bU6Q4VN4zHjd5xvwUA7Z/AAoBmdU96++230957751OOeWULKj4/Oc/nzbbbLNsmNhbbrkl9e/fP2u5+N73vtes7/zYxz6WDjnkkOzG7vieCFhyw4cPT1tssUXWzWrLLbdciWsGQGsxKhQATY4KFU/InjBhwir7zbfeeiv16dMn6w511FFHrbLfBWDFuccCgHZj2bJlWbeo8ePHpw033DAbahaAjkFgAUC7upcjRoHaaqutsi5W8VA+ADoGXaEAAIDS3LwNAACUJrAAAABKE1gAAAClCSwAAIDSBBYAAEBpAgsAAKA0gQUAAFCawAIAAChNYAEAAKSy/h+/vLdafL2A+QAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 800x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxYAAAGGCAYAAADmRxfNAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAa71JREFUeJzt3Qm8TdX///GPjJmHMoVQMiUiIpU5Q0QaNPwylKSoDGUoU5o0IEqlkilUKgqlAUmZShMlqYi+hco8T/f/eK/vf5/vvse51zl339nr+XjsB/ecffZ89lmftT5r7SxxcXFxBgAAAAABnBbkwwAAAAAgBBYAAAAAAiOwAAAAABAYgQUAAACAwAgsAAAAAARGYAEAAAAgMAILAAAAAIERWAAAAAAIjMACAAAAQGAEFkAmliVLFjeVLVs2rTclQxk2bFjo2E2aNCmtNwepSOfbO/e6DjIifd+9fciMnnrqKbdvhQoVsn379qX15mQIGzduDF0TDRs2TPX1P/roo27dxYoV45xlcgQWSLYCmH8qUKCA1a9f3yZMmGBxcXEpdqPU+jXNnj07xX+gP/3009DrujH79zdHjhx25plnWs2aNa1Hjx62Zs2aFNkeIL0Vwr3v4M6dO+1UpHuPdwx0T0LK2rt3rz355JPu/127drU8efLEe/+1116zSy+91PLnz285c+a0EiVK2EUXXWTdunWz5cuXp9p26vfCuy6+/fZbO9V1797dTj/9dNu2bZs999xzab05SEHZUnLhOHXt3r3bli5d6qYvvvjCXn311WRfh37EH3roIff/Tp06Wbt27SytHDlyxP755x83ffPNN/bCCy/Y4MGDQ9sHZNbAYvHixe7/nTt3toIFC9qpGFhMnjw5VOGQHloH33rrLTt48KBl1mtO91kvsPDT/Ta8lWnLli1uWrVqlZUpU8bq1q2baoGFd//XNVGjRg07lRUpUsT9Rs+YMcOeeeYZ69u3r2XLRhE0M6LFAsmmZcuWtmTJEvv444/j3fAnTpxoX331VbKtJ701oz7wwAOucDV9+vRQcKNWmuHDh7sbKNJOertWgNSgGnrV2mvKbPR7IlWrVrWKFSvGa8l4/PHH3f9VM/7000/bJ598Ym+++aZLw1FAkVlTwzLKPbh9+/buXwV68+fPT8OtQoqKAwIYOnSo8pzc1KlTp9Drx48fjytXrlzovVGjRrnXH3/88bgGDRrEnXXWWXG5cuWKO/300+MqV64c9+CDD8bt27cv3rLPPvvs0Od///33uPbt28flz58/rmzZsm4Z3nvhk7bj//7v/0J/L1y4MN5ye/XqFXrvrbfeSnT//NuwaNGi0Ov+9U+cODHeZ/r27Rt6L1++fHE7duyISyvedmg/NmzYEHfVVVfF5c2bN65IkSJxd911V9zevXvjzd+nT5+4evXqxRUvXjwuR44ccXny5Im78MIL45566qm4I0eOJLjsn3/+Oa5NmzZu/kKFCsXdcccdcQcOHAjNq2PnPz/z58+Pu+iii+Jy5swZV7p06bgxY8acsO179uxx11fVqlXdtaJjqeP+/vvvx5tP++UtW+8vXrw4rm7duu4z3jWpc+TNo2XGcl3rs88991zcOeec47a3Zs2acR999FFo3uS61mTZsmVx1157bVyJEiXismfPHlesWLG4li1bxn3zzTfx5ps5c2Zcw4YN4woUKODOk75rPXr0iPvzzz/jzee/TnWcEtq/SNf7X3/95fatYMGC7pq5/vrr4/79998Tzmekaf369aH/X3755fG2ScvImjWre+/8889P9HisXr067qabbnL3CF1X2bJlizvzzDPjWrVq5c6zX/g5njp1qrt2dHwqVKgQ98Ybb5yw/AULFoSuw/Lly7vzHO214r/uIk3++4XWo23W907ntVSpUu7a1PfGz39eXn31VXff1HZFuu4S4z+Pfi+++GJcrVq13PdUx6VkyZJxTZo0iXviiSdC8xw7dizukUceCX3vvO+otv+VV14Jzaftj7SviR2/3377La5r165xZcqUcevXudR19eOPP0a1X/od8Jbdu3fveO8tX7489J5+KyIJ/42R2bNnu2Og61zbdN5558UNGzYsbv/+/Ql+l77//nt3/zzjjDPicufOHXfllVfG/fLLL6F5E7su/N+37777Lu6GG25w91tdFzoft912W9zmzZsTvC50DrR9+ozuifq8fmP0vdL3Vb+Rke7B4fdJ3VN0D9FvsO43gwYNOuEer99xXYeXXHKJW5euhwsuuCDumWeecddJtL/XHm2nN8+tt96a4HlGxkZggRQJLKR69eqh90aMGOFeq1ixYoI33EaNGiV4o9KPq78ge7LAwl/w0Y3aTwVEva6bnv/Gm1yBhQrEurF776uAk1a8bShcuLArzIQfqxYtWsSbX4WIhI5rly5dIi5bx1EFpvD5FSx6/OdDx/S00047Yf6PP/44NP/OnTvjqlWrluC2jBs3LuIPpn6Y9eMXfk0GCSz0Qxq+fhUCPvvssxP2Lci1ph9wr8CdWGGkX79+CR4XFTZUeEuOwML/nfOmm2+++YR9jjRpXd66s2TJ4goanilTpoTme+yxxxI9JjNmzEhwHbqG/IGc/xxH2nbN/9NPP4Xm/+KLL1xBMnw+//lOjsBC16qOQaR5VFhbuXJlxPMS6V7pv+5iDSz8xz18UkWPZ/jw4QnOV79+/SQHFqtWrXKF90jLVeC6YsWKk+7X9OnTE7yv/vDDD/HuSQqiwgvo4QYPHpzgvl522WVxhw4divhdinRudAz/+ecfN29i14X3fVMFSUL32/Dvsf+68O4p4ffxOnXqJHoP9l+vuj50jMLnVzDi17FjxwT3o0OHDlH/Xvt57+kYInMiFQrJ7tChQzZ16lT7/vvvQ69Vq1Yt1IFL773//vsuB/W9996zVq1aufcWLVrk+mREsnXrVhs1apR99NFHLvXo2WeftbFjx56QhqXpwQcftAYNGtg555zj3nv77bfdNskPP/xgv/76q/v/1Vdfbbly5Ur2/c+bN6+df/75ob/TQ8e97du3u9E4lA+uY5c7d273upqj58yZE5pPx045sHpd5+edd96xiy++OJTb/Mcff0TsT6OO6zrODz/8cOj18ePHR9yW33//3dq0aePWe8MNN0ScX9uxevVq939dH/PmzbMpU6ZY8eLF3Wu9e/e2zZs3n7DsP//800qVKuU6cOoaS45+N7pmlNY2d+5ca968eahPTa9evdz/k+Na+89//mN33nmnHTt2zP2t7Z41a5bLlb/99tvd4ACyYsWKUMdVLU/pHvoONWrUKJRicNddd1lyOHDggDuOzz//fGj9r7/+uu3atcsuvPBC913z543PnDkz9B1Uh9nbbrvNva5ylq4pj7bX4z//kSjVZeTIke66XbhwoS1YsMD1X1Kn3OPHj4dSX8L99ttvbv06Z02aNHGvaf5XXnklNI9yvA8fPuz+37RpU3c96vrVeYuG9lH7qnuPR/ck7xjoGOka1bWqY3DaaafZoEGD3LV83XXXufn37Nnj+qZEGuDil19+SfS6i9W7777r/lVe+4svvuiO5bRp09xxKFeu3Anzqb+Mzr/SifTd071b+5wU2j/1g/M6+Gudupc/8cQTljVrVpfG1KVLl5MO9LF27drQ/88999x471WoUMH1ofDuSdre0qVLu0nLXrZsWbz5v/zyy9D9SvulgUZ037vyyivdazqHo0ePjrgd//77r0vJ0jVfvnz50Hf4scceC31W6/ToN8u7LnQ/279/vzseulfofChVS8ejX79+J/0eq2+h7gFvvPGG5cuXz72m7f7xxx/d9a3vRzT3YKWGede8zoE3v/e7rXuPzrv3PdR3WPN7fVS0fk3R/F77eeft559/Dt3vkMmkdWSDjM1fk5LQpFSDo0ePuvnXrFnjmm5Ve67at/B5/Skx/hqQl1566YR1h6fXhHv00UdD77/99tuhVCzvNaXjnExSWixEzfve+2r6T8yXX34Zt2TJkiRNJxOenuJRTVakJunPP/88rm3btq7GTGkn4efn3Xffjbhsf6pOpUqVQq+r5SH8XBUtWjTu4MGD7vUtW7aEXq9Ro4Z7TU3sXouPapQ/+eST0P4q/cCb/+mnnz6hJi68Vjo5rmuvll60P0p98N7btGlTslxro0ePDs2rtIOE3HPPPaH5lHLn+fvvv0O1n6od91KWgrRYzJo1K/S6akS917/99tvQ6wktX5RKolQtvafWJ1ENsGrp9ZrS1U5G9w2lXdSuXdt9LrzmX9dJpJpytZZGSpFp166de23r1q2h13TcvOMlOt+xtG4lVHMvSmXy3rvmmmtCrx8+fNh9x8K/P7Fed7G0WOi+q7+1HH2ndu3aFfGzOi9eDbxS8yKlD8XaYqH983/P/fcwpV5673311VeJ7tedd94ZmjfS91zpcbq/JPRb5P99uffee0OvP/DAA6HtmTNnTuh1f6qe/1p/+eWXQ6+rpdV7XbXxJ/uOib5b3ntKdfQfD6UOed9jfa/Dl6XUQI9SsLzX1friURpb+D3Yf5/UNeC9Hn7Nq8VK9DvgvTZ27NjQ9mnfvddbt24d9e+1Ry0d3nz6HiLzoUs+UoxqOa+//nrXgVk1IqolueSSS1xtUkISGrJSNdyxUk3gkCFDXK2IaubUccyrLS1atGioJjMlqPbKo6F3E3Pttde6Y5MU0Q7lW7hw4Xg1fHXq1IlXuysrV650Nd+qFY3l/GhYR3/NtUb/8M8fvv+q8VKNc6R5RSO+7Nixw/1fNcqqTT5Z7aW/1tLfoTM5eC02on3R8jXyl3fsVCMa9FpT7Z3HqzE92Xz+7TrjjDNczamOia4J1Xb7z3FSqCXGE+k8nYw60N54442udlytT5r++usvV0sveu9k+vTpE69lMlxC23KybfeueVFrk74fHh03ncPkkND5yp49u2vR+OCDD0LzhY8aFM11FwvVoKuGWbXl3ndKrXs6VmoFUYdvUUuPhmXVPaxevXquw7OuLV3Damk477zzAh0HteBedtllEefT9VurVq0k3/suv/xyW7dunWs5VO36559/7loXPAMGDLCOHTu61hj/NqmlwWtt8Pvpp58irtt/bvzfM7UmaLtO1kncv25dA951EL5/Wn94B3z/+vzXrXf+vPtBYvfgSpUqxXvNf8173w3/Nt5zzz1R34NP9nudUsPPI/0gFQrJxktH0s38u+++czc0pT15P+waktELKvSDpfQGze81/3rpCpEojSdWJUuWtBYtWrj/K/1AN0qlkohSEVJqqDvto/85FulxmMFIP3wqAHpBRevWrV0qkc6PfogTOz96SJWf/7hG+hHxz3+yeWMd8Skp10lyHLu0utZOtl3+1/xpB95wnYlJjvPkpUOJ0mq8YEsVDR06dEj0swoqX3rppdD6R4wY4dIldU16BaeEtiXItqfWyEGxrifodl1xxRVu6G+l1imoUTqkUhtVoFRw4RUoNaKfCrq33HKLS+lUBZFS+nQuNJ8XnAW5tpI6ipu/wOxVPoRT0KDrTr8vemaCvo8Kcr30voSChUiOHj0aSm1Mi+sl0vHwBwRKr/NX8ESSktd8Qucrsfuwd960Tn/Qj8yDwALJRjWzql3Rg/EuuOCC0M08Ui2+8i7btm3r5lfOdlJufP6bakIBiVew0Y/DrbfeGpovmtrSpFLNtbdP6m+RWA20v5YrKVMsfSxUi+3xCr3izxH2KHddgaLOj/JlU5MKD17BUMdPNdzh+62CjDfsZEr/yKslx6PzqhrR8GMX9Frz1wIroItmPv92qVbW68+hY+C1TvkLIcrbFm2XhoRODif7DqoWVfcC8XK0RS1jJwsCtU/esxiqV69u/fv3d8+J0DHX9RyEv0+BCtT+Qqr/uxH0GCR0vhTAe60P4fPFet1FS98bVegoQPj666/d90r9V0StGN7wn5pPQbLy69XKpP4PXr8OXUNeP7hI15ZEGkbUv38KTiLdy1RIveOOOxLdh8qVK4f+77+fia6J8Afg6dyoT4Nq6MODIP826V6S0DZ5rasJnRv/9eI9UNVbdzTXhfpaJLRur29NctO15M8ciPR74N9GBfSRttG758RyH/bOm5bv9e1A5kIqFFLN2WefHfq/0htUE6YbmjrNJYW/VlKtJKplU2c23bAU5Hg17/q/aq5UWyfq4KeUrOSyfv16++yzz1zHYRWe/J1T9YCk8Br9tHLTTTe5zqOqpfQ/X0MBXvj5UWChHzwd0w8//DBVt1M/yCqMq9OwCjWqaVVTvAIObbtag9SpXA9dVEEzGup47nWmHDp06AkP0UqMzqkKJqrl1RNjvVo6/e1PRwlyralVQ2kaCkr02Wuuuca1FHlBgIL1m2++2R0XLzVI26KWEqV/6Xx6NasqjHgpEv70t7vvvtvVRqszsD/NIQj/tf3yyy+7QpwqFPxpGQq47r333nid7aMJthR4qIO6ggsVcFUg1mvqbJpQRUK0tByls+j+o+WrE7muMbW0qoN6Uo+BWmVUWNKkoFxpjgqIFEjomtW1p1RAtd4qLUyqVKniAqekXnfR0v5pnc2aNXOfV0uOWn883vWjbdZ9VOlKSpVSrb3/OUTefP5rS/cVtWQo6FCn8HDaP7V+6LurZ/7o2tY1r5QwVayooK7BChJqhfDoe+BRcKRWFX9gocBJx1eDJWjAEC1fnf69ATQUJHiBru6HY8aMcf9XB3t9Xu9pP1RgVsdj3RMjPdx14MCB7vjpqd/6f/i9NPy6UGqWglltT+3atd050IAXf//9twvg9H3Vawp6dDx0D9C1qA7ZKUHXkloMe/bsecI17+2D7jdeR34dZw2ooXuNtlm/eWoJUuWTrulo6dhu2LDhhHOJTCatO3kg8w43G05DTvo7IPqHMIzUWTKhsdg9GnPb3wEyoY5y9913X7z3NVxntKLpvB1pUsc7f2e6tOJtjzrRasz48O1s1qyZG6tcNNxjeOdY/e3vXOk/tgkNJxipQ29iHe0jLUfjnSc23Kz/fISPzx5JkOFm9QyE8HWrY3t4R92g15o6RUYahjfIcLN6PkCkZfo72CfUeTuajrrPPvvsCcsOvx7UMdo/rKY65Ef7bBc9myN8+Tof/g66JzvHCV0fGrY10gAS/vMdzbXi7+zrnzxJHW420jDHCV134SKdRw2FnNB1o2cZ/Prrr24+PdMhofn0XBWv06+GVtUwseHz6JkjsQ43G+maS4iewxHpGSj+Z6ckNOn5D9EONxt+r/Lf1yKdGz0LYtu2baH59ayLSOfduyfOmzcv0eG9/d+jhDqCJ/S9jHQP9n8P1DFf5zx8neEDjSQ23Gysv9fe83e8eebOnRvV+UbGQyoUUo1qb1ULpI5iqtVUp0nVSvuf0h0L1RipdUA1g96weyfL806pNChti2qdVDOn5nylOWioyPRCeceqnVSKg2rZtK0ajlG1qF6ztc6Lag1V06eaYj3ZVsMpqsUgLbZXw0OqdlrHVNeLcsJVY6YaVdXmesMepjTVSGp4R6U5qJVNNcaq9Y/UWhLkWtP3QOdIHb9Vo65rSi0gqhX099PREJ16mrBSSpRXrVpQbVuPHj1cLa4/zUepI8qhV+2ytl21xvrsyfo3REvXumrk9d32p3746VrzD/ur/dH5jYaG01UajoYDVVrcVVdd5WrEw9Msk0I18ko7q1mzpjs2qp3WsfXXQEdDLVXaTt3PIvWl0bChanXSfutYaB61NKnWftWqVa4GOxLVoqulQss92XUXDdVAqxVSncCVxqRWFV1fOje67rwUGG2vrg+tV8dc23vWWWe5z6tl2EuBUn68+jGoll/bp/nHjRsXr8+cn46zWg5039G69BldB7om9Vqklo5IvJZHtX6o5tyj86f7ma5JfV+0b9p2rUPHTN+D8Np1bzhf3Re1P/ouaV/1m6I+PWpxjkT3H7UAqdVB16LOrVqt9bdH91G1Rug7GCmdSq17aglSa4BahrRutcpq2zVoge69KUX3A7XkqNVA93oN4630ZP9QtaKWNe2D7jU67zpn+q6rI79aTmMd2lrnR7Q+r08aMp8sii7SeiOAlKYfMjXB6iafUs3LgHCtnUiFExVqRSMTabQ4nEgpel5hVnn/Gm0M8Sk9UsGzOokriFEwmBoUnCiNS/T9VjCP6KnPlFLw1IFe5yyhABQZHy0WyLSUG6wOanrQj5fX6R/hCEguXGuRqVOw+lZ4He1Ve5yUoaMBj1pRvEKp+t2cbCQppA8adVBBhVqS1LcDmReBBTItdaRU8633lFvd0NTkDiQ3rrXI1DFZqRN6irvcf//9yZLGhFObriMlW6izt1I7kf6p87fOmUYZVForMi8CC2R6yiFVzqxGOIo2txtICq61yNRHQgULjXwFAMi86GMBAAAAIDBaLAAAAAAERmABAAAAIPM9eVtPVNUTjPVcgsQeCw8AAAAgZanXxJ49e9wzeBJ6ZlG6DSwUVGisYwAAAADpg4YP1wMdM1Rg4T1BWRuvp8oCAAAASBt6TpMq/b0yeoYKLLz0JwUVBBYAAABA2oumiwKdtwEAAAAERmABAAAAIDACCwAAAACBpbs+FgCQmGPHjtmRI0fSejOATCd79uyWNWvWtN4MABkYgQWADDOO9pYtW2znzp1pvSlAplWwYEErXrw4z5ECkCQEFgAyBC+oKFq0qOXOnZuCD5DMgfv+/ftt27Zt7u8SJUqk9SYByIAILABkiPQnL6goUqRIWm8OkCmdfvrp7l8FF/qukRYFIFZ03gaQ7nl9KtRSASDleN8x+jEBSAoCCwAZBulPQMriOwYgCAILAAAAAIERWAAA0pVJkya50Yk8w4YNsxo1aqTpNgEATo7O2wAytLID5qXq+jaOuNIyko0bN1q5cuXsm2++SdHCeefOnW3y5Mnu/9myZbPChQvbBRdcYDfeeKN777TTqMcCgMyOwAIZ3sgOrZP82b5vzE3WbQFOZS1atLCJEye6Uby2bt1q8+fPt3vvvdfeeuste++991zAAQDIvKhCAoAUdPz4cXvyySft3HPPtZw5c1qZMmXs0Ucfde+tXr3aGjdu7Ib51DC63bp1s71794Y+27BhQ+vVq1e85bVr1861AHjKli1rjz32mN16662WL18+t/yXXnop9L5aK+TCCy90HXO1zM8++8w9ZVnPBvHTui677LIk76v2Tw9XO+uss6xmzZr2wAMP2LvvvmsffPCBS2/yjBo1yqpVq2Z58uSx0qVL21133RVvv0/myy+/tGbNmtkZZ5xhBQoUsAYNGtjXX38d75kMSp/SsdA2lSxZ0u65554k7xcAIDoEFgCQggYOHGgjRoywwYMH248//mjTp0+3YsWK2b59+6x58+ZWqFAhV1CeOXOmffLJJ9azZ8+Y1zFy5Ei76KKLXLqTCul33nmnrVu3zr23cuVK96+W/ddff9k777xjl19+uZUvX96mTp0aWoaGF502bZoLUGTTpk2WN2/eRCcFNCejwKl69epuvR6lRY0dO9Z++OEHlz61cOFC69evX9T7u2fPHuvUqZN9/vnntnz5cqtQoYK1atXKvS5vv/22jR492saPH2/r16+32bNnu0AGAJCyaJcGgBSigu6YMWPsueeecwVhOeecc+zSSy+1l19+2Q4ePGhTpkxxNfei+dq0aWNPPPGECz6ipUK1Agrp37+/K1QvWrTIKlasaGeeeaZ7XS0iak3w3HbbbS5t6f7773d/z5kzx23P9ddf7/5WLf+3336b6HrVjyIalSpVsu+//z70t78VRi0ujzzyiHXv3t2ef/75qJanYMVPLTTq7L148WJr3bq1C4q0r02bNnUtM2q5qFOnTlTLBgAkHS0WAJBC1q5da4cOHbImTZpEfE81+V5QIfXr13epU15rQ7TUSdqjdCcVqvX05MQoneqXX35xNf6iVCUFFd72qD+E0rcSm6INLJSa5H8+glpPdEyUMqX0rVtuucX+/fdf279/f1TLU/+N22+/3bVUKBUqf/78LpVKAYVcd911duDAAdcqo/lmzZplR48ejWrZAICkI7AAgBSivhNBKGVIhXK/SE9EVq28nwrxClASU7RoUdc6olYLFdTVD8JLg0rOVCgviPL6emiUKrUqKBhSytKqVats3Lhx7r3Dhw9HtTy1/qg1Ra1BS5cudf9Xi4z3efXbUHCmFhCdA7XmKP2Lp0kDQMoiFQoAUohq1FWwXbBggXXt2jXee5UrV3atBOpr4bUSfPHFFy6YUAqTKI1J/SI8Gm1pzZo11qhRo6i3IUeOHKHPhtM2aTjYUqVKuRQttZh4kisVSv0n1Em9d+/e7m8FEgp61C/EG4L2zTfftFjoOCloUAqYbN682f7555948+i4K3DS1KNHD5eOpe1Qp3IAQMogsACAFJIrVy7X50Edk1XAV8H977//dp2Wb775Zhs6dKirfdcIRnr97rvvdmlBXv8K9SXo06ePzZs3zxX8NZrSzp07Y9oGtUyokK2hXxVAaJuUPiTqPK40IvVxGD58eLzPealQsVDal0aa8g83+/jjj7sWio4dO7p5tEy1HDz77LOu0K8g4cUXX4w5YFPHc3VY3717t+sn4m8dUsCmbbj44ostd+7c9tprr7n3zz777JjWAwCIDalQAJCCNBpU3759bciQIa6VokOHDq7/gwq8H374oW3fvt1q165t1157ret3oA7cHqUmKfBQoVxDqqrPQCytFV6AoBGYNEKSWiHatm0bek8tBuproUK4V/APQoFEiRIlXIdsPdNCHci1bg05mzVrVjeP+pUoQFIH9fPPP9+NRKXgIxYTJkywHTt2uNYHBWIaSlYBlEcdudU5XoGcUq7Up0Od05UuBQBIOVniwhN405hqn1SbtmvXLleTBpwMD8jL/DRa0YYNG1yevmrckXw0OpRaS/QAO4DvGoAgZXNSoQDgFKQfCPU50HM1CCoAAMmBwAIATkFKidLD8/T8CD3FGgCAoAgsAOAU9Omnn6b1JgAAMhk6bwMAAAAIjMACAAAAQGAEFgAAAAACI7AAAAAAEBiBBQAAAIDACCwAAAAABMZws3CqTa4W6POrO61Otm0BgGh07tzZdu7cabNnz07rTQEAEFgAyPCGFUjl9e2yjGTjxo1Wrlw5++abb6xGjRopso4sWbIk+v7QoUNt2LBhyb7eMWPGWFxcXLIvFwCQNAQWAIBA/vrrr9D/33jjDRsyZIitW7cu9FrevHlD/1cgcOzYMcuWLfjPT4ECqRxUAgASRR8LAEhBx48ftyeffNLOPfdcy5kzp5UpU8YeffRR997q1autcePGdvrpp1uRIkWsW7dutnfv3tBnGzZsaL169Yq3vHbt2rkUIE/ZsmXtscces1tvvdXy5cvnlv/SSy+F3ldrhVx44YWuZUHL/Oyzzyx79uy2ZcuWeMvWui677LKY97F48eKhSYV9rcf7+6effnLb9cEHH1itWrXcMfj888/t119/tbZt21qxYsVc4FG7dm375JNPQst84IEH7OKLLz5hXdWrV7fhw4e7/+s46Hh43nrrLatWrVroeDZt2tT27dsX8/4AAJKGwAIAUtDAgQNtxIgRNnjwYPvxxx9t+vTprjCtAm/z5s2tUKFC9uWXX9rMmTNdwbpnz54xr2PkyJF20UUXuXSnu+66y+68885Qi8HKlSvdv1q2Whbeeecdu/zyy618+fI2derU0DKOHDli06ZNcwGKbNq0yRX4E5sU0ERrwIAB7jisXbvWLrjgAhdAtWrVyhYsWOC2u0WLFtamTRu3Xrn55pvdtisA8fzwww/2/fff20033XTC8rVvN954o9t+rePTTz+19u3bkyoFAKmIVCgASCF79uxx/QCee+4569Spk3vtnHPOsUsvvdRefvllO3jwoE2ZMsXy5Mnj3tN8Klw/8cQTLviIlgroCiikf//+Nnr0aFu0aJFVrFjRzjzzTPe6avDVguC57bbbbOLEiXb//fe7v+fMmeO25/rrr3d/lyxZ0r799ttE11u4cOGot1GtDM2aNYv3WbU+eB5++GGbNWuWvffeey64qlq1qntfgZiCMlHgo1YMtf5ECiyOHj3qgomzzz7bvabWCwBA6qHFAgBSiGrODx06ZE2aNIn4ngrOXlAh9evXd6lT/v4J0VALgMdLQ9q2bVuin1Ea0S+//GLLly93f0+aNMkFFd72qA+ECvCJTbEEFmpR8VOLxX333WeVK1e2ggULuhYQHROvxcJrtVBgIWp5mDFjhnstEh1LHWcFE9ddd50L3Hbs2BH19gEAgiOwAIAUolz/IE477bQTUnmUshRO/SX8FFwoQElM0aJFXeuIWi22bt3q+kB4aVApkQrlD6BEQYVaKLSMJUuWuNYRBQWHDx8OzaPUJgVZX3/9tS1dutQ2b95sHTp0iLj8rFmz2scff+z2o0qVKvbss8+6FpsNGzZEvY0AgGBIhQKAFFKhQgUXXKgfQdeuXeO9p5p6tRKor4VX6P7iiy9cMKECsSiNyT/ikkZTWrNmjTVq1CjqbciRI0fos+G0TSq8lypVyqVoqcXEk9ypUOG0r2o1ufrqq0MtGBoa10/b1aBBA5cCdeDAAZdKpYAoIQqotA+aNDKVUqIUvPTp0yfJ2wkASKEWC41Drhu3f6pUqVLofeXn9ujRw+XyqjbrmmuucTVhAHAqypUrl+vz0K9fP9eXQh2RlXo0YcIEl9Kj99X3QsGC+kTcfffddsstt4T6V2jEqHnz5rlJoyupU7YeCBcLFcQV3MyfP9/dj3ft+t9zONR5PH/+/PbII49Yly5d4n0uuVOhIgVd6kiu4OW7775zHbIjtbLoOL3++uuuc3tCaVCyYsUK1/rx1VdfudYWLfvvv/92ARwAIJ2mQqlDnWrQvEnDBnp69+7tOgDqB2Dx4sX2559/uo50AHCqUsfjvn37uhp0FXKVyqP+D7lz57YPP/zQtm/f7oZavfbaa10fAXXg9ig1SYFHx44dXc29RnKKpbXCCxDGjh1r48ePd60QGuLVo9YRtRqoNUPrSE2jRo1yI2JdcsklLiVLQU7NmjVPmE/H5d9//7X9+/fHG1o2nAIkDaOrjuznnXeeDRo0yI2W1bJlyxTeEwCAJ0tcDGPxqcVi9uzZEZvHVQumZnt1tNMPgaiGTT+ky5Yts7p160a1jt27d7tx0LU8/VAgdVSbHGz0lNWdVltaGdmhdZI/2/eNucm6LUgZag1VrryeyaBafiQfjQ6lmn2NxgTwXQMQpGwec4vF+vXrXa2Xas7ULO2N4LFq1SrXqVAPJPIoTUoPa1JgAQBIP/QDoRZnVQYpBQsAgFTtvK3xw9XZUB0LlQb10EMPuae0Kj9YT3BVJ0ENG+inXOHwp7v6aShGTf6oCACQspQSpQfQde/ePd7zJQAASJXAwp+rqnHTFWho1I0333wzycMqPv744y5AAQCkHj2ZGgCAdPMcC7VOqJOcHrKkBzJp/PHwEUs0Con/aa/hBg4c6JrkvUnjlAMAAAA4hQILjTuu4RNLlChhtWrVcg9p0njtHj3YSH0w6tWrl+AycubM6TqC+CcAAAAAmTgVSk9K1bCASn/SULJDhw51TzvVA5bUW1yji+hBRBrbXAGCOgQqqIh2RCgAAAAAp0Bg8ccff7ggQmOKa2jZSy+91D3sSf+X0aNHu3HR9WA8dcjWuOTPP/98Sm07AAAAgIwYWOjpp4nRmNfjxo1zEwAAAIBTR0yBBZASxnVfmNabAAAAgLTsvA0AQFoaNmyY1ahRI603AwBAiwWAjK7a5Gqpur7VnVZbRrJx40YrV66cffPNNylaAO/cubMbbnz27NknPC+jUaNGtmPHjhMeoJocNKgITw4HgPSBwAIAkK7pGUk5cuSI91pcXJwdO3bM8ubN6yYAQNojsAACpmGkxWeRcRw/ftyefvppe+mll9wDQIsVK2Z33HGHPfjgg7Z69Wq79957bdmyZZY7d243ot6oUaNCBeWGDRu6VoZnnnkmtLx27dq5mv9Jkya5v8uWLWvdunVzDyqdOXOmFSpUyAYNGuReE7VWyIUXXuj+bdCggQ0fPtyaNGnitsf/ANNevXrZqlWrbMmSJSl2PDSqYM+ePe2zzz5zrRjnnHOOPfDAA27EQY/2+/zzz7ds2bLZa6+9ZtWqVXPDm6vl4/3333f7p2P30UcfuRYRtZJ8++237rP6u1+/fvbDDz+4ZytVrVrVpk+f7oZJBwCkLAKLzGRYgaR/tlyZ5NwSAP/fwIED7eWXX3bDcWuI7r/++st++ukn27dvnxuSW8/6+fLLL23btm3WtWtXV+j2goZojRw50h5++GFXQH/rrbfszjvvdAFExYoVbeXKlVanTh375JNPXCFbNf961lD58uVt6tSpdv/997tlHDlyxKZNm2ZPPvmk+1sPN61SpUqi69X6NMXi4MGD7oGq/fv3d887mjdvnt1yyy0uwNB2eiZPnuz244svvnB/67jJgAEDXKCm7VcQpUDCc/ToURd43X777TZjxgzX0qH9z5IlS0zbCABIGgILAEghe/bssTFjxthzzz1nnTp1cq+pAK0AQ8GGCtlTpkyxPHnyuPc0nx5C+sQTT7iWjWi1atXK7rrrLvd/FdgVxCxatMgFFt5zhooUKRKvdUIPNJ04cWIosJgzZ47bnuuvv979XbJkyVArQEIUoPjNnTv3hLQkpSv5nXXWWa5fhEf9Iz788EN788034wUWFSpUCAU5/sBCrS3NmjWLuD27d++2Xbt2WevWrd1xlsqVKye6DwCA5ENggVPaHwMCpnzkSq4tQWa0du1a97BQpR1Feq969eqhoELq16/vUqfWrVsXU2BxwQUXhP6v2nkFEGoBOVlna6UU6SGndevWda0kCiq87VEa0rnnnmuxUKrSCy+8EO+1FStW2P/93//FCzQee+wxF0j85z//ca0KOkZKBfNTq0YkF110UaKBjvZLLUEKPpo2ber2qUSJEjHtBwAgaRhuFgBSyOmnnx7o86eddprrpOynlKVw6kvgp+BCAUpiihYt6lpH1GqxdetW++CDD+zWW28Nva9UKK9jdEKTAgQ/BSUKRvyTWij8nnrqKdeKo5YVtaqoVUSBgAKM8GVFktDrHu2P+qxccskl9sYbb9h5553ngicAQMqjxQIAUojSeRRcLFiwwPWf8FOKjloJ1NfCKyyrP4GCCaUwidKYvBQgr7Z/zZo1rmUgWt5oSuEpSaJtUqfpUqVKudQhtZh4kpIKFQ3tY9u2bUOtGAqAfv7555P254iFOqprUv8W9WFR5221ygAAUhaBBQCkkFy5crmaeY1SpAK+Cu5///23G7Ho5ptvdiMdqe+FRgjT6+pvoI7MXhpU48aNrU+fPq6Dswr+GjFKz4qIhVomFNzMnz/fBRDapgIF/jvQg1oK1IH6kUcecX0X/JKSChVtsKUO5kuXLnWdr7VPajFJjsBiw4YNbvStq666ygVGSilbv369dezYMVm2HQCQOFKhACAFDR482Pr27WtDhgxxrRQdOnRw/R/Up0Cdlrdv3261a9e2a6+91vXFUAduj1KTFHioYKxRnjQSUiytFV6AMHbsWBs/frwrbKu1wKPWEfVJUGtGahW+1a+jZs2aLqjRsLLqD6KRnJKDjqlG3NKwvUqB0pC7PXr0cMP7AgBSXpa48ATeNKZRPVSbppE9VJOG1BlutlrA4WaDPI14XPeFgdZ9cMeoJH+2Q7n+gdb9Sq4FSf4sz7GInkYrUm20nsmgGnckH40OpdaS9957L603BekA3zUAQcrmpEIBwClIPxB6yJz6HxBUAACSA4EFAJyClBKlh8d17949wedCAAAQCwILADgF+Z9YDQBAcqDzNgAAAIDACCwAAAAABEZgAQAAACAwAgsAAAAAgRFYAAAAAAiMUaEAAACSqOyAeYE+v3HElcm2LUBao8UCADKZsmXL2jPPPGOn8lC6WbJksZ07dyY4z6RJk6xgwYKhv4cNG2Y1atSw9OCLL76watWqWfbs2a1du3ZpvTkAEDVaLABkaGsrVU7V9VX+aW1M8zds2NAVWFOzoP/ll19anjx5Um19mcF9991nd999t6UHffr0cdfMBx98YHnz5k231xkAhCOwyEzNqbmSbVMAZGBnnnlmWm9ChqMCfLSF+JT266+/uieilypVKq03BQBiQioUAKSQzp072+LFi23MmDEuNUfTxo0b3Wt16tSxnDlzWokSJWzAgAF29OjReLXPPXv2dFOBAgXsjDPOsMGDB1tcXFzMqVD6jNJ8ypQp49ZXsmRJu+eee0LzPv/881ahQgXLlSuXFStWzK699tqIy/GoVlzL8yjdqGvXri6YyZ8/vzVu3Ni+++67JB8zrfPhhx+2G2+80bW6nHXWWTZu3LjQ+zp+Oo7ffvttvG3Qa+FPE1dK0QUXXOD2rW7durZmzZoE1xspFerVV1+1qlWrhs6TzsfJnOx4T5061S666CLLly+fFS9e3G666Sbbtm1bvH37999/7dZbb3X/V8qWaNtbtmzpgh+dp1tuucX++eefBK+zDRs22LnnnmtPP/10vO3TcdP7v/zyy0n3BadGi29SJyASAgsASCEq6NWrV89uv/12++uvv9ykvPlWrVpZ7dq1XQH8hRdesAkTJtgjjzwS77OTJ0+2bNmy2cqVK91yRo0aZa+88krM2/D222/b6NGjbfz48bZ+/XqbPXu2y9+Xr776yhV6hw8fbuvWrbP58+fb5ZdfHtPyr7vuOlcwVtrOqlWrrGbNmtakSRPbvn27e3/JkiWh1oCEpmnTpsVb5lNPPWXVq1e3b775xgVd9957r3388ccx7/v9999vI0eOdKlhCnzatGljR44cieqzOi89evSwbt262erVq+29995zBfUgx1u0fgVOOvd6T8GEAgMpXbq0u0YUoCmg0/87dOjgAicFbBdeeKE7ZzpPW7duteuvvz7B60yBjYKTiRMnxts+/a1zHM2+AECsSIUCgBSi1oYcOXJY7ty5Xe20PPjgg64A+dxzz7ma40qVKtmff/5p/fv3tyFDhthpp/23vkfzqICqeSpWrOgKt/pbhcdYbNq0ya27adOmLqhRgVOtJd57ahVo3bq1q0E/++yzXeE1Wp9//rkLfBRYqHZeVEOuAvNbb73lCuWqnfe3LkSiGni/+vXru4BCzjvvPNfyoH1v1qxZTPs+dOjQ0GcUqCm1aNasWaECeWIU6PXt29cFNR4Fg0GOt6iw7ylfvryNHTvWLXfv3r0uyNJndc517XjXjIIjnZfHHnssXmuKrpGff/7ZHaPw60wUsOia0jnSNiiomT59+gmtGACQXGixAIBUtHbtWle7rMKjvyCtguUff/wRek2pO/559BnVgB87dizmFoUDBw64QqyCEhWsvbQrFboVTOg9pdao5WD//v1RL1u17truIkWKxGuBUBqO+gnI6aef7mrHE5sU1PhpX8P/1nGLlX85hQsXdgFaNMtRoKRgTy0vsUrseItaddRyooBD+92gQYNQQJLYcV60aFG8Y6yAVLzjHInSsK688koXhMicOXPs0KFDbhsBICUQWABAJqZabaU5qS+FCvl33XWXS4VR7bUKtl9//bXNmDHD9SFQ7bZSkLxhWtV6Et6vw59KpKBCn1OLhH/S+pSGlNRUqMR4LTr+7Yo2vSlaOk4pcbz37dtnzZs3d6lO2melaCnwkMOHDye4TB1nBSPhx1mB5slS19T/5fXXX3fBjtKglFqllg0ASAmkQgFAClKKir+VoXLlyi4PXwVjr0VCqT4q5PtHAVqxYkW85Sxfvtx1ss6aNWvM26ACrgqmmtRvQLXdSq1Sfwj141DajialDunZDgsXLrT27du7fgnK1/fs3r3btUZ49PktW7a4ZajTdSRJSYXSvob/rePmH/FK2+WlbSW0fH1OLQOyY8cOlzbkLScxOhfanwULFlijRo0suY63zrk6Zo8YMcIFIKI+Eyej46xrRtukYx3NdeZRfx6lu6nPiPpmfPbZZzHvD5DZ+AegSM3PngoILAAgBakwqCBBnXRVO68abHXM1TMTNMqQardVoNezC7zaeC81Rq/dcccdrlXh2Wefdbn2sdKoQipwXnzxxa6m+rXXXnMFX6VAzZ0713777TdX612oUCF7//337fjx4y5lSNRhWJ9XAVkBh1o0/IGNghGlG+khbk8++aTL9VcK0bx58+zqq692QYWXChULBVpanparTtszZ850yxQtT2liKpyXK1fOpS0NGjQo4nLUKV1pWgpc1LdFo2tF+8A5FR405GvRokXdaEx79uxx23WyZ10kdrx1bBUA6Fxq2RrpSR25T0bBycsvv+xGyurXr59L69KoTmqJUId+nZPw60zz6HrSe+prMXDgQBeYhqeZAUByIrBAsgg09FzD/w0lCWTGB6916tTJqlSp4tJRVOOvArxShZR2pALgbbfddkLhuGPHjm5+dbpV4VCdiNUZOlYKCFQIV5CiAq9GKFKuvQrceu+dd95xheiDBw+6gqfSojTEqqgwqu1V5251JlYh2N9ioRYX7YsK7V26dLG///7bdR5WoBLeChELdZpWTf5DDz3k0oY0IpZSiDzqM6BjVqtWLRcEKQi54oorTliO9lvHTSlDGkpW+62CfTR0znRM1Glc51BBiX8o3qQcby/weOCBB1ynbbVEqCP1VVddlegy1VdCQY06+Gs/1U9CgUqLFi1CwWik68xrRdKxUsdvnSMASElZ4qIdGD2VqKldP2C7du1yPyinkuAPyLspyZ+tVu6/6QJJ9ebj/+ucGKuFAQOLgztGJfmzHcr1D7TuV3ItSPJnaU6Nngp4KiiphlrPJMjsTuWnKKsw3KtXLzcheaifizqib968+aQB36n2XUsXv90jrrSMWClY+afYB1RIL0iFSrmyOS0WAABkQmrZUCuSCkIaCSpIKxIARIPAAgAyWO2zcv4TG0EIKUejOanfSyRKT/rhhx8svVBam9Kg1Po1ZcqUtN4cINn8MWBJsAXQGJdiCCwAIJ359NNPE3wvmlGWMjJ1Pk7P1B9CHbMj0QPx0hN12vae6g0AqYHAAgAykKSMsoTko6Fowx/oBwD4Lx6QBwAAACAwWiwAAAAQk3HdFwb6fI8XGyfbtiD9oMUCAAAAQNoGFnoIkB6Q5B9vXGNg6ymhehiQnv55zTXX2NatW4NvKQAAAIDMF1h8+eWXNn78eLvgggvivd67d2/3lNGZM2fa4sWL7c8//7T27dsnx7YCAAAAyEyBhcZJv/nmm+3ll1+2QoUKhV7XE/kmTJhgo0aNssaNG1utWrVs4sSJtnTpUlu+fHlybjcAIJGnV5+KT+0GAGTAzttKdbryyiutadOm9sgjj4ReX7VqlR05csS97qlUqZKVKVPGli1bZnXr1k2erQaAZOpAmNIdDhs2bOgeUJaaBX21KOfJkyfV1gcAQJICi9dff92+/vpr98MVbsuWLZYjRw4rWLBgvNeLFSvm3ovk0KFDbvLs3r2bMwMAAZx55plpvQkAojWsQIDP7krOLQFSNxVq8+bNdu+999q0adMsV67keR76448/bgUKFAhNpUuXTpblAkBa01OP1ddszJgxbqALTXqytF6rU6eO5cyZ00qUKGEDBgywo0ePxmvl6Nmzp5t0XzzjjDNs8ODBFhcXF3MqlD4zbNgw13Ks9ZUsWdLuueee0LzPP/+8VahQwd3TVQl07bXXRlyOR60vWp5n586d1rVrVxfM5M+f36XBfvfdd0k+Zqpouu++++yss85yrS56ynX4k8i/+OILd4xy587t0nGbN29uO3bsCH1e+1e0aFG3T5deemm8ijAtS+dhwYIF7inmWsYll1xi69ati7eOF154wc455xxXWVaxYkWbOnVqvPe1DPUzbN26tVtG5cqVXcv8L7/84rZN267l/vrrr25+nffTTjvNvvrqq3jL0fE9++yz7fjx40k+ZgCQIQMLpTpt27bNatasadmyZXOTfiDHjh3r/q8fpcOHD7sfGj+NClW8ePGIyxw4cKDrm+FNCl4AIDNQQFGvXj27/fbb7a+//nJT9uzZrVWrVla7dm1XAFcBVn3T/GmlMnnyZHdfXblypVuO+q698sorMW/D22+/baNHj3aF4PXr19vs2bOtWrVq7j0VclUIHz58uCtYz58/3y6//PKYln/ddde534UPPvjA/Ubo96FJkya2fft29/6SJUvcCIGJTaqs8iiYUgFdrePff/+9W36LFi3ctsu3337rll+lShU33+eff25t2rSxY8eOuff79evn9lnHT63rekq5Ag9vezwPPvigjRw50h0DHedbb7019N6sWbNcJVrfvn1tzZo1dscdd1iXLl1s0aJF8Zbx8MMPW8eOHd02Ke33pptucvPqd03LVVCn/fGCNKUJq9+hn/5WAKqgAwBOqVQo3cxXr14d7zXdbHVD7d+/v2tt0I+maoI0zKzox2rTpk3uxzUS1aBpAoDMRq0NqvFWjbZXuaICre6Vzz33nKv11v1To+fpHjpkyJBQAVPzKCDQPKox171XfytIiYXuv1q3CrW6P6vlQq0l3nuqWVete758+VzN+YUXXhj1slWoV+CjwMK7jz/99NMueHnrrbesW7durlVABe/EqFLK2x4VtPWvWlZErRcKePT6Y489Zk8++aRbplpaPFWrVnX/7tu3zwVqkyZNspYtW7rXNMjIxx9/7IK3+++/P/SZRx991Bo0aOD+rxYj9RvUcOlq5dA+qLB/1113uff79OnjBiDR640aNYr3+3f99de7/+v86XdOLUsKZETBiebxqGWne/fuLkjU8VLgo/P67rvvRn3MAb9qk/9bSZBUbybblgD/FVMViX54zj///HiTfpT0zAr9Xz+it912m7sJq2ZHtVe6qepmS8dtADBbu3atuycqYPDUr1/fjbb3xx9/hF7TPdM/jz6jWnuvZj5aqvE/cOCAlS9f3gUlqo330q6aNWvmggm9d8stt7iWg/3790e9bLW4aLu95xZ504YNG0IpQKeffrprNUhs0m+LqJCt/TvvvPPiLU8t497yvBaLSDSPBhDR8fQomFIgpePu5x8qXeloogBJNK9/GaK/E1uGFxx5rUHeawpWvL6D7dq1s6xZs7pzIAqAFKioNQMATtlRoRKjGjXVuKnFQrmuqrnx1ywBAFKPWj7UcvzJJ5+4mnvVwj/11FOusK4CvWrN1e/go48+ci0m6j+hPgkahEP38vB+HSq4exRUqFAe3gdCvEE8lArltR4kRGlaGsJcy1PBW5VS+tdPAYYXqCQHBRweL4CLtZ9DpGUktly1Xil1Sq0ver7T9OnTXZobAGQWgQOL8B8UNSOPGzfOTQBwqlNh0t/KoE6+6gOgArtX8FRnZBXyS5UqFZpvxYoV8ZajVBx1sg4vcEdDhXH1Q9Ck4cKVfqXWAa+/nNKkNA0dOtQFBAsXLnQFX3XIVr8Qj2re1Rrh0ec14p+WkVCteyypUErD0rFSy8Fll10WcV61Eijd9qGHHjrhPa+ztY6nWmK8QEiBUq9evaI8Wv89R1pGp06dQq/pb/XrCErpUGrhV4WbWo54gCyAzCTZWywAAP+jAreCBI0KpFp3tRhoJKC7777bdexVa4IK9Eoh9XfgVT8DvabOwGpVePbZZ11n41gp3UaFdY2upL4er732mgs0VPCeO3eu/fbbb67DtkZXev/9913tuvp0iEZ40ucVkCjgUIuGP7BRMKIULaX4qO+DUpjUX2TevHl29dVXu6DCS4WKhj6vlgvV6mtfFWj8/fffLpBQQKF+EOoYrXQjHUf1V1AgodRbpXxp9Kw777zT9aUoXLiw60+i7VJ6l9J0o6XPq++E1q99nDNnjr3zzjuu1ScoBS1Kc1OfDHUYT64WGABIDwgsACAFqfOxar5V262+DqrxVwFehdfq1au7ArAKvYMGDYr3ORWuNb/6B6gwr47A6gwdKwUEI0aMcEGKAgwVylVQVr8IvacCs9Kf1BdALSIzZswIdYZWIV7bq87d6kOnUZD8LRZqcdG+qEO6+tMpCFBHcQUqXitErJQmpBGyNCLTf/7zHxcsqCCubfCCD6VtPfDAA+7YqGCuoOnGG29072tfFRypz8iePXtccPPhhx+6wClaCpSUoqTO2jru5cqVc9ulYWSTg8730qVL441EBQCZQZa4aAdGTyVqatcPmIae1Zjop5KyA+YF+vzGXDcl+bPVypUJtO43H//fGPyxWtgwWNrcwR2jkvzZDuX6B1r3K7kWJPmz/mcBIHEq9KpAqwJecj1DJz1Li6d1I/UoQJs5c6YbTje9OdW+a8mB3+6k6fFi4yR/9o8BSwKtm9/ulCubM3A2AACpQJ3T9VwMDTWsVDgAyGwILAAgAznZA+eQfqlPTa1atVyLFGlQADIj+lgAQDoTafjWWEZZQvqkjvCaACCzIrAAgAwkllGWAABITaRCAQAAAAiMwAIAAABAYAQWAAAAAAIjsAAAAAAQGIEFAAAAgMAILAAgkylbtuwp9dRuDeFasGBBSw+yZMlis2fPTuvNAIA0wXCzADK0kR1ap+r6+r4xN6b59TC0GjVqpGpB/8svv7Q8efKk2vpORcOGDXMBRPgzRf766y8rVKhQmm0XAKQlAgsAyGTOPPPMtN6EU1bx4sXTehMAIM2QCgUAKaRz5862ePFiGzNmjEuR0bRx40b3Wp06dSxnzpxWokQJGzBggB09ejReK0fPnj3dVKBAATvjjDNs8ODBFhcXF3MqlD6j2vUyZcq49ZUsWdLuueee0LzPP/+8VahQwXLlymXFihWza6+9NuJyPGp90fI8O3futK5du7pgJn/+/Na4cWP77rvvknzMDh06ZPfdd5+dddZZrtXl4osvPuFJ5Ep90v7kzp3brr76avv3339POO7t2rWL91qvXr3ccfUcP37cnnzySfewQR0XLe/RRx8Nvd+/f38777zz3DrKly/vjv+RI0dC63/ooYfcfnrn1Xuidngq1OrVq90x0YMNixQpYt26dbO9e/eesK1PP/20uxY0T48ePULrAoCMhMACAFKIAop69erZ7bff7lJkNGXPnt1atWpltWvXdgXTF154wSZMmGCPPPJIvM9OnjzZsmXLZitXrnTLGTVqlL3yyisxb8Pbb79to0ePtvHjx9v69etdobdatWruva+++soFGcOHD7d169bZ/Pnz7fLLL49p+dddd51t27bNPvjgA1u1apXVrFnTmjRpYtu3b3fvL1myxPLmzZvoNG3atNDyFEwtW7bMXn/9dfv+++/d8lu0aOG2XVasWGG33Xabm09pSI0aNTrh2EVj4MCBNmLECBcw/PjjjzZ9+nQXWHny5cvnggW9p+P/8ssvu+MoHTp0sL59+1rVqlVD51Wvhdu3b581b97cpUYpPW3mzJn2ySefuG33W7Rokf3666/uX513rdcLVAAgIyEVCgBSiFobcuTI4Wq9vRSZBx980EqXLm3PPfecq92uVKmS/fnnn66GfMiQIXbaaf+t79E8KshqnooVK7qab/2tICUWmzZtcutu2rSpC2pUM6/WEu89tQq0bt3aFaTPPvtsu/DCC6Ne9ueff+4CHwUWqvUX1bwreHnrrbdc7fxFF110Qj+EcF6BXtszceJE969aVkStFwp49Ppjjz3mCvkKNPr16+feV6vC0qVL3TzR2rNnj1uOzkGnTp3ca+ecc45deumloXkGDRoUr+VG26FgR+tV64MCIgV+iaU+KVg5ePCgTZkyJdTnRets06aNPfHEE6H9VuCh17NmzequhyuvvNIWLFgQ87kGgLRGYAEAqWjt2rWuFUMBg6d+/fouPeaPP/5wBX+pW7duvHn0mZEjR9qxY8dcATRaqvFXOpPSeVQgV2uJCrYqFDdr1swFE957mpRapEAoGmpx0XYrfcfvwIEDrgZeVAhXulE0FDxp/xQshKdHeevQ8dM2+unYxBJYaBlaplpWEvLGG2/Y2LFj3X5oH5WqplSvWGg91atXj9eRXudaaVhqIfICC7V8+M+pUqJ0LAAgoyGwAIBMTC0fKsQqBefjjz+2u+66y5566inXz0OtFF9//bXrw/DRRx+5FhP1n1DajoZvVetJeL8Of+6/CtwqBIf3gRBv+FelQrVs2TLRbVSa1s033+yWpwK2UqrCgye1EETrZNutYCcxSsXS9qgfhVKZ1PKk1goFdilBLUl+CigVfABARkNgAQApSKlQqoX3VK5c2fV7UMHXa5H44osvXCG/VKlSofnUl8Bv+fLlrpN1LK0V/oK0Wik0qWOw0m1UI67+EGq5UJqUpqFDh7qAYOHChda+fXvXIVv9Bzy7d++2DRs2hP7W57ds2eKWoXShSGJJhVIalo6VUqsuu+yyiPPq+EU6Nn7a7jVr1sR7TdvgFeB1HHVMlG6kjufhlFqllhylrXl+//33RM9rQtuqvhLqa+G1WuhcK/BRehsAZDYEFgCQglTgVkFYo0Gp1l0tBkpNuvvuu10nXrUmqEDfp0+fUP8KUT8DvXbHHXe4VoVnn302STXmKtiqAKzRlZTi9Nprr7lCtQrOc+fOtd9++8112Fae//vvv+9qyr1Cr0Yz0ucVkCjgUIuGP7BRMKI0JI1qpBGWlMKk/iLz5s1z6UoKKmJJhdLn1VLQsWNHt68KNP7++28XAFxwwQWu74E6myudSH052rZtax9++OEJaVDabrXKqG+Dtk/7rEDD6z+iEbDUp0X9JRQgaHlazw8//OA6hivw0PFXK4U62Wt/Zs2adcJ5VZClgEUBoQJDr5+JR/uic6t+HGoJ0jp03m+55ZZ4HcUBILNgVCgASEHq9KvCeJUqVVxNulJyVIBXp2fl33fv3t0VZv2dhUWFa/VVUEdrtTLce++9rjN0rBQQaEQjFZ5VOFdK1Jw5c1yfBb33zjvvuIK4atdffPFFmzFjhsv590ZOatCggevcrUK9Agh1cvaoxUX7osCkS5cuLjC44YYbXO1+UgvO6qStfdeoSwpwtE6lZvn7nmh/1Plax08pXOHHTulLGu1JgYMCA3XW1jL99L7WoWBJ+65RndRSIldddZX17t3bBX4aXlctGJrf75prrnF9UjQqlc6rjls4BXIKfDRClrZDQ/mqX4c6agNAZpQlLtqB0VOJmtqVz7pr166YO8pldGUHzAv0+Y25bkryZ6uV+++PdlK9+fj/xuCP1cKG4wKt++COUUn+bIdy/QOt+5VcC5L8Wf+zAJA4jayj2uFy5cq52ubMLi2e1g2cit+15MBvd9Lw251xxFI2p8UCAAAAQGAEFgCQgZzsgXMAAKQVOm8DQDoTafjWWEZZAgAgLRBYAEAGEssoSwAApCZSoQAAAAAERmABAAAAIDACCwAAAACBEVgAAAAACIzAAgAAAEBgBBYAkMmULVs2wz61O7W2PUuWLDZ79uxE5+ncubO1a9cuxbcFADILhpsFkKH9MWBJqq6v1IjLYpq/YcOGVqNGjVQt6H/55ZeWJ0+eVFtfRrdx40YrV66cffPNN+5cAQCShsACADKZM888M603AUl0+PBhy5EjR1pvBgAkCalQAJBClEqzePFiGzNmjEu90aTacb1Wp04dy5kzp5UoUcIGDBhgR48ejdfK0bNnTzcVKFDAzjjjDBs8eLDFxcXFnE6kzwwbNszKlCnj1leyZEm75557QvM+//zzVqFCBcuVK5cVK1bMrr322ojL8ahGX8vz7Ny507p27eqCmfz581vjxo3tu+++C3Tc9u/fb7feeqvly5fPbfdLL70U7/3Nmzfb9ddfbwULFrTChQtb27Zt3XH1t9g0a9bMHTcdvwYNGtjXX3+d4PrUWiEXXnihO0c6/n5PP/20O09FihSxHj162JEjR0LvHTp0yPr372+lS5d2x1cPL5wwYYJ779ixY3bbbbe55evBhhUrVnTXQqR0q0cffdSdG80TzT4CQHpEYAEAKUSFyHr16tntt99uf/31l5uyZ89urVq1stq1a7sC+AsvvOAKoo888ki8z06ePNmyZctmK1eudMsZNWqUvfLKKzFvw9tvv22jR4+28ePH2/r1612/gmrVqrn3vvrqKxdkDB8+3NatW2fz58+3yy+/PKblX3fddbZt2zb74IMPbNWqVVazZk1r0qSJbd++3b2/ZMkSy5s3b6LTtGnT4i1z5MiRdtFFF7nUpLvuusvuvPNOt32iQn3z5s1d0KFlf/HFF24ZLVq0cLX9smfPHuvUqZN9/vnntnz5chc46Zjr9Uh0jOWTTz5x5+idd94Jvbdo0SL79ddf3b86J5MmTXKTp2PHjjZjxgwbO3asrV271h1nbY8cP37cSpUqZTNnzrQff/zRhgwZYg888IC9+eab8da/YMECt38ff/yxzZ07N6p9BID0iFQoAEghqi1XWkvu3LmtePHi7rUHH3zQ1W4/99xzrna8UqVK9ueff7pabxU8Tzvtv/U9mkcBgeZRLfbq1avd3wpSYrFp0ya37qZNm7qgRi0Aai3x3lNfjNatW7tC7Nlnn+1q7aOlgrsK5QosVFvv1e4reHnrrbesW7duLkD49ttvE12OWkr8FAQooBAdF+23CvY6Dm+88YYrsCvI0rGRiRMnupr9Tz/91K644grXauKnFg+9r5Yi7WtCqWNqkfDOk6dQoULuXGXNmtWdqyuvvNIFAjoPP//8swsSFBDo+Er58uVDn9Xxfuihh0J/q+Vi2bJl7jNqjfDoHGh/vBSo11577aT7CADpEYEFAKQi1WqrFcMrMEr9+vVt79699scff7iCv9StWzfePPqMavKVXqNCbiwtCkpnUoFXNd4qtLdp08a1hihdSMGE956mq6++2gVC0VCLi7ZbBXK/AwcOuFp+UQqQ0oNiccEFF4T+r2Ogwr6CF2+dv/zyiwuE/A4ePBha59atW23QoEGuEK7P6ZgpvUqBVKyqVq0a73grJUpBnihg0ntKtUrIuHHj7NVXX3Xr1nFRi0N4B3G1IPn7VUSzjwCQHhFYAEAmppYPpdkozUc162oJeOqpp1ztvQqu6nugAvhHH33kWkzUf0J9FFQ7rtaT8H4d/v4FCipU0Nbnw+nzolSeli1bJrqNSh+6+eab49X0+ym4UA2+t85atWqdkD7lb3lQGtS///7rUsgUOKk1RYFZUtKIEtsWBU2Jef311+2+++5zAaHWr+OtY79ixYp484WP4BXNPgJAhg8slAusyetAppoc/RB5PxqqTenbt6+7mapDm3JE1TEwvJkbAE4VqolWjbmncuXKrt+DCuxei4Ry6FXoVD6+J7zw6fUViKW1wqMCsFopNKnzsVJ6VOuu/hBquVAaj6ahQ4e6gGDhwoXWvn17V4hVnwPP7t27bcOGDaG/9fktW7a4ZaijdyRJSYVKjNapdKiiRYu6zuKR6Hjqt0etM15H6H/++SfBZXqtBf7zFA21NCjIUJDmpUKFb8cll1wSSuuSaFocotlHAMjwnbf1ozdixAjXQU+d/pTHqpEqfvjhB/d+7969bc6cOa6jmm60yhvWjxMAnKpU4FaQoAoZFW5VyFRB9+6777affvrJ3n33XVeg79OnT6h/hSh1Rq+ptUGdg5999lm79957Y16/Ohqrc/iaNWvst99+c/n7CjRUk6+Owup0rIL/77//blOmTHEFZW9kIt3jp06d6lodFIioJcAf2KgwrZp4jWqkFg/t49KlS10/Ev1G+FOhEpvCU34So5YNjfak3x5tlwIdtZioE7pSyUQBmLZbaWc69vpMYq0LKsDrfXVeVxrVrl27oj63OiYawUr9Srxt8Tpnazt0HD788EPXH0Mje6k1KDn2EQAyfGCh2i7VAOlmed5557nh8TRShWrSdCPWj5dGLtGPkZpx1dlMPzJ6HwBORUqFUWG8SpUqrgVAqUTvv/++6/RcvXp16969uxuSVH0C/DTakHLy1dFarQwKKtQZOlZqgXj55ZddPw71XVBKlCqA1C9C72kEJN2z1ZLy4osvuiBGrdEycOBA139AHZ7VaVkBxDnnnBNatlpctC8aSapLly7ud+GGG25wQUpKtVSr/8dnn33m+qKo4krbreOnFnOvdl+/RTt27HA1/7fccosrkCt4SIhaXBRgKSVLQ76qQB8tteJriF4FjGoJUqfuffv2uffuuOMOt40dOnSwiy++2KVn+VsvguwjAKRHWeKiHRg9jJqM1TKh2hoNCajmcA0xqJu5l1srqhXr1auXa82IhpraNZKKApVT7QZadsC8QJ/fmOumJH+2Wrn/dhhNqjcf/98Y/LFa2HBcoHUf3DEqyZ/tUK5/oHW/kmtBkj/rfxYAEqcClWptNaqOnreQ2aXF07qBU/G7lhz47U4afrszjljK5jF33lZzuJq+dfNRa8WsWbNcTZya0pWn6g8qRLVWCjoSor4YmvwbDwAAACCTPyBPubcKIpS3qocWqcVCD/5Jqscff9xFQd6kEUwAAJGd7IFzAACklZhbLNQq4Y1Jrn4U6oimIf2UQ6qh/Hbu3Bmv1UId4cIfOOSnHF51UPS3WBBcADiVRRq+NZZRlgAAyJDPsdAIIkplUpCh8b71RNJrrrnGvafRTDSyiVKnEqLxxb0ntgIAEpeUB84BAJDuAgu1LuiZFRqpYs+ePTZ9+nRXs6ah9JTGpFEr1PpQuHBh17lDwykqqNATZAEAAABkXjEFFtu2bXNDIOqBSQokNHShgopmzZq590ePHu3GYVeLhf8BeQAAAAAyt5gCC40NnhgNTTdu3Dg3AQAAADh1xDwqFAAAAACEI7AAAAAAEBiBBQBkMmXLls2wT+1Oy23PkiWLzZ4929LKpEmTTnjILACcUsPNAkBaGjZsWLpeX8OGDa1GjRqpWljW84Xy5MljGVFabrsGJilUqFCqBVC9evVyk0fPg2rVqlWqrB8AUgKBBQBkMmeeeaZlVGm57Yk9zDUacXFxduzYMcuWLVuSn1GiCQAyKlKhACCFdO7c2RYvXmxjxoxxaTaaNm7c6F6rU6eOezhoiRIlbMCAAXb06NF4rRw9e/Z0k4b2PuOMM2zw4MGu4BprOpE+o1YWPX9I6ytZsqTdc889oXk1JHiFChXcqH7FihWza6+9NuJyPGp98bfa7Ny507p27eoCAj2/qHHjxvbdd98l+ZiFr1PHbPz48da6dWvLnTu3Va5c2ZYtW2a//PKLO05q3bjkkkvs119/DX1G26ftfPXVV91+582b1+666y5X6H/yySddAFG0aFF79NFHE02FWrp0qVuOjo2eeK73NI/35HM9x0l/f/DBB+4hsTq+n3/+uduWtm3buuOpddeuXds++eST0HK13b///rv17t07dF0klAr1wgsv2DnnnGM5cuSwihUr2tSpU0/Y5ldeecWuvvpqd3x0Lt97770kH38ACILAAgBSiAIKPST09ttvd2k2mrJnz+7SXVTYVAFcBUcN5f3II4/E++zkyZNdzffKlSvdckaNGuUKkLF6++233TOGVDhfv369KxxXq1bNvffVV1+5IGP48OG2bt06mz9/vl1++eUxLf+6665zzzhS4XrVqlVWs2ZNa9KkiW3fvt29v2TJEle4TmyaNm1aout4+OGH3TOUVKCvVKmS3XTTTXbHHXe4h7ZqHxQ8KQjzU+Fe26R9mjFjhjvGV155pf3xxx8usHviiSds0KBBtmLFiojr3L17t7Vp08Ydq6+//tptQ//+/SPOq8BwxIgRtnbtWvd8p71797pzvGDBAvvmm2+sRYsWblmbNm1y87/zzjtWqlQpd9y96yKSWbNm2b333mt9+/a1NWvWuH3u0qWLLVq0KN58Dz30kF1//fX2/fffu/XefPPNoeMPAKmJVCgASCFqbVBNs2qSvTSbBx980EqXLm3PPfecq21WQfnPP/90hdYhQ4a4h4yK5lFAoHlUU7169Wr3t4KUWKgwq3U3bdrUBTWqwVdrifeeavzVGpAvXz47++yz7cILL4x62aqdV+CjwEK19fL000+74OWtt96ybt26uZp+r4Y/IarZT4wK0yo4i46TgjW14OghrKLCt+bxO378uGux0H5VqVLFGjVq5IKn999/3x1jHVMFFyqkX3zxxSesc/r06e7Yv/zyy67FQsv4z3/+E/H4K0DwHhQrhQsXturVq4f+VlCiIEEtCQqA9H7WrFndtiWWfqVjqVYvtbZInz59bPny5e517Y9H89x4443u/4899piNHTvWnRcFNACQmmixAIBUpFptFYy99BepX7++q+VWbbqnbt268ebRZ9TioHSeWFsUDhw4YOXLl3eFYhVwvbQrFYYVTOi9W265xbUc7N+/P+plq8VF212kSJF4LRAbNmwIpSapz8C5556b6KQCdmLUChAehHitLt5rBw8edK0M/pQq/3I1j4IDL3DzXlNQFImCEK1XQYXHC8jCKXjy0zG57777XNqWUpt0THTevRaLaOkzujb89LdeT+j4KFBUSlpC+wUAKYnAAgAyMbV8qJCsvhQq5Kv2W+lOR44ccQVvpfkoVUh9PdRiopp29ZsQFcLD+3Xoc/4CtD6nFgn/pPXdf//9yZYKpZYWjxdsRXpNrRSRPuPNE+k1/2eSKnwUKwUVCuDUeqD91zFRIHT48GFLCSm1XwAQK1KhACAFKRXK38qgWmz1e1CB3SsQf/HFF66Qr7x7T3juv1Jg1DFXKTSxUkChHH9NPXr0cOlXSq1Sfwj141CalKahQ4e6GvaFCxda+/btXYdsf/6/WgTUGuHR57ds2eKWoRaCSJIjFSotKFXqtddes0OHDoXSvDQUbjR0PpWepA7VXgCmTvuJXReR6FrRsjp16hRv2Wp5AYD0iMACAFKQCtwKElSw9EYn0qhHd999t8u3V+2+CvTKn/en6ShtRq+pw65aFZ599lkbOXJkzOvXSEMqwKofgfp6qLCsQEMpUHPnzrXffvvNtWDo+Q3qf6CabhWqRSM86fMKSBRwqEXDH9goGFGKVrt27dxoS+edd57rLzJv3jxXqFZQ4aVCZTTqIK7+MOonos7ZOh/q2yD+FLVIFACqg7aOm+ZVf5DwFgRdF5999pndcMMNLnDRyF/h1OqjviXq96JjPWfOHLdc/whTAJCekAoFAClIaTEqjKuWWS0ASiVSAV6da5V21L17d7vtttvcCEV+GgVJfSOU169WBnVQViE3VgoI1AFZufnKxVehVAVU9YvQeyqoKoBQ7fiLL77o0qKqVq3qPqtRlxo0aOA6d2tEJQUQGvrUo0Kz9kWBiTpPK7BQQVlDqabHVohYqJ+CjpNaWzTkrIIMBVbi73cRiUbwUqCmYXAVXKiTuVp3wjt8K9jU8Uzo2R063hoRTAGNzolG9po4caIbrhYA0qMscdEOjJ5K1NSukVR27drlbuynkrID5gX6/MZcNyX5s9XKlQm07jcf/98Y/LFa2HBcoHUf3DEqyZ/tUC7y8JHReiXXggzzxOiMTB1zlYJTrly5kxbqMoO0eFo3Tk59QRRA6fcpsz7I7lT7riUHfruTht/ujCOWsjmpUAAARDBlyhQ3YtZZZ53lRsDSULdKTcqsQQUABEVgAQAZiEYZatmyZYLvq6Mwkoc6piv9Sf9q9CsN3Rv+tG4AwP8QWABAOvPpp58m+F40oywhefTr189NAIDoEFgAQAaSUUdZAgBkfowKBQAAACAwAgsAGUY6G8QOyHT4jgEIgsACQLqXPXt29+/+/fvTelOATM37jnnfOQCIBX0sAKR7esCcHua2bds297eeIH2ypx8DiK2lQkGFvmP6rvmfsA4A0SKwAJAhFC9e3P3rBRcAkp+CCu+7BgCxIrAAkCGohULPEihatKgdOXIkrTcHyHSU/kRLBYAgCCwAZCgq+FD4AQAg/aHzNgAAAIDACCwAAAAABEZgAQAAACAwAgsAAAAAgRFYAAAAAAiMwAIAAABAYAQWAAAAAAIjsAAAAAAQGIEFAAAAgMAILAAAAAAERmABAAAAIDACCwAAAACBEVgAAAAACIzAAgAAAEBgBBYAAAAAAiOwAAAAAJC6gcXjjz9utWvXtnz58lnRokWtXbt2tm7dunjzHDx40Hr06GFFihSxvHnz2jXXXGNbt24NvqUAAAAAMkdgsXjxYhc0LF++3D7++GM7cuSIXXHFFbZv377QPL1797Y5c+bYzJkz3fx//vmntW/fPiW2HQAAAEA6kS2WmefPnx/v70mTJrmWi1WrVtnll19uu3btsgkTJtj06dOtcePGbp6JEyda5cqVXTBSt27d5N16AAAAABm/j4UCCSlcuLD7VwGGWjGaNm0amqdSpUpWpkwZW7ZsWdBtBQAAAJAZWiz8jh8/br169bL69evb+eef717bsmWL5ciRwwoWLBhv3mLFirn3Ijl06JCbPLt3707qJgEAAADIaC0W6muxZs0ae/311wNtgDqEFyhQIDSVLl060PIAAAAAZJDAomfPnjZ37lxbtGiRlSpVKvR68eLF7fDhw7Zz585482tUKL0XycCBA11KlTdt3rw5KZsEAAAAIKMEFnFxcS6omDVrli1cuNDKlSsX7/1atWpZ9uzZbcGCBaHXNBztpk2brF69ehGXmTNnTsufP3+8CQAAAEAm7mOh9CeN+PTuu++6Z1l4/SaUwnT66ae7f2+77Tbr06eP69CtIOHuu+92QQUjQgEAAACZV0yBxQsvvOD+bdiwYbzXNaRs586d3f9Hjx5tp512mnswnjplN2/e3J5//vnk3GYAAAAAGTmwUCrUyeTKlcvGjRvnJgAAAACnhkDPsQAAAAAAIbAAAAAAEBiBBQAAAIDACCwAAAAABEZgAQAAACAwAgsAAAAAgRFYAAAAAAiMwAIAAABAYAQWAAAAAAIjsAAAAAAQGIEFAAAAgMAILAAAAAAERmABAAAAIDACCwAAAACBEVgAAAAACIzAAgAAAEBgBBYAAAAAAiOwAAAAABAYgQUAAACAwAgsAAAAAARGYAEAAAAgMAILAAAAAIERWAAAAAAIjMACAAAAQGAEFgAAAAACI7AAAAAAEBiBBQAAAIDACCwAAAAABEZgAQAAACCwbMEXAQDIrNZWqhzo85V/Wpts2wIASN9osQAAAAAQGIEFAAAAgMAILAAAAAAERmABAAAAIDACCwAAAACBMSoUAKR3wwoE/Pyu5NoSAAASRIsFAAAAgMAILAAAAAAERmABAAAAIDACCwAAAACB0XkbAFJB2QHzkvzZjbmSdVMAAEgfLRafffaZtWnTxkqWLGlZsmSx2bNnx3s/Li7OhgwZYiVKlLDTTz/dmjZtauvXr0/ObQYAAACQ0Vss9u3bZ9WrV7dbb73V2rdvf8L7Tz75pI0dO9YmT55s5cqVs8GDB1vz5s3txx9/tFy5qHYDAKSOPwYsSfJnS424LFm3BQBOBTEHFi1btnRTJGqteOaZZ2zQoEHWtm1b99qUKVOsWLFirmXjhhtuCL7FAAAAADJ35+0NGzbYli1bXPqTp0CBAnbxxRfbsmXLknNVAAAAADJr520FFaIWCj/97b0X7tChQ27y7N69Ozk3CQCQhsZ1X5jkz/Z4sXGybgsAIJMPN/v444+7Vg1vKl26dFpvEgAAAIC0DCyKFy/u/t26dWu81/W39164gQMH2q5du0LT5s2bk3OTAAAAAGS0wEKjQCmAWLBgQbzUphUrVli9evUifiZnzpyWP3/+eBMAAACATN7HYu/evfbLL7/E67D97bffWuHCha1MmTLWq1cve+SRR6xChQqh4Wb1zIt27dol97YDADKxkR1aB/p8h3L9k21bAAApEFh89dVX1qhRo9Dfffr0cf926tTJJk2aZP369XPPuujWrZvt3LnTLr30Ups/fz7PsAAAAAAysZgDi4YNG7rnVSRET+MePny4mwAAyIiGDRuWpp8HgIwozUeFAgAAAJDxEVgAAAAACIzAAgAAAEBgBBYAAAAAAiOwAAAAAJD6o0IBADKWapOrJfmzbybrlgAAMjNaLAAAAAAERmABAAAAIDACCwAAAACBEVgAAAAACIzAAgAAAEBgBBYAAAAAAiOwAAAAABAYgQUAAACAwAgsAAAAAARGYAEAAAAgMAILAAAAAIERWAAAAAAIjMACAAAAQGAEFgAAAAACI7AAAAAAEBiBBQAAAIDACCwAAAAABEZgAQAAACAwAgsAAAAAgRFYAAAAAAiMwAIAAABAYAQWAAAAAAIjsAAAAAAQGIEFAAAAgMAILAAAAAAERmABAAAAIDACCwAAAACBEVgAAAAACIzAAgAAAEBgBBYAAAAAAiOwAAAAABAYgQUAAACAwAgsAAAAAARGYAEAAAAgMAILAAAAAOk3sBg3bpyVLVvWcuXKZRdffLGtXLkypVYFAAAAIDMGFm+88Yb16dPHhg4dal9//bVVr17dmjdvbtu2bUuJ1QEAAADIjIHFqFGj7Pbbb7cuXbpYlSpV7MUXX7TcuXPbq6++mhKrAwAAAJDZAovDhw/bqlWrrGnTpv9byWmnub+XLVuW3KsDAAAAkA5kS+4F/vPPP3bs2DErVqxYvNf1908//XTC/IcOHXKTZ9euXe7f3bt326nm+KH9gT6/O0tckj977MCxQOveeyzpnz9weF+gdR86ciTJn91zKOC6s/zv2o3VqXiNn8qCfL+DfLeDfr+DfLeDfr+DfLeDfr+DfLeF7/epg9/upOG3O+Pw9jkuLoprNS6Z/ec//9Fa45YuXRrv9fvvvz+uTp06J8w/dOhQNz8TExMTExMTExMTk6XLafPmzSeNA5K9xeKMM86wrFmz2tatW+O9rr+LFy9+wvwDBw50Hb09x48ft+3bt1uRIkUsS5Ysyb15SIdRcOnSpW3z5s2WP3/+tN4cAMmI7zeQOfHdPrXExcXZnj17rGTJkiedN9kDixw5clitWrVswYIF1q5du1CwoL979ux5wvw5c+Z0k1/BggWTe7OQzunGxM0JyJz4fgOZE9/tU0eBAgWimi/ZAwtRC0SnTp3soosusjp16tgzzzxj+/btc6NEAQAAAMh8UiSw6NChg/399982ZMgQ27Jli9WoUcPmz59/QoduAAAAAJlDigQWorSnSKlPgJ/S4PQgxfB0OAAZH99vIHPiu42EZFEP7gTfBQAAAIC0evI2AAAAgFMLgQUAAACAwAgsAAAAAARGYAEAAAAgMAILAAAABHLgwIG03gSkAwQWSFV6Cvurr75qrVu3tvPPP9+qVatmV111lU2ZMsU9Mh4AAGQchw4dspEjR1q5cuXSelOQmZ9jAYRT4KAg4v3337fq1au7oEKvrV271jp37mzvvPOOzZ49O603E0AStG/fPqr59D0HkPGCh2HDhtnHH39sOXLksH79+lm7du1s4sSJ9uCDD1rWrFmtd+/eab2ZSAcILJBqJk2aZJ999pktWLDAGjVqFO+9hQsXupuUWi46duyYZtsIIGkKFCiQ1psAIIUMGTLExo8fb02bNrWlS5faddddZ126dLHly5fbqFGj3N8KLgAekIdUc8UVV1jjxo1twIABEd9/7LHHbPHixfbhhx+m+rYBAIDIypcvb88884zLOlizZo1dcMEFLtNgwoQJliVLlrTePKQjBBZINcWLF7f58+dbjRo1Ir7/zTffWMuWLW3Lli2pvm0AACAypT9t2LDBzjrrLPf36aefbitXrnQpzYAfnbeRarZv327FihVL8H29t2PHjlTdJgAAkLhjx4654MKTLVs2y5s3b5puE9In+lggVW9MuhklRPmZR48eTdVtAgAAiVNyi1KfcubM6f4+ePCgde/e3fLkyRNvPgZnAIEF0uzGFGnUCQAAkL506tQp3t//93//l2bbgvSNPhZINRpBIhoavg4AAAAZC4EFAAAAgMDovA0AAAAgMAILAAAAAIERWAAAAAAIjMACAAAAQGAEFgAAAAACI7AAAKSaYcOGWY0aNdJ6MwAAKYAH5AEAUpxGNj927FhabwYAIAXRYgEAOEHDhg2tZ8+ebipQoICdccYZNnjwYBcgyNSpU+2iiy6yfPnyWfHixe2mm26ybdu2hT7/6aefWpYsWeyDDz6wWrVqWc6cOe21116zhx56yL777jv3nqZJkybZrbfeaq1bt463/iNHjljRokVtwoQJqb7vAICkIbAAAEQ0efJky5Ytm61cudLGjBljo0aNsldeeSVU8H/44YddkDB79mzbuHGjde7c+YRlDBgwwEaMGGFr1661Zs2aWd++fa1q1ar2119/ualDhw7WtWtXmz9/vvvbM3fuXNu/f797HwCQMfDkbQBAxBYLtUD88MMPrmXBCxLee+89+/HHH0+Y/6uvvrLatWvbnj17LG/evK7FolGjRi7oaNu2bbw+Fnrt22+/jfd5BRudOnWyfv36ub+vuuoqK1KkiE2cODHF9xUAkDxosQAARFS3bt1QUCH16tWz9evXu74Sq1atsjZt2liZMmVcOlSDBg3cPJs2bYq3DKVLRUOtFl4QsXXrVpdCpRQpAEDGQWABAIjJwYMHrXnz5pY/f36bNm2affnllzZr1iz33uHDh+PNmydPnqiW2bFjR/vtt99s2bJlri9GuXLl7LLLLkuR7QcApAxGhQIARLRixYp4fy9fvtwqVKhgP/30k/3777+u70Tp0qVDqVDRyJEjR8TRoZT21K5dO9dqoeCiS5cuybQXAIDUQosFACAipTX16dPH1q1bZzNmzLBnn33W7r33Xpf+pABBf6uVQf0u1JE7GmXLlrUNGza4Phb//POPHTp0KF46lDqMq6O3+lsAADIWAgsAQILpSQcOHLA6depYjx49XFDRrVs3O/PMM90wsTNnzrQqVaq4lounn346qmVec8011qJFC9exW8tRwOJp2rSplShRwqVZlSxZMgX3DACQEhgVCgAQcVQoPSH7mWeeSbV17t2718466yyXDtW+fftUWy8AIHnQxwIAkKaOHz/u0qJGjhxpBQsWdEPNAgAyHgILAECa9+XQKFClSpVyKVZ6KB8AIOMhFQoAAABAYHTeBgAAABAYgQUAAACAwAgsAAAAAARGYAEAAAAgMAILAAAAAIERWAAAAAAIjMACAAAAQGAEFgAAAAACI7AAAAAAYEH9PwQONOFWp+JQAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 800x400 with 1 Axes>"
       ]
@@ -945,21 +1117,21 @@
    "id": "s8",
    "metadata": {},
    "source": [
-    "## 8. Registry-based chart — `ChartTypeRegistry` and a registered creator\n",
+    "## 9. Registry-based chart — `ChartTypeRegistry` and a registered creator\n",
     "\n",
     "`ChartTypeRegistry` is the extensibility hook for the chart system. We pull a built-in chart type's parameter list, register a custom creator for `bar_chart`, and call `create_chart` to produce a fresh figure off the September issue percents."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "c8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T23:28:33.653165Z",
-     "iopub.status.busy": "2026-04-28T23:28:33.653076Z",
-     "iopub.status.idle": "2026-04-28T23:28:36.859616Z",
-     "shell.execute_reply": "2026-04-28T23:28:36.859113Z"
+     "iopub.execute_input": "2026-04-29T05:45:17.744368Z",
+     "iopub.status.busy": "2026-04-29T05:45:17.744273Z",
+     "iopub.status.idle": "2026-04-29T05:45:18.359963Z",
+     "shell.execute_reply": "2026-04-29T05:45:18.359621Z"
     }
    },
    "outputs": [
@@ -967,77 +1139,77 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[siege_utilities] 2026-04-28 18:28:36,751 INFO: Registered chart type: bivariate_choropleth\n"
+      "[siege_utilities] 2026-04-29 00:45:18,221 INFO: Registered chart type: bivariate_choropleth\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[siege_utilities] 2026-04-28 18:28:36,751 INFO: Registered chart type: marker_map\n"
+      "[siege_utilities] 2026-04-29 00:45:18,222 INFO: Registered chart type: marker_map\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[siege_utilities] 2026-04-28 18:28:36,751 INFO: Registered chart type: 3d_map\n"
+      "[siege_utilities] 2026-04-29 00:45:18,222 INFO: Registered chart type: 3d_map\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[siege_utilities] 2026-04-28 18:28:36,751 INFO: Registered chart type: heatmap_map\n"
+      "[siege_utilities] 2026-04-29 00:45:18,222 INFO: Registered chart type: heatmap_map\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[siege_utilities] 2026-04-28 18:28:36,752 INFO: Registered chart type: cluster_map\n"
+      "[siege_utilities] 2026-04-29 00:45:18,222 INFO: Registered chart type: cluster_map\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[siege_utilities] 2026-04-28 18:28:36,752 INFO: Registered chart type: flow_map\n"
+      "[siege_utilities] 2026-04-29 00:45:18,222 INFO: Registered chart type: flow_map\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[siege_utilities] 2026-04-28 18:28:36,752 INFO: Registered chart type: bar_chart\n"
+      "[siege_utilities] 2026-04-29 00:45:18,222 INFO: Registered chart type: bar_chart\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[siege_utilities] 2026-04-28 18:28:36,752 INFO: Registered chart type: line_chart\n"
+      "[siege_utilities] 2026-04-29 00:45:18,223 INFO: Registered chart type: line_chart\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[siege_utilities] 2026-04-28 18:28:36,752 INFO: Registered chart type: scatter_plot\n"
+      "[siege_utilities] 2026-04-29 00:45:18,223 INFO: Registered chart type: scatter_plot\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[siege_utilities] 2026-04-28 18:28:36,752 INFO: Registered chart type: time_series\n"
+      "[siege_utilities] 2026-04-29 00:45:18,223 INFO: Registered chart type: time_series\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[siege_utilities] 2026-04-28 18:28:36,752 INFO: Registered chart type: comparison_chart\n"
+      "[siege_utilities] 2026-04-29 00:45:18,223 INFO: Registered chart type: comparison_chart\n"
      ]
     },
     {
@@ -1046,7 +1218,7 @@
      "text": [
       "chart categories     : ['comparative', 'geographic', 'statistical', 'temporal']\n",
       "statistical chart types: ['bar_chart', 'line_chart', 'scatter_plot']\n",
-      "[siege_utilities] 2026-04-28 18:28:36,754 INFO: Updated create function for chart type: bar_chart\n"
+      "[siege_utilities] 2026-04-29 00:45:18,224 INFO: Updated create function for chart type: bar_chart\n"
      ]
     },
     {
@@ -1056,7 +1228,7 @@
        "<Figure size 800x400 with 1 Axes>"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -1107,21 +1279,21 @@
    "id": "s9",
    "metadata": {},
    "source": [
-    "## 9. Cross-Argument helper — base notes and tags\n",
+    "## 10. Cross-Argument helper — base notes and tags\n",
     "\n",
     "Each `Argument` carries metadata that downstream renderers read — `base_note` (warns about MULTIPLE_RESPONSE percent semantics), `layout` (full-width vs side-by-side, depending on whether a map exists), `tags` (table_type-derived for filtering)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "c9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T23:28:36.860943Z",
-     "iopub.status.busy": "2026-04-28T23:28:36.860780Z",
-     "iopub.status.idle": "2026-04-28T23:28:36.865348Z",
-     "shell.execute_reply": "2026-04-28T23:28:36.865046Z"
+     "iopub.execute_input": "2026-04-29T05:45:18.361339Z",
+     "iopub.status.busy": "2026-04-29T05:45:18.361240Z",
+     "iopub.status.idle": "2026-04-29T05:45:18.365631Z",
+     "shell.execute_reply": "2026-04-29T05:45:18.365236Z"
     }
    },
    "outputs": [
@@ -1201,7 +1373,7 @@
        "4  Party trajectory       longitudinal  side_by_side     3"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1227,21 +1399,21 @@
    "id": "s10",
    "metadata": {},
    "source": [
-    "## 10. Assemble all five Arguments + three charts into a branded PDF\n",
+    "## 11. Assemble all five Arguments + three charts into a branded PDF\n",
     "\n",
     "`ReportGenerator` reads the `elect_info` branding template (added in PR #418) for header / footer / fonts / colors, then accepts text + chart + table sections in narrative order. The output is one multi-page PDF a Q1 client deliverable could ship as-is."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "c10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T23:28:36.866683Z",
-     "iopub.status.busy": "2026-04-28T23:28:36.866628Z",
-     "iopub.status.idle": "2026-04-28T23:28:37.903605Z",
-     "shell.execute_reply": "2026-04-28T23:28:37.903118Z"
+     "iopub.execute_input": "2026-04-29T05:45:18.366734Z",
+     "iopub.status.busy": "2026-04-29T05:45:18.366672Z",
+     "iopub.status.idle": "2026-04-29T05:45:20.678443Z",
+     "shell.execute_reply": "2026-04-29T05:45:20.677998Z"
     }
    },
    "outputs": [
@@ -1326,21 +1498,21 @@
    "id": "s11",
    "metadata": {},
    "source": [
-    "## 11. Write the PDF\n",
+    "## 12. Write the PDF\n",
     "\n",
     "`generate_pdf_report` returns `True` on success. The artifact is written to disk under `output_showcase/` (gitignored)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "c11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T23:28:37.904850Z",
-     "iopub.status.busy": "2026-04-28T23:28:37.904736Z",
-     "iopub.status.idle": "2026-04-28T23:28:37.986161Z",
-     "shell.execute_reply": "2026-04-28T23:28:37.985819Z"
+     "iopub.execute_input": "2026-04-29T05:45:20.679595Z",
+     "iopub.status.busy": "2026-04-29T05:45:20.679471Z",
+     "iopub.status.idle": "2026-04-29T05:45:20.764082Z",
+     "shell.execute_reply": "2026-04-29T05:45:20.763618Z"
     }
    },
    "outputs": [
@@ -1348,28 +1520,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[siege_utilities] 2026-04-28 18:28:37,905 WARNING: Liberation-Serif not fully registered. Defaulting to standard ReportLab fonts.\n"
+      "[siege_utilities] 2026-04-29 00:45:20,680 WARNING: Liberation-Serif not fully registered. Defaulting to standard ReportLab fonts.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[siege_utilities] 2026-04-28 18:28:37,906 INFO: Image cache directory ensured: /Users/dheerajchand/.siege_utilities/image_cache\n"
+      "[siege_utilities] 2026-04-29 00:45:20,681 INFO: Image cache directory ensured: /Users/dheerajchand/.siege_utilities/image_cache\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[siege_utilities] 2026-04-28 18:28:37,984 INFO: Document 'output_showcase/acme_q1_2026_full.pdf' built successfully.\n"
+      "[siege_utilities] 2026-04-29 00:45:20,761 INFO: Document 'output_showcase/acme_q1_2026_full.pdf' built successfully.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[siege_utilities] 2026-04-28 18:28:37,984 INFO: PDF report generated successfully: output_showcase/acme_q1_2026_full.pdf\n"
+      "[siege_utilities] 2026-04-29 00:45:20,762 INFO: PDF report generated successfully: output_showcase/acme_q1_2026_full.pdf\n"
      ]
     },
     {
@@ -1397,7 +1569,7 @@
     "- **Source**: `siege_utilities/survey/` (build_chain, chain_to_argument, WaveSet), `siege_utilities/reporting/wave_charts.py`, `siege_utilities/reporting/chart_types.py`, `siege_utilities/reporting/report_generator.py`, `siege_utilities/reporting/client_branding.py`.\n",
     "- **Tests**: `tests/test_survey_*.py`, `tests/test_chart_types*.py`, `tests/test_client_branding*.py`.\n",
     "- **Sibling notebooks**: `reports/03_polling_survey_analysis.ipynb` (survey pipeline alone), `reports/01_charts_and_pdf.ipynb` (PDF builder alone), `engines/04_statistics_primitives.ipynb` (the underlying stats primitives).\n",
-    "- **TableType reference**: every value of `siege_utilities.reporting.pages.page_models.TableType` except `BANNER` is exercised here. BANNER is shape-equivalent to CROSS_TAB — a multi-banner deck slide rather than a different statistical operation.\n"
+    "- **TableType reference**: all seven values of `siege_utilities.reporting.pages.page_models.TableType` are exercised here — SINGLE_RESPONSE, MULTIPLE_RESPONSE, CROSS_TAB (implicit in the banner with multiple breaks), RANKING, MEAN_SCALE, BANNER, and LONGITUDINAL.\n"
    ]
   }
  ],


### PR DESCRIPTION
Adds a §6 BANNER section so the showcase covers every value of `TableType`. Multi-banner with two break variables (`county` + `top_issue`) produces 8 side-by-side columns — the OSCAR executive-slide shape BANNER targets.

Subsequent sections renumbered (LONGITUDINAL → §7, etc). Title intro and Related footer updated.

## Test plan
- [x] Notebook re-executes end-to-end against geo31111 with embedded outputs
- [x] 108 hygiene checks pass
- [x] BANNER cell output shows 8 banner columns (3 county + 5 top_issue)