### PR TITLE
phase 2 + 3: load-bearing docs, silent-swallow sweep

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -79,6 +79,36 @@ A follow-up PR will add a `pydeps` CI check that fails on upward edges.
 | [0006](adr/0006-polling-analyzer-location.md) | PollingAnalyzer deprecation | **Accepted** | ELE-2439 + ELE-2440 |
 | [0007](adr/0007-argument-tabletype-location.md) | Argument + TableType location | Proposed | ELE-2420 |
 
+## Consumer extras and the upward-import trap
+
+The "Analysis + output" layer (`reporting/`, `survey/`, `analytics/`,
+`admin/`, `hygiene/`) ships as **optional extras** in `pyproject.toml`
+(`[reporting]`, `[survey]`, `[analytics]`, …). The trap that catches
+agents and refactor-happy contributors is:
+
+> *"This helper in `reporting/` is generic. Let me move it down into
+> `core/` or `data/` so other code can use it."*
+
+Don't. Even if the helper is technically generic, moving it down pulls
+the heavy reporting-extra deps (matplotlib, seaborn, folium, reportlab)
+into a layer that's supposed to install with no graphics stack. The
+foundation has to be installable on a Spark worker without a display
+server; an upward edge breaks that.
+
+**Rules of thumb:**
+
+1. If consumer code wants something from a lower layer, **the lower
+   layer adds the abstraction** (see `DataFrameEngine` for why we don't
+   special-case backends in `reporting/`).
+2. If two consumer modules genuinely share a helper, the helper lives
+   in **whichever consumer module owns the larger half** of the
+   surface — not in a foundation layer.
+3. The `[all]` extra exists for end-user convenience. It is not an
+   excuse for an internal module to assume `[all]` is installed.
+
+The single invariant — **imports go DOWN** — is what keeps a `pip install
+"siege-utilities[geo]"` lean and predictable on a 4 GB EC2 image.
+
 ## Known invariant violations
 
 | Violation | Resolution | Target |

--- a/siege_utilities/admin/profile_manager.py
+++ b/siege_utilities/admin/profile_manager.py
@@ -316,13 +316,24 @@ def get_profile_summary(profile_location: Optional[Path] = None) -> Dict[str, an
         summary["client_profiles"] = len(client_files)
         summary["client_codes"] = [f.stem for f in client_files]
     
-    # Calculate total size
+    # Calculate total size. Best-effort: a stat() can fail on a single
+    # file (broken symlink, perms, race) without us wanting to abort the
+    # whole summary. Narrow to OSError so genuine bugs (TypeError, etc.)
+    # propagate, and log so a 0 isn't silently indistinguishable from
+    # an empty profile.
     try:
         total_size = sum(
             f.stat().st_size for f in profile_location.rglob("*") if f.is_file()
         )
         summary["total_size_mb"] = round(total_size / (1024 * 1024), 2)
-    except Exception:
+    except OSError as e:
+        # Keep the numeric type so existing callers (and the
+        # test_admin_profile_manager.py >= 0 assertion) don't break.
+        # The log line is the actual fix — silent 0 was the bug.
+        log.warning(
+            "Could not compute size of profile location %s: %s",
+            profile_location, e,
+        )
         summary["total_size_mb"] = 0
     
     return summary

--- a/siege_utilities/admin/profile_manager.py
+++ b/siege_utilities/admin/profile_manager.py
@@ -9,9 +9,8 @@ from pathlib import Path
 from typing import Optional, Dict, List, Tuple
 from ..config.enhanced_config import (
     UserProfile, ClientProfile,
-    load_user_profile, save_user_profile,
-    load_client_profile, save_client_profile,
-    list_client_profiles
+    save_user_profile,
+    save_client_profile,
 )
 from ..config.models import ContactInfo, BrandingConfig, ReportPreferences
 

--- a/siege_utilities/engines/dataframe_engine.py
+++ b/siege_utilities/engines/dataframe_engine.py
@@ -4,6 +4,19 @@ Engine-agnostic DataFrame operations.
 Provides a thin abstraction so the same analytical operations can run on
 DuckDB, Spark, or PostGIS instead of only pandas/GeoPandas.
 
+Why one abstraction
+-------------------
+The point is **not** that the back-ends are interchangeable in performance —
+they are not. The point is that **consumer code should not branch on
+back-end**. A reporting module asked to summarise voter rolls should not
+care whether the frame came from a 10-million-row Spark job or a 5-row
+pandas test fixture; it calls ``engine.groupby_agg(...)`` and is done.
+
+This is load-bearing. The anti-pattern to avoid: ``if isinstance(df,
+pd.DataFrame): ... else: ...`` scattered through ``reporting/``. If you
+find yourself reaching for it, the right fix is a new method on the
+``DataFrameEngine`` interface — not a special case in the consumer.
+
 Usage::
 
     from siege_utilities.engines.dataframe_engine import get_engine, Engine

--- a/siege_utilities/reporting/analytics_reports.py
+++ b/siege_utilities/reporting/analytics_reports.py
@@ -826,17 +826,14 @@ class AnalyticsReportGenerator:
                 ]
             }
             
-        except Exception as e:
-            log.error(f"Error processing DataFrame data: {e}")
-            return {
-                'title': 'DataFrame Analysis Report',
-                'subtitle': 'Error processing data',
-                'sections': [{
-                    'type': 'text',
-                    'title': 'Error',
-                    'content': f'Error processing DataFrame: {str(e)}'
-                }]
-            }
+        except Exception:
+            # Don't swallow into a dict that says "Error" but still
+            # claims to be a report — the outer caller (and the public
+            # API at create_custom_analytics_report) re-raises, and a
+            # downstream report builder can't tell a success report
+            # from an error-dict by shape alone. Fail-fast.
+            log.exception("Error processing DataFrame data")
+            raise
 
     def _process_dict_data(self, data: Dict[str, Any], 
                           report_config: Dict[str, Any]) -> Dict[str, Any]:
@@ -886,17 +883,9 @@ class AnalyticsReportGenerator:
                 'sections': sections
             }
             
-        except Exception as e:
-            log.error(f"Error processing dictionary data: {e}")
-            return {
-                'title': 'Dictionary Analysis Report',
-                'subtitle': 'Error processing data',
-                'sections': [{
-                    'type': 'text',
-                    'title': 'Error',
-                    'content': f'Error processing dictionary: {str(e)}'
-                }]
-            }
+        except Exception:
+            log.exception("Error processing dictionary data")
+            raise
 
     def _process_json_data(self, json_data: str, 
                           report_config: Dict[str, Any]) -> Dict[str, Any]:
@@ -905,17 +894,9 @@ class AnalyticsReportGenerator:
             import json
             data = json.loads(json_data)
             return self._process_dict_data(data, report_config)
-        except Exception as e:
-            log.error(f"Error processing JSON data: {e}")
-            return {
-                'title': 'JSON Analysis Report',
-                'subtitle': 'Error processing data',
-                'sections': [{
-                    'type': 'text',
-                    'title': 'Error',
-                    'content': f'Error processing JSON: {str(e)}'
-                }]
-            }
+        except Exception:
+            log.exception("Error processing JSON data")
+            raise
 
     def _process_csv_data(self, csv_path: str, 
                          report_config: Dict[str, Any]) -> Dict[str, Any]:
@@ -923,17 +904,9 @@ class AnalyticsReportGenerator:
         try:
             df = pd.read_csv(csv_path)
             return self._process_dataframe_data(df, report_config)
-        except Exception as e:
-            log.error(f"Error processing CSV data: {e}")
-            return {
-                'title': 'CSV Analysis Report',
-                'subtitle': 'Error processing data',
-                'sections': [{
-                    'type': 'text',
-                    'title': 'Error',
-                    'content': f'Error processing CSV: {str(e)}'
-                }]
-            }
+        except Exception:
+            log.exception("Error processing CSV data")
+            raise
 
     def _get_metric_status(self, change_value: float) -> str:
         """Get status for a metric based on change value."""

--- a/siege_utilities/reporting/report_generator.py
+++ b/siege_utilities/reporting/report_generator.py
@@ -20,7 +20,6 @@ except ImportError:
 try:
     from reportlab.platypus import Paragraph, Spacer, Table, TableStyle, PageBreak
     from reportlab.platypus import Image as RLImage
-    from reportlab.lib.styles import getSampleStyleSheet
     from reportlab.lib import colors
     from reportlab.lib.units import inch
     REPORTLAB_AVAILABLE = True
@@ -486,7 +485,6 @@ class ReportGenerator:
             return []
 
         import io
-        import tempfile
 
         result = []
 
@@ -647,7 +645,6 @@ class ReportGenerator:
             charts = content.get('charts', [])
             image_path = content.get('image_path')
             description = content.get('description', '')
-            layout = content.get('layout', 'vertical')
 
             # Add description if provided
             if description:

--- a/siege_utilities/reporting/report_generator.py
+++ b/siege_utilities/reporting/report_generator.py
@@ -513,12 +513,17 @@ class ReportGenerator:
                     buf.seek(0)
                     img = RLImage(buf, width=width*inch, height=height*inch)
                     result.append(img)
-                    # Close the figure to free memory
+                    # Close the figure to free memory. If matplotlib
+                    # isn't installed the import raises ImportError; if
+                    # close() fails on a malformed figure it raises
+                    # something matplotlib-specific. Either way memory
+                    # cleanup isn't worth aborting the report — but log
+                    # so we can spot it when it happens.
                     try:
                         import matplotlib.pyplot as plt
                         plt.close(chart)
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        log.debug("Could not close matplotlib figure: %s", e)
                     continue
 
                 # Handle PIL Image


### PR DESCRIPTION
## Summary

Phases 2 and 3 of the post-audit cleanup. Bundled because Phase 2 is doc-only and small, and Phase 3 directly addresses the audit's headline Blocker. After this lands we cut the 3.14.0 release.

## Phase 2 — load-bearing decisions documented

The audit's surveys turned up two undocumented load-bearing choices that surprise readers and tempt agents to "fix" things that were intentionally that way:

- **`DataFrameEngine` — *why* one abstraction.** The existing docstring stated what (run the same ops on DuckDB / Spark / PostGIS / pandas), but not why. The why is that **consumer code must not branch on backend**. Added a "Why one abstraction" section with the explicit anti-pattern (`isinstance(df, pd.DataFrame): ...` scattered through `reporting/`).
- **`ARCHITECTURE.md` — the upward-import trap.** Layer table + the "imports go DOWN" invariant were already there, but the doc missed the most common refactor mistake: moving a "generic" helper from `reporting/` down into `core/` and dragging matplotlib/seaborn/folium into the foundation install. Added a "Consumer extras and the upward-import trap" section with three rules of thumb.

## Phase 3 — silent-swallow sweep

Audit findings: 13 silent-swallow sites in reporting/ and admin/, 5 of them Blocker. Triaged:

**Fixed (5):**
- `reporting/analytics_reports.py` — `_process_dataframe / _dict / _json / _csv _data()` were returning `{'title': '… Report', 'subtitle': 'Error processing data', 'sections': [{'type': 'text', 'content': 'Error processing …'}]}` on any exception. The shape is indistinguishable from a real report, so a downstream report builder ships an "error" PDF that looks like a normal one. Worse, the public entry point (`create_custom_analytics_report`) already wraps in try/except + log+re-raise, so the inner swallow was only neutralising the outer guard. Changed to `log.exception(); raise` — fail-fast.
- `admin/profile_manager.py` — bare-ish `except Exception: summary['total_size_mb'] = 0` with no logging, so a permissions error on `rglob`/`stat` is indistinguishable from an empty profile. Narrowed to `OSError` and logged at WARNING. Kept the `0` return so the existing `test_admin_profile_manager.py` `>= 0` contract holds; the log line is the actual fix.
- `reporting/report_generator.py` — broad `except Exception: pass` around matplotlib `plt.close(chart)` for memory cleanup. Cleanup itself isn't load-bearing, but a silent flood of close-failures has no signal. Added `log.debug(...)`.

**Left alone, with reasoning (8):** branding-config loaders that fall back to defaults are intentional graceful degradation; `generate_pdf_report` returning `False` is the documented contract; etc. See audit notes for the breakdown.

## Test plan

- [x] Local: `pytest tests/test_admin_profile_manager.py tests/test_survey_*.py tests/test_notebook_hygiene.py tests/test_country_codes*.py tests/test_report*.py -k "not slow"` → **292 passed, 4 skipped**
- [ ] Full CI matrix on push
- [ ] CodeRabbit review pass

## Out of scope

- The remaining 8 silent-swallow sites (config-loader graceful degradation, public-API bool-return contracts) — intentional, documented in the audit.
- Audit Phases 4–7 (engine abstraction tightening, test coverage epic, geo subsystem audit, branding-data-as-data refactor) — separate later work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded architecture guidance on module layering, optional extras, import rules, and engine-agnostic notes for DataFrame usage.

* **Bug Fixes**
  * Safer profile size computation with narrower error handling.
  * Improved memory cleanup and resilience in PDF/chart generation.

* **Refactor**
  * Reporting now surfaces processing errors by propagating exceptions for clearer failure visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->