### PR TITLE
feat(geo): h3_resolution_for_admin_level — H3 ↔ US admin geography crosswalk (#431)

### DIFF
--- a/siege_utilities/geo/__init__.py
+++ b/siege_utilities/geo/__init__.py
@@ -230,6 +230,7 @@ _register([
     'H3_AVAILABLE',
     'h3_index_points', 'h3_index_polygon', 'h3_spatial_join',
     'h3_hex_to_boundary', 'h3_resolution_for_area',
+    'h3_resolution_for_admin_level', 'ADMIN_LEVEL_AVG_AREA_KM2',
 ], '.h3_utils')
 
 # --- temporal (pure-Python temporal data management) ---

--- a/siege_utilities/geo/h3_utils.py
+++ b/siege_utilities/geo/h3_utils.py
@@ -305,6 +305,95 @@ def h3_hex_to_boundary(hex_id: str) -> list:
     return list(boundary)
 
 
+# ---------------------------------------------------------------------------
+# Admin-geography → H3 resolution mapping
+#
+# Average areas are approximate, drawn from US Census Bureau publications:
+#   - State: 9.83 M km^2 / 50 states ≈ 196,600 km^2 (mainland weighted differs;
+#     here we take the simple average across 50 states + DC).
+#   - County: ~3,000 km^2 average across ~3,143 counties.
+#   - ZCTA (ZIP Code Tabulation Area): ~110 km^2 average across ~33,000 ZCTAs
+#     (highly variable; rural ZCTAs can exceed 1,000 km^2).
+#   - Census Tract: ~5 km^2 average across ~85,000 tracts.
+#   - Block Group: ~1 km^2 average across ~240,000 BGs.
+#   - Census Block: ~0.04 km^2 average across ~11.1 M blocks.
+#
+# These are intentionally rough — within an order of magnitude is sufficient
+# for selecting an H3 resolution. The H3 documentation
+# (https://h3geo.org/docs/comparisons/admin) makes the point that admin
+# boundaries are an *unreliable* unit of analysis precisely because the
+# variance within a level (e.g. NY tract vs WY tract) is huge. The resolution
+# returned here is a starting point; tune up or down by ±1 if the polygons
+# you actually have are systematically larger or smaller than the average.
+# ---------------------------------------------------------------------------
+ADMIN_LEVEL_AVG_AREA_KM2 = {
+    "state": 196_600.0,
+    "county": 3_000.0,
+    "zcta": 110.0,
+    "tract": 5.0,
+    "block_group": 1.0,
+    "block": 0.04,
+}
+
+# Aliases that map common variants to the canonical key above.
+_ADMIN_LEVEL_ALIASES = {
+    "states": "state",
+    "us_state": "state",
+    "counties": "county",
+    "us_county": "county",
+    "zip": "zcta",
+    "zip_code": "zcta",
+    "zipcode": "zcta",
+    "zctas": "zcta",
+    "tracts": "tract",
+    "census_tract": "tract",
+    "bg": "block_group",
+    "block_groups": "block_group",
+    "blockgroup": "block_group",
+    "blocks": "block",
+    "census_block": "block",
+}
+
+
+def h3_resolution_for_admin_level(level: str) -> int:
+    """
+    Suggest an H3 resolution whose average hex area matches a US admin level.
+
+    Useful when you want to bin point data into hexes that are roughly the
+    same scale as a familiar admin unit (e.g. "give me hexes the size of
+    counties"). The mapping is deliberately approximate — admin polygons
+    vary by orders of magnitude within a single level, so this is a
+    starting point, not a precision tool.
+
+    Recognised levels (case-insensitive):
+      ``state``, ``county``, ``zcta``, ``tract``, ``block_group``, ``block``.
+    Common aliases are accepted (``zip`` → ``zcta``, ``bg`` →
+    ``block_group``, plurals, etc.).
+
+    Args:
+        level: Admin geography level name.
+
+    Returns:
+        int: H3 resolution (0-15) closest in average hex area to the
+        average polygon area at the requested admin level.
+
+    Raises:
+        ImportError: If h3 is not installed.
+        ValueError: If ``level`` is not recognised.
+    """
+    _require_h3()
+
+    normalized = level.strip().lower()
+    canonical = _ADMIN_LEVEL_ALIASES.get(normalized, normalized)
+    if canonical not in ADMIN_LEVEL_AVG_AREA_KM2:
+        valid = sorted(ADMIN_LEVEL_AVG_AREA_KM2)
+        raise ValueError(
+            f"Unknown admin level {level!r}. "
+            f"Recognised levels: {valid}."
+        )
+    return h3_resolution_for_area(ADMIN_LEVEL_AVG_AREA_KM2[canonical])
+
+
 def h3_resolution_for_area(target_area_km2: float) -> int:
     """
     Suggest the H3 resolution whose hex area best matches a target area.

--- a/tests/test_h3_utils.py
+++ b/tests/test_h3_utils.py
@@ -346,3 +346,60 @@ class TestH3ResolutionForArea:
         areas = [_H3_RESOLUTION_AREA_KM2[r] for r in range(16)]
         for i in range(len(areas) - 1):
             assert areas[i] > areas[i + 1]
+
+
+@pytest.mark.skipif(not h3_utils.H3_AVAILABLE, reason="h3 package not installed")
+class TestResolutionForAdminLevel:
+    """h3_resolution_for_admin_level: admin geography level → H3 resolution."""
+
+    def test_state_returns_low_resolution(self):
+        # ~196,600 km^2 sits between H3 res 1 (609k) and res 2 (87k).
+        # The closest in log-space is res 2.
+        assert h3_utils.h3_resolution_for_admin_level("state") in (1, 2)
+
+    def test_county_returns_mid_resolution(self):
+        # ~3,000 km^2 sits between res 3 (12,393) and res 4 (1,770);
+        # res 4 is closer in log-space.
+        assert h3_utils.h3_resolution_for_admin_level("county") in (3, 4)
+
+    def test_tract_returns_high_resolution(self):
+        # ~5 km^2 ≈ res 6-7
+        assert h3_utils.h3_resolution_for_admin_level("tract") in (6, 7)
+
+    def test_levels_are_monotonic(self):
+        """Larger admin units → lower H3 resolutions."""
+        levels = ["state", "county", "zcta", "tract", "block_group", "block"]
+        resolutions = [h3_utils.h3_resolution_for_admin_level(L) for L in levels]
+        for i in range(len(resolutions) - 1):
+            assert resolutions[i] <= resolutions[i + 1], (
+                f"{levels[i]} (res {resolutions[i]}) should be ≤ "
+                f"{levels[i+1]} (res {resolutions[i+1]})"
+            )
+
+    def test_aliases_map_to_canonical(self):
+        canonical = h3_utils.h3_resolution_for_admin_level("zcta")
+        for alias in ("zip", "zip_code", "zipcode", "ZIP", "ZCTAs"):
+            assert h3_utils.h3_resolution_for_admin_level(alias) == canonical
+
+        bg = h3_utils.h3_resolution_for_admin_level("block_group")
+        for alias in ("bg", "BG", "blockgroup", "block_groups"):
+            assert h3_utils.h3_resolution_for_admin_level(alias) == bg
+
+    def test_case_insensitive(self):
+        assert h3_utils.h3_resolution_for_admin_level("STATE") == \
+            h3_utils.h3_resolution_for_admin_level("state")
+        assert h3_utils.h3_resolution_for_admin_level("County") == \
+            h3_utils.h3_resolution_for_admin_level("county")
+
+    def test_unknown_level_raises(self):
+        with pytest.raises(ValueError, match="Unknown admin level"):
+            h3_utils.h3_resolution_for_admin_level("metro")
+        with pytest.raises(ValueError, match="Recognised levels"):
+            h3_utils.h3_resolution_for_admin_level("")
+
+    def test_admin_table_values_descend(self):
+        """ADMIN_LEVEL_AVG_AREA_KM2 should be ordered largest to smallest."""
+        levels = ["state", "county", "zcta", "tract", "block_group", "block"]
+        areas = [h3_utils.ADMIN_LEVEL_AVG_AREA_KM2[L] for L in levels]
+        for i in range(len(areas) - 1):
+            assert areas[i] > areas[i + 1]


### PR DESCRIPTION
Closes #431.

## Summary

The H3 docs (https://h3geo.org/docs/comparisons/admin) explain *why* H3 is preferable to admin boundaries (consistent area, no political reshuffling, hierarchical aggregation). But users still ask the practical question: "give me hexes the size of counties." Today they have to know that average county area ≈ 3,000 km² and pass that to `h3_resolution_for_area`.

This PR closes that gap with a tiny reference table + helper.

## What changed

- **`siege_utilities/geo/h3_utils.py`**:
  - New `ADMIN_LEVEL_AVG_AREA_KM2` table — Census-published averages for `state`, `county`, `zcta`, `tract`, `block_group`, `block`.
  - New `h3_resolution_for_admin_level(level: str)` — wraps `h3_resolution_for_area` with the table.
  - Alias map handles common variants (`zip` → `zcta`, `bg` → `block_group`, plurals, case-insensitive).
  - Unknown levels raise `ValueError` with the recognized list.
  - Inline comment explains the limitation: admin polygons vary by orders of magnitude within a level (NY tract vs WY tract); the recommendation is a starting point, not a precision tool.
- **`siege_utilities/geo/__init__.py`**: extend the `h3_utils` lazy-import registry to expose the two new names.
- **`tests/test_h3_utils.py`**: 8 new tests (state/county/tract resolution band checks, monotonicity, alias resolution, case-insensitivity, unknown-level error, table descent invariant). Skips cleanly when `h3` isn't installed, consistent with the rest of the module.

## Test plan

- [x] Local: `pytest tests/test_h3_utils.py` → **31 passed** (with `h3>=4.0` installed)
- [x] Local: same module skips cleanly when h3 absent (3 unconditional + 28 skipped)
- [ ] Full CI matrix on push

## Out of scope

- An "H3 cells covering this admin polygon" helper that auto-fetches the boundary from `BoundaryProvider` — a thin wrapper over the existing `h3_index_polygon`, but it crosses into `geo.providers` territory. Worth a follow-on if there's demand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added support for determining appropriate H3 resolution values based on US administrative levels, including state, county, tract, block group, and zip code boundaries
- Supports common naming aliases and variations for administrative boundary names
- Offers case-insensitive and whitespace-normalized input handling for flexible usage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->