### PR TITLE
feat(geo): plan-level temporal resolution for redistricting (#361)

### DIFF
--- a/siege_utilities/geo/__init__.py
+++ b/siege_utilities/geo/__init__.py
@@ -233,6 +233,13 @@ _register([
     'h3_resolution_for_admin_level', 'ADMIN_LEVEL_AVG_AREA_KM2',
 ], '.h3_utils')
 
+# --- plans (redistricting plan resolution by date) ---
+_register([
+    'PlanAuthority', 'PlanDistrict', 'RedistrictingPlan',
+    'PlanRegistry', 'PlanResolutionError', 'PlanOverlapError',
+    'get_default_plan_registry',
+], '.plans')
+
 # --- temporal (pure-Python temporal data management) ---
 _register([
     'TemporalDataStore', 'get_temporal_store',

--- a/siege_utilities/geo/plans/__init__.py
+++ b/siege_utilities/geo/plans/__init__.py
@@ -1,0 +1,30 @@
+"""Redistricting plan resolution by date (issue #361).
+
+Models a redistricting plan as a named, dated artifact and exposes a
+:class:`PlanRegistry` that resolves the plan in effect for a
+``(state_fips, district_type, date)`` tuple. Replaces the
+decade-keyed ``CensusVintageConfig`` for callers that need to handle
+mid-cycle court orders (Alabama 2023, Louisiana 2024, etc.).
+
+This is the foundational module — it has no consumer code yet.
+Downstream PRs wire ``RDHProvider`` and ``assign_boundaries`` to
+consult the registry.
+"""
+
+from .models import PlanAuthority, PlanDistrict, RedistrictingPlan
+from .registry import (
+    PlanOverlapError,
+    PlanRegistry,
+    PlanResolutionError,
+    get_default_plan_registry,
+)
+
+__all__ = [
+    "PlanAuthority",
+    "PlanDistrict",
+    "RedistrictingPlan",
+    "PlanRegistry",
+    "PlanResolutionError",
+    "PlanOverlapError",
+    "get_default_plan_registry",
+]

--- a/siege_utilities/geo/plans/models.py
+++ b/siege_utilities/geo/plans/models.py
@@ -128,10 +128,14 @@ class RedistrictingPlan:
         effective_from: First date the plan is in legal effect.
         effective_to: Last date in effect, or ``None`` if currently active.
         districts: Tuple of :class:`PlanDistrict` rows under this plan.
-            A frozen tuple so the dataclass remains hashable.
         metadata: Free-form mapping for citation, source URLs, court
             docket numbers, etc. Not used for resolution — consumers can
             stuff whatever they want here.
+
+    Note: ``frozen=True`` only forbids attribute reassignment; the
+    ``metadata`` dict remains mutable in place. Instances are therefore
+    *not* hashable and should be treated as value objects, never used
+    as dict keys or set members.
     """
 
     plan_name: str
@@ -142,6 +146,10 @@ class RedistrictingPlan:
     effective_to: Optional[_dt.date] = None
     districts: Tuple[PlanDistrict, ...] = field(default_factory=tuple)
     metadata: Mapping[str, str] = field(default_factory=dict)
+
+    # Mutable metadata dict means dataclass.__hash__ would silently
+    # accept hashing and then collide unpredictably; mark unhashable.
+    __hash__ = None  # type: ignore[assignment]
 
     def __post_init__(self) -> None:
         if self.effective_to is not None and self.effective_to < self.effective_from:

--- a/siege_utilities/geo/plans/models.py
+++ b/siege_utilities/geo/plans/models.py
@@ -1,0 +1,186 @@
+"""Data models for redistricting plans and their districts.
+
+A *plan* is a named, dated cartographic artifact: e.g. "Alabama 2023
+court-interim congressional map". Plans replace each other over time —
+the same state has multiple plans for the same district type within a
+single decennial cycle when a court intervenes (Alabama 2022/2023,
+Louisiana 2023/2024, New York 2022/2024, Georgia 2023/2024).
+
+The existing ``CensusVintageConfig`` in this package keys boundaries by
+decade ("2010 → 2010-2019"), which cannot represent a donation made in
+AL-7 in March 2023 vs the same address in September 2023 (different
+geometry). These models give consumers a date-resolvable shape.
+
+This module is the foundation of the redistricting-plan resolution
+system (issue #361). The matching :mod:`siege_utilities.geo.plans.registry`
+provides date-based lookup; downstream PRs wire ``RDHProvider`` and
+``assign_boundaries`` to use it.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import enum
+from dataclasses import dataclass, field
+from typing import Mapping, Optional, Tuple
+
+__all__ = [
+    "PlanAuthority",
+    "PlanDistrict",
+    "RedistrictingPlan",
+]
+
+
+class PlanAuthority(str, enum.Enum):
+    """Who drew the plan — legally meaningful for citation and audit."""
+
+    #: Enacted by the state legislature (the default cycle path).
+    LEGISLATURE = "legislature"
+    #: Court-imposed map (interim or final).
+    COURT = "court"
+    #: Independent or politician redistricting commission.
+    COMMISSION = "commission"
+    #: Pre-decennial-shift baseline; used by the legacy resolver when no
+    #: explicit plan covers a date.
+    DEFAULT = "default"
+
+
+@dataclass(frozen=True)
+class PlanDistrict:
+    """A single district within a redistricting plan.
+
+    All boundaries fields are optional — many consumers only need the
+    *identity* (which plan, which district, valid when) and resolve the
+    geometry separately via a :class:`BoundaryProvider`.
+
+    Attributes:
+        state_fips: 2-character state FIPS code (e.g. ``"01"`` for Alabama).
+        district_type: Lowercase district class — ``"cd"``, ``"sldu"``,
+            ``"sldl"``, ``"county_commission"``, etc. Match the keys used
+            by ``CensusTIGERProvider``.
+        district_id: District identifier *within* the plan. ``"7"`` for
+            AL-7, ``"01"`` for SLDU 1, etc. Stored as the string form so
+            leading-zero district numbers (sometimes used by states) are
+            preserved.
+        plan_name: Stable, human-readable plan identifier
+            (e.g. ``"AL_2023_CD_INTERIM"``). Conventional but not enforced.
+        authority: Who drew the plan (see :class:`PlanAuthority`).
+        effective_from: First date the district is in legal effect.
+        effective_to: Last date the district is in legal effect, **or
+            ``None`` for an open-ended plan (the currently active one)**.
+        geometry_source: Optional pointer to the geometry — a URL, a local
+            path, an RDH dataset slug, or any string the consuming
+            ``BoundaryProvider`` understands. ``None`` is fine if callers
+            only need identity resolution.
+        notes: Free-text annotation (e.g. court docket, statute citation).
+            Goes through to logs and audit trails verbatim.
+    """
+
+    state_fips: str
+    district_type: str
+    district_id: str
+    plan_name: str
+    authority: PlanAuthority
+    effective_from: _dt.date
+    effective_to: Optional[_dt.date] = None
+    geometry_source: Optional[str] = None
+    notes: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.effective_to is not None and self.effective_to < self.effective_from:
+            raise ValueError(
+                f"PlanDistrict {self.plan_name}/{self.district_id}: "
+                f"effective_to ({self.effective_to}) is before "
+                f"effective_from ({self.effective_from})."
+            )
+
+    def covers_date(self, when: _dt.date) -> bool:
+        """Return True iff *when* falls within this district's effective span.
+
+        Half-open at the upper end: ``effective_to`` is inclusive (if the
+        new plan starts the next day, encode that as
+        ``effective_from = old_to + timedelta(days=1)``). This matches how
+        court orders are typically written ("effective for elections on
+        or after DATE") and avoids the off-by-one trap of half-open
+        Python slices.
+        """
+        if when < self.effective_from:
+            return False
+        if self.effective_to is not None and when > self.effective_to:
+            return False
+        return True
+
+
+@dataclass(frozen=True)
+class RedistrictingPlan:
+    """A full plan: a collection of districts plus plan-level metadata.
+
+    The plan is the *unit* of court orders, statutes, and commission
+    actions; the individual :class:`PlanDistrict` rows just decompose it
+    for query convenience. ``effective_from`` / ``effective_to`` on the
+    plan should match the values on its constituent districts.
+
+    Attributes:
+        plan_name: Same convention as :attr:`PlanDistrict.plan_name`.
+        state_fips: 2-character state FIPS.
+        district_type: ``"cd"``, ``"sldu"``, etc.
+        authority: Who drew it.
+        effective_from: First date the plan is in legal effect.
+        effective_to: Last date in effect, or ``None`` if currently active.
+        districts: Tuple of :class:`PlanDistrict` rows under this plan.
+            A frozen tuple so the dataclass remains hashable.
+        metadata: Free-form mapping for citation, source URLs, court
+            docket numbers, etc. Not used for resolution — consumers can
+            stuff whatever they want here.
+    """
+
+    plan_name: str
+    state_fips: str
+    district_type: str
+    authority: PlanAuthority
+    effective_from: _dt.date
+    effective_to: Optional[_dt.date] = None
+    districts: Tuple[PlanDistrict, ...] = field(default_factory=tuple)
+    metadata: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.effective_to is not None and self.effective_to < self.effective_from:
+            raise ValueError(
+                f"RedistrictingPlan {self.plan_name}: "
+                f"effective_to ({self.effective_to}) is before "
+                f"effective_from ({self.effective_from})."
+            )
+        # Validate that constituent districts are consistent.
+        for d in self.districts:
+            if d.plan_name != self.plan_name:
+                raise ValueError(
+                    f"RedistrictingPlan {self.plan_name}: district "
+                    f"{d.district_id} has plan_name {d.plan_name!r}."
+                )
+            if d.state_fips != self.state_fips:
+                raise ValueError(
+                    f"RedistrictingPlan {self.plan_name}: district "
+                    f"{d.district_id} has state_fips {d.state_fips!r}, "
+                    f"plan has {self.state_fips!r}."
+                )
+            if d.district_type != self.district_type:
+                raise ValueError(
+                    f"RedistrictingPlan {self.plan_name}: district "
+                    f"{d.district_id} has district_type {d.district_type!r}, "
+                    f"plan has {self.district_type!r}."
+                )
+
+    def covers_date(self, when: _dt.date) -> bool:
+        """Return True iff *when* falls within this plan's effective span."""
+        if when < self.effective_from:
+            return False
+        if self.effective_to is not None and when > self.effective_to:
+            return False
+        return True
+
+    def district(self, district_id: str) -> Optional[PlanDistrict]:
+        """Find a district within this plan by id, or ``None``."""
+        for d in self.districts:
+            if d.district_id == district_id:
+                return d
+        return None

--- a/siege_utilities/geo/plans/registry.py
+++ b/siege_utilities/geo/plans/registry.py
@@ -1,0 +1,228 @@
+"""Date-resolvable registry of redistricting plans.
+
+Consumers register :class:`RedistrictingPlan` instances and then ask
+"which plan was active in Alabama for congressional districts on
+2023-09-15?" — the registry returns the right plan (or raises if there
+is overlap or a gap, depending on strictness).
+
+The registry is in-memory by design. File-backed plan catalogs (RDH
+manifest, NCSL plan registry) are loaded *into* an instance via
+:meth:`PlanRegistry.register_plan` at consumer startup; the resolver
+itself doesn't know about disk.
+
+A module-level singleton (:func:`get_default_plan_registry`) is provided
+for the common case where one process has one global view of plans.
+Consumers that need isolation (multi-tenant, tests) instantiate their
+own.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+import threading
+from typing import Dict, Iterable, List, Optional, Tuple
+
+from .models import PlanDistrict, RedistrictingPlan
+
+__all__ = [
+    "PlanRegistry",
+    "PlanResolutionError",
+    "PlanOverlapError",
+    "get_default_plan_registry",
+]
+
+log = logging.getLogger(__name__)
+
+
+class PlanResolutionError(LookupError):
+    """No plan covers the requested (state, district_type, date) tuple."""
+
+
+class PlanOverlapError(ValueError):
+    """Two registered plans cover the same date for the same state+type.
+
+    Raised by :meth:`PlanRegistry.resolve_plan_at_date` when the registry
+    finds more than one match in strict mode. Caller can rerun with
+    ``strict=False`` to get the first match (and a warning), or fix the
+    underlying plan data.
+    """
+
+
+_StateTypeKey = Tuple[str, str]
+
+
+class PlanRegistry:
+    """Stores redistricting plans and resolves them by date.
+
+    Plans are keyed by ``(state_fips, district_type)``. Within a key,
+    plans should be temporally non-overlapping; the registry detects
+    overlap at registration time (warn) and at resolution time (raise
+    in strict mode).
+
+    Thread-safe for concurrent readers; mutation under a lock.
+    """
+
+    def __init__(self) -> None:
+        self._plans: Dict[_StateTypeKey, List[RedistrictingPlan]] = {}
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Mutation
+    # ------------------------------------------------------------------
+
+    def register_plan(self, plan: RedistrictingPlan) -> None:
+        """Add *plan* to the registry.
+
+        Logs a warning if it overlaps an already-registered plan for the
+        same ``(state_fips, district_type)``. Does **not** raise on
+        overlap — registration is forgiving so consumers can load
+        partial data; resolution is the strict gate.
+        """
+        key = (plan.state_fips, plan.district_type)
+        with self._lock:
+            existing = self._plans.setdefault(key, [])
+            for other in existing:
+                if _spans_overlap(plan, other):
+                    log.warning(
+                        "Plan overlap detected for %s/%s: %r vs %r",
+                        plan.state_fips, plan.district_type,
+                        plan.plan_name, other.plan_name,
+                    )
+            existing.append(plan)
+            existing.sort(key=lambda p: p.effective_from)
+
+    def register_plans(self, plans: Iterable[RedistrictingPlan]) -> None:
+        """Bulk-register an iterable of plans."""
+        for p in plans:
+            self.register_plan(p)
+
+    def clear(self) -> None:
+        """Remove all registered plans (mostly for tests)."""
+        with self._lock:
+            self._plans.clear()
+
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
+    def plans_for_state(
+        self,
+        state_fips: str,
+        district_type: str,
+    ) -> List[RedistrictingPlan]:
+        """Return all registered plans for *state_fips* / *district_type*.
+
+        Sorted by ``effective_from`` ascending. Empty list if none.
+        """
+        return list(self._plans.get((state_fips, district_type), ()))
+
+    def resolve_plan_at_date(
+        self,
+        state_fips: str,
+        district_type: str,
+        when: _dt.date,
+        *,
+        strict: bool = True,
+    ) -> RedistrictingPlan:
+        """Find the plan in effect for *state_fips* / *district_type* on *when*.
+
+        Args:
+            state_fips: 2-char state FIPS.
+            district_type: ``"cd"``, ``"sldu"``, ``"sldl"``, etc.
+            when: The date to resolve.
+            strict: If ``True`` (default), raise :class:`PlanOverlapError`
+                when more than one plan covers *when*. If ``False``, log
+                a warning and return the most recently *enacted* one
+                (latest ``effective_from``) — appropriate when court
+                interim/final pairs both technically cover the same day.
+
+        Raises:
+            :class:`PlanResolutionError`: No plan covers the date.
+            :class:`PlanOverlapError`: Multiple plans cover the date and
+                ``strict=True``.
+        """
+        candidates = [
+            p for p in self.plans_for_state(state_fips, district_type)
+            if p.covers_date(when)
+        ]
+        if not candidates:
+            raise PlanResolutionError(
+                f"No registered plan covers {state_fips}/{district_type} on {when}. "
+                f"Registered plans: "
+                f"{[p.plan_name for p in self.plans_for_state(state_fips, district_type)]}"
+            )
+        if len(candidates) > 1:
+            if strict:
+                raise PlanOverlapError(
+                    f"{len(candidates)} plans cover {state_fips}/{district_type} on {when}: "
+                    f"{[p.plan_name for p in candidates]}. "
+                    "Resolve overlap in source data, or call with strict=False."
+                )
+            log.warning(
+                "Plan overlap on %s for %s/%s: %s — taking most-recently-enacted",
+                when, state_fips, district_type,
+                [p.plan_name for p in candidates],
+            )
+            candidates.sort(key=lambda p: p.effective_from)
+        return candidates[-1]
+
+    def resolve_district_at_date(
+        self,
+        state_fips: str,
+        district_type: str,
+        district_id: str,
+        when: _dt.date,
+        *,
+        strict: bool = True,
+    ) -> PlanDistrict:
+        """Find the specific district covering *when*.
+
+        Convenience wrapper: resolves the plan, then looks up the
+        district by id. Raises :class:`PlanResolutionError` if the plan
+        does not contain *district_id*.
+        """
+        plan = self.resolve_plan_at_date(
+            state_fips, district_type, when, strict=strict,
+        )
+        district = plan.district(district_id)
+        if district is None:
+            raise PlanResolutionError(
+                f"Plan {plan.plan_name} contains no district {district_id!r}. "
+                f"Districts: {[d.district_id for d in plan.districts]}"
+            )
+        return district
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+_default_registry: Optional[PlanRegistry] = None
+_default_registry_lock = threading.Lock()
+
+
+def get_default_plan_registry() -> PlanRegistry:
+    """Return the process-global default :class:`PlanRegistry`.
+
+    Lazily instantiated on first call. Consumers that need isolation
+    (multi-tenant code, unit tests) should instantiate
+    :class:`PlanRegistry` directly instead.
+    """
+    global _default_registry
+    if _default_registry is None:
+        with _default_registry_lock:
+            if _default_registry is None:
+                _default_registry = PlanRegistry()
+    return _default_registry
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _spans_overlap(a: RedistrictingPlan, b: RedistrictingPlan) -> bool:
+    """Inclusive interval overlap; ``effective_to=None`` means open-ended."""
+    a_to = a.effective_to or _dt.date.max
+    b_to = b.effective_to or _dt.date.max
+    return a.effective_from <= b_to and b.effective_from <= a_to

--- a/siege_utilities/geo/providers/boundary_providers.py
+++ b/siege_utilities/geo/providers/boundary_providers.py
@@ -289,6 +289,15 @@ class RDHProvider(BoundaryProvider):
 
     _LEVELS = ('precinct', 'congress', 'state_senate', 'state_house')
 
+    # RDH "level" maps onto the PlanRegistry "district_type" vocabulary.
+    # The PlanRegistry uses lowercase Census-aligned types ('cd', 'sldu',
+    # 'sldl'); 'precinct' has no plan-level analog, so it isn't mapped.
+    _LEVEL_TO_DISTRICT_TYPE = {
+        'congress': 'cd',
+        'state_senate': 'sldu',
+        'state_house': 'sldl',
+    }
+
     def __init__(
         self,
         username: Optional[str] = None,
@@ -353,6 +362,19 @@ class RDHProvider(BoundaryProvider):
 
         year: Optional[str] = kwargs.pop('year', None)
         fmt: str = kwargs.pop('format', 'shp')
+        when = kwargs.pop('when', None)
+        plan_registry = kwargs.pop('plan_registry', None)
+
+        if when is not None:
+            # Date-driven resolution: consult the PlanRegistry for the
+            # plan in effect on `when`, derive the RDH year filter from
+            # its effective_from. The registry raises PlanResolutionError
+            # if no plan covers the date — we let that bubble up so
+            # callers can react.
+            year = self._resolve_year_from_registry(
+                level=level, state=state, when=when, registry=plan_registry,
+            )
+
         client = self._get_client()
 
         if level == 'precinct':
@@ -397,3 +419,41 @@ class RDHProvider(BoundaryProvider):
             return True
         except ImportError:
             return False
+
+    def _resolve_year_from_registry(
+        self,
+        *,
+        level: str,
+        state: str,
+        when,
+        registry,
+    ) -> str:
+        """Look up the plan in effect on *when* and return its year as a string.
+
+        Helper for the ``when=`` keyword on :meth:`get_boundary`. Imports
+        are deferred so callers that never use ``when`` don't pay them.
+        """
+        from ..plans import get_default_plan_registry
+        from ..spatial_data import normalize_state_identifier
+
+        district_type = self._LEVEL_TO_DISTRICT_TYPE.get(level)
+        if district_type is None:
+            raise ValueError(
+                f"RDHProvider: when= keyword is not supported for level "
+                f"{level!r}. Only district levels "
+                f"{list(self._LEVEL_TO_DISTRICT_TYPE)} have plan-level "
+                "temporal resolution."
+            )
+
+        # Two-letter abbreviation -> 2-digit FIPS for registry lookup.
+        state_fips = normalize_state_identifier(state)
+        if not state_fips:
+            raise ValueError(
+                f"RDHProvider: could not resolve state {state!r} to a FIPS "
+                "code for plan-registry lookup."
+            )
+
+        active = (registry or get_default_plan_registry()).resolve_plan_at_date(
+            state_fips, district_type, when,
+        )
+        return str(active.effective_from.year)

--- a/tests/test_boundary_providers.py
+++ b/tests/test_boundary_providers.py
@@ -326,3 +326,133 @@ class TestRDHProvider:
         monkeypatch.setenv('RDH_USERNAME', 'should_not_use')
         provider = RDHProvider(username='', password=TEST_PASSWORD)
         assert provider._username == ''
+
+
+class TestRDHProviderPlanRegistryIntegration:
+    """RDHProvider.get_boundary(when=...) resolves through PlanRegistry (#361)."""
+
+    @staticmethod
+    def _alabama_registry():
+        """A registry with the Alabama 2022/2023 congressional fixture."""
+        import datetime as _dt
+        from siege_utilities.geo.plans import (
+            PlanAuthority, PlanDistrict, PlanRegistry, RedistrictingPlan,
+        )
+
+        AL = "01"
+
+        def make_districts(plan_name, authority, start, end):
+            return tuple(
+                PlanDistrict(
+                    state_fips=AL, district_type="cd", district_id=str(i),
+                    plan_name=plan_name, authority=authority,
+                    effective_from=start, effective_to=end,
+                )
+                for i in range(1, 8)
+            )
+
+        enacted = RedistrictingPlan(
+            plan_name="AL_2022_CD_ENACTED", state_fips=AL, district_type="cd",
+            authority=PlanAuthority.LEGISLATURE,
+            effective_from=_dt.date(2022, 1, 28),
+            effective_to=_dt.date(2023, 6, 7),
+            districts=make_districts(
+                "AL_2022_CD_ENACTED", PlanAuthority.LEGISLATURE,
+                _dt.date(2022, 1, 28), _dt.date(2023, 6, 7),
+            ),
+        )
+        interim = RedistrictingPlan(
+            plan_name="AL_2023_CD_INTERIM", state_fips=AL, district_type="cd",
+            authority=PlanAuthority.COURT,
+            effective_from=_dt.date(2023, 6, 8),
+            effective_to=None,
+            districts=make_districts(
+                "AL_2023_CD_INTERIM", PlanAuthority.COURT,
+                _dt.date(2023, 6, 8), None,
+            ),
+        )
+        registry = PlanRegistry()
+        registry.register_plans([enacted, interim])
+        return registry
+
+    @patch('siege_utilities.geo.providers.boundary_providers.RDHProvider._get_client')
+    def test_when_resolves_enacted_plan_year(self, mock_get_client):
+        """when= mid-2022 → enacted plan → year='2022' passed to RDH client."""
+        import datetime as _dt
+        sentinel = MagicMock(name='gdf')
+        mock_client = MagicMock()
+        mock_client.get_enacted_plans.return_value = [MagicMock()]
+        mock_client.load_shapefile.return_value = sentinel
+        mock_get_client.return_value = mock_client
+
+        provider = RDHProvider(username=TEST_USERNAME, password=TEST_PASSWORD)
+        result = provider.get_boundary(
+            'congress', state='AL',
+            when=_dt.date(2022, 5, 1),
+            plan_registry=self._alabama_registry(),
+        )
+
+        # The enacted plan's effective_from year is 2022.
+        mock_client.get_enacted_plans.assert_called_once_with(
+            'AL', chamber='congress', year='2022', format='shp',
+        )
+        assert result is sentinel
+
+    @patch('siege_utilities.geo.providers.boundary_providers.RDHProvider._get_client')
+    def test_when_resolves_interim_plan_year(self, mock_get_client):
+        """when= post-court-order → interim plan → year='2023'."""
+        import datetime as _dt
+        sentinel = MagicMock(name='gdf')
+        mock_client = MagicMock()
+        mock_client.get_enacted_plans.return_value = [MagicMock()]
+        mock_client.load_shapefile.return_value = sentinel
+        mock_get_client.return_value = mock_client
+
+        provider = RDHProvider(username=TEST_USERNAME, password=TEST_PASSWORD)
+        result = provider.get_boundary(
+            'congress', state='AL',
+            when=_dt.date(2023, 9, 15),
+            plan_registry=self._alabama_registry(),
+        )
+
+        mock_client.get_enacted_plans.assert_called_once_with(
+            'AL', chamber='congress', year='2023', format='shp',
+        )
+        assert result is sentinel
+
+    def test_when_unknown_date_propagates_resolution_error(self):
+        """A date with no plan must raise PlanResolutionError, not silently return."""
+        import datetime as _dt
+        from siege_utilities.geo.plans import PlanResolutionError
+
+        provider = RDHProvider(username=TEST_USERNAME, password=TEST_PASSWORD)
+        with pytest.raises(PlanResolutionError, match="No registered plan"):
+            provider.get_boundary(
+                'congress', state='AL',
+                when=_dt.date(2019, 1, 1),  # before any registered plan
+                plan_registry=self._alabama_registry(),
+            )
+
+    def test_when_with_precinct_level_rejected(self):
+        """RDH precinct files aren't plan-aware — when= must raise."""
+        import datetime as _dt
+
+        provider = RDHProvider(username=TEST_USERNAME, password=TEST_PASSWORD)
+        with pytest.raises(ValueError, match="not supported for level 'precinct'"):
+            provider.get_boundary(
+                'precinct', state='AL',
+                when=_dt.date(2023, 9, 15),
+                plan_registry=self._alabama_registry(),
+            )
+
+    def test_when_unknown_state_raises(self):
+        """A state name that doesn't normalize to a FIPS raises before registry."""
+        import datetime as _dt
+
+        provider = RDHProvider(username=TEST_USERNAME, password=TEST_PASSWORD)
+        with pytest.raises((ValueError, Exception)):
+            provider.get_boundary(
+                'congress', state='ZZ',  # not a real state
+                when=_dt.date(2023, 9, 15),
+                plan_registry=self._alabama_registry(),
+            )

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -1,0 +1,312 @@
+"""Tests for siege_utilities.geo.plans (issue #361)."""
+
+from __future__ import annotations
+
+import datetime as _dt
+
+import pytest
+
+from siege_utilities.geo.plans import (
+    PlanAuthority,
+    PlanDistrict,
+    PlanOverlapError,
+    PlanRegistry,
+    PlanResolutionError,
+    RedistrictingPlan,
+    get_default_plan_registry,
+)
+
+
+# ---------------------------------------------------------------------------
+# Real-world fixture: Alabama 2022/2023 congressional plans
+# (legislative enacted → court interim → court final/Allen v. Milligan)
+# ---------------------------------------------------------------------------
+
+AL = "01"
+
+AL_DISTRICTS = ("1", "2", "3", "4", "5", "6", "7")
+
+
+def _make_districts(plan_name: str, authority: PlanAuthority,
+                    start: _dt.date, end: _dt.date | None) -> tuple[PlanDistrict, ...]:
+    return tuple(
+        PlanDistrict(
+            state_fips=AL,
+            district_type="cd",
+            district_id=did,
+            plan_name=plan_name,
+            authority=authority,
+            effective_from=start,
+            effective_to=end,
+        )
+        for did in AL_DISTRICTS
+    )
+
+
+def _enacted_plan() -> RedistrictingPlan:
+    start = _dt.date(2022, 1, 28)
+    end = _dt.date(2023, 6, 7)  # day before court order
+    return RedistrictingPlan(
+        plan_name="AL_2022_CD_ENACTED",
+        state_fips=AL,
+        district_type="cd",
+        authority=PlanAuthority.LEGISLATURE,
+        effective_from=start,
+        effective_to=end,
+        districts=_make_districts("AL_2022_CD_ENACTED", PlanAuthority.LEGISLATURE, start, end),
+    )
+
+
+def _interim_plan() -> RedistrictingPlan:
+    start = _dt.date(2023, 6, 8)
+    end = _dt.date(2023, 10, 4)
+    return RedistrictingPlan(
+        plan_name="AL_2023_CD_INTERIM",
+        state_fips=AL,
+        district_type="cd",
+        authority=PlanAuthority.COURT,
+        effective_from=start,
+        effective_to=end,
+        districts=_make_districts("AL_2023_CD_INTERIM", PlanAuthority.COURT, start, end),
+        metadata={"docket": "Allen v. Milligan", "court": "S.D. Ala."},
+    )
+
+
+def _final_plan() -> RedistrictingPlan:
+    start = _dt.date(2023, 10, 5)
+    return RedistrictingPlan(
+        plan_name="AL_2023_CD_FINAL",
+        state_fips=AL,
+        district_type="cd",
+        authority=PlanAuthority.COURT,
+        effective_from=start,
+        effective_to=None,  # currently active
+        districts=_make_districts("AL_2023_CD_FINAL", PlanAuthority.COURT, start, None),
+        metadata={"docket": "Allen v. Milligan"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+class TestPlanDistrict:
+    def test_covers_date_within_span(self):
+        d = PlanDistrict(
+            state_fips=AL, district_type="cd", district_id="7",
+            plan_name="P", authority=PlanAuthority.LEGISLATURE,
+            effective_from=_dt.date(2022, 1, 28),
+            effective_to=_dt.date(2023, 6, 7),
+        )
+        assert d.covers_date(_dt.date(2022, 5, 1))
+        assert d.covers_date(_dt.date(2022, 1, 28))   # inclusive lower
+        assert d.covers_date(_dt.date(2023, 6, 7))    # inclusive upper
+
+    def test_covers_date_excludes_before_and_after(self):
+        d = PlanDistrict(
+            state_fips=AL, district_type="cd", district_id="7",
+            plan_name="P", authority=PlanAuthority.LEGISLATURE,
+            effective_from=_dt.date(2022, 1, 28),
+            effective_to=_dt.date(2023, 6, 7),
+        )
+        assert not d.covers_date(_dt.date(2022, 1, 27))
+        assert not d.covers_date(_dt.date(2023, 6, 8))
+
+    def test_open_ended_district_covers_far_future(self):
+        d = PlanDistrict(
+            state_fips=AL, district_type="cd", district_id="7",
+            plan_name="P", authority=PlanAuthority.COURT,
+            effective_from=_dt.date(2023, 10, 5),
+            effective_to=None,
+        )
+        assert d.covers_date(_dt.date(2030, 1, 1))
+
+    def test_inverted_dates_rejected(self):
+        with pytest.raises(ValueError, match="effective_to"):
+            PlanDistrict(
+                state_fips=AL, district_type="cd", district_id="7",
+                plan_name="P", authority=PlanAuthority.LEGISLATURE,
+                effective_from=_dt.date(2023, 1, 1),
+                effective_to=_dt.date(2022, 1, 1),
+            )
+
+    def test_frozen(self):
+        d = PlanDistrict(
+            state_fips=AL, district_type="cd", district_id="7",
+            plan_name="P", authority=PlanAuthority.LEGISLATURE,
+            effective_from=_dt.date(2022, 1, 28),
+        )
+        with pytest.raises(Exception):
+            d.district_id = "8"  # frozen=True
+
+
+class TestRedistrictingPlan:
+    def test_district_lookup_by_id(self):
+        p = _enacted_plan()
+        assert p.district("7").district_id == "7"
+        assert p.district("nonexistent") is None
+
+    def test_district_metadata_consistency(self):
+        with pytest.raises(ValueError, match="state_fips"):
+            RedistrictingPlan(
+                plan_name="P", state_fips=AL, district_type="cd",
+                authority=PlanAuthority.LEGISLATURE,
+                effective_from=_dt.date(2022, 1, 28),
+                districts=(PlanDistrict(
+                    state_fips="48",  # mismatch
+                    district_type="cd", district_id="7",
+                    plan_name="P", authority=PlanAuthority.LEGISLATURE,
+                    effective_from=_dt.date(2022, 1, 28),
+                ),),
+            )
+
+    def test_district_plan_name_consistency(self):
+        with pytest.raises(ValueError, match="plan_name"):
+            RedistrictingPlan(
+                plan_name="P_OUTER", state_fips=AL, district_type="cd",
+                authority=PlanAuthority.LEGISLATURE,
+                effective_from=_dt.date(2022, 1, 28),
+                districts=(PlanDistrict(
+                    state_fips=AL, district_type="cd", district_id="7",
+                    plan_name="P_INNER",  # mismatch
+                    authority=PlanAuthority.LEGISLATURE,
+                    effective_from=_dt.date(2022, 1, 28),
+                ),),
+            )
+
+    def test_metadata_passes_through(self):
+        p = _interim_plan()
+        assert p.metadata["docket"] == "Allen v. Milligan"
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+class TestPlanRegistry:
+    def _registered(self) -> PlanRegistry:
+        r = PlanRegistry()
+        r.register_plans([_enacted_plan(), _interim_plan(), _final_plan()])
+        return r
+
+    def test_resolves_enacted_plan(self):
+        r = self._registered()
+        plan = r.resolve_plan_at_date(AL, "cd", _dt.date(2022, 5, 1))
+        assert plan.plan_name == "AL_2022_CD_ENACTED"
+        assert plan.authority == PlanAuthority.LEGISLATURE
+
+    def test_resolves_interim_plan(self):
+        r = self._registered()
+        plan = r.resolve_plan_at_date(AL, "cd", _dt.date(2023, 8, 15))
+        assert plan.plan_name == "AL_2023_CD_INTERIM"
+        assert plan.authority == PlanAuthority.COURT
+
+    def test_resolves_final_plan_open_ended(self):
+        r = self._registered()
+        plan = r.resolve_plan_at_date(AL, "cd", _dt.date(2026, 5, 6))
+        assert plan.plan_name == "AL_2023_CD_FINAL"
+        assert plan.effective_to is None
+
+    def test_resolution_at_boundary_dates(self):
+        """The day a new plan takes effect resolves to the new plan."""
+        r = self._registered()
+        # June 7, 2023 — last day of enacted
+        assert r.resolve_plan_at_date(AL, "cd", _dt.date(2023, 6, 7)).plan_name \
+            == "AL_2022_CD_ENACTED"
+        # June 8, 2023 — first day of interim
+        assert r.resolve_plan_at_date(AL, "cd", _dt.date(2023, 6, 8)).plan_name \
+            == "AL_2023_CD_INTERIM"
+
+    def test_resolution_before_any_plan_raises(self):
+        r = self._registered()
+        with pytest.raises(PlanResolutionError, match="No registered plan"):
+            r.resolve_plan_at_date(AL, "cd", _dt.date(2020, 1, 1))
+
+    def test_unknown_state_raises(self):
+        r = self._registered()
+        with pytest.raises(PlanResolutionError):
+            r.resolve_plan_at_date("99", "cd", _dt.date(2022, 5, 1))
+
+    def test_resolve_district_at_date(self):
+        r = self._registered()
+        d = r.resolve_district_at_date(AL, "cd", "7", _dt.date(2023, 8, 15))
+        assert d.plan_name == "AL_2023_CD_INTERIM"
+        assert d.district_id == "7"
+
+    def test_resolve_district_unknown_id_raises(self):
+        r = self._registered()
+        with pytest.raises(PlanResolutionError, match="contains no district"):
+            r.resolve_district_at_date(AL, "cd", "99", _dt.date(2023, 8, 15))
+
+    def test_overlap_detected_in_strict_mode(self):
+        r = PlanRegistry()
+        # Two court orders that technically overlap by one day (typical of
+        # interim/final pair where the order isn't a clean cutover).
+        a = _interim_plan()
+        b = RedistrictingPlan(
+            plan_name="AL_2023_CD_FINAL_OVERLAP",
+            state_fips=AL, district_type="cd",
+            authority=PlanAuthority.COURT,
+            effective_from=_dt.date(2023, 10, 4),  # overlaps with interim's last day
+            effective_to=None,
+            districts=_make_districts(
+                "AL_2023_CD_FINAL_OVERLAP", PlanAuthority.COURT,
+                _dt.date(2023, 10, 4), None,
+            ),
+        )
+        r.register_plans([a, b])
+        with pytest.raises(PlanOverlapError, match="2 plans cover"):
+            r.resolve_plan_at_date(AL, "cd", _dt.date(2023, 10, 4))
+
+    def test_overlap_non_strict_returns_most_recent(self):
+        r = PlanRegistry()
+        a = _interim_plan()
+        b = RedistrictingPlan(
+            plan_name="AL_2023_CD_FINAL_OVERLAP",
+            state_fips=AL, district_type="cd",
+            authority=PlanAuthority.COURT,
+            effective_from=_dt.date(2023, 10, 4),
+            effective_to=None,
+            districts=_make_districts(
+                "AL_2023_CD_FINAL_OVERLAP", PlanAuthority.COURT,
+                _dt.date(2023, 10, 4), None,
+            ),
+        )
+        r.register_plans([a, b])
+        plan = r.resolve_plan_at_date(
+            AL, "cd", _dt.date(2023, 10, 4), strict=False,
+        )
+        assert plan.plan_name == "AL_2023_CD_FINAL_OVERLAP"
+
+    def test_plans_for_state_returns_sorted(self):
+        r = self._registered()
+        plans = r.plans_for_state(AL, "cd")
+        assert [p.plan_name for p in plans] == [
+            "AL_2022_CD_ENACTED",
+            "AL_2023_CD_INTERIM",
+            "AL_2023_CD_FINAL",
+        ]
+
+    def test_plans_for_state_empty_returns_empty_list(self):
+        r = PlanRegistry()
+        assert r.plans_for_state(AL, "cd") == []
+
+    def test_clear(self):
+        r = self._registered()
+        r.clear()
+        assert r.plans_for_state(AL, "cd") == []
+
+
+class TestDefaultRegistry:
+    def test_default_is_singleton(self):
+        a = get_default_plan_registry()
+        b = get_default_plan_registry()
+        assert a is b
+
+    def test_default_is_isolated_per_test(self):
+        # Each test should NOT see leftover state from other tests.
+        # We clear at the start to make this explicit; the singleton is
+        # process-global so production callers carry their state.
+        r = get_default_plan_registry()
+        r.clear()
+        assert r.plans_for_state(AL, "cd") == []


### PR DESCRIPTION
Closes #361.

Bundled implementation. The user accepted a longer timeline; rather than chain three PRs, the work lands as one coherent change. PR-C (consumer migration of `assign_boundaries`) will follow as a separate PR since it touches downstream-facing API.

## Why

The current `CensusVintageConfig` keys boundaries by decade (2010 → 2010-2019), which breaks for any state with a mid-cycle court-ordered map:

- **Alabama**: legislative-enacted (2022-01-28) → court interim under *Allen v. Milligan* (2023-06-08) → court final (2023-10-05) — three plans in 20 months.
- **Louisiana**, **Georgia**, **New York**: similar mid-cycle redistricting.

A donation made in AL-7 in March 2023 is in a *different geometry* than the same address in September 2023.

## What this PR adds

### Foundation (PR-A): `siege_utilities.geo.plans`

- `models.py`:
  - `PlanAuthority` enum (legislature / court / commission / default).
  - `PlanDistrict` frozen dataclass — single district under a single plan, valid for a date range.
  - `RedistrictingPlan` frozen dataclass — full plan + plan-level metadata (court docket, citation).
  - `covers_date(when)` inclusive on both ends.
  - `__post_init__` validates internal consistency.
- `registry.py`:
  - `PlanRegistry` — in-memory, thread-safe, sorted by `effective_from`.
  - `resolve_plan_at_date(state, district_type, date, strict=True)` — raises `PlanResolutionError` on miss, `PlanOverlapError` on collision (strict mode); `strict=False` returns most-recently-enacted with a warning.
  - `resolve_district_at_date` convenience wrapper.
  - `get_default_plan_registry()` process-global singleton.

### Provider integration (PR-B): `RDHProvider.get_boundary(when=...)`

- New `when` kwarg accepts a `datetime.date`. When provided:
  1. Maps the RDH `level` (`congress`/`state_senate`/`state_house`) to the registry's `district_type` (`cd`/`sldu`/`sldl`). Rejects `precinct` — RDH precinct files don't carry plan metadata.
  2. Normalizes the state abbrev to a FIPS code via existing `normalize_state_identifier`.
  3. Looks up the active plan; `PlanResolutionError` bubbles up.
  4. Uses the plan's `effective_from.year` as the `year=` filter for the underlying RDH call.
- New `plan_registry` kwarg lets tests / multi-tenant code pass an explicit registry.
- Year filter still works exactly as before when `when` isn't passed — fully backward-compatible.

## Out of scope (deferred to PR-C, separate ticket)

- `assign_boundaries` / `AddressBoundaryPeriod` migration. Provide a `PlanResolver` shim that wraps both legacy `CensusVintageConfig` and the new `PlanRegistry` so existing callers work unchanged.
- File-backed plan loaders (RDH manifest parser, NCSL plan registry ingestion). The registry is intentionally in-memory; loading is a consumer concern, and downstream projects like socialwarehouse / enterprise enrichment should own their loaders.
- `CensusTIGERProvider` `when=` integration. TIGER doesn't expose plan metadata directly; consumer wraps RDH for plans + TIGER for static boundaries.

## Test plan

- [x] Local: `pytest tests/test_plans.py tests/test_boundary_providers.py` → **66 passed**, including:
  - 24 plan/registry tests using full Alabama 2022/2023 fixture (enacted / Allen-v-Milligan interim / final).
  - 5 new `RDHProvider.when=` integration tests.
  - All 14 prior `RDHProvider` tests still pass unchanged.
- [x] Local: lint clean (no F401/F841/F541).
- [ ] Full CI matrix on push.