### PR TITLE
feat(analytics): VistaSocialConnector — bearer-auth REST client (#306)

### DIFF
--- a/siege_utilities/analytics/__init__.py
+++ b/siege_utilities/analytics/__init__.py
@@ -64,6 +64,11 @@ _register([
     'insert_paragraph', 'insert_table', 'replace_text',
 ], '.google_docs')
 
+_register([
+    'VistaSocialConnector', 'VistaSocialResponse',
+    'VistaSocialError', 'VistaSocialAuthError', 'VistaSocialRateLimitError',
+], '.vista_social')
+
 __all__ = list(_LAZY_IMPORTS.keys())
 
 

--- a/siege_utilities/analytics/vista_social.py
+++ b/siege_utilities/analytics/vista_social.py
@@ -240,10 +240,21 @@ class VistaSocialConnector:
                     f"{resp.text[:200]}"
                 )
 
-            try:
-                data = resp.json() if resp.content else {}
-            except ValueError:
-                data = {}
+            if not resp.content:
+                # 204 No Content / empty body — legitimately empty.
+                data: Mapping[str, Any] = {}
+            else:
+                try:
+                    data = resp.json()
+                except ValueError as exc:
+                    # 2xx with non-JSON body. Don't silently treat as
+                    # empty (that violates the no-silent-swallow rule
+                    # set by the Phase-3 sweep) — surface it.
+                    raise VistaSocialError(
+                        f"Vista Social {method} {url} returned "
+                        f"{resp.status_code} with non-JSON body "
+                        f"(first 200 chars: {resp.text[:200]!r})."
+                    ) from exc
             return VistaSocialResponse(
                 status_code=resp.status_code,
                 data=data,

--- a/siege_utilities/analytics/vista_social.py
+++ b/siege_utilities/analytics/vista_social.py
@@ -1,0 +1,349 @@
+"""Vista Social analytics connector (issue #306).
+
+Vista Social (https://vistasocial.com) is a social-media management
+platform that aggregates engagement, posts, and audience metrics across
+Facebook, Instagram, LinkedIn, X, TikTok, YouTube, and other channels.
+This module provides a thin connector that auths against the Vista
+Social REST API and exposes a few common reporting calls in the same
+shape as the other connectors in this package
+(``FacebookBusinessConnector``, ``DataDotWorldConnector``).
+
+Why "thin"
+----------
+Vista Social's REST API documentation requires an authenticated
+account; the public website does not enumerate endpoint URLs. This
+connector ships with:
+
+  * The base ``_request`` helper that handles auth headers, retries,
+    and error normalization — fully tested.
+  * Concrete ``account``, ``profiles``, ``posts``, ``analytics``
+    methods that wrap likely endpoint paths (``/v1/accounts``,
+    ``/v1/profiles``, ``/v1/posts``, ``/v1/analytics``). These are
+    informed by the publicly visible URL structure on the Vista
+    Social web app and are documented as "best-known" rather than
+    spec-confirmed.
+
+When you obtain real Vista Social API documentation (request access at
+api@vistasocial.com), verify the endpoints against the docs and adjust
+this module. The ``_request`` plumbing is correct regardless of which
+endpoints exist.
+
+The intended consumer is :mod:`siege_utilities.reporting`, which will
+embed the returned analytics into a combined GA4 + social-media PDF
+report (the second half of #306). That work lives in a follow-up PR.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Mapping, Optional
+
+try:
+    import requests
+    REQUESTS_AVAILABLE = True
+except ImportError:  # pragma: no cover - requests is a core dep, but be defensive
+    REQUESTS_AVAILABLE = False
+
+log = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "https://api.vistasocial.com"
+DEFAULT_TIMEOUT_SECONDS = 30
+DEFAULT_RETRY_ATTEMPTS = 3
+DEFAULT_RETRY_BACKOFF = 1.5  # exponential factor, seconds
+
+
+__all__ = [
+    "VistaSocialError",
+    "VistaSocialAuthError",
+    "VistaSocialRateLimitError",
+    "VistaSocialResponse",
+    "VistaSocialConnector",
+]
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+class VistaSocialError(RuntimeError):
+    """Base class for all Vista Social connector failures."""
+
+
+class VistaSocialAuthError(VistaSocialError):
+    """Authentication failed (401/403). Token is missing, wrong, or expired."""
+
+
+class VistaSocialRateLimitError(VistaSocialError):
+    """API rate limit hit (429). Caller can back off and retry later."""
+
+
+# ---------------------------------------------------------------------------
+# Response model
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class VistaSocialResponse:
+    """Structured response from a Vista Social API call.
+
+    The connector returns this rather than the raw ``requests.Response``
+    so consumers don't need to know about the underlying HTTP library.
+
+    Attributes:
+        status_code: HTTP status code (200 / 201 etc.).
+        data: Parsed JSON body. Empty dict if the response had no body
+            (e.g. 204 No Content) or wasn't JSON-decodable.
+        headers: Response headers — useful for inspecting rate-limit
+            counters (``X-RateLimit-Remaining``, ``Retry-After``).
+        url: The fully-qualified URL that was called, for logging.
+    """
+
+    status_code: int
+    data: Mapping[str, Any]
+    headers: Mapping[str, str] = field(default_factory=dict)
+    url: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Connector
+# ---------------------------------------------------------------------------
+
+class VistaSocialConnector:
+    """Bearer-token authenticated client for the Vista Social REST API.
+
+    Usage::
+
+        from siege_utilities.analytics.vista_social import VistaSocialConnector
+
+        client = VistaSocialConnector(api_token=os.environ["VISTA_SOCIAL_TOKEN"])
+        accounts = client.list_accounts()
+        analytics = client.get_account_analytics(
+            account_id=accounts[0]["id"],
+            start_date="2026-01-01",
+            end_date="2026-01-31",
+        )
+
+    All methods raise:
+
+      * :class:`VistaSocialAuthError` on 401/403,
+      * :class:`VistaSocialRateLimitError` on 429,
+      * :class:`VistaSocialError` on other non-2xx responses or
+        network failures.
+
+    The connector follows the project's failure-mode discipline (see
+    ``docs/FAILURE_MODES.md`` and the Phase-3 silent-swallow sweep in
+    PR #433): no method silently returns an empty dict on failure.
+    """
+
+    def __init__(
+        self,
+        api_token: str,
+        *,
+        base_url: str = DEFAULT_BASE_URL,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+        retry_attempts: int = DEFAULT_RETRY_ATTEMPTS,
+        retry_backoff: float = DEFAULT_RETRY_BACKOFF,
+    ) -> None:
+        if not REQUESTS_AVAILABLE:  # pragma: no cover
+            raise ImportError(
+                "VistaSocialConnector requires `requests`. Install via "
+                "`pip install siege-utilities` (it's a core dependency)."
+            )
+        if not api_token:
+            raise ValueError(
+                "VistaSocialConnector requires an api_token. Pass one "
+                "explicitly or read from VISTA_SOCIAL_TOKEN before "
+                "constructing the client."
+            )
+        self._token = api_token
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+        self._retry_attempts = max(1, retry_attempts)
+        self._retry_backoff = retry_backoff
+        self._session = requests.Session()
+        self._session.headers.update({
+            "Authorization": f"Bearer {api_token}",
+            "Accept": "application/json",
+            "User-Agent": "siege_utilities/VistaSocialConnector",
+        })
+        log.info("VistaSocialConnector initialised against %s", self._base_url)
+
+    # ------------------------------------------------------------------
+    # Low-level: HTTP plumbing (well-tested; endpoints sit on top)
+    # ------------------------------------------------------------------
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Mapping[str, Any]] = None,
+        json_body: Optional[Mapping[str, Any]] = None,
+    ) -> VistaSocialResponse:
+        """Send an authenticated request to *path* (relative to base URL).
+
+        Retries with exponential backoff on 5xx and on transport errors
+        (``requests.exceptions.RequestException``). 401/403 is fatal —
+        retry won't fix bad credentials. 429 is surfaced as
+        :class:`VistaSocialRateLimitError` so callers can back off
+        intelligently rather than have us double-retry into a longer
+        ban.
+        """
+        url = f"{self._base_url}/{path.lstrip('/')}"
+        last_exc: Optional[BaseException] = None
+
+        for attempt in range(1, self._retry_attempts + 1):
+            try:
+                resp = self._session.request(
+                    method, url,
+                    params=dict(params) if params else None,
+                    json=dict(json_body) if json_body is not None else None,
+                    timeout=self._timeout,
+                )
+            except requests.exceptions.RequestException as exc:
+                last_exc = exc
+                log.warning(
+                    "VistaSocial %s %s attempt %d/%d failed: %s",
+                    method, url, attempt, self._retry_attempts, exc,
+                )
+                if attempt < self._retry_attempts:
+                    time.sleep(self._retry_backoff ** attempt)
+                continue
+
+            if resp.status_code in (401, 403):
+                raise VistaSocialAuthError(
+                    f"Vista Social {method} {url} returned {resp.status_code}. "
+                    "Check the api_token (expired? revoked? wrong scope?)."
+                )
+            if resp.status_code == 429:
+                retry_after = resp.headers.get("Retry-After", "<unset>")
+                raise VistaSocialRateLimitError(
+                    f"Vista Social rate limit hit on {method} {url}. "
+                    f"Retry-After: {retry_after}."
+                )
+            if 500 <= resp.status_code < 600:
+                last_exc = VistaSocialError(
+                    f"Vista Social {method} {url} returned {resp.status_code}."
+                )
+                log.warning(
+                    "VistaSocial %s %s 5xx %d attempt %d/%d",
+                    method, url, resp.status_code, attempt, self._retry_attempts,
+                )
+                if attempt < self._retry_attempts:
+                    time.sleep(self._retry_backoff ** attempt)
+                continue
+            if not 200 <= resp.status_code < 300:
+                # 4xx other than 401/403/429 — caller error, not retried.
+                raise VistaSocialError(
+                    f"Vista Social {method} {url} returned {resp.status_code}: "
+                    f"{resp.text[:200]}"
+                )
+
+            try:
+                data = resp.json() if resp.content else {}
+            except ValueError:
+                data = {}
+            return VistaSocialResponse(
+                status_code=resp.status_code,
+                data=data,
+                headers=dict(resp.headers),
+                url=url,
+            )
+
+        # Exhausted retries on transport / 5xx.
+        raise VistaSocialError(
+            f"Vista Social {method} {url} failed after {self._retry_attempts} "
+            f"attempts. Last error: {last_exc}"
+        ) from last_exc
+
+    # ------------------------------------------------------------------
+    # High-level: best-known endpoint paths (verify against real docs)
+    # ------------------------------------------------------------------
+
+    def list_accounts(self) -> List[Mapping[str, Any]]:
+        """Return the list of accounts this token can access.
+
+        Wraps ``GET /v1/accounts``. Returns the decoded ``data`` list
+        from the response, or an empty list if the API returned nothing.
+        Raises on auth / rate-limit / network failures (no silent
+        empty-on-error).
+        """
+        resp = self._request("GET", "/v1/accounts")
+        items = resp.data.get("data") if isinstance(resp.data, Mapping) else None
+        return list(items) if items else []
+
+    def list_profiles(self, account_id: str) -> List[Mapping[str, Any]]:
+        """Return social profiles connected to *account_id*.
+
+        Wraps ``GET /v1/accounts/{account_id}/profiles``.
+        """
+        if not account_id:
+            raise ValueError("list_profiles requires a non-empty account_id")
+        resp = self._request("GET", f"/v1/accounts/{account_id}/profiles")
+        items = resp.data.get("data") if isinstance(resp.data, Mapping) else None
+        return list(items) if items else []
+
+    def get_account_analytics(
+        self,
+        account_id: str,
+        *,
+        start_date: str,
+        end_date: str,
+        metrics: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """Fetch aggregate analytics for *account_id* over a date range.
+
+        Args:
+            account_id: Vista Social account id (string, opaque).
+            start_date: ISO-8601 date (``YYYY-MM-DD``), inclusive.
+            end_date: ISO-8601 date, inclusive.
+            metrics: Optional list of metric names (e.g. ``["impressions",
+                "engagements", "reach", "follower_count"]``). If omitted,
+                Vista Social returns its default metric set.
+
+        Wraps ``GET /v1/accounts/{account_id}/analytics``. Returns the
+        decoded JSON body verbatim — Vista Social returns a structured
+        document with metric breakdowns; consumers can extract what
+        they need.
+        """
+        if not account_id:
+            raise ValueError("get_account_analytics requires a non-empty account_id")
+        params: Dict[str, Any] = {
+            "start_date": start_date,
+            "end_date": end_date,
+        }
+        if metrics:
+            params["metrics"] = ",".join(metrics)
+        resp = self._request(
+            "GET", f"/v1/accounts/{account_id}/analytics", params=params,
+        )
+        return dict(resp.data) if isinstance(resp.data, Mapping) else {}
+
+    def list_posts(
+        self,
+        account_id: str,
+        *,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        limit: int = 100,
+    ) -> List[Mapping[str, Any]]:
+        """Return posts for *account_id* with optional date filtering.
+
+        Wraps ``GET /v1/accounts/{account_id}/posts``. Pagination is
+        intentionally simple here — consumers that need full enumeration
+        should call repeatedly with adjusted date ranges or extend this
+        connector with cursor handling once the real API spec is known.
+        """
+        if not account_id:
+            raise ValueError("list_posts requires a non-empty account_id")
+        params: Dict[str, Any] = {"limit": limit}
+        if start_date:
+            params["start_date"] = start_date
+        if end_date:
+            params["end_date"] = end_date
+        resp = self._request(
+            "GET", f"/v1/accounts/{account_id}/posts", params=params,
+        )
+        items = resp.data.get("data") if isinstance(resp.data, Mapping) else None
+        return list(items) if items else []

--- a/tests/test_vista_social.py
+++ b/tests/test_vista_social.py
@@ -227,3 +227,32 @@ class TestHighLevelMethods:
         c = VistaSocialConnector(api_token=TEST_TOKEN)
         with pytest.raises(ValueError, match="account_id"):
             c.list_posts("")
+
+
+class TestNonJsonBody:
+    """A 2xx with non-JSON body must raise rather than silently empty
+    (Phase-3 silent-swallow discipline)."""
+
+    def test_non_json_body_raises(self):
+        c = VistaSocialConnector(api_token=TEST_TOKEN)
+        bad = MagicMock()
+        bad.status_code = 200
+        bad.content = b"<html>oops</html>"
+        bad.json.side_effect = ValueError("Expecting value")
+        bad.headers = {}
+        bad.text = "<html>oops</html>"
+        with patch.object(c._session, "request", return_value=bad):
+            with pytest.raises(VistaSocialError, match="non-JSON body"):
+                c._request("GET", "/v1/accounts")
+
+    def test_empty_body_ok(self):
+        """204 No Content — empty body returns empty data, not an error."""
+        c = VistaSocialConnector(api_token=TEST_TOKEN)
+        empty = MagicMock()
+        empty.status_code = 204
+        empty.content = b""
+        empty.headers = {}
+        with patch.object(c._session, "request", return_value=empty):
+            resp = c._request("GET", "/v1/accounts")
+        assert resp.status_code == 204
+        assert resp.data == {}

--- a/tests/test_vista_social.py
+++ b/tests/test_vista_social.py
@@ -1,0 +1,229 @@
+"""Tests for VistaSocialConnector (issue #306).
+
+The endpoint *paths* this connector wraps are best-known and
+unverified against Vista Social's private API docs. The tests below
+verify the auth header, retry logic, error handling, and parameter
+construction — i.e. everything we *can* validate without hitting the
+real API.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from siege_utilities.analytics.vista_social import (
+    DEFAULT_BASE_URL,
+    VistaSocialAuthError,
+    VistaSocialConnector,
+    VistaSocialError,
+    VistaSocialRateLimitError,
+    VistaSocialResponse,
+)
+
+
+TEST_TOKEN = "vs_test_token_abcd1234"  # noqa: S105 — test fixture
+
+
+# ---------------------------------------------------------------------------
+# Construction + auth header
+# ---------------------------------------------------------------------------
+
+class TestConstruction:
+    def test_token_required(self):
+        with pytest.raises(ValueError, match="api_token"):
+            VistaSocialConnector(api_token="")
+
+    def test_auth_header_set(self):
+        c = VistaSocialConnector(api_token=TEST_TOKEN)
+        assert c._session.headers["Authorization"] == f"Bearer {TEST_TOKEN}"
+        assert c._session.headers["Accept"] == "application/json"
+
+    def test_default_base_url(self):
+        c = VistaSocialConnector(api_token=TEST_TOKEN)
+        assert c._base_url == DEFAULT_BASE_URL
+
+    def test_custom_base_url_strips_trailing_slash(self):
+        c = VistaSocialConnector(api_token=TEST_TOKEN, base_url="https://custom/")
+        assert c._base_url == "https://custom"
+
+    def test_retry_attempts_floor_at_one(self):
+        c = VistaSocialConnector(api_token=TEST_TOKEN, retry_attempts=0)
+        assert c._retry_attempts == 1
+
+
+# ---------------------------------------------------------------------------
+# _request — HTTP plumbing
+# ---------------------------------------------------------------------------
+
+def _ok_response(json_body=None, status=200, headers=None):
+    r = MagicMock()
+    r.status_code = status
+    r.content = b'{"data": []}' if json_body is None else b'{"x": 1}'
+    r.json.return_value = json_body if json_body is not None else {"data": []}
+    r.headers = headers or {}
+    r.text = ""
+    return r
+
+
+class TestRequest:
+    def test_get_success_returns_response(self):
+        c = VistaSocialConnector(api_token=TEST_TOKEN)
+        with patch.object(c._session, "request",
+                          return_value=_ok_response({"data": [{"id": "1"}]})) as mock_req:
+            resp = c._request("GET", "/v1/accounts")
+        assert isinstance(resp, VistaSocialResponse)
+        assert resp.status_code == 200
+        assert resp.data == {"data": [{"id": "1"}]}
+        mock_req.assert_called_once()
+        # URL is fully qualified, leading slash on path is fine.
+        kwargs = mock_req.call_args.kwargs
+        assert kwargs["timeout"] == c._timeout
+        # `requests.Session.request` got method + url positionally; check both.
+        args = mock_req.call_args.args
+        assert args[0] == "GET"
+        assert args[1] == f"{DEFAULT_BASE_URL}/v1/accounts"
+
+    def test_401_raises_auth_error(self):
+        c = VistaSocialConnector(api_token=TEST_TOKEN, retry_attempts=2)
+        with patch.object(c._session, "request",
+                          return_value=_ok_response(status=401)) as mock_req:
+            with pytest.raises(VistaSocialAuthError, match="api_token"):
+                c._request("GET", "/v1/accounts")
+        # Auth failure must NOT be retried.
+        mock_req.assert_called_once()
+
+    def test_429_raises_rate_limit_error(self):
+        c = VistaSocialConnector(api_token=TEST_TOKEN, retry_attempts=2)
+        resp = _ok_response(status=429, headers={"Retry-After": "30"})
+        with patch.object(c._session, "request", return_value=resp) as mock_req:
+            with pytest.raises(VistaSocialRateLimitError, match="Retry-After: 30"):
+                c._request("GET", "/v1/accounts")
+        # 429 is intentionally NOT retried — caller backs off.
+        mock_req.assert_called_once()
+
+    def test_500_retries_then_raises(self):
+        c = VistaSocialConnector(
+            api_token=TEST_TOKEN,
+            retry_attempts=2,
+            retry_backoff=1.0,
+        )
+        with patch.object(c._session, "request",
+                          return_value=_ok_response(status=500)) as mock_req, \
+                patch("siege_utilities.analytics.vista_social.time.sleep"):
+            with pytest.raises(VistaSocialError, match="500"):
+                c._request("GET", "/v1/accounts")
+        assert mock_req.call_count == 2
+
+    def test_400_does_not_retry(self):
+        c = VistaSocialConnector(api_token=TEST_TOKEN, retry_attempts=3)
+        bad_resp = _ok_response(status=400)
+        bad_resp.text = "missing required field"
+        with patch.object(c._session, "request", return_value=bad_resp) as mock_req:
+            with pytest.raises(VistaSocialError, match="400"):
+                c._request("GET", "/v1/accounts")
+        mock_req.assert_called_once()
+
+    def test_transport_error_retries(self):
+        import requests as _r
+        c = VistaSocialConnector(
+            api_token=TEST_TOKEN, retry_attempts=3, retry_backoff=1.0,
+        )
+        with patch.object(c._session, "request",
+                          side_effect=_r.exceptions.ConnectionError("nope")) as mock_req, \
+                patch("siege_utilities.analytics.vista_social.time.sleep"):
+            with pytest.raises(VistaSocialError, match="3 attempts"):
+                c._request("GET", "/v1/accounts")
+        assert mock_req.call_count == 3
+
+    def test_recovers_after_transient_500(self):
+        c = VistaSocialConnector(
+            api_token=TEST_TOKEN, retry_attempts=3, retry_backoff=1.0,
+        )
+        bad = _ok_response(status=500)
+        good = _ok_response({"data": [{"id": "ok"}]})
+        with patch.object(c._session, "request",
+                          side_effect=[bad, good]) as mock_req, \
+                patch("siege_utilities.analytics.vista_social.time.sleep"):
+            resp = c._request("GET", "/v1/accounts")
+        assert resp.data == {"data": [{"id": "ok"}]}
+        assert mock_req.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# High-level methods — verify URL/params, not endpoint correctness
+# ---------------------------------------------------------------------------
+
+class TestHighLevelMethods:
+    def test_list_accounts_calls_correct_path(self):
+        c = VistaSocialConnector(api_token=TEST_TOKEN)
+        with patch.object(c._session, "request",
+                          return_value=_ok_response({"data": [{"id": "a1"}, {"id": "a2"}]})) as mock_req:
+            accounts = c.list_accounts()
+        assert accounts == [{"id": "a1"}, {"id": "a2"}]
+        args = mock_req.call_args.args
+        assert args[0] == "GET"
+        assert args[1].endswith("/v1/accounts")
+
+    def test_list_accounts_empty_returns_empty_list(self):
+        c = VistaSocialConnector(api_token=TEST_TOKEN)
+        with patch.object(c._session, "request",
+                          return_value=_ok_response({"data": []})):
+            assert c.list_accounts() == []
+
+    def test_list_profiles_requires_account_id(self):
+        c = VistaSocialConnector(api_token=TEST_TOKEN)
+        with pytest.raises(ValueError, match="account_id"):
+            c.list_profiles("")
+
+    def test_list_profiles_uses_path_segment(self):
+        c = VistaSocialConnector(api_token=TEST_TOKEN)
+        with patch.object(c._session, "request",
+                          return_value=_ok_response({"data": []})) as mock_req:
+            c.list_profiles("acc_123")
+        args = mock_req.call_args.args
+        assert args[1].endswith("/v1/accounts/acc_123/profiles")
+
+    def test_get_account_analytics_passes_params(self):
+        c = VistaSocialConnector(api_token=TEST_TOKEN)
+        with patch.object(c._session, "request",
+                          return_value=_ok_response({"impressions": 42})) as mock_req:
+            data = c.get_account_analytics(
+                account_id="acc_123",
+                start_date="2026-01-01",
+                end_date="2026-01-31",
+                metrics=["impressions", "engagements"],
+            )
+        assert data == {"impressions": 42}
+        kwargs = mock_req.call_args.kwargs
+        assert kwargs["params"] == {
+            "start_date": "2026-01-01",
+            "end_date": "2026-01-31",
+            "metrics": "impressions,engagements",
+        }
+
+    def test_get_account_analytics_omits_metrics_when_none(self):
+        c = VistaSocialConnector(api_token=TEST_TOKEN)
+        with patch.object(c._session, "request",
+                          return_value=_ok_response({})) as mock_req:
+            c.get_account_analytics(
+                account_id="acc_123",
+                start_date="2026-01-01",
+                end_date="2026-01-31",
+            )
+        params = mock_req.call_args.kwargs["params"]
+        assert "metrics" not in params
+
+    def test_list_posts_optional_dates(self):
+        c = VistaSocialConnector(api_token=TEST_TOKEN)
+        with patch.object(c._session, "request",
+                          return_value=_ok_response({"data": []})) as mock_req:
+            c.list_posts("acc_123", start_date="2026-01-01", limit=50)
+        params = mock_req.call_args.kwargs["params"]
+        assert params == {"limit": 50, "start_date": "2026-01-01"}
+
+    def test_list_posts_requires_account_id(self):
+        c = VistaSocialConnector(api_token=TEST_TOKEN)
+        with pytest.raises(ValueError, match="account_id"):
+            c.list_posts("")


### PR DESCRIPTION
Closes #306.

## Summary

Adds a Vista Social analytics connector following the shape of `FacebookBusinessConnector` and `DataDotWorldConnector`. The connector ships with the parts that are testable without an active Vista Social API token; concrete endpoint paths are best-known from the public web-app URL structure and documented as such.

## What's solid

- **Auth + Session**: Bearer-token `requests.Session` with `Authorization` header set at construct time.
- **`_request` plumbing**: full error / retry handling with strict failure-mode discipline (no silent swallows).
  - 401/403 → `VistaSocialAuthError` (not retried — bad creds won't be fixed).
  - 429 → `VistaSocialRateLimitError` with the `Retry-After` header surfaced (not retried — avoid extending the ban).
  - 5xx + transport errors → exponential backoff retry, raise after exhaustion.
  - Other 4xx → `VistaSocialError`, no retry.
- **`VistaSocialResponse`** structured dataclass wraps the raw response.
- **20 tests** cover construction (token-required, header set, retry floor), full `_request` plumbing (success, 401/403, 429, 500-retry-then-raise, 400-no-retry, transport-error-retry, transient-500-recovery), and each high-level method's URL/parameter construction.

## What's best-known (verify against real docs)

The four high-level methods wrap likely endpoint paths inferred from Vista Social's public web-app URL structure:

- `list_accounts()` → `GET /v1/accounts`
- `list_profiles(account_id)` → `GET /v1/accounts/{id}/profiles`
- `get_account_analytics(account_id, start_date, end_date, metrics=...)` → `GET /v1/accounts/{id}/analytics`
- `list_posts(account_id, start_date=, end_date=, limit=)` → `GET /v1/accounts/{id}/posts`

Once a real Vista Social API token + private docs are available (request from api@vistasocial.com), validate the paths and adjust if needed. The `_request` plumbing underneath is correct regardless of which endpoints exist.

## Why this approach

Vista Social's API documentation requires an authenticated account; the public website doesn't enumerate endpoint URLs. Rather than fabricate confidence in unverified paths, the docstrings flag what's unverified and the test suite verifies what we can — auth, retry, error handling, parameter construction.

## Out of scope

- The PDF-report integration described in the issue's Scope section ("New report sections in the PDF generator for social media metrics. Combined GA4 + social media dashboard view"). The connector is the data source; the report layout is a separate piece of work that lands in a follow-up PR once we have real Vista Social responses to validate the chart shapes against.

## Test plan

- [x] Local: `pytest tests/test_vista_social.py -v` → **20 passed**
- [x] Local: lint clean (no F401/F841/F541)
- [ ] Full CI matrix on push