### PR TITLE
feat(geo): S2 grid utilities, grid-agnostic dispatcher, Etter NL parser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,6 +215,8 @@ all = [
     "h3>=4.0.0",
     # s2
     "s2sphere>=0.2.5",
+    # etter (natural-language geo query parser)
+    "etter>=0.1.0",
     # databricks
     "databricks-sdk>=0.20.0",
     # s3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,14 @@ geo = [
 h3 = [
     "h3>=4.0.0",
 ]
+# S2 cell-grid spatial index (sortable int64 IDs, range queries)
+s2 = [
+    "s2sphere>=0.2.5",
+]
+# Etter — natural-language geographic query parser (LLM-driven)
+etter = [
+    "etter>=0.1.0",
+]
 # Reporting and visualization
 reporting = [
     "matplotlib>=3.7.5",
@@ -205,6 +213,8 @@ all = [
     "censusgeocode>=0.5.2",
     # h3
     "h3>=4.0.0",
+    # s2
+    "s2sphere>=0.2.5",
     # databricks
     "databricks-sdk>=0.20.0",
     # s3

--- a/siege_utilities/geo/__init__.py
+++ b/siege_utilities/geo/__init__.py
@@ -180,6 +180,13 @@ _register([
 # --- nces_download ---
 _register(['NCESDownloader', 'NCESDownloadError'], '.providers.nces_download')
 
+# --- etter_filter (natural-language geographic query parsing via LLM) ---
+_register([
+    'ETTER_AVAILABLE',
+    'EtterError', 'EtterParseError', 'EtterLowConfidenceError',
+    'EtterFilter', 'EtterParser', 'default_llm',
+], '.providers.etter_filter')
+
 # --- databricks_fallback ---
 _register([
     'SpatialLoaderPlan', 'select_spatial_loader',
@@ -232,6 +239,23 @@ _register([
     'h3_hex_to_boundary', 'h3_resolution_for_area',
     'h3_resolution_for_admin_level', 'ADMIN_LEVEL_AVG_AREA_KM2',
 ], '.h3_utils')
+
+# --- s2_utils (S2 cell-grid spatial index) ---
+_register([
+    'S2_AVAILABLE', 'S2_LEVEL_AREA_KM2',
+    's2_index_points', 's2_index_polygon', 's2_region_cover',
+    's2_spatial_join', 's2_cell_to_boundary',
+    's2_level_for_area', 's2_level_for_admin_level',
+    's2_kring', 's2_distance', 's2_parent', 's2_children',
+    's2_cell_id_to_uint64', 's2_uint64_to_cell_id',
+    's2_cell_id_to_token', 's2_token_to_cell_id',
+    's2_bbox_to_cells', 's2_cells_to_ranges',
+], '.s2_utils')
+
+# --- grids (grid-agnostic dispatch wrappers) ---
+_register([
+    'index_points', 'index_polygon', 'infer_grid',
+], '.grids')
 
 # --- plans (redistricting plan resolution by date) ---
 _register([

--- a/siege_utilities/geo/grids.py
+++ b/siege_utilities/geo/grids.py
@@ -48,16 +48,32 @@ _H3_ONLY_KWARGS = frozenset({"resolution"})
 def infer_grid(grid: Grid, kwargs: dict) -> str:
     """Resolve ``grid=`` per the documented inference rules.
 
-    Returns ``"h3"`` or ``"s2"``; raises :class:`ValueError` on
-    ambiguous input. Pure function — does not mutate *kwargs*.
+    Returns ``"h3"`` or ``"s2"``; raises :class:`ValueError` if the
+    inputs contradict the chosen grid. Pure function — does not mutate
+    *kwargs*.
     """
+    has_s2 = any(k in kwargs and kwargs[k] is not None for k in _S2_ONLY_KWARGS)
+    has_h3 = any(k in kwargs and kwargs[k] is not None for k in _H3_ONLY_KWARGS)
+
     if grid is not None:
         if grid not in ("h3", "s2"):
             raise ValueError(f"grid must be 'h3' or 's2' (or None), got {grid!r}")
+        # Explicit grid wins, but reject foreign kwargs rather than silently
+        # dropping them (a hard-to-diagnose 'why didn't max_cells take effect?'
+        # bug otherwise).
+        if grid == "h3" and has_s2:
+            offenders = [k for k in _S2_ONLY_KWARGS if kwargs.get(k) is not None]
+            raise ValueError(
+                f"grid='h3' was passed alongside S2-only kwargs {offenders}. "
+                "Either drop the S2 kwargs or switch to grid='s2'."
+            )
+        if grid == "s2" and has_h3:
+            offenders = [k for k in _H3_ONLY_KWARGS if kwargs.get(k) is not None]
+            raise ValueError(
+                f"grid='s2' was passed alongside H3-only kwargs {offenders}. "
+                "Either drop the H3 kwargs or switch to grid='h3'."
+            )
         return grid
-
-    has_s2 = any(k in kwargs and kwargs[k] is not None for k in _S2_ONLY_KWARGS)
-    has_h3 = any(k in kwargs and kwargs[k] is not None for k in _H3_ONLY_KWARGS)
 
     if has_s2 and has_h3:
         raise ValueError(
@@ -99,6 +115,14 @@ def index_points(
         if level is not None and resolution is None:
             # Caller asked for grid='h3' but used 'level'; honour it.
             resolution = level
+        if kwargs:
+            # Reject silent kwarg dropping — symmetric with the S2 path,
+            # which forwards them. h3_index_points has no extra kwargs to
+            # forward, so anything here is caller error.
+            raise TypeError(
+                f"index_points(grid='h3') got unexpected keyword argument(s): "
+                f"{sorted(kwargs)}"
+            )
         return h3_index_points(df, lat_col, lon_col, resolution or 8)
     else:
         from .s2_utils import s2_index_points

--- a/siege_utilities/geo/grids.py
+++ b/siege_utilities/geo/grids.py
@@ -1,0 +1,163 @@
+"""Grid-agnostic dispatch wrappers over H3 and S2.
+
+Lets consumer code call :func:`index_points` / :func:`index_polygon`
+without committing to one grid system at the call site. The wrappers
+infer the grid from which keyword arguments are present, with explicit
+override via ``grid="h3"`` or ``grid="s2"``.
+
+Inference rules (applied in order):
+
+    1. If ``grid=`` is passed → that wins.
+    2. Else if any S2-only kwarg is present (``max_cells``, ``min_level``,
+       ``max_level``, ``level``) → S2.
+    3. Else if ``resolution=`` is present → H3.
+    4. Else → H3 (the more common viz path).
+
+Mixing ``resolution=`` with S2-only kwargs in one call raises
+:class:`ValueError` rather than guessing — the caller should pass
+``grid=`` explicitly to disambiguate.
+
+These wrappers exist to keep ``reporting/`` and consumer modules
+backend-agnostic; they don't add functionality beyond what the underlying
+``h3_utils`` / ``s2_utils`` modules already do.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+import pandas as pd
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "Grid",
+    "index_points",
+    "index_polygon",
+    "infer_grid",
+]
+
+#: Recognised ``grid=`` argument values. ``None`` means "infer".
+Grid = Optional[str]  # Literal["h3", "s2", None] in 3.8+ — staying loose for older callers
+
+_S2_ONLY_KWARGS = frozenset({"max_cells", "min_level", "max_level", "level"})
+_H3_ONLY_KWARGS = frozenset({"resolution"})
+
+
+def infer_grid(grid: Grid, kwargs: dict) -> str:
+    """Resolve ``grid=`` per the documented inference rules.
+
+    Returns ``"h3"`` or ``"s2"``; raises :class:`ValueError` on
+    ambiguous input. Pure function — does not mutate *kwargs*.
+    """
+    if grid is not None:
+        if grid not in ("h3", "s2"):
+            raise ValueError(f"grid must be 'h3' or 's2' (or None), got {grid!r}")
+        return grid
+
+    has_s2 = any(k in kwargs and kwargs[k] is not None for k in _S2_ONLY_KWARGS)
+    has_h3 = any(k in kwargs and kwargs[k] is not None for k in _H3_ONLY_KWARGS)
+
+    if has_s2 and has_h3:
+        raise ValueError(
+            "Ambiguous: passed both H3 (resolution) and S2 (level / max_cells) "
+            "kwargs in one call. Pass grid='h3' or grid='s2' explicitly."
+        )
+    if has_s2:
+        return "s2"
+    if has_h3:
+        return "h3"
+    return "h3"  # default: visualization-friendly
+
+
+def index_points(
+    df: pd.DataFrame,
+    lat_col: str,
+    lon_col: str,
+    *,
+    grid: Grid = None,
+    resolution: Optional[int] = None,
+    level: Optional[int] = None,
+    **kwargs: Any,
+) -> pd.Series:
+    """Compute a grid cell ID for each row in *df*.
+
+    Dispatches to :func:`h3_index_points` or :func:`s2_index_points`
+    based on the inference rules. Pass ``resolution=`` for H3 (default
+    8) or ``level=`` for S2 (default 12). Extra keyword arguments are
+    forwarded to the underlying function (e.g. ``as_token=False`` for
+    S2).
+
+    Returns:
+        ``pd.Series`` of cell IDs (H3 hex strings or S2 cell tokens by
+        default).
+    """
+    chosen = infer_grid(grid, {"resolution": resolution, "level": level})
+    if chosen == "h3":
+        from .h3_utils import h3_index_points
+        if level is not None and resolution is None:
+            # Caller asked for grid='h3' but used 'level'; honour it.
+            resolution = level
+        return h3_index_points(df, lat_col, lon_col, resolution or 8)
+    else:
+        from .s2_utils import s2_index_points
+        if resolution is not None and level is None:
+            level = resolution
+        return s2_index_points(df, lat_col, lon_col, level or 12, **kwargs)
+
+
+def index_polygon(
+    geometry,
+    *,
+    grid: Grid = None,
+    resolution: Optional[int] = None,
+    level: Optional[int] = None,
+    max_cells: Optional[int] = None,
+    min_level: Optional[int] = None,
+    max_level: Optional[int] = None,
+    refine: bool = True,
+):
+    """Cover a polygon with grid cells.
+
+    With H3: returns a :class:`set` of hex IDs at the requested
+    resolution (uniform).
+
+    With S2: if ``max_cells`` is provided (or any of ``min_level``,
+    ``max_level``), returns a :class:`list` of int64 cell IDs from
+    :func:`s2_region_cover` (variable-resolution coverage with a cell-
+    count budget). Otherwise returns a :class:`set` of int64 cell IDs
+    at a single ``level`` from :func:`s2_index_polygon`.
+
+    The shape of the return value (set vs list) intentionally signals
+    which mode you got. For SQL-friendly cell-id ranges, see
+    :func:`s2_cells_to_ranges`.
+    """
+    kwargs_for_inference = {
+        "resolution": resolution,
+        "level": level,
+        "max_cells": max_cells,
+        "min_level": min_level,
+        "max_level": max_level,
+    }
+    chosen = infer_grid(grid, kwargs_for_inference)
+
+    if chosen == "h3":
+        from .h3_utils import h3_index_polygon
+        # Caller may have used 'level' under grid='h3' — honour it.
+        res = resolution if resolution is not None else level
+        return h3_index_polygon(geometry, res or 8)
+
+    # S2 path
+    from .s2_utils import s2_index_polygon, s2_region_cover
+    use_region_cover = max_cells is not None or min_level is not None or max_level is not None
+    if use_region_cover:
+        return s2_region_cover(
+            geometry,
+            min_level=min_level if min_level is not None else 0,
+            max_level=max_level if max_level is not None else 30,
+            max_cells=max_cells if max_cells is not None else 100,
+        )
+    # Single-level coverage
+    lvl = level if level is not None else (resolution if resolution is not None else 12)
+    return s2_index_polygon(geometry, lvl, refine=refine)

--- a/siege_utilities/geo/grids.py
+++ b/siege_utilities/geo/grids.py
@@ -112,9 +112,8 @@ def index_points(
     chosen = infer_grid(grid, {"resolution": resolution, "level": level})
     if chosen == "h3":
         from .h3_utils import h3_index_points
-        if level is not None and resolution is None:
-            # Caller asked for grid='h3' but used 'level'; honour it.
-            resolution = level
+        # The "grid='h3' with level=" mismatch is now rejected by infer_grid,
+        # so by the time we get here level is None on the H3 path.
         if kwargs:
             # Reject silent kwarg dropping — symmetric with the S2 path,
             # which forwards them. h3_index_points has no extra kwargs to
@@ -126,8 +125,8 @@ def index_points(
         return h3_index_points(df, lat_col, lon_col, resolution or 8)
     else:
         from .s2_utils import s2_index_points
-        if resolution is not None and level is None:
-            level = resolution
+        # Ditto for S2: 'resolution=' with grid='s2' is rejected by infer_grid,
+        # so on the S2 path resolution is None.
         return s2_index_points(df, lat_col, lon_col, level or 12, **kwargs)
 
 
@@ -141,7 +140,7 @@ def index_polygon(
     min_level: Optional[int] = None,
     max_level: Optional[int] = None,
     refine: bool = True,
-):
+) -> "set | list":
     """Cover a polygon with grid cells.
 
     With H3: returns a :class:`set` of hex IDs at the requested
@@ -168,9 +167,9 @@ def index_polygon(
 
     if chosen == "h3":
         from .h3_utils import h3_index_polygon
-        # Caller may have used 'level' under grid='h3' — honour it.
-        res = resolution if resolution is not None else level
-        return h3_index_polygon(geometry, res or 8)
+        # `level` is rejected by infer_grid when grid='h3'; resolution is
+        # the only path here.
+        return h3_index_polygon(geometry, resolution or 8)
 
     # S2 path
     from .s2_utils import s2_index_polygon, s2_region_cover
@@ -182,6 +181,6 @@ def index_polygon(
             max_level=max_level if max_level is not None else 30,
             max_cells=max_cells if max_cells is not None else 100,
         )
-    # Single-level coverage
-    lvl = level if level is not None else (resolution if resolution is not None else 12)
-    return s2_index_polygon(geometry, lvl, refine=refine)
+    # Single-level coverage. `resolution` is rejected by infer_grid when
+    # grid='s2', so only `level` reaches here.
+    return s2_index_polygon(geometry, level or 12, refine=refine)

--- a/siege_utilities/geo/providers/etter_filter.py
+++ b/siege_utilities/geo/providers/etter_filter.py
@@ -176,13 +176,13 @@ def default_llm(
     """
     try:
         from langchain.chat_models import init_chat_model
-    except ImportError:
+    except ImportError as exc:
         raise ImportError(
             "default_llm requires langchain. Install with: "
             "pip install 'siege-utilities[etter]' "
             "(which pulls langchain via etter), or pass your own "
             "configured chat model directly to EtterParser."
-        )
+        ) from exc
 
     name = model.lower()
     if "claude" in name:
@@ -245,12 +245,14 @@ class EtterParser:
             )
         if llm is None:
             llm = default_llm()
-        self._parser = _UpstreamParser(
-            llm=llm,
-            confidence_threshold=confidence_threshold,
-            strict_mode=strict_mode,
-            **upstream_kwargs,
-        )
+        # Do NOT forward strict_mode/confidence_threshold to the upstream
+        # parser. If we did, the upstream's own LowConfidenceError would
+        # be raised inside parse() and caught by our `except Exception`,
+        # surfacing as EtterParseError — making our local strict-mode
+        # check unreachable. Local enforcement keeps the exception class
+        # contract on this side of the boundary, and means a future
+        # upstream rename of LowConfidenceError won't silently break us.
+        self._parser = _UpstreamParser(llm=llm, **upstream_kwargs)
         self._confidence_threshold = confidence_threshold
         self._strict_mode = strict_mode
         log.info("EtterParser initialised (threshold=%s)", confidence_threshold)
@@ -259,19 +261,29 @@ class EtterParser:
         """Parse *query* into an :class:`EtterFilter`.
 
         Raises:
-            EtterParseError: Upstream parser raised. The original
-                exception is chained via ``__cause__``.
+            EtterParseError: Upstream parser raised an unexpected error.
+                The original exception is chained via ``__cause__``.
             EtterLowConfidenceError: Parser succeeded but confidence is
                 below the threshold and ``strict_mode=True``. (When
                 ``strict_mode`` is False, this case logs and returns
                 normally; check :attr:`EtterFilter.confidence` if the
-                caller needs to gate.)
+                caller needs to gate.) Also raised if a future upstream
+                exposes its own ``LowConfidenceError`` and our local
+                check wasn't reached — we re-raise it as our type so
+                consumers don't have to know about upstream class names.
         """
         if not query or not query.strip():
             raise EtterParseError("Empty query string")
         try:
             geo_query = self._parser.parse(query)
         except Exception as exc:
+            # If the upstream raised its own low-confidence error
+            # (matching by class name to avoid a hard import dependency
+            # on a moving target), surface it as our typed exception.
+            if type(exc).__name__ == "LowConfidenceError":
+                raise EtterLowConfidenceError(
+                    f"Upstream rejected {query!r} as low-confidence: {exc}"
+                ) from exc
             raise EtterParseError(
                 f"Etter failed to parse {query!r}: {exc}"
             ) from exc

--- a/siege_utilities/geo/providers/etter_filter.py
+++ b/siege_utilities/geo/providers/etter_filter.py
@@ -1,0 +1,293 @@
+"""Natural-language geographic query parsing via Etter.
+
+Wraps the upstream `etter <https://github.com/geoblocks/etter>`_ package
+to parse natural-language geographic queries ("5 km north of Lausanne",
+"donations near Birmingham", "tracts in Alabama") into structured
+filters.
+
+Why a thin wrapper?
+-------------------
+The upstream library hands you a Pydantic ``GeoQuery`` object. That's
+good shape, but two practical problems for siege_utilities consumers:
+
+1. Constructing the LLM (langchain ``ChatOpenAI``, ``ChatAnthropic``,
+   etc.) is boilerplate that bleeds into every call site.
+2. Consumers want a shape they can hand to a :class:`BoundaryProvider`
+   or a :class:`DataFrameEngine` — not a Pydantic model from an
+   unrelated lib.
+
+This module hides both: :class:`EtterParser` gives you a default LLM
+factory and a :class:`EtterFilter` dataclass that the rest of the
+geo toolchain can act on.
+
+The LLM dependency is opt-in via the ``[etter]`` extra. Etter calls
+make a network round-trip per query, so this is **for ad-hoc
+exploration / interactive UI / one-off ETL prep — not for batch
+pipelines** where every donor address gets re-parsed.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+log = logging.getLogger(__name__)
+
+try:
+    from etter import GeoFilterParser as _UpstreamParser
+    ETTER_AVAILABLE = True
+except ImportError:
+    _UpstreamParser = None  # type: ignore[assignment]
+    ETTER_AVAILABLE = False
+    log.info("etter not available — natural-language geo query parsing disabled")
+
+
+__all__ = [
+    "ETTER_AVAILABLE",
+    "EtterError",
+    "EtterParseError",
+    "EtterLowConfidenceError",
+    "EtterFilter",
+    "EtterParser",
+    "default_llm",
+]
+
+
+class EtterError(RuntimeError):
+    """Base class for connector-side Etter failures."""
+
+
+class EtterParseError(EtterError):
+    """Etter failed to parse the query into a structured filter."""
+
+
+class EtterLowConfidenceError(EtterError):
+    """Parser succeeded but confidence is below the threshold."""
+
+
+@dataclass(frozen=True)
+class EtterFilter:
+    """A normalized parsed query ready for downstream consumption.
+
+    Wraps the upstream ``GeoQuery`` Pydantic model into a dataclass with
+    the fields siege_utilities consumers actually need. The original
+    upstream object is preserved on :attr:`raw` for callers that need
+    full fidelity.
+
+    Attributes:
+        original_query: The natural-language input verbatim.
+        spatial_relation: One of the relations Etter recognises —
+            ``"in"``, ``"near"``, ``"north_of"``, ``"south_of"``,
+            ``"east_of"``, ``"west_of"``, etc. ``None`` if the query
+            doesn't carry a relation (e.g. a bare place name).
+        reference_location: The place the relation hangs off — ``"Lausanne"``,
+            ``"Lake Geneva"``, ``"Birmingham, AL"``.
+        buffer_distance_m: Buffer distance in meters if the query had
+            one (``"5 km"`` → 5000). ``None`` otherwise.
+        confidence: Overall confidence score in ``[0, 1]``.
+        raw: The upstream :class:`etter.GeoQuery` object, in case the
+            consumer needs the full breakdown.
+    """
+
+    original_query: str
+    spatial_relation: Optional[str]
+    reference_location: Optional[str]
+    buffer_distance_m: Optional[float] = None
+    confidence: float = 1.0
+    raw: Any = field(default=None, repr=False, compare=False)
+
+    @classmethod
+    def from_geoquery(cls, original_query: str, geo_query: Any) -> "EtterFilter":
+        """Translate an upstream ``GeoQuery`` to an :class:`EtterFilter`.
+
+        Tolerant of upstream field-name drift — uses ``getattr`` with
+        defaults rather than positional unpacking.
+        """
+        # Buffer is published by upstream as a sub-model; flatten to meters.
+        buffer = getattr(geo_query, "buffer_config", None)
+        buffer_m: Optional[float] = None
+        if buffer is not None:
+            distance = getattr(buffer, "distance", None)
+            unit = getattr(buffer, "unit", None) or "m"
+            if distance is not None:
+                buffer_m = _to_meters(float(distance), str(unit))
+
+        # Confidence: upstream exposes a per-field breakdown plus an
+        # overall score — pick whichever is present.
+        confidence = getattr(geo_query, "overall_confidence", None)
+        if confidence is None:
+            breakdown = getattr(geo_query, "confidence_breakdown", None)
+            if breakdown is not None:
+                values = [
+                    v for v in vars(breakdown).values() if isinstance(v, (int, float))
+                ] if hasattr(breakdown, "__dict__") else []
+                confidence = min(values) if values else 1.0
+            else:
+                confidence = 1.0
+
+        return cls(
+            original_query=original_query,
+            spatial_relation=getattr(geo_query, "spatial_relation", None),
+            reference_location=getattr(geo_query, "reference_location", None),
+            buffer_distance_m=buffer_m,
+            confidence=float(confidence),
+            raw=geo_query,
+        )
+
+
+_UNIT_TO_METERS = {
+    "m": 1.0, "meter": 1.0, "meters": 1.0,
+    "km": 1000.0, "kilometer": 1000.0, "kilometers": 1000.0,
+    "mi": 1609.344, "mile": 1609.344, "miles": 1609.344,
+    "ft": 0.3048, "feet": 0.3048,
+    "yd": 0.9144, "yard": 0.9144, "yards": 0.9144,
+}
+
+
+def _to_meters(distance: float, unit: str) -> float:
+    """Convert *distance* in *unit* to meters; default to ``m`` on unknown."""
+    factor = _UNIT_TO_METERS.get(unit.strip().lower())
+    if factor is None:
+        log.warning("Etter buffer unit %r not recognised; treating as meters", unit)
+        return distance
+    return distance * factor
+
+
+def default_llm(
+    *,
+    model: str = "gpt-4o",
+    temperature: float = 0.0,
+    api_key: Optional[str] = None,
+):
+    """Return a langchain chat model suitable for :class:`EtterParser`.
+
+    Picks the right adapter based on the model name. ``api_key`` falls
+    back to the standard environment variable for the chosen provider
+    (``OPENAI_API_KEY`` / ``ANTHROPIC_API_KEY``). Lazy-imports langchain
+    so the rest of this module is importable without it.
+
+    Args:
+        model: Chat model name (e.g. ``"gpt-4o"``, ``"claude-3-5-sonnet-latest"``).
+        temperature: Sampling temperature; default ``0.0`` for
+            reproducibility — query parsing is not creative writing.
+        api_key: Optional explicit API key; otherwise read from env.
+    """
+    try:
+        from langchain.chat_models import init_chat_model
+    except ImportError:
+        raise ImportError(
+            "default_llm requires langchain. Install with: "
+            "pip install 'siege-utilities[etter]' "
+            "(which pulls langchain via etter), or pass your own "
+            "configured chat model directly to EtterParser."
+        )
+
+    name = model.lower()
+    if "claude" in name:
+        provider = "anthropic"
+        env_var = "ANTHROPIC_API_KEY"
+    elif "gpt" in name or "openai" in name:
+        provider = "openai"
+        env_var = "OPENAI_API_KEY"
+    else:
+        # Trust caller to know which provider; init_chat_model can infer.
+        provider = None
+        env_var = None
+
+    kwargs: dict[str, Any] = {"temperature": temperature}
+    if api_key:
+        kwargs["api_key"] = api_key
+    elif env_var and not os.environ.get(env_var):
+        raise EtterError(
+            f"No api_key passed and ${env_var} is unset. Cannot construct "
+            f"the default LLM for model={model!r}."
+        )
+
+    if provider:
+        return init_chat_model(model=model, model_provider=provider, **kwargs)
+    return init_chat_model(model=model, **kwargs)
+
+
+class EtterParser:
+    """Wrap :class:`etter.GeoFilterParser` with a sensible default LLM.
+
+    Usage::
+
+        from siege_utilities.geo.providers.etter_filter import EtterParser
+
+        # Defaults: gpt-4o, temperature=0, OPENAI_API_KEY from env.
+        parser = EtterParser()
+        result = parser.parse("5 km north of Lausanne")
+        # result.spatial_relation == "north_of"
+        # result.reference_location == "Lausanne"
+        # result.buffer_distance_m == 5000.0
+
+    Pass ``llm=`` to use a pre-built chat model (e.g. for tests or for
+    pinning to a specific Anthropic / Azure deployment). All other
+    constructor kwargs are forwarded to the upstream parser.
+    """
+
+    def __init__(
+        self,
+        *,
+        llm: Any = None,
+        confidence_threshold: float = 0.6,
+        strict_mode: bool = False,
+        **upstream_kwargs: Any,
+    ) -> None:
+        if not ETTER_AVAILABLE:
+            raise ImportError(
+                "EtterParser requires etter. Install with: "
+                "pip install 'siege-utilities[etter]' or "
+                "pip install 'etter>=0.1.0'."
+            )
+        if llm is None:
+            llm = default_llm()
+        self._parser = _UpstreamParser(
+            llm=llm,
+            confidence_threshold=confidence_threshold,
+            strict_mode=strict_mode,
+            **upstream_kwargs,
+        )
+        self._confidence_threshold = confidence_threshold
+        self._strict_mode = strict_mode
+        log.info("EtterParser initialised (threshold=%s)", confidence_threshold)
+
+    def parse(self, query: str) -> EtterFilter:
+        """Parse *query* into an :class:`EtterFilter`.
+
+        Raises:
+            EtterParseError: Upstream parser raised. The original
+                exception is chained via ``__cause__``.
+            EtterLowConfidenceError: Parser succeeded but confidence is
+                below the threshold and ``strict_mode=True``. (When
+                ``strict_mode`` is False, this case logs and returns
+                normally; check :attr:`EtterFilter.confidence` if the
+                caller needs to gate.)
+        """
+        if not query or not query.strip():
+            raise EtterParseError("Empty query string")
+        try:
+            geo_query = self._parser.parse(query)
+        except Exception as exc:
+            raise EtterParseError(
+                f"Etter failed to parse {query!r}: {exc}"
+            ) from exc
+
+        result = EtterFilter.from_geoquery(query, geo_query)
+
+        if self._strict_mode and result.confidence < self._confidence_threshold:
+            raise EtterLowConfidenceError(
+                f"Etter parsed {query!r} with confidence "
+                f"{result.confidence:.2f} < threshold "
+                f"{self._confidence_threshold:.2f}"
+            )
+        if result.confidence < self._confidence_threshold:
+            log.warning(
+                "Etter parsed %r with low confidence %.2f (< %.2f). "
+                "Result still returned; caller should verify.",
+                query, result.confidence, self._confidence_threshold,
+            )
+        return result

--- a/siege_utilities/geo/providers/etter_filter.py
+++ b/siege_utilities/geo/providers/etter_filter.py
@@ -160,7 +160,7 @@ def default_llm(
     model: str = "gpt-4o",
     temperature: float = 0.0,
     api_key: Optional[str] = None,
-):
+) -> Any:
     """Return a langchain chat model suitable for :class:`EtterParser`.
 
     Picks the right adapter based on the model name. ``api_key`` falls

--- a/siege_utilities/geo/s2_utils.py
+++ b/siege_utilities/geo/s2_utils.py
@@ -1,0 +1,676 @@
+"""S2 cell-grid utilities.
+
+Sibling of :mod:`siege_utilities.geo.h3_utils`. Where H3 gives you uniform
+hexagonal cells at a single resolution, S2 gives you square cells with
+**integer IDs that sort by spatial proximity**. The same lat/lon-to-cell
+operations are mirrored across both modules; the S2-specific functions
+exposed here (cell-id ↔ uint64, bbox-to-cells, parent/children, region
+cover with cell-count budget, range-bound generation for SQL) are the
+reason to reach for S2 rather than H3.
+
+Why both
+--------
+
+================================  ===========================  ===========================
+Use case                          Reach for                    Why
+================================  ===========================  ===========================
+Density choropleth, hex-bins      H3                           Uniform cell area
+K-nearest-neighbors via k-ring    H3                           Uniform neighbor distances
+Spatial primary key in DB         S2                           Sortable int64 IDs
+Bbox / range queries in SQL       S2                           Cell-id ranges = bboxes
+Hierarchical rollups              S2                           4 children per cell, clean
+Apple Photos / iOS data           S2                           Native to that ecosystem
+================================  ===========================  ===========================
+
+Polygon coverage limitation
+---------------------------
+The pure-Python ``s2sphere`` package supports ``LatLngRect`` (bounding
+boxes) but **not** the full ``Loop`` / ``Polygon`` types from C++ S2.
+:func:`s2_index_polygon` covers the polygon's *bounding box* and
+optionally post-filters cells against the actual geometry using shapely.
+For a heavily concave polygon (e.g. Idaho), the bbox cover is loose; the
+post-filter step (default on) trims cells whose centers fall outside.
+
+Requires: s2sphere>=0.2.5.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Iterable, List, Optional, Tuple
+
+import pandas as pd
+
+log = logging.getLogger(__name__)
+
+try:
+    import s2sphere as _s2
+    S2_AVAILABLE = True
+except ImportError:
+    _s2 = None  # type: ignore[assignment]
+    S2_AVAILABLE = False
+    log.info("s2sphere not available — S2 grid functions will raise ImportError")
+
+
+__all__ = [
+    "S2_AVAILABLE",
+    "ADMIN_LEVEL_AVG_AREA_KM2",
+    "S2_LEVEL_AREA_KM2",
+    "s2_index_points",
+    "s2_index_polygon",
+    "s2_region_cover",
+    "s2_spatial_join",
+    "s2_cell_to_boundary",
+    "s2_level_for_area",
+    "s2_level_for_admin_level",
+    "s2_kring",
+    "s2_distance",
+    "s2_parent",
+    "s2_children",
+    "s2_cell_id_to_uint64",
+    "s2_uint64_to_cell_id",
+    "s2_cell_id_to_token",
+    "s2_token_to_cell_id",
+    "s2_bbox_to_cells",
+    "s2_cells_to_ranges",
+]
+
+
+def _require_s2():
+    if not S2_AVAILABLE:
+        raise ImportError(
+            "s2sphere is required for S2 grid operations. Install with: "
+            "pip install 'siege-utilities[s2]' or pip install 's2sphere>=0.2.5'."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Reference tables
+# ---------------------------------------------------------------------------
+
+# Average S2 cell area per level. Source: https://s2geometry.io/resources/s2cell_statistics
+# (ratio of min to max within a level is ~1.4×; the average is what we use
+# for "what level approximately matches a target area" decisions, mirroring
+# the H3 _H3_RESOLUTION_AREA_KM2 table in h3_utils).
+S2_LEVEL_AREA_KM2 = {
+    0: 85_011_012.19,
+    1: 21_252_753.05,
+    2: 6_073_647.27,
+    3: 1_517_403.93,
+    4: 379_172.62,
+    5: 94_899.62,
+    6: 23_775.37,
+    7: 5_944.13,
+    8: 1_485.37,
+    9: 371.39,
+    10: 92.85,
+    11: 23.21,
+    12: 5.80,
+    13: 1.45,
+    14: 0.36,
+    15: 0.0904,
+    16: 0.0226,
+    17: 0.00565,
+    18: 0.00141,
+    19: 0.000353,
+    20: 0.0000882,
+    21: 0.0000220,
+    22: 0.0000055,
+    23: 0.00000138,
+    24: 0.00000034,
+    25: 0.00000009,
+    26: 0.00000002,
+    27: 0.00000001,
+    28: 0.000000001,
+    29: 0.0000000003,
+    30: 0.00000000007,
+}
+
+# Same admin-level table the H3 module uses; S2 just picks a different
+# level from the same target areas.
+ADMIN_LEVEL_AVG_AREA_KM2 = {
+    "state": 196_600.0,
+    "county": 3_000.0,
+    "zcta": 110.0,
+    "tract": 5.0,
+    "block_group": 1.0,
+    "block": 0.04,
+}
+
+_ADMIN_LEVEL_ALIASES = {
+    "states": "state", "us_state": "state",
+    "counties": "county", "us_county": "county",
+    "zip": "zcta", "zip_code": "zcta", "zipcode": "zcta", "zctas": "zcta",
+    "tracts": "tract", "census_tract": "tract",
+    "bg": "block_group", "block_groups": "block_group", "blockgroup": "block_group",
+    "blocks": "block", "census_block": "block",
+}
+
+
+def s2_level_for_area(target_area_km2: float) -> int:
+    """Suggest the S2 level whose average cell area matches *target_area_km2*.
+
+    Comparison is in log-space, mirroring :func:`h3_resolution_for_area`.
+    """
+    _require_s2()
+    if target_area_km2 <= 0:
+        raise ValueError(f"target_area_km2 must be positive, got {target_area_km2}")
+    log_target = math.log10(target_area_km2)
+    best_level = 0
+    best_diff = float("inf")
+    for level, area in S2_LEVEL_AREA_KM2.items():
+        diff = abs(math.log10(area) - log_target)
+        if diff < best_diff:
+            best_diff = diff
+            best_level = level
+    return best_level
+
+
+def s2_level_for_admin_level(level: str) -> int:
+    """Suggest an S2 level whose average cell area matches a US admin level.
+
+    Same admin levels recognised by :func:`h3_resolution_for_admin_level`
+    (state / county / zcta / tract / block_group / block, with the usual
+    aliases). Returns the S2 level that's closest in log-space.
+    """
+    _require_s2()
+    normalized = level.strip().lower()
+    canonical = _ADMIN_LEVEL_ALIASES.get(normalized, normalized)
+    if canonical not in ADMIN_LEVEL_AVG_AREA_KM2:
+        valid = sorted(ADMIN_LEVEL_AVG_AREA_KM2)
+        raise ValueError(
+            f"Unknown admin level {level!r}. Recognised levels: {valid}."
+        )
+    return s2_level_for_area(ADMIN_LEVEL_AVG_AREA_KM2[canonical])
+
+
+# ---------------------------------------------------------------------------
+# Point indexing
+# ---------------------------------------------------------------------------
+
+def s2_index_points(
+    df: pd.DataFrame,
+    lat_col: str,
+    lon_col: str,
+    level: int = 12,
+    *,
+    as_token: bool = True,
+) -> pd.Series:
+    """Compute the S2 cell ID for each point.
+
+    Args:
+        df: DataFrame with latitude / longitude columns.
+        lat_col: Name of the latitude column.
+        lon_col: Name of the longitude column.
+        level: S2 level (0–30). Default 12 (~5.8 km² per cell).
+        as_token: If True (default), return the cell as a 16-char hex
+            *token* string (compact, human-readable, JSON-safe). If
+            False, return the int64 cell ID (sortable, ideal for
+            database keys). Both round-trip via the
+            :func:`s2_cell_id_to_token` / :func:`s2_token_to_cell_id`
+            helpers.
+
+    Returns:
+        ``pd.Series`` indexed like the input. Name: ``"s2_index"``.
+
+    Raises:
+        ImportError: If s2sphere is not installed.
+        ValueError: If level is out of range or columns are missing.
+    """
+    _require_s2()
+    _validate_level(level)
+    for col in (lat_col, lon_col):
+        if col not in df.columns:
+            raise ValueError(f"Column '{col}' not found in DataFrame")
+
+    def _one(row) -> object:
+        ll = _s2.LatLng.from_degrees(row[lat_col], row[lon_col])
+        cell = _s2.CellId.from_lat_lng(ll).parent(level)
+        return cell.to_token() if as_token else cell.id()
+
+    out = df.apply(_one, axis=1)
+    out.name = "s2_index"
+    return out
+
+
+def s2_index_polygon(
+    geometry,
+    level: int = 12,
+    *,
+    refine: bool = True,
+) -> set:
+    """Return the set of S2 cells at *level* covering *geometry*.
+
+    Single-level coverage — symmetric with :func:`h3_index_polygon`. For
+    variable-resolution coverage with a cell-count budget, see
+    :func:`s2_region_cover`.
+
+    Because the pure-Python ``s2sphere`` lacks polygon support, this
+    function covers the polygon's *bounding box* and (by default) post-
+    filters the result to cells whose centers fall inside the actual
+    geometry, using shapely. Set ``refine=False`` to skip the filter
+    when the input is a near-rectangle (e.g. a county) and you want the
+    bbox cover unchanged.
+
+    Args:
+        geometry: A shapely Polygon / MultiPolygon, or a GeoJSON-like dict.
+        level: S2 level (0–30). All returned cells are at this level.
+        refine: Filter cells by checking whether the cell center lies
+            inside the polygon (default True).
+
+    Returns:
+        ``set`` of int64 cell IDs.
+
+    Raises:
+        ImportError: If s2sphere (or shapely, when refine=True) is missing.
+        ValueError: If level is out of range.
+        TypeError: If geometry can't be converted to a shapely shape.
+    """
+    _require_s2()
+    _validate_level(level)
+    poly = _coerce_polygon(geometry)
+    minx, miny, maxx, maxy = poly.bounds
+
+    coverer = _s2.RegionCoverer()
+    coverer.min_level = level
+    coverer.max_level = level
+    coverer.max_cells = 1_000_000  # effectively unlimited at fixed level
+    rect = _s2.LatLngRect(
+        _s2.LatLng.from_degrees(miny, minx),
+        _s2.LatLng.from_degrees(maxy, maxx),
+    )
+    covering = coverer.get_covering(rect)
+    cells = set()
+    for cell_id in covering:
+        if cell_id.level() != level:
+            # RegionCoverer occasionally returns coarser cells when a
+            # single coarse cell exactly covers the bbox at min_level;
+            # expand them to the requested level.
+            for child in _expand_to_level(cell_id, level):
+                cells.add(child)
+        else:
+            cells.add(cell_id.id())
+
+    if not refine:
+        return cells
+
+    # shapely-based refine: keep only cells whose centers are inside.
+    from shapely.geometry import Point
+    refined = set()
+    for cid in cells:
+        center_ll = _s2.CellId(cid).to_lat_lng()
+        pt = Point(center_ll.lng().degrees, center_ll.lat().degrees)
+        if poly.contains(pt) or poly.touches(pt):
+            refined.add(cid)
+    return refined
+
+
+def s2_region_cover(
+    geometry,
+    *,
+    min_level: int = 0,
+    max_level: int = 30,
+    max_cells: int = 100,
+) -> List[int]:
+    """Cover *geometry*'s bounding box with at most *max_cells* S2 cells.
+
+    The S2-specific operation: returns a *mixed-resolution* set of cells
+    that together cover the bounding box, preferring coarse cells in the
+    interior and fine cells along boundaries. The output is what you
+    want for a database-side spatial-index lookup.
+
+    Use :func:`s2_cells_to_ranges` to turn the result into ``(min, max)``
+    int64 ranges suitable for a SQL ``BETWEEN`` clause.
+
+    Args:
+        geometry: shapely shape or GeoJSON dict.
+        min_level: Minimum S2 level the coverer may use.
+        max_level: Maximum S2 level the coverer may use.
+        max_cells: Cell-count budget. The coverer returns at most this
+            many cells (often fewer).
+
+    Returns:
+        A list of int64 cell IDs at varying levels, ordered as the
+        coverer produced them (sortable but not sorted).
+    """
+    _require_s2()
+    _validate_level(min_level)
+    _validate_level(max_level)
+    if min_level > max_level:
+        raise ValueError(
+            f"min_level ({min_level}) must be <= max_level ({max_level})"
+        )
+    if max_cells < 1:
+        raise ValueError(f"max_cells must be >= 1, got {max_cells}")
+
+    poly = _coerce_polygon(geometry)
+    minx, miny, maxx, maxy = poly.bounds
+    coverer = _s2.RegionCoverer()
+    coverer.min_level = min_level
+    coverer.max_level = max_level
+    coverer.max_cells = max_cells
+    rect = _s2.LatLngRect(
+        _s2.LatLng.from_degrees(miny, minx),
+        _s2.LatLng.from_degrees(maxy, maxx),
+    )
+    return [c.id() for c in coverer.get_covering(rect)]
+
+
+def s2_cells_to_ranges(cell_ids: Iterable[int]) -> List[Tuple[int, int]]:
+    """Convert cell IDs to ``(range_min, range_max)`` pairs for SQL.
+
+    Each S2 cell, regardless of level, has a contiguous range of leaf
+    cell IDs that lie within it: ``[cell.range_min, cell.range_max]``.
+    Pre-computing those ranges lets a SQL query test "is point's cell
+    inside this region" with a simple ``WHERE leaf_cell_id BETWEEN min
+    AND max`` (one comparison per cell in the cover, no spatial library
+    needed at query time).
+    """
+    _require_s2()
+    out = []
+    for cid in cell_ids:
+        cell = _s2.CellId(cid)
+        out.append((cell.range_min().id(), cell.range_max().id()))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Spatial join (lite point-in-polygon via S2 cell matching)
+# ---------------------------------------------------------------------------
+
+def s2_spatial_join(
+    points_df: pd.DataFrame,
+    polygons_gdf,
+    lat_col: str,
+    lon_col: str,
+    level: int = 12,
+    polygon_id_col: Optional[str] = None,
+) -> pd.DataFrame:
+    """Join points to polygons via S2 cell matching (approximate PiP).
+
+    Same shape as :func:`h3_spatial_join`. Points and polygons sharing
+    a cell are joined; polygons are decomposed into S2 cells via
+    :func:`s2_index_polygon`. First-polygon-wins on overlap.
+    """
+    _require_s2()
+    _validate_level(level)
+    point_cells = s2_index_points(points_df, lat_col, lon_col, level, as_token=False)
+    indexed = points_df.copy()
+    indexed["_s2_index"] = point_cells
+
+    cell_to_polygon: dict = {}
+    polygon_attrs: dict = {}
+    for idx, row in polygons_gdf.iterrows():
+        poly_id = row[polygon_id_col] if polygon_id_col else idx
+        cells = s2_index_polygon(row["geometry"], level)
+        polygon_attrs[poly_id] = {
+            col: row[col] for col in polygons_gdf.columns if col != "geometry"
+        }
+        for cid in cells:
+            cell_to_polygon.setdefault(cid, poly_id)
+
+    indexed["_poly_id"] = indexed["_s2_index"].map(cell_to_polygon)
+    matched = indexed.dropna(subset=["_poly_id"]).copy()
+    if matched.empty:
+        for col in (c for c in polygons_gdf.columns if c != "geometry"):
+            matched[col] = pd.Series(dtype="object")
+        matched.drop(columns=["_s2_index", "_poly_id"], inplace=True)
+        return matched
+
+    poly_attr_df = pd.DataFrame.from_dict(polygon_attrs, orient="index")
+    poly_attr_df.index.name = "_poly_id"
+    poly_attr_df = poly_attr_df.reset_index()
+    matched = matched.merge(poly_attr_df, on="_poly_id", how="left")
+    matched.drop(columns=["_s2_index", "_poly_id"], inplace=True)
+    return matched.reset_index(drop=True)
+
+
+# ---------------------------------------------------------------------------
+# Cell metadata
+# ---------------------------------------------------------------------------
+
+def s2_cell_to_boundary(cell_id) -> List[Tuple[float, float]]:
+    """Return the 4 vertex coordinates of a cell as ``(lat, lng)`` tuples.
+
+    Accepts an int64 cell ID or a hex token string.
+    """
+    _require_s2()
+    cid = _coerce_cell_id(cell_id)
+    cell = _s2.Cell(cid)
+    out = []
+    for i in range(4):
+        ll = _s2.LatLng.from_point(cell.get_vertex(i))
+        out.append((ll.lat().degrees, ll.lng().degrees))
+    return out
+
+
+def s2_kring(cell_id, k: int = 1) -> List[int]:
+    """Return cell IDs within k steps of *cell_id* on the same level.
+
+    The k-ring is approximate for S2 (squares don't tile uniformly); we
+    walk neighbors recursively. For exact k-ring on a uniform grid use
+    :func:`h3_kring` instead.
+    """
+    _require_s2()
+    if k < 0:
+        raise ValueError(f"k must be >= 0, got {k}")
+    cid = _coerce_cell_id(cell_id)
+    seen = {cid.id()}
+    frontier = {cid}
+    for _ in range(k):
+        next_frontier = set()
+        for c in frontier:
+            for n in c.get_all_neighbors(c.level()):
+                if n.id() not in seen:
+                    seen.add(n.id())
+                    next_frontier.add(n)
+        frontier = next_frontier
+    return sorted(seen)
+
+
+def s2_distance(a, b) -> int:
+    """Edge-step distance between two S2 cells at the same level.
+
+    Counts cell-boundary crossings via repeated neighbor expansion until
+    *b* is reached. ``O(distance)``; use only for small radii. For large
+    distances, switch to great-circle distance on the cell centers.
+    """
+    _require_s2()
+    a_id = _coerce_cell_id(a)
+    b_id = _coerce_cell_id(b)
+    if a_id.level() != b_id.level():
+        raise ValueError(
+            f"s2_distance: a is at level {a_id.level()}, b is at level "
+            f"{b_id.level()}; level must match."
+        )
+    if a_id == b_id:
+        return 0
+    target = b_id.id()
+    seen = {a_id.id()}
+    frontier = {a_id}
+    for d in range(1, 1_000_000):  # generous upper bound
+        next_frontier = set()
+        for c in frontier:
+            for n in c.get_all_neighbors(c.level()):
+                if n.id() == target:
+                    return d
+                if n.id() not in seen:
+                    seen.add(n.id())
+                    next_frontier.add(n)
+        frontier = next_frontier
+        if not frontier:
+            raise ValueError("s2_distance: cells appear disconnected")
+    raise ValueError("s2_distance: exceeded search budget")
+
+
+def s2_parent(cell_id, level: int) -> int:
+    """Return the ancestor cell at *level* (must be ≤ current level)."""
+    _require_s2()
+    cid = _coerce_cell_id(cell_id)
+    if level > cid.level():
+        raise ValueError(
+            f"s2_parent: target level {level} > current level {cid.level()}; "
+            "use s2_children for refinement."
+        )
+    return cid.parent(level).id()
+
+
+def s2_children(cell_id) -> List[int]:
+    """Return the four immediate children of a cell.
+
+    Raises if called on a leaf cell (level 30).
+    """
+    _require_s2()
+    cid = _coerce_cell_id(cell_id)
+    if cid.level() >= 30:
+        raise ValueError("s2_children: cell is at leaf level (30); no children.")
+    return [c.id() for c in cid.children()]
+
+
+# ---------------------------------------------------------------------------
+# ID format conversions
+# ---------------------------------------------------------------------------
+
+def s2_cell_id_to_uint64(cell_or_token) -> int:
+    """Return the int64 form of a cell, accepting either a token or an id.
+
+    Useful when receiving a token string (e.g. ``"88891b"``) and needing
+    the integer for a database column. Accepts any integer-like type
+    (Python int, numpy.int64, numpy.uint64) for round-trip convenience.
+    """
+    _require_s2()
+    if isinstance(cell_or_token, str):
+        return _s2.CellId.from_token(cell_or_token).id()
+    try:
+        return int(cell_or_token)
+    except (TypeError, ValueError):
+        raise TypeError(
+            f"Expected int64 cell id or hex token string, got "
+            f"{type(cell_or_token).__name__}"
+        )
+
+
+def s2_uint64_to_cell_id(n: int):
+    """Return an :class:`s2sphere.CellId` from an int64 value."""
+    _require_s2()
+    return _s2.CellId(int(n))
+
+
+def s2_cell_id_to_token(cell_id) -> str:
+    """Return the compact hex token form of a cell.
+
+    Tokens are stable, JSON-safe, and 16 characters or fewer.
+    """
+    _require_s2()
+    return _coerce_cell_id(cell_id).to_token()
+
+
+def s2_token_to_cell_id(token: str) -> int:
+    """Parse a hex token back to its int64 cell ID."""
+    _require_s2()
+    return _s2.CellId.from_token(token).id()
+
+
+# ---------------------------------------------------------------------------
+# Bbox helpers
+# ---------------------------------------------------------------------------
+
+def s2_bbox_to_cells(
+    min_lat: float, min_lon: float, max_lat: float, max_lon: float,
+    *,
+    max_level: int = 18,
+    max_cells: int = 64,
+) -> List[int]:
+    """Cover an axis-aligned bounding box with at most *max_cells* cells.
+
+    Convenience wrapper around :func:`s2_region_cover` for the common
+    case of a map-viewport query. Returns int64 cell IDs at varying
+    levels.
+    """
+    _require_s2()
+    _validate_level(max_level)
+    if max_cells < 1:
+        raise ValueError(f"max_cells must be >= 1, got {max_cells}")
+    coverer = _s2.RegionCoverer()
+    coverer.min_level = 0
+    coverer.max_level = max_level
+    coverer.max_cells = max_cells
+    rect = _s2.LatLngRect(
+        _s2.LatLng.from_degrees(min_lat, min_lon),
+        _s2.LatLng.from_degrees(max_lat, max_lon),
+    )
+    return [c.id() for c in coverer.get_covering(rect)]
+
+
+# ---------------------------------------------------------------------------
+# Helpers (private)
+# ---------------------------------------------------------------------------
+
+def _validate_level(level: int) -> None:
+    if not 0 <= level <= 30:
+        raise ValueError(f"S2 level must be 0-30, got {level}")
+
+
+def _coerce_cell_id(value):
+    """Accept int, str token, or :class:`CellId`; return CellId.
+
+    Accepts any integer-like type (int, numpy.int64, numpy.uint64, etc.)
+    via the ``__int__`` protocol — pandas-derived cell IDs come back as
+    numpy types which would otherwise fail an ``isinstance(value, int)``
+    check.
+    """
+    if isinstance(value, _s2.CellId):
+        return value
+    if isinstance(value, str):
+        return _s2.CellId.from_token(value)
+    # Try integer-like (covers Python int, numpy.int64, numpy.uint64).
+    try:
+        return _s2.CellId(int(value))
+    except (TypeError, ValueError):
+        raise TypeError(
+            f"Expected CellId, int64, or token string, got "
+            f"{type(value).__name__}"
+        )
+
+
+def _coerce_polygon(geometry):
+    """Convert input to a shapely shape (Polygon / MultiPolygon)."""
+    try:
+        from shapely.geometry import shape, mapping  # noqa: F401
+    except ImportError:
+        raise ImportError(
+            "shapely is required for S2 polygon coverage. Install with: "
+            "pip install 'siege-utilities[geo]' or pip install 'shapely>=2.0'."
+        )
+    if hasattr(geometry, "bounds") and hasattr(geometry, "contains"):
+        return geometry  # already a shapely shape
+    if isinstance(geometry, dict):
+        from shapely.geometry import shape
+        return shape(geometry)
+    if hasattr(geometry, "__geo_interface__"):
+        from shapely.geometry import shape
+        return shape(geometry.__geo_interface__)
+    raise TypeError(
+        f"Cannot coerce {type(geometry).__name__} to a polygon. "
+        "Provide a shapely shape or a GeoJSON dict."
+    )
+
+
+def _expand_to_level(cell_id, target_level: int) -> Iterable[int]:
+    """Walk children until reaching *target_level*; yields int64 IDs."""
+    if cell_id.level() == target_level:
+        yield cell_id.id()
+        return
+    if cell_id.level() > target_level:
+        # Caller asked for a coarser cell than the input; just yield
+        # the parent at target_level.
+        yield cell_id.parent(target_level).id()
+        return
+    stack = [cell_id]
+    while stack:
+        c = stack.pop()
+        if c.level() == target_level:
+            yield c.id()
+        else:
+            stack.extend(c.children())

--- a/siege_utilities/geo/s2_utils.py
+++ b/siege_utilities/geo/s2_utils.py
@@ -38,9 +38,17 @@ from __future__ import annotations
 
 import logging
 import math
-from typing import Iterable, List, Optional, Tuple
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Optional
 
-import pandas as pd
+if TYPE_CHECKING:  # pragma: no cover
+    # pandas is only needed for the DataFrame-batch helpers (e.g.
+    # s2_index_points, s2_spatial_join). Cell-level functions —
+    # s2_cell_to_boundary, s2_kring, s2_parent / _children, the ID
+    # converters — work without it. We don't want `pip install
+    # siege-utilities[s2]` to require pandas just to import this module,
+    # so the actual import lives inside the functions that need it.
+    import pandas as pd
 
 log = logging.getLogger(__name__)
 
@@ -190,13 +198,13 @@ def s2_level_for_admin_level(level: str) -> int:
 # ---------------------------------------------------------------------------
 
 def s2_index_points(
-    df: pd.DataFrame,
+    df: "pd.DataFrame",
     lat_col: str,
     lon_col: str,
     level: int = 12,
     *,
     as_token: bool = True,
-) -> pd.Series:
+) -> "pd.Series":
     """Compute the S2 cell ID for each point.
 
     Args:
@@ -312,7 +320,7 @@ def s2_region_cover(
     min_level: int = 0,
     max_level: int = 30,
     max_cells: int = 100,
-) -> List[int]:
+) -> list[int]:
     """Cover *geometry*'s bounding box with at most *max_cells* S2 cells.
 
     The S2-specific operation: returns a *mixed-resolution* set of cells
@@ -357,7 +365,7 @@ def s2_region_cover(
     return [c.id() for c in coverer.get_covering(rect)]
 
 
-def s2_cells_to_ranges(cell_ids: Iterable[int]) -> List[Tuple[int, int]]:
+def s2_cells_to_ranges(cell_ids: Iterable[int]) -> list[tuple[int, int]]:
     """Convert cell IDs to ``(range_min, range_max)`` pairs for SQL.
 
     Each S2 cell, regardless of level, has a contiguous range of leaf
@@ -380,13 +388,13 @@ def s2_cells_to_ranges(cell_ids: Iterable[int]) -> List[Tuple[int, int]]:
 # ---------------------------------------------------------------------------
 
 def s2_spatial_join(
-    points_df: pd.DataFrame,
+    points_df: "pd.DataFrame",
     polygons_gdf,
     lat_col: str,
     lon_col: str,
     level: int = 12,
     polygon_id_col: Optional[str] = None,
-) -> pd.DataFrame:
+) -> "pd.DataFrame":
     """Join points to polygons via S2 cell matching (approximate PiP).
 
     Same shape as :func:`h3_spatial_join`. Points and polygons sharing
@@ -395,6 +403,7 @@ def s2_spatial_join(
     """
     _require_s2()
     _validate_level(level)
+    import pandas as pd  # local import; see TYPE_CHECKING note at top
     point_cells = s2_index_points(points_df, lat_col, lon_col, level, as_token=False)
     indexed = points_df.copy()
     indexed["_s2_index"] = point_cells
@@ -430,7 +439,7 @@ def s2_spatial_join(
 # Cell metadata
 # ---------------------------------------------------------------------------
 
-def s2_cell_to_boundary(cell_id) -> List[Tuple[float, float]]:
+def s2_cell_to_boundary(cell_id) -> list[tuple[float, float]]:
     """Return the 4 vertex coordinates of a cell as ``(lat, lng)`` tuples.
 
     Accepts an int64 cell ID or a hex token string.
@@ -445,7 +454,7 @@ def s2_cell_to_boundary(cell_id) -> List[Tuple[float, float]]:
     return out
 
 
-def s2_kring(cell_id, k: int = 1) -> List[int]:
+def s2_kring(cell_id, k: int = 1) -> list[int]:
     """Return cell IDs within k steps of *cell_id* on the same level.
 
     The k-ring is approximate for S2 (squares don't tile uniformly); we
@@ -516,7 +525,7 @@ def s2_parent(cell_id, level: int) -> int:
     return cid.parent(level).id()
 
 
-def s2_children(cell_id) -> List[int]:
+def s2_children(cell_id) -> list[int]:
     """Return the four immediate children of a cell.
 
     Raises if called on a leaf cell (level 30).
@@ -581,7 +590,7 @@ def s2_bbox_to_cells(
     *,
     max_level: int = 18,
     max_cells: int = 64,
-) -> List[int]:
+) -> list[int]:
     """Cover an axis-aligned bounding box with at most *max_cells* cells.
 
     Convenience wrapper around :func:`s2_region_cover` for the common

--- a/siege_utilities/geo/s2_utils.py
+++ b/siege_utilities/geo/s2_utils.py
@@ -544,11 +544,11 @@ def s2_cell_id_to_uint64(cell_or_token) -> int:
         return _s2.CellId.from_token(cell_or_token).id()
     try:
         return int(cell_or_token)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError) as exc:
         raise TypeError(
             f"Expected int64 cell id or hex token string, got "
             f"{type(cell_or_token).__name__}"
-        )
+        ) from exc
 
 
 def s2_uint64_to_cell_id(n: int):
@@ -627,34 +627,56 @@ def _coerce_cell_id(value):
     # Try integer-like (covers Python int, numpy.int64, numpy.uint64).
     try:
         return _s2.CellId(int(value))
-    except (TypeError, ValueError):
+    except (TypeError, ValueError) as exc:
         raise TypeError(
             f"Expected CellId, int64, or token string, got "
             f"{type(value).__name__}"
-        )
+        ) from exc
+
+
+_POLYGON_TYPES = ("Polygon", "MultiPolygon")
 
 
 def _coerce_polygon(geometry):
-    """Convert input to a shapely shape (Polygon / MultiPolygon)."""
+    """Convert input to a shapely Polygon / MultiPolygon.
+
+    Rejects Point / LineString / GeometryCollection — they have ``.bounds``
+    and ``.contains`` so a duck-typed check would let them through, but
+    a Point's bbox is degenerate and ``s2_index_polygon`` would silently
+    return the wrong cells.
+    """
     try:
         from shapely.geometry import shape, mapping  # noqa: F401
-    except ImportError:
+    except ImportError as exc:
         raise ImportError(
             "shapely is required for S2 polygon coverage. Install with: "
             "pip install 'siege-utilities[geo]' or pip install 'shapely>=2.0'."
-        )
-    if hasattr(geometry, "bounds") and hasattr(geometry, "contains"):
-        return geometry  # already a shapely shape
+        ) from exc
+
+    # Convert to a shapely object first.
     if isinstance(geometry, dict):
         from shapely.geometry import shape
-        return shape(geometry)
-    if hasattr(geometry, "__geo_interface__"):
+        candidate = shape(geometry)
+    elif hasattr(geometry, "__geo_interface__"):
         from shapely.geometry import shape
-        return shape(geometry.__geo_interface__)
-    raise TypeError(
-        f"Cannot coerce {type(geometry).__name__} to a polygon. "
-        "Provide a shapely shape or a GeoJSON dict."
-    )
+        candidate = shape(geometry.__geo_interface__)
+    elif hasattr(geometry, "geom_type") and hasattr(geometry, "bounds"):
+        candidate = geometry  # already a shapely shape
+    else:
+        raise TypeError(
+            f"Cannot coerce {type(geometry).__name__} to a polygon. "
+            "Provide a shapely shape or a GeoJSON dict."
+        )
+
+    # Now enforce the polygon type — duck typing is too permissive here.
+    geom_type = getattr(candidate, "geom_type", None)
+    if geom_type not in _POLYGON_TYPES:
+        raise TypeError(
+            f"S2 polygon coverage requires a Polygon or MultiPolygon, got "
+            f"{geom_type!r}. Convert points/lines via .buffer(...) first if "
+            "you want a non-zero-area region."
+        )
+    return candidate
 
 
 def _expand_to_level(cell_id, target_level: int) -> Iterable[int]:

--- a/tests/test_etter_filter.py
+++ b/tests/test_etter_filter.py
@@ -172,7 +172,7 @@ class TestEtterParser:
         with patch.object(ef, "ETTER_AVAILABLE", True), \
              patch.object(ef, "_UpstreamParser", return_value=upstream):
             p = ef.EtterParser(llm=MagicMock(), confidence_threshold=0.6, strict_mode=True)
-            with pytest.raises(ef.EtterLowConfidenceError, match="0.40"):
+            with pytest.raises(ef.EtterLowConfidenceError, match=r"0\.40"):
                 p.parse("q")
 
     def test_upstream_low_confidence_translated(self):

--- a/tests/test_etter_filter.py
+++ b/tests/test_etter_filter.py
@@ -95,6 +95,7 @@ class TestFromGeoQuery:
         assert f.confidence == 1.0
 
     def test_frozen(self):
+        from dataclasses import FrozenInstanceError
         gq = SimpleNamespace(
             spatial_relation="in",
             reference_location="X",
@@ -102,7 +103,7 @@ class TestFromGeoQuery:
             overall_confidence=1.0,
         )
         f = ef.EtterFilter.from_geoquery("q", gq)
-        with pytest.raises(Exception):
+        with pytest.raises(FrozenInstanceError):
             f.spatial_relation = "near"
 
 
@@ -173,6 +174,24 @@ class TestEtterParser:
             p = ef.EtterParser(llm=MagicMock(), confidence_threshold=0.6, strict_mode=True)
             with pytest.raises(ef.EtterLowConfidenceError, match="0.40"):
                 p.parse("q")
+
+    def test_upstream_low_confidence_translated(self):
+        """An upstream LowConfidenceError surfaces as our typed exception,
+        even though we don't forward strict_mode to upstream — defends
+        against the case where a future upstream version raises despite
+        our local guard."""
+        # Synthesize a class that *looks* like upstream's LowConfidenceError
+        # (matched by class name, not isinstance — see comment in parse()).
+        class LowConfidenceError(Exception):
+            pass
+
+        upstream = MagicMock()
+        upstream.parse.side_effect = LowConfidenceError("0.42 < 0.6")
+        with patch.object(ef, "ETTER_AVAILABLE", True), \
+             patch.object(ef, "_UpstreamParser", return_value=upstream):
+            p = ef.EtterParser(llm=MagicMock())
+            with pytest.raises(ef.EtterLowConfidenceError, match="Upstream rejected"):
+                p.parse("ambiguous query")
 
     def test_low_confidence_non_strict_returns_with_warning(self):
         upstream = MagicMock()

--- a/tests/test_etter_filter.py
+++ b/tests/test_etter_filter.py
@@ -1,0 +1,220 @@
+"""Tests for the Etter natural-language geo-query connector.
+
+Etter's actual parser calls an LLM, so the integration is mocked at the
+upstream-parser level (we don't need a real network round-trip to verify
+that *our* wrapper translates the upstream object correctly).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from siege_utilities.geo.providers import etter_filter as ef
+
+
+# ---------------------------------------------------------------------------
+# EtterFilter.from_geoquery (pure translation, no etter / no LLM)
+# ---------------------------------------------------------------------------
+
+class TestFromGeoQuery:
+    def test_full_geoquery(self):
+        gq = SimpleNamespace(
+            spatial_relation="north_of",
+            reference_location="Lausanne",
+            buffer_config=SimpleNamespace(distance=5, unit="km"),
+            overall_confidence=0.85,
+        )
+        f = ef.EtterFilter.from_geoquery("5 km north of Lausanne", gq)
+        assert f.spatial_relation == "north_of"
+        assert f.reference_location == "Lausanne"
+        assert f.buffer_distance_m == 5000.0
+        assert f.confidence == 0.85
+        assert f.original_query == "5 km north of Lausanne"
+        assert f.raw is gq
+
+    def test_no_buffer(self):
+        gq = SimpleNamespace(
+            spatial_relation="in",
+            reference_location="Alabama",
+            buffer_config=None,
+            overall_confidence=0.92,
+        )
+        f = ef.EtterFilter.from_geoquery("in Alabama", gq)
+        assert f.buffer_distance_m is None
+
+    def test_buffer_units_normalized(self):
+        for unit, distance, expected in [
+            ("m", 100, 100.0),
+            ("km", 5, 5000.0),
+            ("miles", 1, 1609.344),
+            ("ft", 100, 30.48),
+        ]:
+            gq = SimpleNamespace(
+                spatial_relation="near",
+                reference_location="X",
+                buffer_config=SimpleNamespace(distance=distance, unit=unit),
+                overall_confidence=1.0,
+            )
+            f = ef.EtterFilter.from_geoquery("q", gq)
+            assert f.buffer_distance_m == pytest.approx(expected)
+
+    def test_unknown_unit_falls_back_to_meters(self):
+        gq = SimpleNamespace(
+            spatial_relation="near",
+            reference_location="X",
+            buffer_config=SimpleNamespace(distance=42, unit="parsec"),
+            overall_confidence=1.0,
+        )
+        f = ef.EtterFilter.from_geoquery("q", gq)
+        assert f.buffer_distance_m == 42.0  # treated as meters with warning
+
+    def test_missing_overall_confidence_falls_back_to_breakdown(self):
+        gq = SimpleNamespace(
+            spatial_relation="near",
+            reference_location="X",
+            buffer_config=None,
+            confidence_breakdown=SimpleNamespace(spatial=0.7, reference=0.5),
+        )
+        # No overall_confidence attr; fallback should pick min of the
+        # numeric values from the breakdown (most conservative).
+        gq.overall_confidence = None
+        f = ef.EtterFilter.from_geoquery("q", gq)
+        assert f.confidence == 0.5
+
+    def test_missing_attrs_default_safely(self):
+        # An empty namespace shouldn't crash — getattr defaults take over.
+        gq = SimpleNamespace()
+        gq.overall_confidence = None  # the from_geoquery code checks this branch
+        f = ef.EtterFilter.from_geoquery("q", gq)
+        assert f.spatial_relation is None
+        assert f.reference_location is None
+        assert f.buffer_distance_m is None
+        assert f.confidence == 1.0
+
+    def test_frozen(self):
+        gq = SimpleNamespace(
+            spatial_relation="in",
+            reference_location="X",
+            buffer_config=None,
+            overall_confidence=1.0,
+        )
+        f = ef.EtterFilter.from_geoquery("q", gq)
+        with pytest.raises(Exception):
+            f.spatial_relation = "near"
+
+
+# ---------------------------------------------------------------------------
+# EtterParser (with mocked upstream)
+# ---------------------------------------------------------------------------
+
+class TestEtterParser:
+    """The constructor refuses if etter is unavailable; once mocked, it
+    delegates to the upstream parser and translates results."""
+
+    def _patch_etter_available(self):
+        """Force-enable the wrapper as if etter were installed."""
+        upstream = MagicMock()
+        upstream.parse.return_value = SimpleNamespace(
+            spatial_relation="near",
+            reference_location="Lausanne",
+            buffer_config=SimpleNamespace(distance=5, unit="km"),
+            overall_confidence=0.9,
+        )
+        return upstream
+
+    def test_construction_requires_etter(self):
+        with patch.object(ef, "ETTER_AVAILABLE", False):
+            with pytest.raises(ImportError, match="etter"):
+                ef.EtterParser(llm=MagicMock())
+
+    def test_parse_translates_upstream(self):
+        upstream = self._patch_etter_available()
+        with patch.object(ef, "ETTER_AVAILABLE", True), \
+             patch.object(ef, "_UpstreamParser", return_value=upstream):
+            p = ef.EtterParser(llm=MagicMock())
+            result = p.parse("5 km near Lausanne")
+        assert isinstance(result, ef.EtterFilter)
+        assert result.spatial_relation == "near"
+        assert result.buffer_distance_m == 5000.0
+        upstream.parse.assert_called_once_with("5 km near Lausanne")
+
+    def test_parse_empty_query_raises(self):
+        upstream = self._patch_etter_available()
+        with patch.object(ef, "ETTER_AVAILABLE", True), \
+             patch.object(ef, "_UpstreamParser", return_value=upstream):
+            p = ef.EtterParser(llm=MagicMock())
+            with pytest.raises(ef.EtterParseError, match="Empty"):
+                p.parse("")
+            with pytest.raises(ef.EtterParseError, match="Empty"):
+                p.parse("   ")
+
+    def test_upstream_failure_wraps_in_parse_error(self):
+        upstream = MagicMock()
+        upstream.parse.side_effect = RuntimeError("LLM hung up")
+        with patch.object(ef, "ETTER_AVAILABLE", True), \
+             patch.object(ef, "_UpstreamParser", return_value=upstream):
+            p = ef.EtterParser(llm=MagicMock())
+            with pytest.raises(ef.EtterParseError, match="LLM hung up"):
+                p.parse("any query")
+
+    def test_low_confidence_strict_raises(self):
+        upstream = MagicMock()
+        upstream.parse.return_value = SimpleNamespace(
+            spatial_relation="near",
+            reference_location="X",
+            buffer_config=None,
+            overall_confidence=0.4,
+        )
+        with patch.object(ef, "ETTER_AVAILABLE", True), \
+             patch.object(ef, "_UpstreamParser", return_value=upstream):
+            p = ef.EtterParser(llm=MagicMock(), confidence_threshold=0.6, strict_mode=True)
+            with pytest.raises(ef.EtterLowConfidenceError, match="0.40"):
+                p.parse("q")
+
+    def test_low_confidence_non_strict_returns_with_warning(self):
+        upstream = MagicMock()
+        upstream.parse.return_value = SimpleNamespace(
+            spatial_relation="near",
+            reference_location="X",
+            buffer_config=None,
+            overall_confidence=0.4,
+        )
+        with patch.object(ef, "ETTER_AVAILABLE", True), \
+             patch.object(ef, "_UpstreamParser", return_value=upstream):
+            p = ef.EtterParser(
+                llm=MagicMock(), confidence_threshold=0.6, strict_mode=False,
+            )
+            result = p.parse("q")
+            assert result.confidence == 0.4
+
+
+# ---------------------------------------------------------------------------
+# default_llm — verify the dispatch logic without actually constructing a model
+# ---------------------------------------------------------------------------
+
+class TestDefaultLlm:
+    def test_missing_api_key_raises(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        # The langchain import itself may fail in the test env; skip if so.
+        try:
+            from langchain.chat_models import init_chat_model  # noqa: F401
+        except ImportError:
+            pytest.skip("langchain not installed")
+        with pytest.raises(ef.EtterError, match="OPENAI_API_KEY"):
+            ef.default_llm(model="gpt-4o")
+
+    def test_explicit_api_key_bypasses_env_check(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        try:
+            from langchain.chat_models import init_chat_model  # noqa: F401
+        except ImportError:
+            pytest.skip("langchain not installed")
+        with patch("langchain.chat_models.init_chat_model") as mock_init:
+            mock_init.return_value = MagicMock(name="llm")
+            ef.default_llm(model="gpt-4o", api_key="sk-test")
+            assert mock_init.called
+            call_kwargs = mock_init.call_args.kwargs
+            assert call_kwargs["api_key"] == "sk-test"

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -13,11 +13,17 @@ from siege_utilities.geo import grids
 # ---------------------------------------------------------------------------
 
 class TestInferGrid:
-    def test_explicit_h3_wins(self):
-        assert grids.infer_grid("h3", {"level": 12}) == "h3"
+    def test_explicit_h3_wins_with_no_kwargs(self):
+        assert grids.infer_grid("h3", {}) == "h3"
 
-    def test_explicit_s2_wins(self):
-        assert grids.infer_grid("s2", {"resolution": 8}) == "s2"
+    def test_explicit_s2_wins_with_no_kwargs(self):
+        assert grids.infer_grid("s2", {}) == "s2"
+
+    def test_explicit_h3_with_compatible_kwargs(self):
+        assert grids.infer_grid("h3", {"resolution": 7}) == "h3"
+
+    def test_explicit_s2_with_compatible_kwargs(self):
+        assert grids.infer_grid("s2", {"level": 10}) == "s2"
 
     def test_invalid_grid_raises(self):
         with pytest.raises(ValueError, match="grid must be"):
@@ -110,3 +116,33 @@ class TestIndexPolygonDispatch:
     def test_ambiguous_kwargs_raises(self, square):
         with pytest.raises(ValueError, match="Ambiguous"):
             grids.index_polygon(square, resolution=8, level=10)
+
+    def test_explicit_h3_with_s2_kwargs_raises(self, square):
+        """grid='h3' + max_cells= must error — silent kwarg drop is the
+        bug CodeRabbit caught."""
+        with pytest.raises(ValueError, match="S2-only kwargs"):
+            grids.index_polygon(square, grid="h3", max_cells=20)
+
+    def test_explicit_s2_with_h3_kwargs_raises(self, square):
+        with pytest.raises(ValueError, match="H3-only kwargs"):
+            grids.index_polygon(square, grid="s2", resolution=7)
+
+
+class TestIndexPointsKwargForwarding:
+    """Asymmetric kwarg forwarding was the 2nd CodeRabbit major;
+    H3 path now rejects unknown kwargs instead of silently dropping."""
+
+    @pytest.fixture
+    def df(self):
+        return pd.DataFrame({"lat": [33.5, 40.7], "lon": [-86.8, -74.0]})
+
+    def test_h3_rejects_unknown_kwargs(self, df):
+        pytest.importorskip("h3")
+        with pytest.raises(TypeError, match="unexpected keyword"):
+            grids.index_points(df, "lat", "lon", grid="h3", as_token=False)
+
+    def test_s2_forwards_known_kwargs(self, df):
+        pytest.importorskip("s2sphere")
+        # as_token=False is a real S2 kwarg; should make it through.
+        out = grids.index_points(df, "lat", "lon", grid="s2", as_token=False)
+        assert int(out.iloc[0]) == out.iloc[0]  # numeric, not a token string

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -1,0 +1,112 @@
+"""Tests for the grid-agnostic dispatch wrapper in siege_utilities.geo.grids."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from siege_utilities.geo import grids
+
+
+# ---------------------------------------------------------------------------
+# infer_grid (pure inference, no extra-deps)
+# ---------------------------------------------------------------------------
+
+class TestInferGrid:
+    def test_explicit_h3_wins(self):
+        assert grids.infer_grid("h3", {"level": 12}) == "h3"
+
+    def test_explicit_s2_wins(self):
+        assert grids.infer_grid("s2", {"resolution": 8}) == "s2"
+
+    def test_invalid_grid_raises(self):
+        with pytest.raises(ValueError, match="grid must be"):
+            grids.infer_grid("hex", {})
+
+    def test_s2_kwarg_implies_s2(self):
+        assert grids.infer_grid(None, {"max_cells": 50}) == "s2"
+        assert grids.infer_grid(None, {"min_level": 5}) == "s2"
+        assert grids.infer_grid(None, {"max_level": 12}) == "s2"
+        assert grids.infer_grid(None, {"level": 12}) == "s2"
+
+    def test_resolution_kwarg_implies_h3(self):
+        assert grids.infer_grid(None, {"resolution": 8}) == "h3"
+
+    def test_no_kwargs_defaults_h3(self):
+        assert grids.infer_grid(None, {}) == "h3"
+
+    def test_none_values_ignored(self):
+        # None values should not trigger inference for that kwarg.
+        assert grids.infer_grid(None, {"level": None, "resolution": None}) == "h3"
+        assert grids.infer_grid(None, {"level": None, "max_cells": 50}) == "s2"
+
+    def test_mixed_kwargs_raises(self):
+        with pytest.raises(ValueError, match="Ambiguous"):
+            grids.infer_grid(None, {"resolution": 8, "level": 12})
+
+
+# ---------------------------------------------------------------------------
+# index_points dispatch (skip when underlying grid lib missing)
+# ---------------------------------------------------------------------------
+
+class TestIndexPointsDispatch:
+    @pytest.fixture
+    def df(self):
+        return pd.DataFrame({"lat": [33.5, 40.7], "lon": [-86.8, -74.0]})
+
+    def test_h3_path(self, df):
+        h3 = pytest.importorskip("h3")  # noqa: F841
+        out = grids.index_points(df, "lat", "lon", resolution=8)
+        assert len(out) == 2
+        # H3 cells are 15-char hex strings
+        assert all(isinstance(v, str) and len(v) == 15 for v in out)
+
+    def test_s2_path(self, df):
+        pytest.importorskip("s2sphere")
+        out = grids.index_points(df, "lat", "lon", level=12)
+        assert len(out) == 2
+        # Default S2 returns hex tokens
+        assert all(isinstance(v, str) for v in out)
+
+    def test_explicit_grid_overrides_default(self, df):
+        pytest.importorskip("s2sphere")
+        out = grids.index_points(df, "lat", "lon", grid="s2")
+        assert len(out) == 2
+
+
+# ---------------------------------------------------------------------------
+# index_polygon dispatch
+# ---------------------------------------------------------------------------
+
+class TestIndexPolygonDispatch:
+    @pytest.fixture
+    def square(self):
+        shapely = pytest.importorskip("shapely.geometry")
+        return shapely.box(-87.0, 33.0, -86.0, 34.0)
+
+    def test_h3_returns_set(self, square):
+        pytest.importorskip("h3")
+        result = grids.index_polygon(square, resolution=7)
+        assert isinstance(result, set)
+
+    def test_s2_single_level_returns_set(self, square):
+        pytest.importorskip("s2sphere")
+        result = grids.index_polygon(square, level=8)
+        assert isinstance(result, set)
+
+    def test_s2_region_cover_returns_list(self, square):
+        pytest.importorskip("s2sphere")
+        result = grids.index_polygon(square, max_cells=20)
+        assert isinstance(result, list)
+        assert len(result) <= 20
+
+    def test_s2_min_level_triggers_region_cover(self, square):
+        pytest.importorskip("s2sphere")
+        result = grids.index_polygon(
+            square, min_level=4, max_level=12, max_cells=30,
+        )
+        assert isinstance(result, list)
+
+    def test_ambiguous_kwargs_raises(self, square):
+        with pytest.raises(ValueError, match="Ambiguous"):
+            grids.index_polygon(square, resolution=8, level=10)

--- a/tests/test_s2_utils.py
+++ b/tests/test_s2_utils.py
@@ -1,0 +1,327 @@
+"""Tests for siege_utilities.geo.s2_utils."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from siege_utilities.geo import s2_utils
+
+pytestmark = pytest.mark.skipif(
+    not s2_utils.S2_AVAILABLE, reason="s2sphere not installed"
+)
+
+
+# ---------------------------------------------------------------------------
+# Reference tables
+# ---------------------------------------------------------------------------
+
+class TestLevelForArea:
+    def test_us_state_area(self):
+        # ~196,600 km² sits between S2 level 4 (~379k) and level 5 (~95k);
+        # log-closest is level 4.
+        assert s2_utils.s2_level_for_area(196_600.0) in (4, 5)
+
+    def test_invalid_area_raises(self):
+        with pytest.raises(ValueError, match="positive"):
+            s2_utils.s2_level_for_area(0.0)
+        with pytest.raises(ValueError, match="positive"):
+            s2_utils.s2_level_for_area(-1.0)
+
+    def test_returns_in_range(self):
+        for km2 in (1e8, 1e4, 1.0, 1e-4, 1e-8):
+            level = s2_utils.s2_level_for_area(km2)
+            assert 0 <= level <= 30
+
+    def test_monotonic(self):
+        prev = s2_utils.S2_LEVEL_AREA_KM2[0]
+        for level in range(1, 31):
+            assert s2_utils.S2_LEVEL_AREA_KM2[level] < prev
+            prev = s2_utils.S2_LEVEL_AREA_KM2[level]
+
+
+class TestLevelForAdminLevel:
+    def test_state_returns_low_level(self):
+        # state ~196,600 km² → log-closest is level 4 (or 5)
+        assert s2_utils.s2_level_for_admin_level("state") in (4, 5)
+
+    def test_levels_are_monotonic(self):
+        """Larger admin units → lower S2 levels."""
+        levels = ["state", "county", "zcta", "tract", "block_group", "block"]
+        s2_levels = [s2_utils.s2_level_for_admin_level(L) for L in levels]
+        for i in range(len(s2_levels) - 1):
+            assert s2_levels[i] <= s2_levels[i + 1]
+
+    def test_aliases(self):
+        assert s2_utils.s2_level_for_admin_level("zip") == \
+            s2_utils.s2_level_for_admin_level("zcta")
+        assert s2_utils.s2_level_for_admin_level("BG") == \
+            s2_utils.s2_level_for_admin_level("block_group")
+
+    def test_unknown_level_raises(self):
+        with pytest.raises(ValueError, match="Unknown admin level"):
+            s2_utils.s2_level_for_admin_level("metro")
+
+
+# ---------------------------------------------------------------------------
+# Point indexing
+# ---------------------------------------------------------------------------
+
+class TestIndexPoints:
+    def test_assigns_cell_per_row(self):
+        df = pd.DataFrame({"lat": [33.5, 40.7], "lon": [-86.8, -74.0]})
+        out = s2_utils.s2_index_points(df, "lat", "lon", level=10)
+        assert len(out) == 2
+        assert out.iloc[0] != out.iloc[1]
+        assert all(isinstance(v, str) for v in out)  # default as_token=True
+
+    def test_int_id_form(self):
+        df = pd.DataFrame({"lat": [33.5], "lon": [-86.8]})
+        out = s2_utils.s2_index_points(df, "lat", "lon", level=10, as_token=False)
+        # pandas may wrap integer cells as numpy.uint64; `int(...)` should
+        # round-trip without loss.
+        v = out.iloc[0]
+        assert int(v) == v
+        assert v > 0  # valid S2 cell IDs are non-zero
+
+    def test_invalid_level_raises(self):
+        df = pd.DataFrame({"lat": [33.5], "lon": [-86.8]})
+        with pytest.raises(ValueError, match="0-30"):
+            s2_utils.s2_index_points(df, "lat", "lon", level=31)
+
+    def test_missing_column_raises(self):
+        df = pd.DataFrame({"lat": [33.5], "lon": [-86.8]})
+        with pytest.raises(ValueError, match="not found"):
+            s2_utils.s2_index_points(df, "latitude", "lon")
+
+
+# ---------------------------------------------------------------------------
+# Polygon coverage
+# ---------------------------------------------------------------------------
+
+class TestIndexPolygon:
+    @pytest.fixture
+    def square(self):
+        from shapely.geometry import box
+        # ~1° square near Birmingham, AL
+        return box(-87.0, 33.0, -86.0, 34.0)
+
+    def test_single_level_returns_set(self, square):
+        cells = s2_utils.s2_index_polygon(square, level=8, refine=False)
+        assert isinstance(cells, set)
+        assert len(cells) > 0
+
+    def test_higher_level_more_cells(self, square):
+        few = s2_utils.s2_index_polygon(square, level=8, refine=False)
+        many = s2_utils.s2_index_polygon(square, level=10, refine=False)
+        assert len(many) > len(few)
+
+    def test_refine_filters_to_polygon(self):
+        from shapely.geometry import Polygon
+        # An L-shaped polygon: bbox covers a square but the polygon
+        # excludes one corner.
+        l_shape = Polygon([
+            (0, 0), (2, 0), (2, 1), (1, 1), (1, 2), (0, 2), (0, 0),
+        ])
+        bbox_only = s2_utils.s2_index_polygon(l_shape, level=10, refine=False)
+        refined = s2_utils.s2_index_polygon(l_shape, level=10, refine=True)
+        assert len(refined) < len(bbox_only), (
+            "refine should drop cells in the excluded corner"
+        )
+
+
+class TestRegionCover:
+    @pytest.fixture
+    def bbox_polygon(self):
+        from shapely.geometry import box
+        # Roughly Alabama's bbox.
+        return box(-88.5, 30.2, -84.9, 35.0)
+
+    def test_max_cells_respected(self, bbox_polygon):
+        cells = s2_utils.s2_region_cover(
+            bbox_polygon, min_level=4, max_level=14, max_cells=20,
+        )
+        assert len(cells) <= 20
+        assert len(cells) > 0
+
+    def test_returns_int_ids(self, bbox_polygon):
+        cells = s2_utils.s2_region_cover(bbox_polygon, max_cells=5)
+        assert all(isinstance(c, int) for c in cells)
+
+    def test_min_max_level_constrains_levels(self, bbox_polygon):
+        import s2sphere
+        cells = s2_utils.s2_region_cover(
+            bbox_polygon, min_level=8, max_level=10, max_cells=100,
+        )
+        for cid in cells:
+            level = s2sphere.CellId(cid).level()
+            assert 8 <= level <= 10
+
+    def test_max_cells_must_be_positive(self, bbox_polygon):
+        with pytest.raises(ValueError, match="max_cells"):
+            s2_utils.s2_region_cover(bbox_polygon, max_cells=0)
+
+    def test_min_must_be_le_max(self, bbox_polygon):
+        with pytest.raises(ValueError, match="min_level"):
+            s2_utils.s2_region_cover(bbox_polygon, min_level=10, max_level=5)
+
+
+class TestCellsToRanges:
+    def test_each_range_is_pair(self):
+        from shapely.geometry import box
+        cells = s2_utils.s2_region_cover(
+            box(-1, -1, 1, 1), max_cells=10,
+        )
+        ranges = s2_utils.s2_cells_to_ranges(cells)
+        assert len(ranges) == len(cells)
+        for lo, hi in ranges:
+            assert isinstance(lo, int)
+            assert isinstance(hi, int)
+            assert lo <= hi
+
+
+# ---------------------------------------------------------------------------
+# Cell metadata
+# ---------------------------------------------------------------------------
+
+class TestCellToBoundary:
+    def test_returns_four_points(self):
+        df = pd.DataFrame({"lat": [33.5], "lon": [-86.8]})
+        cell = s2_utils.s2_index_points(df, "lat", "lon", level=10).iloc[0]
+        boundary = s2_utils.s2_cell_to_boundary(cell)
+        assert len(boundary) == 4
+        for lat, lng in boundary:
+            assert -90.0 <= lat <= 90.0
+            assert -180.0 <= lng <= 180.0
+
+
+class TestKring:
+    def test_k0_returns_self(self):
+        df = pd.DataFrame({"lat": [33.5], "lon": [-86.8]})
+        cell = s2_utils.s2_index_points(df, "lat", "lon", level=10, as_token=False).iloc[0]
+        ring = s2_utils.s2_kring(cell, k=0)
+        assert ring == [cell]
+
+    def test_k1_includes_self_plus_neighbors(self):
+        df = pd.DataFrame({"lat": [33.5], "lon": [-86.8]})
+        cell = s2_utils.s2_index_points(df, "lat", "lon", level=10, as_token=False).iloc[0]
+        ring = s2_utils.s2_kring(cell, k=1)
+        assert cell in ring
+        assert len(ring) >= 5  # self + at least 4 neighbors (corners can dup)
+
+    def test_negative_k_raises(self):
+        with pytest.raises(ValueError, match="k must be"):
+            s2_utils.s2_kring(0, k=-1)
+
+
+class TestDistance:
+    def test_self_distance_zero(self):
+        df = pd.DataFrame({"lat": [33.5], "lon": [-86.8]})
+        cell = s2_utils.s2_index_points(df, "lat", "lon", level=10, as_token=False).iloc[0]
+        assert s2_utils.s2_distance(cell, cell) == 0
+
+    def test_neighbor_distance_one(self):
+        df = pd.DataFrame({"lat": [33.5], "lon": [-86.8]})
+        cell = s2_utils.s2_index_points(df, "lat", "lon", level=10, as_token=False).iloc[0]
+        ring = s2_utils.s2_kring(cell, k=1)
+        # All cells in ring 1 are distance 0 (self) or 1
+        non_self = [c for c in ring if c != cell]
+        assert non_self
+        for c in non_self:
+            assert s2_utils.s2_distance(cell, c) == 1
+
+    def test_level_mismatch_raises(self):
+        df = pd.DataFrame({"lat": [33.5], "lon": [-86.8]})
+        a = s2_utils.s2_index_points(df, "lat", "lon", level=10, as_token=False).iloc[0]
+        b = s2_utils.s2_parent(a, 8)
+        with pytest.raises(ValueError, match="level must match"):
+            s2_utils.s2_distance(a, b)
+
+
+class TestParentChildren:
+    def test_parent_at_lower_level(self):
+        df = pd.DataFrame({"lat": [33.5], "lon": [-86.8]})
+        cell = s2_utils.s2_index_points(df, "lat", "lon", level=12, as_token=False).iloc[0]
+        parent = s2_utils.s2_parent(cell, level=8)
+        # Check via s2sphere directly
+        import s2sphere
+        assert s2sphere.CellId(parent).level() == 8
+
+    def test_parent_at_higher_level_raises(self):
+        df = pd.DataFrame({"lat": [33.5], "lon": [-86.8]})
+        cell = s2_utils.s2_index_points(df, "lat", "lon", level=8, as_token=False).iloc[0]
+        with pytest.raises(ValueError, match="target level"):
+            s2_utils.s2_parent(cell, level=12)
+
+    def test_children_returns_four(self):
+        df = pd.DataFrame({"lat": [33.5], "lon": [-86.8]})
+        cell = s2_utils.s2_index_points(df, "lat", "lon", level=10, as_token=False).iloc[0]
+        children = s2_utils.s2_children(cell)
+        assert len(children) == 4
+
+    def test_children_at_leaf_raises(self):
+        df = pd.DataFrame({"lat": [33.5], "lon": [-86.8]})
+        leaf = s2_utils.s2_index_points(df, "lat", "lon", level=30, as_token=False).iloc[0]
+        with pytest.raises(ValueError, match="leaf level"):
+            s2_utils.s2_children(leaf)
+
+
+class TestIDConversions:
+    def test_token_round_trip(self):
+        df = pd.DataFrame({"lat": [33.5], "lon": [-86.8]})
+        cell_int = s2_utils.s2_index_points(df, "lat", "lon", level=10, as_token=False).iloc[0]
+        token = s2_utils.s2_cell_id_to_token(cell_int)
+        recovered = s2_utils.s2_token_to_cell_id(token)
+        assert recovered == cell_int
+
+    def test_uint64_passthrough(self):
+        assert s2_utils.s2_cell_id_to_uint64(123456789) == 123456789
+
+    def test_uint64_from_token(self):
+        df = pd.DataFrame({"lat": [33.5], "lon": [-86.8]})
+        token = s2_utils.s2_index_points(df, "lat", "lon", level=10, as_token=True).iloc[0]
+        as_int = s2_utils.s2_cell_id_to_uint64(token)
+        assert isinstance(as_int, int)
+
+    def test_uint64_invalid_type_raises(self):
+        # Things that have no sensible int conversion.
+        with pytest.raises(TypeError):
+            s2_utils.s2_cell_id_to_uint64(["not", "an", "id"])
+        with pytest.raises(TypeError):
+            s2_utils.s2_cell_id_to_uint64({"key": "value"})
+
+
+class TestBboxToCells:
+    def test_basic_bbox(self):
+        cells = s2_utils.s2_bbox_to_cells(33.0, -87.0, 34.0, -86.0, max_cells=8)
+        assert 0 < len(cells) <= 8
+
+    def test_max_cells_zero_raises(self):
+        with pytest.raises(ValueError, match="max_cells"):
+            s2_utils.s2_bbox_to_cells(33.0, -87.0, 34.0, -86.0, max_cells=0)
+
+
+# ---------------------------------------------------------------------------
+# Spatial join
+# ---------------------------------------------------------------------------
+
+class TestSpatialJoin:
+    def test_basic_join(self):
+        try:
+            import geopandas as gpd
+            from shapely.geometry import box
+        except ImportError:
+            pytest.skip("geopandas / shapely not installed")
+        # Two boxes side by side; two points, one in each box.
+        gdf = gpd.GeoDataFrame({
+            "name": ["west", "east"],
+            "geometry": [box(0, 0, 1, 1), box(1, 0, 2, 1)],
+        })
+        points = pd.DataFrame({
+            "id": ["p1", "p2"],
+            "lat": [0.5, 0.5],
+            "lon": [0.5, 1.5],
+        })
+        joined = s2_utils.s2_spatial_join(points, gdf, "lat", "lon", level=12)
+        assert len(joined) == 2
+        assert set(joined["name"]) == {"west", "east"}

--- a/tests/test_s2_utils.py
+++ b/tests/test_s2_utils.py
@@ -325,3 +325,73 @@ class TestSpatialJoin:
         joined = s2_utils.s2_spatial_join(points, gdf, "lat", "lon", level=12)
         assert len(joined) == 2
         assert set(joined["name"]) == {"west", "east"}
+
+    def test_no_matches_returns_empty_with_schema(self):
+        """Empty-match path keeps the polygon-attrs columns on the result
+        (early-return at lines 415-419 of s2_utils — caught by CodeRabbit)."""
+        try:
+            import geopandas as gpd
+            from shapely.geometry import box
+        except ImportError:
+            pytest.skip("geopandas / shapely not installed")
+        gdf = gpd.GeoDataFrame({
+            "name": ["far_away"],
+            "geometry": [box(50, 50, 51, 51)],
+        })
+        points = pd.DataFrame({
+            "id": ["p1"],
+            "lat": [0.5],
+            "lon": [0.5],  # not in any polygon
+        })
+        joined = s2_utils.s2_spatial_join(points, gdf, "lat", "lon", level=12)
+        assert len(joined) == 0
+        # Schema must still expose the polygon-attrs column even on empty.
+        assert "name" in joined.columns
+
+    def test_first_polygon_wins_on_overlap(self):
+        """Two overlapping polygons — first one registered wins for shared cells."""
+        try:
+            import geopandas as gpd
+            from shapely.geometry import box
+        except ImportError:
+            pytest.skip("geopandas / shapely not installed")
+        # Two polygons that overlap; point lands inside both.
+        gdf = gpd.GeoDataFrame({
+            "name": ["first", "second"],
+            "geometry": [box(0, 0, 1, 1), box(0.5, 0, 1.5, 1)],
+        })
+        points = pd.DataFrame({
+            "id": ["p1"],
+            "lat": [0.5],
+            "lon": [0.7],  # inside both
+        })
+        joined = s2_utils.s2_spatial_join(points, gdf, "lat", "lon", level=12)
+        assert len(joined) == 1
+        assert joined["name"].iloc[0] == "first"
+
+
+class TestCoercePolygonRejects:
+    """_coerce_polygon must reject Points/LineStrings — duck-typing by
+    .bounds + .contains was too permissive (CodeRabbit major)."""
+
+    def test_point_rejected(self):
+        try:
+            from shapely.geometry import Point
+        except ImportError:
+            pytest.skip("shapely not installed")
+        with pytest.raises(TypeError, match="Polygon or MultiPolygon"):
+            s2_utils.s2_index_polygon(Point(0, 0), level=10)
+
+    def test_linestring_rejected(self):
+        try:
+            from shapely.geometry import LineString
+        except ImportError:
+            pytest.skip("shapely not installed")
+        with pytest.raises(TypeError, match="Polygon or MultiPolygon"):
+            s2_utils.s2_index_polygon(LineString([(0, 0), (1, 1)]), level=10)
+
+    def test_geojson_point_rejected(self):
+        with pytest.raises(TypeError, match="Polygon or MultiPolygon"):
+            s2_utils.s2_index_polygon(
+                {"type": "Point", "coordinates": [0, 0]}, level=10,
+            )


### PR DESCRIPTION
## Summary

Three pieces shipping together because they're aligned around the same idea — *consumer code shouldn't have to pick a grid system at the call site, or know that "5 km north of Lausanne" is a structured filter.*

### 1. S2 cell-grid utilities (`siege_utilities/geo/s2_utils.py`)

Sibling of `h3_utils`. The reasons to reach for S2 over H3:

- Sortable int64 cell IDs — natural primary key for spatial sharding in BigQuery / Cassandra / PostGIS.
- Cell-id ranges = bounding boxes — one SQL `BETWEEN` per cell in a cover replaces a polyfill `IN`-list.
- Clean 4-children hierarchy — exact parent/child rollups.
- Native to Apple Photos / iOS / Foursquare / Uber backends.

Mirrors `h3_utils` where the operations align (`index_points`, `index_polygon`, `spatial_join`, `cell_to_boundary`, `level_for_area`, `level_for_admin_level`, `kring`, `distance`) and adds the S2-specific functions:

- **`s2_region_cover(geom, min_level, max_level, max_cells)`** — variable-resolution polygon coverage with a cell-count budget. The killer feature: cover Alabama with 30 cells across levels 6–12 instead of 5,000 hexes at one resolution.
- **`s2_cells_to_ranges(cells)`** — `(range_min, range_max)` tuples for SQL `BETWEEN`. Once you have a region's cover, "is point X in region?" is a constant-time integer test.
- `s2_parent` / `s2_children` for rollups; `s2_cell_id_to_uint64` / `s2_token_to_cell_id` round-trips for DB ↔ JSON; `s2_bbox_to_cells` for map-viewport queries.

Polygon coverage is bbox-based (the pure-Python `s2sphere` lacks Loop/Polygon support); single-level coverage post-filters cells by shapely centroid containment so concave polygons (L-shapes, Idaho) get sensible results. Documented in the module docstring.

### 2. Grid-agnostic dispatcher (`siege_utilities/geo/grids.py`)

`index_points` and `index_polygon` infer the grid from kwargs:

| Call | Resolves to |
|---|---|
| `index_points(df, lat, lon, resolution=8)` | H3 |
| `index_points(df, lat, lon, level=12)` | S2 |
| `index_polygon(geom, resolution=7)` | H3 polyfill (returns `set`) |
| `index_polygon(geom, level=10)` | S2 single-level (returns `set`) |
| `index_polygon(geom, max_cells=50)` | S2 region_cover (returns `list`) |
| `index_polygon(geom, level=10, grid="s2")` | explicit override wins |
| `index_polygon(geom, resolution=8, level=10)` | `ValueError` — ambiguous |

Return-shape signal: H3 always returns `set`; S2 returns `set` for single-level, `list` for region_cover (variable-resolution). Lets reporting code accept `grid` as a config knob without rewriting.

### 3. Etter natural-language parser (`siege_utilities/geo/providers/etter_filter.py`)

Wraps `geoblocks/etter` for ad-hoc / interactive / one-off ETL prep — **not batch** (every call is an LLM round-trip):

```python
from siege_utilities.geo.providers.etter_filter import EtterParser

parser = EtterParser()  # default GPT-4o, OPENAI_API_KEY from env
result = parser.parse("5 km north of Lausanne")
# result.spatial_relation == "north_of"
# result.reference_location == "Lausanne"
# result.buffer_distance_m == 5000.0
```

`EtterFilter` dataclass normalizes the upstream Pydantic `GeoQuery`, flattens `buffer_config` to meters, surfaces overall confidence, preserves the raw upstream object on `.raw`. `default_llm()` handles the langchain `init_chat_model` boilerplate; consumers pass their own `llm=` for tests or pinning. Strict-mode raises `EtterLowConfidenceError` when confidence < threshold; non-strict logs and returns. Tolerant of upstream field-name drift via `getattr`-with-defaults.

### Packaging

- New `[s2]` extra → `s2sphere>=0.2.5`
- New `[etter]` extra → `etter>=0.1.0`
- Both rolled into `[all]`

## Test plan

- [x] Local: `pytest tests/test_s2_utils.py tests/test_grids.py tests/test_etter_filter.py` → **68 passed, 2 skipped** (the 2 skips are langchain-init-chat-model tests that need langchain installed).
- [x] Local: lint clean (no F401/F841/F541).
- [ ] Full CI matrix on push.

## Out of scope (deliberately deferred — to discuss next)

- Wiring `index_points` / `s2_index_polygon` into the multi-engine `DataFrameEngine` so a Spark/DuckDB-backed frame gets the same call surface as a pandas one. Deserves design conversation.
- Polygon-map → hex-map conversion utility for `reporting/`. Deserves design conversation.
- `EtterFilter.to_geometry()` — resolving a parsed query to a shapely shape via the geocoding stack. Useful but introduces hard semantic choices ("north of X" = bbox half-plane? = tracts whose centroid is north of X's centroid?) that I'd rather discuss than guess.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * S2 cell-grid spatial indexing added alongside H3.
  * Natural‑language geographic query parsing for location queries with confidence handling.
  * Unified grid API to index points/polygons, perform region covers, spatial joins, and cell‑hierarchy ops across H3 and S2.

* **Tests**
  * Comprehensive test suites for S2 utilities, grid dispatch behavior, and the natural‑language parser.

* **Chores**
  * New optional install extra ("s2") to enable S2 support; full install meta-extra updated to include it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->