### PR TITLE
feat(engines): wire H3+S2 grid utilities into DataFrameEngine (ELE-2485)

### DIFF
--- a/siege_utilities/engines/dataframe_engine.py
+++ b/siege_utilities/engines/dataframe_engine.py
@@ -192,6 +192,87 @@ class DataFrameEngine(ABC):
         Always returns a ``geopandas.GeoDataFrame`` regardless of engine.
         """
 
+    # -- Grid indexing (concrete defaults; engines may override) -----------
+
+    def index_points(
+        self,
+        df: Any,
+        lat_col: str,
+        lon_col: str,
+        *,
+        grid: Optional[str] = None,
+        resolution: Optional[int] = None,
+        level: Optional[int] = None,
+        as_token: bool = True,
+    ) -> Any:
+        """Compute a grid (H3 or S2) cell ID for each row.
+
+        Default: round-trip through pandas. Engines that benefit from a
+        native path (Spark via pandas UDF, DuckDB via SQL when the
+        spatial extension is loaded) should override.
+
+        See :func:`siege_utilities.geo.grids.index_points` for the kwarg
+        inference rules — pass ``resolution=`` for H3, ``level=`` for S2,
+        or set ``grid=`` explicitly.
+
+        Returns the same engine-native frame type as ``df`` would have
+        been augmented with — for the default, that's a column appended
+        to a pandas-converted copy. Engines that override return their
+        native shape.
+        """
+        from ..geo.grids import index_points as _index_points, infer_grid
+        pdf = self.to_pandas(df).copy()
+        if grid is None and resolution is None and level is None:
+            # No hint at all → default to S2 level 12 (the most useful
+            # data-warehouse path; H3 callers are expected to pass
+            # resolution=).
+            level = 12
+            grid = "s2"
+        # Resolve the chosen grid up front so the output column name
+        # matches what was computed (otherwise resolution=8 alone would
+        # produce h3_index in the data but be labelled s2_index).
+        chosen = infer_grid(grid, {"resolution": resolution, "level": level})
+        cells = _index_points(
+            pdf, lat_col, lon_col,
+            grid=grid, resolution=resolution, level=level,
+            **({"as_token": as_token} if chosen == "s2" else {}),
+        )
+        col = "h3_index" if chosen == "h3" else "s2_index"
+        pdf[col] = cells.values
+        return pdf
+
+    def index_polygon(
+        self,
+        geometry: Any,
+        *,
+        grid: Optional[str] = None,
+        resolution: Optional[int] = None,
+        level: Optional[int] = None,
+        max_cells: Optional[int] = None,
+        min_level: Optional[int] = None,
+        max_level: Optional[int] = None,
+        refine: bool = True,
+    ) -> Any:
+        """Cover a polygon with grid cells.
+
+        Engine-agnostic by construction — the input is a single geometry,
+        not a frame, so no engine-specific dispatch is required at this
+        level. Provided here for API symmetry with :meth:`index_points`
+        and so consumer code can accept ``engine`` as a config knob and
+        call ``engine.index_polygon(...)`` uniformly.
+        """
+        from ..geo.grids import index_polygon as _index_polygon
+        return _index_polygon(
+            geometry,
+            grid=grid,
+            resolution=resolution,
+            level=level,
+            max_cells=max_cells,
+            min_level=min_level,
+            max_level=max_level,
+            refine=refine,
+        )
+
     # -- Spatial sugar (concrete defaults) ---------------------------------
 
     def point_in_polygon(
@@ -1007,6 +1088,41 @@ class PostGISEngine(DataFrameEngine):
     @property
     def name(self) -> str:
         return POSTGIS
+
+    # -- Grid indexing (overrides the ABC default to surface a useful path) -
+
+    def index_points(
+        self,
+        df: Any,
+        lat_col: str,
+        lon_col: str,
+        *,
+        grid: Optional[str] = None,
+        resolution: Optional[int] = None,
+        level: Optional[int] = None,
+        as_token: bool = True,
+    ) -> Any:
+        """PostGIS does not natively compute H3 / S2 cell IDs.
+
+        For S2-keyed warehouse joins, the recommended pattern is:
+
+          1. Compute cell IDs ONCE during ingest (e.g. via the PandasEngine
+             or in your ETL job using ``s2_index_points``).
+          2. Store as a ``BIGINT`` column on the row.
+          3. For region queries, generate ``(range_min, range_max)`` pairs
+             via :func:`s2_cells_to_ranges` and filter with
+             ``WHERE s2_cell BETWEEN range_min AND range_max``.
+
+        Computing cell IDs at query time over PostGIS would defeat the
+        whole point — the database can't index a value it has to compute
+        per-row. Hence this engine raises rather than silently degrade.
+        """
+        raise NotImplementedError(
+            "PostGISEngine.index_points: compute cell IDs at ingest time "
+            "(via PandasEngine or s2_index_points), store as BIGINT column, "
+            "and use s2_cells_to_ranges() for region queries. "
+            "See engine.index_points docstring for the pattern."
+        )
 
     # -- I/O ----------------------------------------------------------------
 

--- a/siege_utilities/geo/grids.py
+++ b/siege_utilities/geo/grids.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 import logging
 from typing import Any, Optional
 
-import pandas as pd
 
 log = logging.getLogger(__name__)
 
@@ -88,15 +87,16 @@ def infer_grid(grid: Grid, kwargs: dict) -> str:
 
 
 def index_points(
-    df: pd.DataFrame,
+    df: Any,
     lat_col: str,
     lon_col: str,
     *,
     grid: Grid = None,
     resolution: Optional[int] = None,
     level: Optional[int] = None,
+    engine: Any = None,
     **kwargs: Any,
-) -> pd.Series:
+) -> Any:
     """Compute a grid cell ID for each row in *df*.
 
     Dispatches to :func:`h3_index_points` or :func:`s2_index_points`
@@ -109,6 +109,16 @@ def index_points(
         ``pd.Series`` of cell IDs (H3 hex strings or S2 cell tokens by
         default).
     """
+    if engine is not None:
+        # Engine path: hand off to the DataFrameEngine.index_points override.
+        # The default on the ABC round-trips through pandas; concrete engines
+        # may have native fast paths.
+        return engine.index_points(
+            df, lat_col, lon_col,
+            grid=grid, resolution=resolution, level=level,
+            **kwargs,
+        )
+
     chosen = infer_grid(grid, {"resolution": resolution, "level": level})
     if chosen == "h3":
         from .h3_utils import h3_index_points

--- a/tests/test_grids_engine_integration.py
+++ b/tests/test_grids_engine_integration.py
@@ -1,0 +1,135 @@
+"""Tests for DataFrameEngine.index_points / index_polygon (ELE-2485).
+
+The default ABC implementation round-trips through pandas; per-engine
+overrides (PostGISEngine in particular) are also covered.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# PandasEngine path — exercises the ABC default end-to-end
+# ---------------------------------------------------------------------------
+
+class TestPandasEngineIndexPoints:
+    @pytest.fixture
+    def df(self):
+        return pd.DataFrame({"lat": [33.5, 40.7], "lon": [-86.8, -74.0]})
+
+    def test_default_resolves_to_s2(self, df):
+        """No grid kwargs → engine default picks S2 at level 12."""
+        pytest.importorskip("s2sphere")
+        from siege_utilities.engines.dataframe_engine import PandasEngine
+        engine = PandasEngine()
+        result = engine.index_points(df, "lat", "lon")
+        assert "s2_index" in result.columns
+        assert len(result) == 2
+        assert result["s2_index"].iloc[0] != result["s2_index"].iloc[1]
+
+    def test_h3_via_resolution_kwarg(self, df):
+        pytest.importorskip("h3")
+        from siege_utilities.engines.dataframe_engine import PandasEngine
+        engine = PandasEngine()
+        result = engine.index_points(df, "lat", "lon", resolution=8)
+        assert "h3_index" in result.columns
+
+    def test_s2_via_level_kwarg(self, df):
+        pytest.importorskip("s2sphere")
+        from siege_utilities.engines.dataframe_engine import PandasEngine
+        engine = PandasEngine()
+        result = engine.index_points(df, "lat", "lon", level=10)
+        assert "s2_index" in result.columns
+
+    def test_explicit_grid_h3(self, df):
+        pytest.importorskip("h3")
+        from siege_utilities.engines.dataframe_engine import PandasEngine
+        engine = PandasEngine()
+        result = engine.index_points(df, "lat", "lon", grid="h3", resolution=7)
+        assert "h3_index" in result.columns
+
+    def test_index_polygon(self, df):
+        pytest.importorskip("s2sphere")
+        from shapely.geometry import box
+        from siege_utilities.engines.dataframe_engine import PandasEngine
+        engine = PandasEngine()
+        cells = engine.index_polygon(box(-87, 33, -86, 34), level=8)
+        assert isinstance(cells, set)
+        assert len(cells) > 0
+
+    def test_index_polygon_region_cover(self):
+        pytest.importorskip("s2sphere")
+        from shapely.geometry import box
+        from siege_utilities.engines.dataframe_engine import PandasEngine
+        engine = PandasEngine()
+        cells = engine.index_polygon(box(-87, 33, -86, 34), max_cells=10)
+        assert isinstance(cells, list)
+        assert len(cells) <= 10
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher (`grids.index_points`) with `engine=` kwarg
+# ---------------------------------------------------------------------------
+
+class TestDispatcherEngineRouting:
+    @pytest.fixture
+    def df(self):
+        return pd.DataFrame({"lat": [33.5], "lon": [-86.8]})
+
+    def test_engine_kwarg_routes_to_engine(self, df):
+        pytest.importorskip("s2sphere")
+        from siege_utilities.geo.grids import index_points
+        from siege_utilities.engines.dataframe_engine import PandasEngine
+        engine = PandasEngine()
+        result = index_points(df, "lat", "lon", engine=engine, level=10)
+        # Engine path returns the augmented DataFrame, not just a Series.
+        assert isinstance(result, pd.DataFrame)
+        assert "s2_index" in result.columns
+
+    def test_no_engine_returns_series(self, df):
+        """Backward-compat: without engine=, returns a pd.Series of cells."""
+        pytest.importorskip("s2sphere")
+        from siege_utilities.geo.grids import index_points
+        result = index_points(df, "lat", "lon", level=10)
+        assert isinstance(result, pd.Series)
+
+
+# ---------------------------------------------------------------------------
+# PostGISEngine override — index_points raises with the documented pattern
+# ---------------------------------------------------------------------------
+
+class TestPostGISEngineIndexPoints:
+    def test_postgis_raises_with_helpful_pointer(self):
+        from siege_utilities.engines.dataframe_engine import PostGISEngine
+        engine = PostGISEngine.__new__(PostGISEngine)  # skip __init__ (needs DSN)
+        df = pd.DataFrame({"lat": [33.5], "lon": [-86.8]})
+        with pytest.raises(NotImplementedError, match="ingest time"):
+            engine.index_points(df, "lat", "lon", level=10)
+
+
+# ---------------------------------------------------------------------------
+# Cross-engine consistency property test
+# ---------------------------------------------------------------------------
+
+class TestCrossEngineConsistency:
+    """The default ABC path round-trips through pandas, so any engine
+    using the default produces the same cell IDs as PandasEngine. The
+    test covers PandasEngine (only one without specialised dependencies
+    in the test env) — the other engines slot in identically when
+    available.
+    """
+
+    def test_pandas_engine_matches_standalone(self):
+        pytest.importorskip("s2sphere")
+        from siege_utilities.geo.s2_utils import s2_index_points
+        from siege_utilities.engines.dataframe_engine import PandasEngine
+        df = pd.DataFrame({
+            "lat": [33.5, 40.7, 51.5, -33.9],
+            "lon": [-86.8, -74.0, -0.1, 18.4],
+        })
+        engine = PandasEngine()
+        engine_result = engine.index_points(df, "lat", "lon", level=10)
+        standalone = s2_index_points(df, "lat", "lon", level=10)
+        assert list(engine_result["s2_index"]) == list(standalone)


### PR DESCRIPTION
Closes ELE-2485.

## Summary

Wires the H3+S2 grid utilities from PR #438 into the multi-engine `DataFrameEngine` abstraction. Consumer code holding an `Engine` handle can now compute grid cells without per-call-site pandas round-trips.

## What ships

### `DataFrameEngine.index_points` (concrete default on the ABC)

Round-trips through pandas: `self.to_pandas(df) → siege_utilities.geo.grids.index_points → augmented frame`. The kwarg-shape inference is the same as the standalone dispatcher (`resolution=` → H3, `level=`/`max_cells=` → S2, `grid=` explicit override). The **chosen grid drives the output column name** (`h3_index` vs `s2_index`) so the label always matches what was actually computed — `engine.index_points(df, "lat", "lon", resolution=8)` produces `h3_index`, not the auto-default S2.

### `DataFrameEngine.index_polygon` (concrete default on the ABC)

Pure pass-through to `siege_utilities.geo.grids.index_polygon` — there's no per-frame state to convert. Provided for API symmetry so callers can keep one `Engine` handle.

### `PostGISEngine.index_points` (override)

Raises `NotImplementedError` with the recommended pattern spelled out in the docstring: compute cell IDs **once at ingest**, store as `BIGINT`, query via `s2_cells_to_ranges` + `WHERE BETWEEN`. Computing cells per-row at query time would defeat the whole point of using PostGIS — the database can't index a value it has to compute per-row. Hence loud failure rather than silent slow.

### Module-level dispatcher gets `engine=`

`siege_utilities.geo.grids.index_points(..., engine=...)` routes through the engine when provided. Without `engine=`, the function-level API is unchanged (backward compatible).

## Out of scope (explicit per the ticket)

- Native Spark pandas-UDF override (Arrow batched).
- DuckDB SQL-extension native path.

The default round-trip works correctly on every engine; the per-engine optimizations are follow-up work that don't block consumer adoption.

## Test plan

- [x] Local: `pytest tests/test_grids_engine_integration.py tests/test_grids.py tests/test_s2_utils.py -q` → **76 passed**.
- [x] Lint clean (no F401/F841/F541).
- [x] Cross-engine consistency: PandasEngine.index_points produces the same cell IDs as the standalone `s2_index_points` for the same input.
- [ ] Full CI matrix on push.

## Notebook

`notebooks/spatial/02_grid_dispatch.ipynb` is part of ELE-2484 (notebook overhaul tracking) — landing alongside this code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added spatial grid indexing for dataframes using H3 and S2 grid systems
  * New `index_points()` method computes grid cell IDs for geographic coordinates
  * New `index_polygon()` method generates grid cells covering a geographic polygon
  * Intelligent defaults (S2 level 12 when not specified)

* **Improvements**
  * PostGIS backend now raises explicit error with guidance instead of failing silently

<!-- end of auto-generated comment: release notes by coderabbit.ai -->