### PR TITLE
feat(reporting): hex cartograms — algorithmic placement, three sizing modes (ELE-2482)

### DIFF
--- a/siege_utilities/reporting/__init__.py
+++ b/siege_utilities/reporting/__init__.py
@@ -38,6 +38,12 @@ _register(['ChartTypeRegistry'], '.chart_types')
 _register(['PollingAnalyzer'], '.analytics.polling_analyzer')
 _register(['Argument', 'TableType'], '.pages.page_models')
 
+# Hex cartograms (tile maps): one hexagon per admin unit, three sizing modes.
+_register([
+    'Algorithm', 'Sizing',
+    'BUILTIN_LAYOUTS', 'hex_tile_layout', 'hex_tile_map', 'register_layout',
+], '.hex_cartogram')
+
 # IDML (InDesign) export
 _register(['IDMLExporter', 'export_report_idml', 'SIMPLEIDML_AVAILABLE'], '.idml_export')
 

--- a/siege_utilities/reporting/hex_cartogram/__init__.py
+++ b/siege_utilities/reporting/hex_cartogram/__init__.py
@@ -1,0 +1,44 @@
+"""Hex cartogram (tile-map) construction and rendering.
+
+A hex cartogram replaces each administrative unit (state, congressional
+district, county, country) with a single hexagon, positioned to roughly
+preserve geography. The whole point: small jurisdictions get the same
+visual weight as large ones, so Wyoming and DC don't get drowned out by
+California.
+
+Public API (re-exported from this package):
+
+* :func:`hex_tile_layout` — build a layout (GeoDataFrame[geometry, code,
+  q, r]) from either a built-in name, an algorithmic placement of a
+  GeoDataFrame, or a hand-drawn mapping registered via
+  :func:`register_layout`.
+* :func:`hex_tile_map` — matplotlib renderer that takes a values series
+  + a layout and returns a Figure. Three sizing modes (equal,
+  value_proportional, value_sqrt) per the design discussion.
+* :func:`register_layout` — extension hook for user-supplied
+  hand-positioned layouts.
+* :data:`BUILTIN_LAYOUTS` — set of layout names shipped with the
+  package. Empty in v1; populated as we add canonical layouts in
+  follow-up work.
+* :class:`Algorithm` enum — placement-algorithm choices: ``greedy``,
+  ``hungarian``, ``annealing``. (``force_directed`` and ``ilp`` are
+  future work; see ELE-2482.)
+* :class:`Sizing` enum — sizing modes: ``equal``, ``value_proportional``,
+  ``value_sqrt``.
+
+See ``docs/source/hex_cartograms.md`` for the algorithm comparison and
+worked examples.
+"""
+
+from .algorithms import Algorithm
+from .layouts import BUILTIN_LAYOUTS, hex_tile_layout, register_layout
+from .renderer import Sizing, hex_tile_map
+
+__all__ = [
+    "Algorithm",
+    "BUILTIN_LAYOUTS",
+    "Sizing",
+    "hex_tile_layout",
+    "hex_tile_map",
+    "register_layout",
+]

--- a/siege_utilities/reporting/hex_cartogram/algorithms.py
+++ b/siege_utilities/reporting/hex_cartogram/algorithms.py
@@ -1,0 +1,354 @@
+"""Placement algorithms for hex cartograms.
+
+Three algorithms shipped in v1:
+
+* **Greedy** — sort polygons by area (largest first), assign each to the
+  nearest unoccupied hex by centroid distance. Fast, baseline quality.
+* **Hungarian** — bipartite matching via :func:`scipy.optimize.linear_sum_assignment`.
+  Provably optimal for the centroid-distance objective. Doesn't model
+  topology, but sets a strong baseline.
+* **Simulated annealing** — start from greedy or Hungarian, repeatedly
+  swap pairs whose swap improves a weighted ``α·centroid_error +
+  β·topology_violation`` cost. The default for ≤ 200 polygons.
+
+``force_directed`` and ``ilp`` are documented as future work in the
+ticket; the API allows callers to pass the enum but raises
+NotImplementedError so the surface is forward-compatible.
+
+Each algorithm returns a ``dict[code, AxialCoord]`` — a mapping from
+input polygon ID to its assigned hex cell.
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+import math
+import random
+from typing import TYPE_CHECKING, Optional
+
+from .coords import (
+    AxialCoord,
+    axial_distance,
+    axial_to_cartesian,
+    bounding_grid,
+)
+
+if TYPE_CHECKING:  # pragma: no cover
+    import geopandas as gpd
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "Algorithm",
+    "place_polygons",
+]
+
+
+class Algorithm(str, enum.Enum):
+    """Placement-algorithm choices for :func:`hex_tile_layout`."""
+
+    #: Sort by area, place in nearest unoccupied hex. < 100 ms typical.
+    GREEDY = "greedy"
+    #: Optimal centroid-distance assignment (no topology term).
+    HUNGARIAN = "hungarian"
+    #: Centroid + topology weighted; SA refinement of an initial layout.
+    ANNEALING = "annealing"
+    #: Reserved — not implemented in v1.
+    FORCE_DIRECTED = "force_directed"
+    #: Reserved — not implemented in v1.
+    ILP = "ilp"
+
+
+# ---------------------------------------------------------------------------
+# Public entry
+# ---------------------------------------------------------------------------
+
+def place_polygons(
+    gdf: "gpd.GeoDataFrame",
+    code_col: str,
+    *,
+    algorithm: Algorithm = Algorithm.ANNEALING,
+    candidate_cells: Optional[list[AxialCoord]] = None,
+    # Annealing tuning:
+    iterations: int = 5000,
+    initial_temperature: float = 1.0,
+    cooling_rate: float = 0.9995,
+    centroid_weight: float = 1.0,
+    topology_weight: float = 0.5,
+    seed: Optional[int] = None,
+) -> dict[str, AxialCoord]:
+    """Assign each polygon in *gdf* to a hex cell.
+
+    Args:
+        gdf: GeoDataFrame of input polygons. Must have a geometry column
+            and a string-valued *code_col* identifying each polygon.
+        code_col: Column name holding the polygon identifier (used as
+            the key in the returned mapping).
+        algorithm: One of :class:`Algorithm`.
+        candidate_cells: Pre-computed pool of axial coords to assign
+            into. If None, uses :func:`bounding_grid` sized to the
+            polygon count.
+        iterations / initial_temperature / cooling_rate / centroid_weight
+        / topology_weight / seed: Annealing-specific knobs. Ignored by
+            greedy / hungarian.
+
+    Returns:
+        ``dict[code, (q, r)]`` mapping each polygon's code to its hex
+        coordinate.
+
+    Raises:
+        ValueError: Empty GeoDataFrame.
+        NotImplementedError: ``force_directed`` / ``ilp`` (reserved).
+    """
+    if len(gdf) == 0:
+        raise ValueError("place_polygons: empty GeoDataFrame")
+    if code_col not in gdf.columns:
+        raise ValueError(
+            f"place_polygons: code_col {code_col!r} not in gdf columns"
+        )
+    if algorithm in (Algorithm.FORCE_DIRECTED, Algorithm.ILP):
+        raise NotImplementedError(
+            f"Algorithm {algorithm.value!r} is reserved for follow-up "
+            "work (see ELE-2482). Use 'greedy', 'hungarian', or "
+            "'annealing' for now."
+        )
+
+    codes, centroids = _normalized_centroids(gdf, code_col)
+    cells = list(candidate_cells) if candidate_cells is not None else list(bounding_grid(len(codes)))
+    if len(cells) < len(codes):
+        raise ValueError(
+            f"Not enough candidate hex cells: have {len(cells)}, need "
+            f"{len(codes)}. Pass a larger `candidate_cells` or accept the "
+            "default bounding grid."
+        )
+
+    if algorithm == Algorithm.GREEDY:
+        return _greedy_place(codes, centroids, cells, gdf, code_col)
+    if algorithm == Algorithm.HUNGARIAN:
+        return _hungarian_place(codes, centroids, cells)
+    # Annealing: start from Hungarian if scipy is available, else greedy.
+    try:
+        initial = _hungarian_place(codes, centroids, cells)
+    except ImportError:
+        initial = _greedy_place(codes, centroids, cells, gdf, code_col)
+    return _anneal(
+        codes, centroids, cells, gdf, code_col, initial,
+        iterations=iterations,
+        initial_temperature=initial_temperature,
+        cooling_rate=cooling_rate,
+        centroid_weight=centroid_weight,
+        topology_weight=topology_weight,
+        seed=seed,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Greedy
+# ---------------------------------------------------------------------------
+
+def _greedy_place(
+    codes: list[str],
+    centroids: dict[str, tuple[float, float]],
+    cells: list[AxialCoord],
+    gdf: "gpd.GeoDataFrame",
+    code_col: str,
+) -> dict[str, AxialCoord]:
+    """Largest-area first, nearest unoccupied hex."""
+    # Order by polygon area descending so the largest get first pick.
+    area_by_code = {
+        str(row[code_col]): float(row.geometry.area)
+        for _, row in gdf.iterrows()
+    }
+    order = sorted(codes, key=lambda c: area_by_code.get(c, 0.0), reverse=True)
+    cell_centroids = {c: axial_to_cartesian(c) for c in cells}
+    available = set(cells)
+    out: dict[str, AxialCoord] = {}
+    for code in order:
+        cx, cy = centroids[code]
+        # Pick nearest available cell by Cartesian distance.
+        best_cell = min(
+            available,
+            key=lambda c: (cell_centroids[c][0] - cx) ** 2
+                          + (cell_centroids[c][1] - cy) ** 2,
+        )
+        out[code] = best_cell
+        available.remove(best_cell)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Hungarian
+# ---------------------------------------------------------------------------
+
+def _hungarian_place(
+    codes: list[str],
+    centroids: dict[str, tuple[float, float]],
+    cells: list[AxialCoord],
+) -> dict[str, AxialCoord]:
+    """Provably optimal centroid-distance assignment.
+
+    Uses ``scipy.optimize.linear_sum_assignment``. Raises ImportError if
+    scipy isn't installed; callers should fall back to greedy.
+    """
+    try:
+        from scipy.optimize import linear_sum_assignment
+        import numpy as np
+    except ImportError as exc:
+        raise ImportError(
+            "Hungarian assignment requires scipy + numpy. Install "
+            "via 'pip install siege-utilities[analytics]' or fall back "
+            "to algorithm='greedy'."
+        ) from exc
+
+    n_polys = len(codes)
+    n_cells = len(cells)
+    # Cost matrix: rows are polygons, cols are cells.
+    cell_centroids = [axial_to_cartesian(c) for c in cells]
+    cost = np.zeros((n_polys, n_cells), dtype=float)
+    for i, code in enumerate(codes):
+        cx, cy = centroids[code]
+        for j, (xx, yy) in enumerate(cell_centroids):
+            cost[i, j] = math.hypot(cx - xx, cy - yy)
+    row_idx, col_idx = linear_sum_assignment(cost)
+    return {codes[r]: cells[c] for r, c in zip(row_idx, col_idx)}
+
+
+# ---------------------------------------------------------------------------
+# Simulated annealing
+# ---------------------------------------------------------------------------
+
+def _anneal(
+    codes: list[str],
+    centroids: dict[str, tuple[float, float]],
+    cells: list[AxialCoord],
+    gdf: "gpd.GeoDataFrame",
+    code_col: str,
+    initial: dict[str, AxialCoord],
+    *,
+    iterations: int,
+    initial_temperature: float,
+    cooling_rate: float,
+    centroid_weight: float,
+    topology_weight: float,
+    seed: Optional[int],
+) -> dict[str, AxialCoord]:
+    """Refine *initial* with random pair swaps under SA cooling.
+
+    The cost function balances:
+
+    * Centroid error — sum of Cartesian distances between each polygon's
+      normalized centroid and its assigned hex's Cartesian center.
+    * Topology violation — number of input-adjacent polygon pairs whose
+      assigned hexes are NOT grid-neighbors. (Adjacency is computed from
+      the input geometry's ``touches`` predicate.)
+    """
+    rng = random.Random(seed)
+    adjacency = _polygon_adjacency(gdf, code_col, codes)
+    cell_xy = {c: axial_to_cartesian(c) for c in cells}
+
+    def total_cost(assignment: dict[str, AxialCoord]) -> float:
+        # Centroid term.
+        c_term = 0.0
+        for code, cell in assignment.items():
+            cx, cy = centroids[code]
+            xx, yy = cell_xy[cell]
+            c_term += math.hypot(cx - xx, cy - yy)
+        # Topology term: count adjacent-pairs not preserved.
+        violations = 0
+        for a, b in adjacency:
+            if a not in assignment or b not in assignment:
+                continue
+            if axial_distance(assignment[a], assignment[b]) > 1:
+                violations += 1
+        return centroid_weight * c_term + topology_weight * violations
+
+    current = dict(initial)
+    current_cost = total_cost(current)
+    best = dict(current)
+    best_cost = current_cost
+    temperature = initial_temperature
+    code_list = list(codes)
+
+    for _ in range(iterations):
+        a = rng.choice(code_list)
+        b = rng.choice(code_list)
+        if a == b:
+            continue
+        # Swap a and b.
+        current[a], current[b] = current[b], current[a]
+        new_cost = total_cost(current)
+        delta = new_cost - current_cost
+        if delta < 0 or rng.random() < math.exp(-delta / max(temperature, 1e-9)):
+            current_cost = new_cost
+            if new_cost < best_cost:
+                best = dict(current)
+                best_cost = new_cost
+        else:
+            # Reject: undo.
+            current[a], current[b] = current[b], current[a]
+        temperature *= cooling_rate
+
+    log.debug(
+        "Annealing finished: initial_cost=%.3f best_cost=%.3f",
+        total_cost(initial), best_cost,
+    )
+    return best
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _normalized_centroids(
+    gdf: "gpd.GeoDataFrame",
+    code_col: str,
+) -> tuple[list[str], dict[str, tuple[float, float]]]:
+    """Return ``(codes, centroids)`` with centroids in a unit-square frame.
+
+    Normalizing decouples downstream Cartesian distances from the input
+    CRS scale (degrees vs metres) so the algorithm's tuning constants
+    don't have to know about the projection.
+    """
+    raw = []
+    codes: list[str] = []
+    for _, row in gdf.iterrows():
+        codes.append(str(row[code_col]))
+        c = row.geometry.centroid
+        raw.append((float(c.x), float(c.y)))
+    xs = [p[0] for p in raw]
+    ys = [p[1] for p in raw]
+    minx, maxx = min(xs), max(xs)
+    miny, maxy = min(ys), max(ys)
+    span_x = max(maxx - minx, 1e-9)
+    span_y = max(maxy - miny, 1e-9)
+    # Map into roughly the same range as the bounding_grid Cartesian
+    # output (which spans a few units in each direction).
+    centroids = {}
+    for code, (x, y) in zip(codes, raw):
+        nx = (x - minx) / span_x * 6.0 - 3.0
+        ny = (y - miny) / span_y * 6.0 - 3.0
+        centroids[code] = (nx, ny)
+    return codes, centroids
+
+
+def _polygon_adjacency(
+    gdf: "gpd.GeoDataFrame",
+    code_col: str,
+    codes: list[str],
+) -> list[tuple[str, str]]:
+    """Pairs of input-polygon codes that share a border.
+
+    Uses shapely's ``touches`` predicate. O(n²); acceptable for the
+    n ≤ 200 sweet spot the algorithms target.
+    """
+    by_code = {
+        str(row[code_col]): row.geometry
+        for _, row in gdf.iterrows()
+    }
+    pairs: list[tuple[str, str]] = []
+    for i, a in enumerate(codes):
+        for b in codes[i + 1:]:
+            if by_code[a].touches(by_code[b]):
+                pairs.append((a, b))
+    return pairs

--- a/siege_utilities/reporting/hex_cartogram/algorithms.py
+++ b/siege_utilities/reporting/hex_cartogram/algorithms.py
@@ -246,21 +246,30 @@ def _anneal(
     rng = random.Random(seed)
     adjacency = _polygon_adjacency(gdf, code_col, codes)
     cell_xy = {c: axial_to_cartesian(c) for c in cells}
+    # Per-code adjacency for O(deg) incremental cost updates.
+    adj_by_code: dict[str, set[str]] = {c: set() for c in codes}
+    for a, b in adjacency:
+        adj_by_code[a].add(b)
+        adj_by_code[b].add(a)
+
+    def centroid_term(code: str, cell: AxialCoord) -> float:
+        cx, cy = centroids[code]
+        xx, yy = cell_xy[cell]
+        return math.hypot(cx - xx, cy - yy)
+
+    def local_violations(code: str, assignment: dict[str, AxialCoord]) -> int:
+        """Count violating edges incident to *code* (each edge once)."""
+        cell = assignment[code]
+        return sum(
+            1 for nb in adj_by_code[code]
+            if nb in assignment and axial_distance(cell, assignment[nb]) > 1
+        )
 
     def total_cost(assignment: dict[str, AxialCoord]) -> float:
-        # Centroid term.
-        c_term = 0.0
-        for code, cell in assignment.items():
-            cx, cy = centroids[code]
-            xx, yy = cell_xy[cell]
-            c_term += math.hypot(cx - xx, cy - yy)
-        # Topology term: count adjacent-pairs not preserved.
-        violations = 0
-        for a, b in adjacency:
-            if a not in assignment or b not in assignment:
-                continue
-            if axial_distance(assignment[a], assignment[b]) > 1:
-                violations += 1
+        c_term = sum(centroid_term(code, cell) for code, cell in assignment.items())
+        # Sum local violations and halve — each violating pair is touched
+        # from both endpoints.
+        violations = sum(local_violations(c, assignment) for c in assignment) // 2
         return centroid_weight * c_term + topology_weight * violations
 
     current = dict(initial)
@@ -275,15 +284,24 @@ def _anneal(
         b = rng.choice(code_list)
         if a == b:
             continue
-        # Swap a and b.
+        # Compute the delta from swapping a and b without rescanning the
+        # whole assignment. Only edges incident to {a, b} can change
+        # state, and only a's and b's centroid terms change.
+        affected = {a, b} | adj_by_code[a] | adj_by_code[b]
+        old_v = _violation_pairs_in(affected, adj_by_code, current)
+        old_c = centroid_term(a, current[a]) + centroid_term(b, current[b])
         current[a], current[b] = current[b], current[a]
-        new_cost = total_cost(current)
-        delta = new_cost - current_cost
+        new_v = _violation_pairs_in(affected, adj_by_code, current)
+        new_c = centroid_term(a, current[a]) + centroid_term(b, current[b])
+        delta = (
+            centroid_weight * (new_c - old_c)
+            + topology_weight * (new_v - old_v)
+        )
         if delta < 0 or rng.random() < math.exp(-delta / max(temperature, 1e-9)):
-            current_cost = new_cost
-            if new_cost < best_cost:
+            current_cost += delta
+            if current_cost < best_cost:
                 best = dict(current)
-                best_cost = new_cost
+                best_cost = current_cost
         else:
             # Reject: undo.
             current[a], current[b] = current[b], current[a]
@@ -300,6 +318,33 @@ def _anneal(
 # Helpers
 # ---------------------------------------------------------------------------
 
+def _violation_pairs_in(
+    codes: set[str],
+    adj_by_code: dict[str, set[str]],
+    assignment: dict[str, AxialCoord],
+) -> int:
+    """Count violating adjacency pairs with at least one endpoint in *codes*.
+
+    Each pair is counted once even when both endpoints are in *codes*.
+    """
+    seen: set[tuple[str, str]] = set()
+    n = 0
+    for code in codes:
+        if code not in assignment:
+            continue
+        cell = assignment[code]
+        for nb in adj_by_code[code]:
+            if nb not in assignment:
+                continue
+            key = (code, nb) if code < nb else (nb, code)
+            if key in seen:
+                continue
+            seen.add(key)
+            if axial_distance(cell, assignment[nb]) > 1:
+                n += 1
+    return n
+
+
 def _normalized_centroids(
     gdf: "gpd.GeoDataFrame",
     code_col: str,
@@ -312,9 +357,17 @@ def _normalized_centroids(
     """
     raw = []
     codes: list[str] = []
+    polygonal = {"Polygon", "MultiPolygon"}
     for _, row in gdf.iterrows():
+        geom = row.geometry
+        gtype = getattr(geom, "geom_type", None)
+        if gtype not in polygonal:
+            raise ValueError(
+                f"hex cartogram requires Polygon/MultiPolygon geometries; "
+                f"row {row[code_col]!r} has {gtype!r}"
+            )
         codes.append(str(row[code_col]))
-        c = row.geometry.centroid
+        c = geom.centroid
         raw.append((float(c.x), float(c.y)))
     xs = [p[0] for p in raw]
     ys = [p[1] for p in raw]

--- a/siege_utilities/reporting/hex_cartogram/components.py
+++ b/siege_utilities/reporting/hex_cartogram/components.py
@@ -48,7 +48,7 @@ def find_components(
     """
     if len(gdf) == 0:
         return []
-    by_code: dict[str, "gpd.geoseries.GeoSeries.Geometry"] = {  # type: ignore[name-defined]
+    by_code: dict[str, object] = {
         str(row[code_col]): row.geometry
         for _, row in gdf.iterrows()
     }

--- a/siege_utilities/reporting/hex_cartogram/components.py
+++ b/siege_utilities/reporting/hex_cartogram/components.py
@@ -1,0 +1,139 @@
+"""Connected-component splitting for non-contiguous admin sets.
+
+CONUS + Alaska + Hawaii is the canonical case: three disconnected groups
+that each deserve their own sub-grid, with empty hexes between groups so
+the result reads as separated.
+
+The wrapper:
+
+1. Build a graph where nodes are polygons and edges are "share a border"
+   (or "centroids within a tunable distance").
+2. Find connected components.
+3. Lay each component out independently using one of the placement
+   algorithms.
+4. Position the per-component layouts in the output grid by their
+   *group* centroid, with ``component_gap`` empty hexes between groups.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from .coords import AxialCoord
+
+if TYPE_CHECKING:  # pragma: no cover
+    import geopandas as gpd
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "find_components",
+]
+
+
+def find_components(
+    gdf: "gpd.GeoDataFrame",
+    code_col: str,
+) -> list[list[str]]:
+    """Split *gdf* into connected components by polygon adjacency.
+
+    Two polygons are considered adjacent if their geometries share a
+    border (shapely ``touches``). Returns a list of lists of polygon
+    codes — each inner list is one component.
+
+    The result is sorted with the largest component first, then by
+    representative-centroid x-coordinate for stable output across
+    runs.
+    """
+    if len(gdf) == 0:
+        return []
+    by_code: dict[str, "gpd.geoseries.GeoSeries.Geometry"] = {  # type: ignore[name-defined]
+        str(row[code_col]): row.geometry
+        for _, row in gdf.iterrows()
+    }
+    codes = list(by_code)
+
+    # Adjacency: undirected graph as adjacency-list dict.
+    neighbors: dict[str, set[str]] = {c: set() for c in codes}
+    for i, a in enumerate(codes):
+        for b in codes[i + 1:]:
+            if by_code[a].touches(by_code[b]):
+                neighbors[a].add(b)
+                neighbors[b].add(a)
+
+    # Union-find via simple BFS.
+    visited: set[str] = set()
+    components: list[list[str]] = []
+    for start in codes:
+        if start in visited:
+            continue
+        stack = [start]
+        comp: list[str] = []
+        while stack:
+            node = stack.pop()
+            if node in visited:
+                continue
+            visited.add(node)
+            comp.append(node)
+            stack.extend(n for n in neighbors[node] if n not in visited)
+        components.append(comp)
+
+    # Stable ordering: largest first, ties broken by leftmost centroid.
+    def _key(comp: list[str]) -> tuple[int, float]:
+        xs = [float(by_code[c].centroid.x) for c in comp]
+        return (-len(comp), min(xs) if xs else 0.0)
+
+    components.sort(key=_key)
+    return components
+
+
+def offset_layout(
+    layout: dict[str, AxialCoord],
+    *,
+    dq: int,
+    dr: int,
+) -> dict[str, AxialCoord]:
+    """Shift every cell in *layout* by ``(dq, dr)``.
+
+    Used by the multi-component pipeline after each per-component
+    placement, to position the sub-grid in the final output.
+    """
+    return {code: (q + dq, r + dr) for code, (q, r) in layout.items()}
+
+
+def _group_bounding_box(layout: dict[str, AxialCoord]) -> tuple[int, int, int, int]:
+    """Return ``(min_q, min_r, max_q, max_r)`` for a layout (inclusive)."""
+    qs = [q for q, _ in layout.values()]
+    rs = [r for _, r in layout.values()]
+    return min(qs), min(rs), max(qs), max(rs)
+
+
+def stitch_components(
+    component_layouts: list[dict[str, AxialCoord]],
+    *,
+    component_gap: int = 1,
+) -> dict[str, AxialCoord]:
+    """Combine per-component layouts into one, separated by ``component_gap`` cells.
+
+    Components are laid out left-to-right in the order received (which
+    :func:`find_components` already biases by size). Each subsequent
+    component's q-axis starts ``component_gap`` cells past the previous
+    component's max q.
+    """
+    if not component_layouts:
+        return {}
+    if component_gap < 0:
+        raise ValueError(f"component_gap must be >= 0, got {component_gap}")
+
+    final: dict[str, AxialCoord] = {}
+    cursor_q = 0
+    for layout in component_layouts:
+        if not layout:
+            continue
+        min_q, _, max_q, _ = _group_bounding_box(layout)
+        # Shift this component's min_q to cursor_q.
+        shifted = offset_layout(layout, dq=cursor_q - min_q, dr=0)
+        final.update(shifted)
+        cursor_q = cursor_q + (max_q - min_q) + 1 + component_gap
+    return final

--- a/siege_utilities/reporting/hex_cartogram/coords.py
+++ b/siege_utilities/reporting/hex_cartogram/coords.py
@@ -1,0 +1,136 @@
+"""Axial hex-grid coordinate math.
+
+Uses axial ``(q, r)`` coordinates with **pointy-top** hexagons (the
+visual convention for cartograms — wider than tall, easier to read state
+abbreviations inside). All distance / Cartesian math derives from here;
+having one canonical conversion module keeps algorithms / rendering
+internally consistent.
+
+Conventions
+-----------
+* ``(q, r)`` are integers; the third cube coord ``s = -q - r`` is
+  implicit.
+* Cartesian conversion uses unit-side-length hexes — caller can rescale.
+* Neighbor offsets: 6 directions, returned in the standard order
+  (E, NE, NW, W, SW, SE).
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable
+
+__all__ = [
+    "AxialCoord",
+    "axial_distance",
+    "axial_neighbors",
+    "axial_to_cartesian",
+    "hexagon_polygon",
+]
+
+
+# Type alias kept simple — a tuple is fine for hashing into dicts/sets.
+AxialCoord = tuple[int, int]
+
+
+# Pointy-top neighbor offsets, in (E, NE, NW, W, SW, SE) order.
+_AXIAL_NEIGHBORS: tuple[AxialCoord, ...] = (
+    (+1, 0),
+    (+1, -1),
+    (0, -1),
+    (-1, 0),
+    (-1, +1),
+    (0, +1),
+)
+
+
+def axial_neighbors(qr: AxialCoord) -> tuple[AxialCoord, ...]:
+    """Return the six neighbors of ``qr`` in standard order."""
+    q, r = qr
+    return tuple((q + dq, r + dr) for dq, dr in _AXIAL_NEIGHBORS)
+
+
+def axial_distance(a: AxialCoord, b: AxialCoord) -> int:
+    """Hex-grid Manhattan distance between two axial coordinates.
+
+    Equivalent to half the cube-coordinate L1 distance.
+    """
+    aq, ar = a
+    bq, br = b
+    return (abs(aq - bq) + abs(ar - br) + abs((aq + ar) - (bq + br))) // 2
+
+
+def axial_to_cartesian(qr: AxialCoord, *, size: float = 1.0) -> tuple[float, float]:
+    """Convert an axial coord to a Cartesian ``(x, y)`` for a pointy-top hex.
+
+    ``size`` is the hex circumradius (corner distance). For unit
+    side-length hexes the natural choice is ``size = 1``.
+    """
+    q, r = qr
+    x = size * math.sqrt(3.0) * (q + r / 2.0)
+    y = size * 1.5 * r
+    return x, y
+
+
+def hexagon_polygon(
+    qr: AxialCoord,
+    *,
+    size: float = 1.0,
+    scale: float = 1.0,
+) -> list[tuple[float, float]]:
+    """Return the 6 vertices of a pointy-top hexagon at ``qr``.
+
+    Args:
+        qr: Axial coordinate of the cell center.
+        size: The grid's hex circumradius. Controls grid spacing.
+        scale: Multiplier on the **drawn** hex radius. ``< 1.0`` shrinks
+            individual hexagons within the grid (used by the
+            value-proportional / value-sqrt sizing modes).
+
+    Returns:
+        A list of 6 ``(x, y)`` tuples in counter-clockwise order. The
+        polygon is open (no duplicate-first-point); callers that need a
+        closed ring (matplotlib ``Polygon``, shapely) typically don't —
+        matplotlib closes automatically; shapely's ``Polygon`` constructor
+        accepts the open form.
+    """
+    cx, cy = axial_to_cartesian(qr, size=size)
+    radius = size * scale
+    # Pointy-top: first vertex at the top (90°), step 60°.
+    angles = (math.pi / 2 + i * math.pi / 3 for i in range(6))
+    return [(cx + radius * math.cos(a), cy + radius * math.sin(a)) for a in angles]
+
+
+def bounding_grid(
+    n_cells: int,
+    *,
+    aspect_ratio: float = 1.3,
+) -> Iterable[AxialCoord]:
+    """Generate enough hex cells to plausibly hold ``n_cells`` polygons.
+
+    Picks a roughly oval grid sized to ``aspect_ratio`` (slightly wider
+    than tall by default — matches the way countries are usually drawn
+    on a page). The grid is generated as offset axial coords centered
+    at ``(0, 0)``. Used by greedy and annealing algorithms as the
+    candidate cell pool.
+    """
+    if n_cells < 1:
+        raise ValueError(f"n_cells must be >= 1, got {n_cells}")
+    # Target: an ellipse of integer hexes with major/minor axes that
+    # together cover at least n_cells. Ellipse area ≈ π * a * b. For a
+    # hex grid we want ~1.3× slack so the algorithm has room to shuffle.
+    target = max(1, int(math.ceil(n_cells * 1.3)))
+    a_axis = math.ceil(math.sqrt(target * aspect_ratio / math.pi))
+    b_axis = math.ceil(math.sqrt(target / (aspect_ratio * math.pi)))
+    out: list[AxialCoord] = []
+    for r in range(-b_axis, b_axis + 1):
+        for q in range(-a_axis - (r // 2 if r > 0 else 0), a_axis + 1 - (r // 2 if r < 0 else 0)):
+            # Inside-ellipse test in Cartesian space.
+            x, y = axial_to_cartesian((q, r))
+            if (x / (a_axis * math.sqrt(3))) ** 2 + (y / (b_axis * 1.5)) ** 2 <= 1.05:
+                out.append((q, r))
+    if len(out) < n_cells:
+        # Pathological tiny grids — fall back to a slightly larger box.
+        out = [(q, r) for r in range(-b_axis - 1, b_axis + 2)
+               for q in range(-a_axis - 1, a_axis + 2)]
+    return out

--- a/siege_utilities/reporting/hex_cartogram/coords.py
+++ b/siege_utilities/reporting/hex_cartogram/coords.py
@@ -18,7 +18,6 @@ Conventions
 from __future__ import annotations
 
 import math
-from collections.abc import Iterable
 
 __all__ = [
     "AxialCoord",
@@ -105,7 +104,7 @@ def bounding_grid(
     n_cells: int,
     *,
     aspect_ratio: float = 1.3,
-) -> Iterable[AxialCoord]:
+) -> list[AxialCoord]:
     """Generate enough hex cells to plausibly hold ``n_cells`` polygons.
 
     Picks a roughly oval grid sized to ``aspect_ratio`` (slightly wider

--- a/siege_utilities/reporting/hex_cartogram/layouts.py
+++ b/siege_utilities/reporting/hex_cartogram/layouts.py
@@ -1,0 +1,207 @@
+"""Layout dispatcher for hex cartograms.
+
+Resolves three input shapes into a uniform ``GeoDataFrame[geometry,
+code, q, r]``:
+
+* **Built-in name** (``"us_states"``, ``"us_cd_117"``, etc.) — looks up
+  a registered canonical layout. v1 ships with no built-ins; the
+  ``BUILTIN_LAYOUTS`` set is empty until ELE-2482 follow-up work bakes
+  hand-positioned canonical layouts.
+* **Algorithmic placement** — pass a GeoDataFrame of polygons; the
+  module runs one of the algorithms in :mod:`.algorithms` to position
+  them on a hex grid.
+* **Hand-drawn mapping** — register a ``dict[code, (q, r)]`` via
+  :func:`register_layout` and pass the registered name.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Optional, Union
+
+from .algorithms import Algorithm, place_polygons
+from .components import find_components, stitch_components
+from .coords import AxialCoord, hexagon_polygon
+
+if TYPE_CHECKING:  # pragma: no cover
+    import geopandas as gpd
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "BUILTIN_LAYOUTS",
+    "REGISTERED_LAYOUTS",
+    "hex_tile_layout",
+    "register_layout",
+]
+
+
+#: Set of layout names shipped with the package. Empty in v1; will grow
+#: as canonical layouts (NPR-style US states, US CDs) are added in the
+#: ELE-2482 follow-up.
+BUILTIN_LAYOUTS: set[str] = set()
+
+#: User-registered layouts, populated by :func:`register_layout`.
+REGISTERED_LAYOUTS: dict[str, dict[str, AxialCoord]] = {}
+
+
+def register_layout(name: str, mapping: dict[str, AxialCoord]) -> None:
+    """Register a hand-positioned layout under *name*.
+
+    The mapping must be ``{code: (q, r)}`` with no duplicate ``(q, r)``
+    pairs. Use any reproducible code convention (``"AL"``, ``"01"``,
+    ``"al-cd-7"``); :func:`hex_tile_layout` will join your data on
+    whichever column you provide via ``code_col``.
+    """
+    if not name:
+        raise ValueError("register_layout: name is required")
+    seen_cells: set[AxialCoord] = set()
+    for code, qr in mapping.items():
+        if not isinstance(code, str):
+            raise TypeError(
+                f"register_layout({name!r}): codes must be str, got "
+                f"{type(code).__name__}: {code!r}"
+            )
+        if qr in seen_cells:
+            raise ValueError(
+                f"register_layout({name!r}): duplicate hex {qr} for code {code!r}"
+            )
+        seen_cells.add(qr)
+    REGISTERED_LAYOUTS[name] = dict(mapping)
+    log.info("Registered layout %r with %d cells", name, len(mapping))
+
+
+def hex_tile_layout(
+    source: Union[str, "gpd.GeoDataFrame"],
+    *,
+    code_col: str = "code",
+    algorithm: Union[Algorithm, str] = Algorithm.ANNEALING,
+    components: Optional[Union[str, list[list[str]]]] = "auto",
+    component_gap: int = 1,
+    hex_size: float = 1.0,
+    seed: Optional[int] = None,
+) -> "gpd.GeoDataFrame":
+    """Build a hex tile layout.
+
+    Args:
+        source: Either a registered/builtin layout name, or a
+            GeoDataFrame of polygons to place algorithmically.
+        code_col: Column name on the GeoDataFrame containing the
+            polygon identifier (e.g. state abbreviation, FIPS code).
+            Ignored when *source* is a string layout name.
+        algorithm: One of :class:`Algorithm` (or its string value).
+            Ignored when *source* is a registered layout name.
+        components: ``"auto"`` (default) splits the input into
+            connected components by polygon adjacency and lays each
+            out independently with ``component_gap`` empty cells
+            between them. ``"single"`` forces everything into one
+            component. A pre-computed ``list[list[code]]`` lets the
+            caller specify groups explicitly.
+        component_gap: Number of empty hex cells between neighbouring
+            components in the final output.
+        hex_size: Cell circumradius in CRS units used for the output
+            geometry. ``1.0`` is fine for visualization; choose a
+            smaller value if you plan to overlay the cartogram on a
+            real map.
+        seed: Random seed for the annealing algorithm; ignored otherwise.
+
+    Returns:
+        ``GeoDataFrame[geometry, code, q, r]`` — one hexagon per
+        polygon, with axial coords on each row for downstream tooling.
+    """
+    try:
+        import geopandas as gpd  # noqa: F401  -- needed by _mapping_to_geodataframe
+        from shapely.geometry import Polygon  # noqa: F401  -- ditto
+    except ImportError as exc:
+        raise ImportError(
+            "hex_tile_layout requires geopandas + shapely. Install via "
+            "'pip install siege-utilities[geo]'."
+        ) from exc
+
+    if isinstance(algorithm, str):
+        algorithm = Algorithm(algorithm)
+
+    if isinstance(source, str):
+        mapping = _resolve_named_layout(source)
+        return _mapping_to_geodataframe(mapping, hex_size=hex_size)
+
+    # Algorithmic placement of a GeoDataFrame.
+    if not hasattr(source, "geometry") or not hasattr(source, "iterrows"):
+        raise TypeError(
+            "hex_tile_layout: source must be a layout name or a "
+            "GeoDataFrame; got " f"{type(source).__name__}"
+        )
+    if code_col not in source.columns:
+        raise ValueError(
+            f"hex_tile_layout: code_col={code_col!r} not in source.columns "
+            f"({list(source.columns)})"
+        )
+
+    # Component splitting.
+    if components == "single":
+        comps = [[str(row[code_col]) for _, row in source.iterrows()]]
+    elif components == "auto":
+        comps = find_components(source, code_col)
+    elif isinstance(components, list):
+        comps = components
+    else:
+        raise ValueError(
+            f"components must be 'auto', 'single', or a list of code-lists; "
+            f"got {components!r}"
+        )
+
+    # Place each component independently.
+    component_layouts: list[dict[str, AxialCoord]] = []
+    for comp_codes in comps:
+        comp_gdf = source[source[code_col].astype(str).isin(comp_codes)].copy()
+        if comp_gdf.empty:
+            continue
+        layout = place_polygons(
+            comp_gdf, code_col, algorithm=algorithm, seed=seed,
+        )
+        component_layouts.append(layout)
+
+    final_mapping = stitch_components(
+        component_layouts, component_gap=component_gap,
+    )
+    return _mapping_to_geodataframe(final_mapping, hex_size=hex_size)
+
+
+def _resolve_named_layout(name: str) -> dict[str, AxialCoord]:
+    """Look up a layout name in the user registry, then built-ins."""
+    if name in REGISTERED_LAYOUTS:
+        return REGISTERED_LAYOUTS[name]
+    if name in BUILTIN_LAYOUTS:
+        # Will be implemented in ELE-2482 follow-up; placeholder for now.
+        raise NotImplementedError(
+            f"Built-in layout {name!r} is reserved but not yet shipped. "
+            "Until follow-up work lands, supply a hand-drawn layout via "
+            "register_layout(name, mapping) or pass a GeoDataFrame for "
+            "algorithmic placement."
+        )
+    available_registered = sorted(REGISTERED_LAYOUTS) or ["(none)"]
+    raise KeyError(
+        f"Unknown layout {name!r}. Registered: {available_registered}. "
+        f"Built-in: {sorted(BUILTIN_LAYOUTS) or '(none)'}."
+    )
+
+
+def _mapping_to_geodataframe(
+    mapping: dict[str, AxialCoord],
+    *,
+    hex_size: float,
+) -> "gpd.GeoDataFrame":
+    """Convert ``{code: (q, r)}`` to a GeoDataFrame with hex polygons."""
+    import geopandas as gpd
+    from shapely.geometry import Polygon
+
+    rows = []
+    for code, (q, r) in sorted(mapping.items()):
+        verts = hexagon_polygon((q, r), size=hex_size)
+        rows.append({
+            "code": code,
+            "q": q,
+            "r": r,
+            "geometry": Polygon(verts),
+        })
+    return gpd.GeoDataFrame(rows, geometry="geometry")

--- a/siege_utilities/reporting/hex_cartogram/renderer.py
+++ b/siege_utilities/reporting/hex_cartogram/renderer.py
@@ -1,0 +1,181 @@
+"""Matplotlib renderer for hex cartograms.
+
+Three sizing modes per the design discussion:
+
+* ``Sizing.EQUAL`` — every hex same size. Most charming, perceptually
+  honest for "states are equal political units" (NPR's pick). Default.
+* ``Sizing.VALUE_PROPORTIONAL`` — hex area ∝ value. Tilegram-style.
+* ``Sizing.VALUE_SQRT`` — hex side ∝ √value, perception-corrected for
+  size-encoding.
+
+The renderer takes a layout :class:`GeoDataFrame` (from
+:func:`hex_tile_layout`) plus a values series indexed by code, and
+returns a :class:`matplotlib.figure.Figure`.
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+import math
+from typing import TYPE_CHECKING, Optional, Union
+
+from .coords import axial_to_cartesian, hexagon_polygon
+
+if TYPE_CHECKING:  # pragma: no cover
+    import geopandas as gpd
+    import matplotlib.figure
+    import pandas as pd
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "Sizing",
+    "hex_tile_map",
+]
+
+
+class Sizing(str, enum.Enum):
+    """Sizing-mode choices for :func:`hex_tile_map`."""
+
+    #: Every hex same size; values map to colour only.
+    EQUAL = "equal"
+    #: Hex area proportional to value.
+    VALUE_PROPORTIONAL = "value_proportional"
+    #: Hex side proportional to ``√value`` (perception-correct).
+    VALUE_SQRT = "value_sqrt"
+
+
+def hex_tile_map(
+    values: "pd.Series",
+    layout: "gpd.GeoDataFrame",
+    *,
+    sizing: Union[Sizing, str] = Sizing.EQUAL,
+    cmap: str = "viridis",
+    code_col: str = "code",
+    label_col: Optional[str] = "code",
+    title: Optional[str] = None,
+    figsize: tuple[float, float] = (10.0, 7.0),
+    edge_color: str = "#888",
+    missing_color: str = "#eeeeee",
+) -> "matplotlib.figure.Figure":
+    """Render a hex cartogram.
+
+    Args:
+        values: Values to encode, indexed by polygon code (matching the
+            ``code_col`` of *layout*). Codes present in the layout but
+            absent from *values* render in *missing_color*.
+        layout: GeoDataFrame from :func:`hex_tile_layout` — needs at
+            minimum ``code``, ``q``, ``r`` columns.
+        sizing: One of :class:`Sizing` (or its string value). ``EQUAL``
+            uses the layout's geometry as-is; the proportional modes
+            scale per-hex around the cell center.
+        cmap: matplotlib colour map name.
+        code_col: Name of the code column on *layout*.
+        label_col: Column to write inside each hex (typically the
+            code). Pass ``None`` to omit labels.
+        title / figsize / edge_color / missing_color: Standard mpl knobs.
+    """
+    try:
+        import matplotlib.pyplot as plt
+        import matplotlib.colors as mcolors
+        from matplotlib.patches import Polygon as MplPolygon
+    except ImportError as exc:
+        raise ImportError(
+            "hex_tile_map requires matplotlib. Install via "
+            "'pip install siege-utilities[reporting]'."
+        ) from exc
+
+    if isinstance(sizing, str):
+        sizing = Sizing(sizing)
+    if code_col not in layout.columns:
+        raise ValueError(
+            f"hex_tile_map: code_col={code_col!r} not in layout columns"
+        )
+
+    # Align values to layout codes.
+    layout_codes = [str(c) for c in layout[code_col]]
+    aligned = values.reindex(layout_codes)
+    finite = aligned.dropna()
+    if len(finite) == 0:
+        log.warning(
+            "hex_tile_map: no values aligned with the layout — every hex "
+            "will render as 'missing'."
+        )
+        vmin, vmax = 0.0, 1.0
+    else:
+        vmin = float(finite.min())
+        vmax = float(finite.max())
+        if vmin == vmax:
+            # Avoid divide-by-zero in the normalizer.
+            vmax = vmin + 1.0
+
+    # Sizing scale per hex.
+    if sizing == Sizing.EQUAL:
+        def scale_for(v: float) -> float:
+            return 1.0
+    elif sizing == Sizing.VALUE_PROPORTIONAL:
+        # Area ∝ value → side ∝ √(value / max).
+        v_max = max(abs(vmax), 1e-9)
+        def scale_for(v: float) -> float:
+            return math.sqrt(max(v, 0.0) / v_max) if v == v else 0.0
+    elif sizing == Sizing.VALUE_SQRT:
+        # Side ∝ √value (perception-correct).
+        v_max = max(abs(vmax), 1e-9)
+        def scale_for(v: float) -> float:
+            # Side scales as the 4th root of value (since "side ∝ √value"
+            # but we normalize against the max, so scale = √(v / v_max)).
+            return math.sqrt(max(v, 0.0) / v_max) if v == v else 0.0
+    else:  # pragma: no cover - exhaustive enum
+        raise ValueError(f"Unknown sizing mode: {sizing!r}")
+
+    norm = mcolors.Normalize(vmin=vmin, vmax=vmax)
+    cmap_obj = plt.get_cmap(cmap)
+
+    fig, ax = plt.subplots(figsize=figsize)
+    ax.set_aspect("equal")
+    ax.set_axis_off()
+    if title is not None:
+        ax.set_title(title)
+
+    # Determine grid hex size from the layout's first row geometry.
+    # The hexagon_polygon call in layouts uses size=1.0 by default; we
+    # respect whatever size the GeoDataFrame already has.
+    # Easier: just iterate rows and re-compute polygons at the chosen
+    # scale (the layout's stored geometry is the equal-size one).
+    for _, row in layout.iterrows():
+        code = str(row[code_col])
+        q, r = int(row["q"]), int(row["r"])
+        v = aligned.get(code)
+        if v is None or (isinstance(v, float) and math.isnan(v)):
+            face = missing_color
+            scale = 1.0
+        else:
+            face = cmap_obj(norm(float(v)))
+            scale = scale_for(float(v))
+        verts = hexagon_polygon((q, r), size=1.0, scale=scale)
+        ax.add_patch(MplPolygon(verts, facecolor=face, edgecolor=edge_color, lw=0.7))
+        if label_col is not None and label_col in layout.columns:
+            cx, cy = axial_to_cartesian((q, r))
+            ax.text(
+                cx, cy, str(row[label_col]),
+                ha="center", va="center",
+                fontsize=8, color="white" if scale > 0.6 else "black",
+            )
+
+    # Frame the figure.
+    qs = [int(r["q"]) for _, r in layout.iterrows()]
+    rs = [int(r["r"]) for _, r in layout.iterrows()]
+    if qs and rs:
+        xs = [axial_to_cartesian((q, r))[0] for q in qs for r in rs]
+        ys = [axial_to_cartesian((q, r))[1] for q in qs for r in rs]
+        pad = 1.5
+        ax.set_xlim(min(xs) - pad, max(xs) + pad)
+        ax.set_ylim(min(ys) - pad, max(ys) + pad)
+
+    # Colourbar.
+    sm = plt.cm.ScalarMappable(norm=norm, cmap=cmap_obj)
+    sm.set_array([])
+    fig.colorbar(sm, ax=ax, fraction=0.04, pad=0.02)
+
+    return fig

--- a/siege_utilities/reporting/hex_cartogram/renderer.py
+++ b/siege_utilities/reporting/hex_cartogram/renderer.py
@@ -115,17 +115,18 @@ def hex_tile_map(
         def scale_for(v: float) -> float:
             return 1.0
     elif sizing == Sizing.VALUE_PROPORTIONAL:
-        # Area ∝ value → side ∝ √(value / max).
+        # Area ∝ value → side ∝ √(value / max). Tilegram-style; faithful
+        # to the data but the eye reads area non-linearly.
         v_max = max(abs(vmax), 1e-9)
         def scale_for(v: float) -> float:
             return math.sqrt(max(v, 0.0) / v_max) if v == v else 0.0
     elif sizing == Sizing.VALUE_SQRT:
-        # Side ∝ √value (perception-correct).
+        # Perception-correct: human area perception scales sublinearly
+        # with true area, so to make perceived size track value linearly
+        # we want area ∝ √value ⇒ side ∝ value^(1/4).
         v_max = max(abs(vmax), 1e-9)
         def scale_for(v: float) -> float:
-            # Side scales as the 4th root of value (since "side ∝ √value"
-            # but we normalize against the max, so scale = √(v / v_max)).
-            return math.sqrt(max(v, 0.0) / v_max) if v == v else 0.0
+            return (max(v, 0.0) / v_max) ** 0.25 if v == v else 0.0
     else:  # pragma: no cover - exhaustive enum
         raise ValueError(f"Unknown sizing mode: {sizing!r}")
 
@@ -163,12 +164,15 @@ def hex_tile_map(
                 fontsize=8, color="white" if scale > 0.6 else "black",
             )
 
-    # Frame the figure.
-    qs = [int(r["q"]) for _, r in layout.iterrows()]
-    rs = [int(r["r"]) for _, r in layout.iterrows()]
-    if qs and rs:
-        xs = [axial_to_cartesian((q, r))[0] for q in qs for r in rs]
-        ys = [axial_to_cartesian((q, r))[1] for q in qs for r in rs]
+    # Frame the figure: iterate the actual placed cells, not the
+    # Cartesian product of every q with every r.
+    cell_xy = [
+        axial_to_cartesian((int(r["q"]), int(r["r"])))
+        for _, r in layout.iterrows()
+    ]
+    if cell_xy:
+        xs = [x for x, _ in cell_xy]
+        ys = [y for _, y in cell_xy]
         pad = 1.5
         ax.set_xlim(min(xs) - pad, max(xs) + pad)
         ax.set_ylim(min(ys) - pad, max(ys) + pad)

--- a/tests/test_hex_cartogram.py
+++ b/tests/test_hex_cartogram.py
@@ -1,0 +1,319 @@
+"""Tests for siege_utilities.reporting.hex_cartogram (ELE-2482)."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: synthetic GeoDataFrame of contiguous + non-contiguous polygons
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def gpd_box():
+    pytest.importorskip("geopandas")
+    pytest.importorskip("shapely")
+    from shapely.geometry import box  # noqa: F401
+    return box
+
+
+@pytest.fixture
+def grid_3x3(gpd_box):
+    """A 3x3 contiguous grid of unit squares — 9 polygons, all touching neighbours."""
+    import geopandas as gpd
+    rows = []
+    for i in range(3):
+        for j in range(3):
+            rows.append({
+                "code": f"r{i}c{j}",
+                "geometry": gpd_box(j, i, j + 1, i + 1),
+            })
+    return gpd.GeoDataFrame(rows, geometry="geometry")
+
+
+@pytest.fixture
+def disconnected_groups(gpd_box):
+    """3 disconnected groups: 3 cells + 2 cells + 1 cell = 6 polygons total."""
+    import geopandas as gpd
+    rows = []
+    # Group A: 3 in a row at y=0
+    for j in range(3):
+        rows.append({"code": f"a{j}", "geometry": gpd_box(j, 0, j + 1, 1)})
+    # Group B: 2 squares far away at y=10
+    for j in range(2):
+        rows.append({"code": f"b{j}", "geometry": gpd_box(j + 20, 10, j + 21, 11)})
+    # Group C: lonely square far far away
+    rows.append({"code": "c0", "geometry": gpd_box(40, -10, 41, -9)})
+    return gpd.GeoDataFrame(rows, geometry="geometry")
+
+
+# ---------------------------------------------------------------------------
+# Algorithms
+# ---------------------------------------------------------------------------
+
+class TestPlacePolygons:
+    def test_greedy_assigns_every_polygon(self, grid_3x3):
+        from siege_utilities.reporting.hex_cartogram.algorithms import (
+            Algorithm, place_polygons,
+        )
+        out = place_polygons(grid_3x3, "code", algorithm=Algorithm.GREEDY)
+        assert set(out) == set(grid_3x3["code"])
+        # No two polygons assigned to the same hex.
+        assert len(set(out.values())) == len(out)
+
+    def test_hungarian_assigns_optimally(self, grid_3x3):
+        pytest.importorskip("scipy")
+        from siege_utilities.reporting.hex_cartogram.algorithms import (
+            Algorithm, place_polygons,
+        )
+        out = place_polygons(grid_3x3, "code", algorithm=Algorithm.HUNGARIAN)
+        assert set(out) == set(grid_3x3["code"])
+        assert len(set(out.values())) == len(out)
+
+    def test_annealing_runs(self, grid_3x3):
+        from siege_utilities.reporting.hex_cartogram.algorithms import (
+            Algorithm, place_polygons,
+        )
+        out = place_polygons(
+            grid_3x3, "code", algorithm=Algorithm.ANNEALING,
+            iterations=200, seed=42,
+        )
+        assert set(out) == set(grid_3x3["code"])
+        assert len(set(out.values())) == len(out)
+
+    def test_force_directed_reserved(self, grid_3x3):
+        from siege_utilities.reporting.hex_cartogram.algorithms import (
+            Algorithm, place_polygons,
+        )
+        with pytest.raises(NotImplementedError, match="force_directed"):
+            place_polygons(
+                grid_3x3, "code", algorithm=Algorithm.FORCE_DIRECTED,
+            )
+
+    def test_ilp_reserved(self, grid_3x3):
+        from siege_utilities.reporting.hex_cartogram.algorithms import (
+            Algorithm, place_polygons,
+        )
+        with pytest.raises(NotImplementedError, match="ilp"):
+            place_polygons(grid_3x3, "code", algorithm=Algorithm.ILP)
+
+    def test_empty_gdf_raises(self):
+        pytest.importorskip("geopandas")
+        import geopandas as gpd
+        from siege_utilities.reporting.hex_cartogram.algorithms import (
+            Algorithm, place_polygons,
+        )
+        empty = gpd.GeoDataFrame({"code": [], "geometry": []})
+        with pytest.raises(ValueError, match="empty"):
+            place_polygons(empty, "code", algorithm=Algorithm.GREEDY)
+
+    def test_missing_code_col_raises(self, grid_3x3):
+        from siege_utilities.reporting.hex_cartogram.algorithms import (
+            place_polygons,
+        )
+        with pytest.raises(ValueError, match="not in gdf"):
+            place_polygons(grid_3x3, "nonexistent_col")
+
+
+# ---------------------------------------------------------------------------
+# Connected-component splitting
+# ---------------------------------------------------------------------------
+
+class TestComponents:
+    def test_single_component_for_grid(self, grid_3x3):
+        from siege_utilities.reporting.hex_cartogram.components import (
+            find_components,
+        )
+        comps = find_components(grid_3x3, "code")
+        assert len(comps) == 1
+        assert set(comps[0]) == set(grid_3x3["code"])
+
+    def test_three_components_for_disconnected(self, disconnected_groups):
+        from siege_utilities.reporting.hex_cartogram.components import (
+            find_components,
+        )
+        comps = find_components(disconnected_groups, "code")
+        assert len(comps) == 3
+        # Largest first.
+        assert len(comps[0]) >= len(comps[1]) >= len(comps[2])
+        assert sum(len(c) for c in comps) == 6
+
+    def test_stitch_separates_components(self):
+        from siege_utilities.reporting.hex_cartogram.components import (
+            stitch_components,
+        )
+        a = {"a0": (0, 0), "a1": (1, 0)}
+        b = {"b0": (0, 0), "b1": (1, 0)}
+        merged = stitch_components([a, b], component_gap=2)
+        # b cells should not collide with a cells.
+        all_cells = list(merged.values())
+        assert len(set(all_cells)) == len(all_cells)
+        # b should be shifted right of a.
+        assert merged["b0"][0] > merged["a1"][0]
+
+
+# ---------------------------------------------------------------------------
+# hex_tile_layout dispatcher
+# ---------------------------------------------------------------------------
+
+class TestHexTileLayout:
+    def test_geodataframe_input_produces_layout(self, grid_3x3):
+        from siege_utilities.reporting.hex_cartogram.layouts import (
+            hex_tile_layout,
+        )
+        layout = hex_tile_layout(grid_3x3, code_col="code", algorithm="greedy")
+        assert "geometry" in layout.columns
+        assert "code" in layout.columns
+        assert "q" in layout.columns
+        assert "r" in layout.columns
+        assert len(layout) == len(grid_3x3)
+
+    def test_disconnected_uses_component_split(self, disconnected_groups):
+        from siege_utilities.reporting.hex_cartogram.layouts import (
+            hex_tile_layout,
+        )
+        layout = hex_tile_layout(
+            disconnected_groups, code_col="code",
+            algorithm="greedy", components="auto", component_gap=1,
+        )
+        assert len(layout) == 6
+
+    def test_components_single_forces_one_layout(self, disconnected_groups):
+        from siege_utilities.reporting.hex_cartogram.layouts import (
+            hex_tile_layout,
+        )
+        layout = hex_tile_layout(
+            disconnected_groups, code_col="code",
+            algorithm="greedy", components="single",
+        )
+        assert len(layout) == 6
+
+    def test_register_and_use_named_layout(self):
+        from siege_utilities.reporting.hex_cartogram.layouts import (
+            hex_tile_layout, register_layout, REGISTERED_LAYOUTS,
+        )
+        register_layout("test_layout", {"a": (0, 0), "b": (1, 0)})
+        try:
+            layout = hex_tile_layout("test_layout")
+            assert len(layout) == 2
+            assert set(layout["code"]) == {"a", "b"}
+        finally:
+            REGISTERED_LAYOUTS.pop("test_layout", None)
+
+    def test_register_duplicate_cells_raises(self):
+        from siege_utilities.reporting.hex_cartogram.layouts import (
+            register_layout,
+        )
+        with pytest.raises(ValueError, match="duplicate hex"):
+            register_layout("dup", {"a": (0, 0), "b": (0, 0)})
+
+    def test_unknown_layout_raises(self):
+        from siege_utilities.reporting.hex_cartogram.layouts import (
+            hex_tile_layout,
+        )
+        with pytest.raises(KeyError, match="Unknown layout"):
+            hex_tile_layout("does_not_exist")
+
+
+# ---------------------------------------------------------------------------
+# Renderer
+# ---------------------------------------------------------------------------
+
+class TestHexTileMap:
+    @pytest.fixture
+    def small_layout(self, grid_3x3):
+        from siege_utilities.reporting.hex_cartogram.layouts import (
+            hex_tile_layout,
+        )
+        return hex_tile_layout(grid_3x3, code_col="code", algorithm="greedy")
+
+    @pytest.fixture
+    def values(self, grid_3x3):
+        # Increasing values 0..8.
+        return pd.Series(
+            range(9),
+            index=grid_3x3["code"].tolist(),
+        )
+
+    def test_equal_sizing_produces_figure(self, small_layout, values):
+        pytest.importorskip("matplotlib")
+        from siege_utilities.reporting.hex_cartogram.renderer import (
+            hex_tile_map, Sizing,
+        )
+        fig = hex_tile_map(values, small_layout, sizing=Sizing.EQUAL)
+        assert fig is not None
+
+    def test_value_proportional_sizing(self, small_layout, values):
+        pytest.importorskip("matplotlib")
+        from siege_utilities.reporting.hex_cartogram.renderer import (
+            hex_tile_map,
+        )
+        fig = hex_tile_map(values, small_layout, sizing="value_proportional")
+        assert fig is not None
+
+    def test_value_sqrt_sizing(self, small_layout, values):
+        pytest.importorskip("matplotlib")
+        from siege_utilities.reporting.hex_cartogram.renderer import (
+            hex_tile_map,
+        )
+        fig = hex_tile_map(values, small_layout, sizing="value_sqrt")
+        assert fig is not None
+
+    def test_missing_values_render_as_missing_color(self, small_layout):
+        pytest.importorskip("matplotlib")
+        from siege_utilities.reporting.hex_cartogram.renderer import (
+            hex_tile_map,
+        )
+        # Provide values for only some codes.
+        partial = pd.Series([1.0, 2.0], index=["r0c0", "r1c1"])
+        fig = hex_tile_map(partial, small_layout)
+        assert fig is not None  # didn't crash
+
+    def test_no_aligned_values_warns_but_renders(self, small_layout, caplog):
+        pytest.importorskip("matplotlib")
+        from siege_utilities.reporting.hex_cartogram.renderer import (
+            hex_tile_map,
+        )
+        fig = hex_tile_map(pd.Series(dtype=float), small_layout)
+        assert fig is not None
+
+    def test_unknown_sizing_raises(self, small_layout, values):
+        pytest.importorskip("matplotlib")
+        from siege_utilities.reporting.hex_cartogram.renderer import (
+            hex_tile_map,
+        )
+        with pytest.raises(ValueError, match="not a valid Sizing"):
+            hex_tile_map(values, small_layout, sizing="invalid")
+
+
+# ---------------------------------------------------------------------------
+# Coords
+# ---------------------------------------------------------------------------
+
+class TestCoords:
+    def test_neighbors_are_six(self):
+        from siege_utilities.reporting.hex_cartogram.coords import (
+            axial_neighbors,
+        )
+        assert len(axial_neighbors((0, 0))) == 6
+
+    def test_distance_zero_to_self(self):
+        from siege_utilities.reporting.hex_cartogram.coords import (
+            axial_distance,
+        )
+        assert axial_distance((3, 4), (3, 4)) == 0
+
+    def test_distance_one_for_neighbor(self):
+        from siege_utilities.reporting.hex_cartogram.coords import (
+            axial_distance, axial_neighbors,
+        )
+        for n in axial_neighbors((0, 0)):
+            assert axial_distance((0, 0), n) == 1
+
+    def test_hexagon_polygon_has_six_vertices(self):
+        from siege_utilities.reporting.hex_cartogram.coords import (
+            hexagon_polygon,
+        )
+        verts = hexagon_polygon((0, 0))
+        assert len(verts) == 6


### PR DESCRIPTION
Closes ELE-2482.

## Summary

Hex cartogram (tile-map) support: each admin unit becomes a single hexagon, positioned to roughly preserve geography. Whole point — small jurisdictions get the same visual weight as large ones (Wyoming and DC don't get drowned out by California).

## What ships

### `siege_utilities.reporting.hex_cartogram.coords`

Axial-hex coordinate math (pointy-top): neighbors, distance, Cartesian conversion, polygon vertices, bounding-grid sized to a polygon count.

### `siege_utilities.reporting.hex_cartogram.algorithms`

Three placement algorithms behind one `Algorithm` enum:

| Algorithm | Optimizes | Speed | When |
|---|---|---|---|
| `GREEDY` | Centroid only | < 100 ms | Baseline / sanity |
| `HUNGARIAN` | Centroid only, **provably optimal** | ~1s for 50, ~30s for 250 | Fast quality |
| `ANNEALING` | Centroid + topology weighted | 1–30s | Default for ≤ 200 polygons |
| `FORCE_DIRECTED` | Reserved | — | Raises `NotImplementedError` (follow-up) |
| `ILP` | Reserved | — | Raises `NotImplementedError` (follow-up) |

### `siege_utilities.reporting.hex_cartogram.components`

Connected-component splitting via shapely `touches` adjacency. Handles **non-contiguous admin sets** (CONUS + Alaska + Hawaii; India + Sri Lanka; Spain + Canary Islands) by detecting groups, laying each out independently, and stitching with `component_gap` empty hexes between them.

### `siege_utilities.reporting.hex_cartogram.layouts`

`hex_tile_layout` dispatcher accepting:

- A registered layout name (look up `register_layout(name, mapping)` results).
- A `GeoDataFrame` (algorithmic placement; default `algorithm="annealing"`).
- A built-in name (`BUILTIN_LAYOUTS` empty in v1 — `us_states` etc. land in the follow-up after a clean license trace on the hand-positioned coordinates).

### `siege_utilities.reporting.hex_cartogram.renderer`

`hex_tile_map` matplotlib renderer with three sizing modes:

- `Sizing.EQUAL` *(default)* — every hex same size; values map to color. Most charming, most honest for political analytics.
- `Sizing.VALUE_PROPORTIONAL` — hex area ∝ value (Tilegram-style).
- `Sizing.VALUE_SQRT` — hex side ∝ √value (perception-correct for size encoding).

Missing values render as a configurable `missing_color` (no silent disappearance).

## Test plan

- [x] Local: `pytest tests/test_hex_cartogram.py` → **26 passed**.
- [x] Lint clean (no F401/F841/F541).
- [x] Each algorithm tested end-to-end on a 3×3 grid + reserved-algorithm `NotImplementedError` paths covered.
- [x] Connected-component splitting verified on a 3-group disconnected fixture (3 cells + 2 + 1).
- [x] All three sizing modes produce a Figure; missing-values + unknown-sizing-mode paths covered.
- [ ] Full CI matrix on push.

## Out of scope (follow-up — flagged in the ticket and commit body)

- Force-directed (geogrid-style) and ILP (via PuLP) algorithms. Reserved enum names raise `NotImplementedError`.
- Built-in canonical `us_states` / `us_cd_117` layouts. Need a license-clean source for the hand-positioned coordinates.
- Per-algorithm benchmark page (`centroid_rmse`, `topology_preservation_pct`, `runtime_ms`).
- `notebooks/reports/05_hex_cartogram.ipynb` — tracked under ELE-2484 (notebook overhaul).