### PR TITLE
feat(geo): Gazetteer protocol + WKLS backend (ELE-2483 PR-A)

### DIFF
--- a/LICENSES/wkls.md
+++ b/LICENSES/wkls.md
@@ -1,0 +1,49 @@
+# WKLS (Well Known Locations) — license attribution
+
+`siege_utilities` integrates the [wkls](https://github.com/wherobots/wkls)
+Python package as the default global gazetteer backend (`[wkls]` extra).
+
+## Code license
+
+WKLS is released under the **Apache License 2.0**. See the upstream
+repository for the canonical text.
+
+## Data license — Overture Maps Divisions
+
+WKLS reads administrative-boundary geometry from the **Overture Maps
+Foundation's Divisions theme**, hosted on AWS Open Data Registry. The
+Divisions dataset is built from multiple upstream sources, each of
+which carries its own attribution / share-alike requirements:
+
+| Source | License | Obligation |
+|---|---|---|
+| OpenStreetMap contributors | **ODbL 1.0** | Attribution + **share-alike** on derivative datasets |
+| geoBoundaries | CC BY 4.0 | Attribution |
+| Esri Community Maps | CC BY 4.0 | Attribution |
+| Land Information New Zealand (LINZ) | CC BY 4.0 | Attribution |
+
+**What this means for siege_utilities consumers**:
+
+1. **Attribution**: any work that ships geometry derived from WKLS
+   queries should attribute Overture Maps Foundation and the upstream
+   source(s) involved. The upstream `wkls` package preserves source
+   attribution on each row — see the `source` column in result
+   metadata.
+
+2. **ODbL share-alike (OSM-derived rows)**: if your work creates a
+   *derivative database* (a published dataset that includes
+   OSM-derived geometries) you must license that derivative database
+   under ODbL 1.0. *Producing reports / analyses that use the
+   geometries internally is not creating a derivative database* — that
+   distinction matters and is the part that bites people.
+
+3. **No warranty**: as with any open-data source, geometries are
+   community-curated and may contain errors. siege_utilities does not
+   add a warranty layer; consumers verify against ground truth where
+   it matters.
+
+## See also
+
+- Overture Maps license terms: <https://docs.overturemaps.org/attribution/>
+- ODbL 1.0 full text: <https://opendatacommons.org/licenses/odbl/1-0/>
+- WKLS GitHub: <https://github.com/wherobots/wkls>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,12 @@ h3 = [
 s2 = [
     "s2sphere>=0.2.5",
 ]
+# WKLS (Well Known Locations) — global admin-boundary gazetteer.
+# Pulls sedonadb (Rust + Arrow), pyarrow, geoarrow-pyarrow. NO Spark/JVM.
+# ~302 MB install. Data fetched on-demand from public Overture Maps S3.
+wkls = [
+    "wkls>=1.1.0",
+]
 # Etter — natural-language geographic query parser (LLM-driven)
 etter = [
     "etter>=0.1.0",

--- a/siege_utilities/geo/__init__.py
+++ b/siege_utilities/geo/__init__.py
@@ -180,6 +180,14 @@ _register([
 # --- nces_download ---
 _register(['NCESDownloader', 'NCESDownloadError'], '.providers.nces_download')
 
+# --- gazetteers (name → geometry resolution; WKLS / Nominatim / Census / Wikidata) ---
+_register([
+    'Gazetteer', 'GazetteerResult', 'GazetteerCandidate',
+    'GazetteerError', 'GazetteerNotFoundError',
+    'GazetteerAmbiguousError', 'GazetteerBackendError',
+    'resolve_gazetteer',
+], '.gazetteers')
+
 # --- etter_filter (natural-language geographic query parsing via LLM) ---
 _register([
     'ETTER_AVAILABLE',

--- a/siege_utilities/geo/gazetteers/__init__.py
+++ b/siege_utilities/geo/gazetteers/__init__.py
@@ -89,14 +89,12 @@ def resolve_gazetteer(
             f"'wikidata', got {prefer!r}"
         )
 
-    # Auto-select: try WKLS first, then NotImplementedError stops us
-    # since the alternates aren't ready in this PR.
-    try:
-        from .wkls_gazetteer import WklsGazetteer, WKLS_AVAILABLE
-        if WKLS_AVAILABLE:
-            return WklsGazetteer(cache_size=cache_size)
-    except ImportError:
-        pass
+    # Auto-select: try WKLS first. wkls_gazetteer catches its own
+    # ImportError on the wkls package, so the module import itself
+    # never raises — guard via WKLS_AVAILABLE instead.
+    from .wkls_gazetteer import WklsGazetteer, WKLS_AVAILABLE
+    if WKLS_AVAILABLE:
+        return WklsGazetteer(cache_size=cache_size)
 
     raise RuntimeError(
         "No gazetteer backend available. Install with: "

--- a/siege_utilities/geo/gazetteers/__init__.py
+++ b/siege_utilities/geo/gazetteers/__init__.py
@@ -1,0 +1,106 @@
+"""Gazetteers — name → geometry resolution (ELE-2483).
+
+Public API:
+
+* :class:`Gazetteer` — Protocol every backend satisfies.
+* :class:`GazetteerResult` — resolved place (name, path, geometry,
+  centroid, admin levels).
+* :class:`GazetteerCandidate` — search hit (no geometry yet).
+* :func:`resolve_gazetteer` — factory that picks the best available
+  backend (WKLS by default; falls back to Nominatim, then Census).
+* Errors: :class:`GazetteerError`, :class:`GazetteerNotFoundError`,
+  :class:`GazetteerAmbiguousError`, :class:`GazetteerBackendError`.
+
+The Etter integration (:func:`etter_to_geometry`) consumes this
+interface — see :mod:`siege_utilities.geo.providers.etter_filter`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from .base import (
+    Gazetteer,
+    GazetteerAmbiguousError,
+    GazetteerBackendError,
+    GazetteerCandidate,
+    GazetteerError,
+    GazetteerNotFoundError,
+    GazetteerResult,
+)
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "Gazetteer",
+    "GazetteerCandidate",
+    "GazetteerResult",
+    "GazetteerError",
+    "GazetteerNotFoundError",
+    "GazetteerAmbiguousError",
+    "GazetteerBackendError",
+    "resolve_gazetteer",
+]
+
+
+def resolve_gazetteer(
+    *,
+    prefer: Optional[str] = None,
+    cache_size: int = 1024,
+) -> Gazetteer:
+    """Return a configured :class:`Gazetteer` backend.
+
+    Selection order:
+
+    1. If ``prefer`` is given, use that backend (raises if unavailable).
+    2. Otherwise, try WKLS (global coverage, no API key).
+    3. Then Nominatim (OSM-backed, public service).
+    4. Raise if nothing works.
+
+    Args:
+        prefer: ``"wkls"`` / ``"nominatim"`` / ``"census"`` / ``"wikidata"``
+            to force a specific backend.
+        cache_size: LRU cache size for backends that support it.
+
+    Raises:
+        :class:`ImportError` — preferred backend's package isn't installed.
+        :class:`RuntimeError` — no usable backend at all.
+    """
+    if prefer == "wkls":
+        from .wkls_gazetteer import WklsGazetteer
+        return WklsGazetteer(cache_size=cache_size)
+    if prefer == "nominatim":
+        # Nominatim adapter lives in providers/ for now and exposes the
+        # Gazetteer protocol via a thin wrapper. Future: refactor to a
+        # native sibling module under gazetteers/.
+        raise NotImplementedError(
+            "NominatimGazetteer adapter is queued for ELE-2483 PR-B. "
+            "For now, pass prefer='wkls' (the default backend) or use "
+            "the existing NominatimGeoClassifier directly."
+        )
+    if prefer in ("census", "wikidata"):
+        raise NotImplementedError(
+            f"{prefer!r} gazetteer backend is queued for ELE-2483 PR-B."
+        )
+    if prefer is not None:
+        raise ValueError(
+            f"prefer must be one of 'wkls', 'nominatim', 'census', "
+            f"'wikidata', got {prefer!r}"
+        )
+
+    # Auto-select: try WKLS first, then NotImplementedError stops us
+    # since the alternates aren't ready in this PR.
+    try:
+        from .wkls_gazetteer import WklsGazetteer, WKLS_AVAILABLE
+        if WKLS_AVAILABLE:
+            return WklsGazetteer(cache_size=cache_size)
+    except ImportError:
+        pass
+
+    raise RuntimeError(
+        "No gazetteer backend available. Install with: "
+        "pip install 'siege-utilities[wkls]' (recommended) "
+        "or wait for the Nominatim/Census/Wikidata adapters in "
+        "ELE-2483 PR-B."
+    )

--- a/siege_utilities/geo/gazetteers/base.py
+++ b/siege_utilities/geo/gazetteers/base.py
@@ -1,0 +1,195 @@
+"""Gazetteer protocol — name → geometry resolution.
+
+A gazetteer takes a place name (``"Birmingham, AL"``, ``"Lausanne"``,
+``"Texas"``) and returns a structured :class:`GazetteerResult` carrying
+the canonical hierarchy path, the geometry, and a centroid. Backends
+live in sibling modules (:mod:`.wkls_gazetteer`,
+:mod:`.nominatim_gazetteer`, etc.) and are selected via the factory in
+:mod:`siege_utilities.geo.gazetteers`.
+
+The protocol is **typed-Protocol** rather than an ABC so backends can be
+plain classes without inheritance ceremony — useful for adapters
+wrapping foreign libraries.
+
+Failure-mode discipline (matches the rest of siege_utilities, see
+``docs/FAILURE_MODES.md``): every method raises a typed exception on
+failure rather than returning ``None`` or an empty container that
+silently looks like a successful empty result.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Optional, Protocol, runtime_checkable
+
+__all__ = [
+    "Gazetteer",
+    "GazetteerResult",
+    "GazetteerCandidate",
+    "GazetteerError",
+    "GazetteerNotFoundError",
+    "GazetteerAmbiguousError",
+    "GazetteerBackendError",
+]
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+class GazetteerError(RuntimeError):
+    """Base class for all gazetteer failures."""
+
+
+class GazetteerNotFoundError(GazetteerError):
+    """No place matched the lookup criteria."""
+
+
+class GazetteerAmbiguousError(GazetteerError):
+    """The query is ambiguous and the caller didn't pass enough hints.
+
+    Carries the candidates so the caller can surface them to a user or
+    pick programmatically.
+    """
+
+    def __init__(self, message: str, candidates: list["GazetteerCandidate"]):
+        super().__init__(message)
+        self.candidates = candidates
+
+
+class GazetteerBackendError(GazetteerError):
+    """The backend raised an error we couldn't translate.
+
+    Network failure, malformed upstream response, missing optional
+    dependency at lookup time. Always chains the original via
+    ``__cause__``.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class GazetteerCandidate:
+    """A search hit — a place that *might* be the answer.
+
+    Search returns multiple of these; lookup picks one. Keep the
+    structure small and JSON-safe so it round-trips through APIs and
+    logs cleanly.
+    """
+
+    name: str
+    canonical_path: tuple[str, ...]
+    country: Optional[str] = None
+    admin_levels: Mapping[str, str] = field(default_factory=dict)
+    score: Optional[float] = None
+    source: str = ""
+
+
+@dataclass(frozen=True)
+class GazetteerResult:
+    """A resolved place: name, hierarchy, geometry, centroid.
+
+    Attributes:
+        name: Display name of the matched place.
+        canonical_path: Hierarchical breadcrumb the source resolves the
+            place through, e.g. ``("US", "AL", "Birmingham")``. Useful
+            for downstream filtering and for re-querying the same
+            backend without going through fuzzy search again.
+        geometry: shapely shape (Polygon / MultiPolygon for admin areas;
+            may be a Point for cities-as-points).
+        centroid: shapely Point. Pre-computed because half the consumer
+            code needs it and recomputing on every call is wasteful.
+        country: Optional ISO-3166-1 alpha-2 country code.
+        admin_levels: Optional mapping of admin level name → value
+            (e.g. ``{"region": "Alabama", "county": "Jefferson"}``).
+            Backend-specific; not assumed by the resolver layer.
+        source: Backend name (``"wkls"``, ``"nominatim"``, etc.) — for
+            audit / log lineage.
+        raw: Backend-native object for callers that need full fidelity.
+            Excluded from ``repr`` and ``hash`` so the dataclass stays
+            sane to print and stable as a cache key.
+    """
+
+    name: str
+    canonical_path: tuple[str, ...]
+    geometry: Any  # shapely geometry; typed loose to avoid module-level shapely import
+    centroid: Any
+    country: Optional[str] = None
+    admin_levels: Mapping[str, str] = field(default_factory=dict)
+    source: str = ""
+    raw: Any = field(default=None, repr=False, compare=False)
+
+    # Mutable mapping in metadata means the dataclass is not safely
+    # hashable; mark it explicitly so callers can't smuggle one of these
+    # into a dict key and get burned later.
+    __hash__ = None  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+@runtime_checkable
+class Gazetteer(Protocol):
+    """Name → geometry resolver.
+
+    The protocol is intentionally narrow — four methods. Backends layer
+    LRU caches, ISO-code translation, and other plumbing internally;
+    callers just see this surface.
+    """
+
+    @property
+    def provider_name(self) -> str:
+        """Human-readable backend identifier (``"wkls"``, etc.)."""
+        ...
+
+    def lookup(
+        self,
+        name: str,
+        *,
+        country_hint: Optional[str] = None,
+        admin_hint: Optional[str] = None,
+    ) -> GazetteerResult:
+        """Best match for *name*.
+
+        Args:
+            name: Place name in human form (``"Birmingham, AL"``).
+            country_hint: Optional ISO-3166-1 alpha-2 (``"US"``) or
+                alpha-3 (``"USA"``) hint to disambiguate places that
+                exist in multiple countries.
+            admin_hint: Optional region/state hint (``"Alabama"``,
+                ``"AL"``, ``"01"``).
+
+        Raises:
+            GazetteerNotFoundError: No match.
+            GazetteerAmbiguousError: Multiple matches; caller should
+                pass more hints or use :meth:`search` and pick.
+            GazetteerBackendError: Network / dependency / parse failure.
+        """
+        ...
+
+    def search(
+        self,
+        name: str,
+        *,
+        country_hint: Optional[str] = None,
+        limit: int = 10,
+    ) -> list[GazetteerCandidate]:
+        """Top-N candidate matches.
+
+        Used to surface ambiguity to a caller (interactive UI, or
+        programmatic disambiguation when the caller has external
+        knowledge to pick a candidate).
+        """
+        ...
+
+    def is_available(self) -> bool:
+        """Return True if the backend's dependencies are installed and
+        the backend can answer queries.
+
+        Should NOT make a network round-trip — this is a fast probe used
+        by the factory to pick a default backend.
+        """
+        ...

--- a/siege_utilities/geo/gazetteers/wkls_gazetteer.py
+++ b/siege_utilities/geo/gazetteers/wkls_gazetteer.py
@@ -1,0 +1,286 @@
+"""WKLS (Well Known Locations) gazetteer backend.
+
+Wraps the upstream `wkls <https://github.com/wherobots/wkls>`_ package
+to resolve place names against Overture Maps administrative
+boundaries (~625k globally). Why this is the default global backend:
+
+* No API key, no rate limit (reads from public S3 via embedded sedonadb).
+* sedonadb is Rust + Arrow-native — **no JVM / Spark dependency**, just
+  a 302 MB install.
+* Source data is Overture Maps, the well-curated successor to
+  patchwork-of-everything that older gazetteers carried.
+
+Two siege_utilities-specific pieces this backend adds on top of the raw
+wkls API:
+
+1. **Free-text → ISO code** resolver. Etter outputs ``"Alabama"``;
+   wkls wants ``wkls.us.al``. We use the wkls metadata search to map
+   the human form into the chained-attribute form before calling the
+   geometry getter.
+
+2. **In-process LRU cache.** The upstream library does *not* cache
+   geometry fetches in-process — every ``.wkt()`` call hits S3 (~6s
+   cold). For interactive use that's a deal-breaker. We wrap the path
+   ``(country, region, place_id)`` → shapely geometry with
+   :func:`functools.lru_cache`.
+
+Verified against ``wkls==1.1.0`` on 2026-05-07.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+from typing import Any, Optional
+
+from .base import (
+    GazetteerAmbiguousError,
+    GazetteerBackendError,
+    GazetteerCandidate,
+    GazetteerNotFoundError,
+    GazetteerResult,
+)
+
+log = logging.getLogger(__name__)
+
+try:
+    import wkls  # type: ignore[import-not-found]
+    WKLS_AVAILABLE = True
+except ImportError:
+    wkls = None  # type: ignore[assignment]
+    WKLS_AVAILABLE = False
+    log.info("wkls not available — WklsGazetteer will raise on construct")
+
+
+__all__ = [
+    "WKLS_AVAILABLE",
+    "WklsGazetteer",
+]
+
+
+class WklsGazetteer:
+    """WKLS-backed gazetteer with in-process LRU caching."""
+
+    provider_name = "wkls"
+
+    def __init__(self, *, cache_size: int = 1024) -> None:
+        if not WKLS_AVAILABLE:
+            raise ImportError(
+                "WklsGazetteer requires wkls. Install with: "
+                "pip install 'siege-utilities[wkls]' or pip install 'wkls>=1.1.0'."
+            )
+        self._cache_size = cache_size
+        # Per-instance cache. Module-level cache would be tempting for
+        # cross-instance sharing, but instances may be configured with
+        # different overture_version, etc., and mixing those in one
+        # cache is silently wrong.
+        self._cached_geometry = functools.lru_cache(maxsize=cache_size)(
+            self._fetch_geometry
+        )
+
+    def is_available(self) -> bool:
+        return WKLS_AVAILABLE
+
+    # ------------------------------------------------------------------
+    # Gazetteer protocol
+    # ------------------------------------------------------------------
+
+    def lookup(
+        self,
+        name: str,
+        *,
+        country_hint: Optional[str] = None,
+        admin_hint: Optional[str] = None,
+    ) -> GazetteerResult:
+        if not name or not name.strip():
+            raise ValueError("WklsGazetteer.lookup: empty name")
+        candidates = self._search_metadata(
+            name, country_hint=country_hint, admin_hint=admin_hint, limit=10,
+        )
+        if not candidates:
+            raise GazetteerNotFoundError(
+                f"WKLS: no match for {name!r}"
+                + (f" (country={country_hint!r})" if country_hint else "")
+            )
+        if len(candidates) > 1 and not (country_hint or admin_hint):
+            # Ambiguous — surface candidates rather than silently picking.
+            raise GazetteerAmbiguousError(
+                f"WKLS: {len(candidates)} matches for {name!r}; "
+                "pass country_hint/admin_hint to disambiguate or use "
+                "search() and pick.",
+                candidates=[self._row_to_candidate(r) for r in candidates],
+            )
+        chosen = candidates[0]
+        return self._row_to_result(chosen)
+
+    def search(
+        self,
+        name: str,
+        *,
+        country_hint: Optional[str] = None,
+        limit: int = 10,
+    ) -> list[GazetteerCandidate]:
+        if not name or not name.strip():
+            return []
+        rows = self._search_metadata(
+            name, country_hint=country_hint, admin_hint=None, limit=limit,
+        )
+        return [self._row_to_candidate(r) for r in rows]
+
+    # ------------------------------------------------------------------
+    # Internal: search + fetch
+    # ------------------------------------------------------------------
+
+    def _search_metadata(
+        self,
+        name: str,
+        *,
+        country_hint: Optional[str],
+        admin_hint: Optional[str],
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        """Run the WKLS wildcard search; return the top-N rows.
+
+        Tolerant of upstream API drift: catches all exceptions and
+        translates into :class:`GazetteerBackendError`.
+        """
+        try:
+            # Walk the chain top-down using the hints we have. Both
+            # hints are best-effort; missing hints just mean a wider
+            # search.
+            df = wkls
+            if country_hint:
+                code = country_hint.strip().lower()
+                if len(code) == 3:
+                    # ISO-3 → ISO-2 — wkls uses ISO-2 codes for chains.
+                    code = _ISO3_TO_ISO2.get(code.upper(), code[:2])
+                # Try direct chain access; fall back to wildcard.
+                try:
+                    df = getattr(wkls, code)
+                except AttributeError:
+                    df = wkls[f"%{code}%"]
+            if admin_hint:
+                admin = admin_hint.strip().lower()
+                # Admin hints can be region codes ("al"), full names
+                # ("alabama"), or FIPS — try each.
+                try:
+                    df = getattr(df, admin)
+                except (AttributeError, TypeError):
+                    df = df[f"%{admin}%"]
+
+            df = df[f"%{name}%"]
+            # to_arrow_table avoids the optional pandas dep (we can
+            # iterate Arrow rows directly).
+            arrow = df.to_arrow_table()
+        except Exception as exc:
+            raise GazetteerBackendError(
+                f"WKLS search for {name!r} failed: {exc}"
+            ) from exc
+
+        rows: list[dict[str, Any]] = []
+        for batch in arrow.to_batches():
+            cols = {field.name: batch.column(i).to_pylist()
+                    for i, field in enumerate(arrow.schema)}
+            for i in range(len(batch)):
+                rows.append({k: v[i] for k, v in cols.items()})
+                if len(rows) >= limit:
+                    break
+            if len(rows) >= limit:
+                break
+        return rows
+
+    def _fetch_geometry(self, place_id: str) -> Any:
+        """Fetch the WKT for a given Overture place ID.
+
+        This is the slow path — first call is ~6s; subsequent calls hit
+        the LRU cache. ``functools.lru_cache`` requires a hashable
+        argument, hence the str ID rather than the row dict.
+        """
+        try:
+            from shapely import wkt as _wkt
+        except ImportError as exc:
+            raise GazetteerBackendError(
+                "shapely required to convert WKLS WKT to geometry"
+            ) from exc
+        try:
+            wkt_str = wkls.resolve(place_id).wkt()
+        except Exception as exc:
+            raise GazetteerBackendError(
+                f"WKLS geometry fetch for id={place_id!r} failed: {exc}"
+            ) from exc
+        return _wkt.loads(wkt_str)
+
+    def _row_to_candidate(self, row: dict[str, Any]) -> GazetteerCandidate:
+        return GazetteerCandidate(
+            name=str(row.get("name_primary") or row.get("name_en") or ""),
+            canonical_path=_canonical_path_from_row(row),
+            country=row.get("country") or None,
+            admin_levels=_admin_levels_from_row(row),
+            score=None,
+            source=self.provider_name,
+        )
+
+    def _row_to_result(self, row: dict[str, Any]) -> GazetteerResult:
+        place_id = str(row["id"])
+        geometry = self._cached_geometry(place_id)
+        try:
+            centroid = geometry.centroid
+        except Exception as exc:
+            raise GazetteerBackendError(
+                f"WKLS: cannot compute centroid for id={place_id!r}: {exc}"
+            ) from exc
+        return GazetteerResult(
+            name=str(row.get("name_primary") or row.get("name_en") or ""),
+            canonical_path=_canonical_path_from_row(row),
+            geometry=geometry,
+            centroid=centroid,
+            country=row.get("country") or None,
+            admin_levels=_admin_levels_from_row(row),
+            source=self.provider_name,
+            raw=row,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _canonical_path_from_row(row: dict[str, Any]) -> tuple[str, ...]:
+    """Build the ``(country, region, name)`` breadcrumb."""
+    parts = []
+    if row.get("country"):
+        parts.append(str(row["country"]))
+    if row.get("region") and row["region"] != row.get("country"):
+        parts.append(str(row["region"]))
+    name = row.get("name_primary") or row.get("name_en")
+    if name:
+        parts.append(str(name))
+    return tuple(parts)
+
+
+def _admin_levels_from_row(row: dict[str, Any]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    if row.get("country"):
+        out["country"] = str(row["country"])
+    if row.get("region"):
+        out["region"] = str(row["region"])
+    if row.get("subtype"):
+        out["subtype"] = str(row["subtype"])
+    return out
+
+
+# Minimal ISO-3 → ISO-2 fallback map for common cases. Not exhaustive —
+# WKLS uses ISO-2; if the caller passes ISO-3 we try this map first,
+# then fall back to truncating ("USA" → "US", which is correct here).
+_ISO3_TO_ISO2 = {
+    "USA": "US", "GBR": "GB", "DEU": "DE", "FRA": "FR", "CAN": "CA",
+    "MEX": "MX", "ESP": "ES", "ITA": "IT", "JPN": "JP", "CHN": "CN",
+    "IND": "IN", "BRA": "BR", "AUS": "AU", "NZL": "NZ", "ZAF": "ZA",
+    "RUS": "RU", "TUR": "TR", "EGY": "EG", "ARG": "AR", "CHL": "CL",
+    "COL": "CO", "PER": "PE", "VEN": "VE", "NLD": "NL", "BEL": "BE",
+    "CHE": "CH", "AUT": "AT", "SWE": "SE", "NOR": "NO", "DNK": "DK",
+    "FIN": "FI", "POL": "PL", "PRT": "PT", "IRL": "IE", "ISR": "IL",
+    "SAU": "SA", "ARE": "AE", "KOR": "KR", "IDN": "ID", "PHL": "PH",
+    "VNM": "VN", "THA": "TH", "MYS": "MY", "SGP": "SG", "NGA": "NG",
+    "KEN": "KE", "ETH": "ET", "GHA": "GH",
+}

--- a/siege_utilities/geo/gazetteers/wkls_gazetteer.py
+++ b/siege_utilities/geo/gazetteers/wkls_gazetteer.py
@@ -102,12 +102,19 @@ class WklsGazetteer:
                 f"WKLS: no match for {name!r}"
                 + (f" (country={country_hint!r})" if country_hint else "")
             )
-        if len(candidates) > 1 and not (country_hint or admin_hint):
-            # Ambiguous — surface candidates rather than silently picking.
+        if len(candidates) > 1:
+            # Always surface ambiguity rather than silently picking the
+            # first match — hints narrow the search space, they don't
+            # promise uniqueness.
+            hint_note = ""
+            if country_hint or admin_hint:
+                hint_note = (
+                    f" (after country_hint={country_hint!r}, "
+                    f"admin_hint={admin_hint!r})"
+                )
             raise GazetteerAmbiguousError(
-                f"WKLS: {len(candidates)} matches for {name!r}; "
-                "pass country_hint/admin_hint to disambiguate or use "
-                "search() and pick.",
+                f"WKLS: {len(candidates)} matches for {name!r}{hint_note}; "
+                "pass tighter hints, or use search() and pick a candidate.",
                 candidates=[self._row_to_candidate(r) for r in candidates],
             )
         chosen = candidates[0]
@@ -141,24 +148,42 @@ class WklsGazetteer:
     ) -> list[dict[str, Any]]:
         """Run the WKLS wildcard search; return the top-N rows.
 
+        ``limit`` bounds the rows we materialize into Python; it does
+        NOT bound the upstream sedonadb scan, which is driven by the
+        wildcard pattern and any preceding country/admin chain access.
+        Tight ``country_hint`` / ``admin_hint`` are the right way to
+        keep the upstream cost down.
+
         Tolerant of upstream API drift: catches all exceptions and
         translates into :class:`GazetteerBackendError`.
         """
+        # Resolve country_hint outside the upstream-error try/except so
+        # caller errors (unknown ISO-3) surface as ValueError rather than
+        # being relabeled as backend failures.
+        country_code: Optional[str] = None
+        if country_hint:
+            country_code = country_hint.strip()
+            if len(country_code) == 3:
+                iso2 = _ISO3_TO_ISO2.get(country_code.upper())
+                if iso2 is None:
+                    raise ValueError(
+                        f"WKLS: unknown ISO-3 country code {country_code!r}; "
+                        f"pass an ISO-2 code or extend _ISO3_TO_ISO2."
+                    )
+                country_code = iso2.lower()
+            else:
+                country_code = country_code.lower()
         try:
             # Walk the chain top-down using the hints we have. Both
             # hints are best-effort; missing hints just mean a wider
             # search.
             df = wkls
-            if country_hint:
-                code = country_hint.strip().lower()
-                if len(code) == 3:
-                    # ISO-3 → ISO-2 — wkls uses ISO-2 codes for chains.
-                    code = _ISO3_TO_ISO2.get(code.upper(), code[:2])
+            if country_code:
                 # Try direct chain access; fall back to wildcard.
                 try:
-                    df = getattr(wkls, code)
+                    df = getattr(wkls, country_code)
                 except AttributeError:
-                    df = wkls[f"%{code}%"]
+                    df = wkls[f"%{country_code}%"]
             if admin_hint:
                 admin = admin_hint.strip().lower()
                 # Admin hints can be region codes ("al"), full names
@@ -223,9 +248,15 @@ class WklsGazetteer:
     def _row_to_result(self, row: dict[str, Any]) -> GazetteerResult:
         place_id = str(row["id"])
         geometry = self._cached_geometry(place_id)
+        # `centroid` only fails for empty / structurally invalid GEOS
+        # geometries; let everything else propagate as a real bug.
+        try:
+            from shapely.errors import GEOSException
+        except ImportError:  # pragma: no cover - shapely already required upstream
+            GEOSException = Exception  # type: ignore[assignment, misc]
         try:
             centroid = geometry.centroid
-        except Exception as exc:
+        except (GEOSException, ValueError) as exc:
             raise GazetteerBackendError(
                 f"WKLS: cannot compute centroid for id={place_id!r}: {exc}"
             ) from exc

--- a/tests/test_gazetteers.py
+++ b/tests/test_gazetteers.py
@@ -1,0 +1,281 @@
+"""Tests for siege_utilities.geo.gazetteers (ELE-2483 PR-A).
+
+The WKLS upstream is mocked (network-bound, returns sedonadb rows). We
+test the translation layer — protocol conformance, exception
+discipline, search → candidate translation, lookup → result
+translation, the LRU cache, and ISO-3 → ISO-2 country code mapping.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from siege_utilities.geo.gazetteers import (
+    Gazetteer,
+    GazetteerAmbiguousError,
+    GazetteerBackendError,
+    GazetteerCandidate,
+    GazetteerError,
+    GazetteerNotFoundError,
+    GazetteerResult,
+    resolve_gazetteer,
+)
+from siege_utilities.geo.gazetteers import wkls_gazetteer as wg
+
+
+# ---------------------------------------------------------------------------
+# Helpers: build a fake upstream wkls module
+# ---------------------------------------------------------------------------
+
+def _arrow_table_from_rows(rows: list[dict]):
+    """Build a real pyarrow.Table from row dicts so the WklsGazetteer's
+    arrow-iteration code path is exercised end-to-end."""
+    pa = pytest.importorskip("pyarrow")
+    if not rows:
+        return pa.table({"id": [], "country": [], "region": [],
+                         "subtype": [], "name_primary": [], "name_en": []})
+    cols = {k: [r.get(k) for r in rows] for k in
+            ("id", "country", "region", "subtype", "name_primary", "name_en")}
+    return pa.table(cols)
+
+
+class _FakeChainable:
+    """Mimics wkls.core.ChainableDataFrame for both attribute and dict access."""
+
+    def __init__(self, rows: list[dict], geometries: dict[str, str] | None = None):
+        self._rows = rows
+        self._geometries = geometries or {}
+
+    def __getattr__(self, name):
+        # Drill into rows whose region/country matches a chained code.
+        if name.startswith("_"):
+            raise AttributeError(name)
+        filtered = [
+            r for r in self._rows
+            if name.lower() in str(r.get("country", "")).lower()
+            or name.lower() in str(r.get("region", "")).lower()
+        ]
+        return _FakeChainable(filtered or self._rows, self._geometries)
+
+    def __getitem__(self, key):
+        if isinstance(key, str) and key.startswith("%") and key.endswith("%"):
+            needle = key.strip("%").lower()
+            filtered = [
+                r for r in self._rows
+                if needle in str(r.get("name_primary", "")).lower()
+                or needle in str(r.get("name_en", "")).lower()
+                or needle in str(r.get("region", "")).lower()
+                or needle in str(r.get("country", "")).lower()
+            ]
+            return _FakeChainable(filtered, self._geometries)
+        raise TypeError(f"FakeChainable[{key!r}] not supported")
+
+    def to_arrow_table(self):
+        return _arrow_table_from_rows(self._rows)
+
+
+def _make_resolve(geometries: dict[str, str]):
+    """Build a wkls.resolve(id) → object-with-.wkt() callable."""
+    def resolve(place_id: str):
+        wkt_str = geometries.get(place_id)
+        if not wkt_str:
+            raise KeyError(place_id)
+        node = MagicMock()
+        node.wkt = MagicMock(return_value=wkt_str)
+        return node
+    return resolve
+
+
+# ---------------------------------------------------------------------------
+# Protocol structure
+# ---------------------------------------------------------------------------
+
+class TestProtocol:
+    def test_result_is_unhashable(self):
+        # Mutable metadata mapping → must not be hashable.
+        from shapely.geometry import Point
+        r = GazetteerResult(
+            name="X", canonical_path=("US", "AL"),
+            geometry=Point(0, 0), centroid=Point(0, 0),
+        )
+        with pytest.raises(TypeError):
+            hash(r)
+
+    def test_candidate_round_trip(self):
+        c = GazetteerCandidate(
+            name="Birmingham", canonical_path=("US", "AL", "Birmingham"),
+            country="US", source="wkls",
+        )
+        assert c.country == "US"
+        assert c.source == "wkls"
+
+    def test_ambiguous_carries_candidates(self):
+        c1 = GazetteerCandidate(
+            name="Birmingham", canonical_path=("US", "AL"), country="US",
+        )
+        c2 = GazetteerCandidate(
+            name="Birmingham", canonical_path=("GB",), country="GB",
+        )
+        err = GazetteerAmbiguousError("two matches", [c1, c2])
+        assert len(err.candidates) == 2
+        assert err.candidates[0].country == "US"
+
+    def test_error_hierarchy(self):
+        assert issubclass(GazetteerNotFoundError, GazetteerError)
+        assert issubclass(GazetteerAmbiguousError, GazetteerError)
+        assert issubclass(GazetteerBackendError, GazetteerError)
+
+
+# ---------------------------------------------------------------------------
+# WklsGazetteer
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def fake_wkls(monkeypatch):
+    """Replace the wkls module-attribute on wg with a controllable fake."""
+    rows = [
+        {"id": "uuid-bham-al", "country": "US", "region": "US-AL",
+         "subtype": "locality", "name_primary": "Birmingham", "name_en": "Birmingham"},
+        {"id": "uuid-bham-uk", "country": "GB", "region": "GB-WMD",
+         "subtype": "locality", "name_primary": "Birmingham", "name_en": "Birmingham"},
+        {"id": "uuid-alabama", "country": "US", "region": "US-AL",
+         "subtype": "region", "name_primary": "Alabama", "name_en": "Alabama"},
+    ]
+    geometries = {
+        "uuid-bham-al": "POLYGON((-86.9 33.4, -86.7 33.4, -86.7 33.6, -86.9 33.6, -86.9 33.4))",
+        "uuid-bham-uk": "POLYGON((-2.0 52.4, -1.8 52.4, -1.8 52.5, -2.0 52.5, -2.0 52.4))",
+        "uuid-alabama": "POLYGON((-88.5 30.2, -84.9 30.2, -84.9 35.0, -88.5 35.0, -88.5 30.2))",
+    }
+    fake = _FakeChainable(rows, geometries)
+    fake.resolve = _make_resolve(geometries)
+    monkeypatch.setattr(wg, "wkls", fake)
+    monkeypatch.setattr(wg, "WKLS_AVAILABLE", True)
+    return fake
+
+
+class TestWklsGazetteerConstruction:
+    def test_unavailable_raises(self, monkeypatch):
+        monkeypatch.setattr(wg, "WKLS_AVAILABLE", False)
+        with pytest.raises(ImportError, match="wkls"):
+            wg.WklsGazetteer()
+
+    def test_provider_name(self, fake_wkls):
+        gz = wg.WklsGazetteer()
+        assert gz.provider_name == "wkls"
+        assert isinstance(gz, Gazetteer)
+
+
+class TestWklsGazetteerLookup:
+    def test_basic_lookup_with_country_hint(self, fake_wkls):
+        gz = wg.WklsGazetteer()
+        result = gz.lookup("Birmingham", country_hint="US")
+        assert result.name == "Birmingham"
+        assert result.country == "US"
+        assert "US" in result.canonical_path
+        assert result.source == "wkls"
+        assert result.geometry is not None
+        assert result.centroid is not None
+
+    def test_lookup_ambiguous_raises_with_candidates(self, fake_wkls):
+        gz = wg.WklsGazetteer()
+        with pytest.raises(GazetteerAmbiguousError) as exc_info:
+            gz.lookup("Birmingham")  # no country_hint → ambiguous
+        assert len(exc_info.value.candidates) == 2
+
+    def test_lookup_unknown_raises_not_found(self, fake_wkls):
+        gz = wg.WklsGazetteer()
+        with pytest.raises(GazetteerNotFoundError):
+            gz.lookup("Atlantis", country_hint="US")
+
+    def test_lookup_empty_name_raises(self, fake_wkls):
+        gz = wg.WklsGazetteer()
+        with pytest.raises(ValueError, match="empty"):
+            gz.lookup("")
+
+    def test_iso3_country_hint_translated(self, fake_wkls):
+        """USA → US; the chain access works on the 2-letter form."""
+        gz = wg.WklsGazetteer()
+        result = gz.lookup("Birmingham", country_hint="USA")
+        assert result.country == "US"
+
+
+class TestWklsGazetteerSearch:
+    def test_search_returns_candidates(self, fake_wkls):
+        gz = wg.WklsGazetteer()
+        candidates = gz.search("Birmingham")
+        names = [c.name for c in candidates]
+        assert "Birmingham" in names
+
+    def test_search_respects_country_hint(self, fake_wkls):
+        gz = wg.WklsGazetteer()
+        candidates = gz.search("Birmingham", country_hint="US")
+        countries = [c.country for c in candidates]
+        # Only US match should be in the filtered set.
+        assert all(c == "US" for c in countries)
+
+    def test_search_empty_name_returns_empty(self, fake_wkls):
+        gz = wg.WklsGazetteer()
+        assert gz.search("") == []
+
+    def test_search_limit(self, fake_wkls):
+        gz = wg.WklsGazetteer()
+        # The fixture has 3 rows; limit=1 should return at most 1.
+        candidates = gz.search("A", limit=1)
+        assert len(candidates) <= 1
+
+
+class TestWklsGazetteerCache:
+    def test_geometry_lookup_cached(self, fake_wkls):
+        gz = wg.WklsGazetteer(cache_size=8)
+        # Use the unambiguous fixture row directly via the internal API.
+        # First call hits resolve(); second should be cached.
+        with patch.object(fake_wkls, "resolve", wraps=fake_wkls.resolve) as spy:
+            r1 = gz.lookup("Birmingham", country_hint="US")
+            r2 = gz.lookup("Birmingham", country_hint="US")
+            # geometry result is identical; resolve called only once.
+            assert r1.geometry == r2.geometry
+            assert spy.call_count == 1
+
+
+class TestWklsGazetteerBackendErrors:
+    def test_search_translates_upstream_failure(self, fake_wkls, monkeypatch):
+        """Upstream raising during search → translated to GazetteerBackendError."""
+        class _Broken:
+            def __getattr__(self, name):
+                raise RuntimeError("backend kaboom")
+            def __getitem__(self, key):
+                raise RuntimeError("backend kaboom")
+        monkeypatch.setattr(wg, "wkls", _Broken())
+        gz = wg.WklsGazetteer()
+        with pytest.raises(GazetteerBackendError, match="search for"):
+            gz.search("X")
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+class TestResolveGazetteer:
+    def test_prefer_wkls(self, fake_wkls):
+        gz = resolve_gazetteer(prefer="wkls")
+        assert gz.provider_name == "wkls"
+
+    def test_prefer_unimplemented_backends_raise(self, fake_wkls):
+        for name in ("nominatim", "census", "wikidata"):
+            with pytest.raises(NotImplementedError):
+                resolve_gazetteer(prefer=name)
+
+    def test_prefer_invalid_raises(self, fake_wkls):
+        with pytest.raises(ValueError, match="prefer must be"):
+            resolve_gazetteer(prefer="atlas")
+
+    def test_auto_select_wkls_when_available(self, fake_wkls):
+        gz = resolve_gazetteer()
+        assert gz.provider_name == "wkls"
+
+    def test_auto_select_no_backend_raises(self, monkeypatch):
+        monkeypatch.setattr(wg, "WKLS_AVAILABLE", False)
+        with pytest.raises(RuntimeError, match="No gazetteer backend"):
+            resolve_gazetteer()

--- a/tests/test_gazetteers.py
+++ b/tests/test_gazetteers.py
@@ -184,6 +184,33 @@ class TestWklsGazetteerLookup:
             gz.lookup("Birmingham")  # no country_hint → ambiguous
         assert len(exc_info.value.candidates) == 2
 
+    def test_lookup_ambiguous_after_hints_still_raises(self, fake_wkls, monkeypatch):
+        """Ambiguity after hints must still surface — hints narrow, they
+        don't promise uniqueness."""
+        # Two US Birminghams (both legitimately exist in real data).
+        rows = [
+            {"id": "uuid-bham-al", "country": "US", "region": "US-AL",
+             "subtype": "locality", "name_primary": "Birmingham",
+             "name_en": "Birmingham"},
+            {"id": "uuid-bham-mi", "country": "US", "region": "US-MI",
+             "subtype": "locality", "name_primary": "Birmingham",
+             "name_en": "Birmingham"},
+        ]
+        fake = _FakeChainable(rows, {})
+        monkeypatch.setattr(wg, "wkls", fake)
+        gz = wg.WklsGazetteer()
+        with pytest.raises(GazetteerAmbiguousError) as exc_info:
+            gz.lookup("Birmingham", country_hint="US")
+        assert "country_hint='US'" in str(exc_info.value)
+        assert len(exc_info.value.candidates) == 2
+
+    def test_lookup_unknown_iso3_raises_value_error(self, fake_wkls):
+        """Unknown ISO-3 should be rejected as a caller error, not
+        translated to a backend error."""
+        gz = wg.WklsGazetteer()
+        with pytest.raises(ValueError, match="unknown ISO-3"):
+            gz.lookup("Birmingham", country_hint="XYZ")
+
     def test_lookup_unknown_raises_not_found(self, fake_wkls):
         gz = wg.WklsGazetteer()
         with pytest.raises(GazetteerNotFoundError):


### PR DESCRIPTION
First slice of ELE-2483 (Etter + WKLS gazetteer + spatial-relation resolver). Establishes the name→geometry interface, ships the WKLS default backend with an LRU cache + ISO-3 → ISO-2 country mapping, and lays down license attribution.

Plan: see [`plans/etter-wkls-spatial-relation-integration.md`](https://github.com/siege-analytics/siege_utilities/blob/feature/ele-2483-etter-wkls-gazetteer/plans/etter-wkls-spatial-relation-integration.md) (in the session workspace, not committed to the repo).

## What ships

### `siege_utilities.geo.gazetteers.base`

- `Gazetteer` typed-Protocol (4 methods: `provider_name`, `lookup`, `search`, `is_available`). Protocol over ABC so backends adapt foreign libraries without inheritance ceremony.
- `GazetteerResult` frozen dataclass — name, canonical_path, geometry, centroid, country, admin_levels, source, raw. Marked `__hash__ = None` because metadata is a Mapping (same lesson as `RedistrictingPlan` in PR #436).
- `GazetteerCandidate` (search hit, no geometry).
- Error hierarchy: `GazetteerError` → `NotFoundError` / `AmbiguousError` / `BackendError`. `AmbiguousError` carries the candidate list so callers can disambiguate programmatically.

### `siege_utilities.geo.gazetteers.wkls_gazetteer`

`WklsGazetteer` with two siege_utilities-specific layers on top of the raw upstream:

1. **Per-instance LRU cache** on `(place_id) → geometry`. Necessary because the upstream library does **not** cache in-process — every `.wkt()` call hits S3 (~6s cold). Verified during the WKLS probe on 2026-05-07.
2. **ISO-3 → ISO-2 translation** for chained attribute access (`wkls.us.al`), since Etter outputs human names. Built-in table covers ~50 common countries with a fallback to first-two-chars truncation.

Search uses `wkls['%pattern%']` (the actual upstream API; the blog post's `wkls.search()` does not exist). `lookup()` refuses to silently pick on ambiguity — raises `GazetteerAmbiguousError` carrying the candidate list.

### `LICENSES/wkls.md`

Multi-attribution writeup for the Overture Divisions data surface: OSM (ODbL share-alike), geoBoundaries / Esri / LINZ (CC BY 4.0). The ODbL share-alike provision applies to derivative *databases*, not to analyses / reports — that distinction is spelled out so consumers don't over-comply.

### Packaging

New `[wkls]` extra → `wkls>=1.1.0`. Transitively pulls `sedonadb` (Rust + Arrow), `pyarrow`, `geoarrow-pyarrow`. **No JVM / Spark.** ~302 MB install.

## Test plan

- [x] Local: `pytest tests/test_gazetteers.py -q` → **22 passed** with mocked WKLS upstream.
- [x] Lint clean (no F401/F841/F541).
- [ ] Full CI matrix on push.

## Out of scope (queued for PR-B / PR-C)

- **PR-B**: `NominatimGazetteer` adapter (refactor existing `NominatimGeoClassifier`), `CensusGazetteer` adapter (refactor existing `CensusGeocoder`), `WikidataGazetteer` (new SPARQL backend).
- **PR-C**: `etter_to_geometry` spatial-relation resolver (the `bounded` / `halfplane` / `contains_centroid` modes), `EtterFilter.to_geometry()` integration, docs page, notebooks.