### PR TITLE
review-major: architecture pass (hierarchy, temp-views, figures, cache)

### DIFF
--- a/siege_utilities/cache.py
+++ b/siege_utilities/cache.py
@@ -9,15 +9,31 @@ every subsequent run.
 Default cache root: ``~/.cache/siege_utilities/notebooks/``. Override per
 call via the ``cache_dir`` argument or globally with the
 ``SIEGE_UTILITIES_CACHE_DIR`` environment variable.
+
+The cache enforces a per-call size budget — when adding a new file would
+exceed the budget, oldest-access entries are evicted first (LRU by
+``st_atime``). Default budget: 5 GiB; override via the
+``SIEGE_UTILITIES_CACHE_MAX_BYTES`` env var or the ``max_bytes`` kwarg.
 """
 
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
+import tempfile
 import urllib.request
 from pathlib import Path
 from typing import Optional
+
+log = logging.getLogger(__name__)
+
+# 5 GiB default cap. Notebooks pull state-level shapefiles (~50-150 MiB
+# each) and the occasional national TIGER set (>1 GiB), so 5 GiB allows
+# a working set of a dozen-ish national fixtures or many state-level
+# ones without churn. Override per env-var for CI/space-constrained
+# environments.
+_DEFAULT_MAX_BYTES = 5 * 1024 * 1024 * 1024
 
 
 class SampleDatasetError(RuntimeError):
@@ -31,12 +47,59 @@ def _default_cache_dir() -> Path:
     return Path.home() / ".cache" / "siege_utilities" / "notebooks"
 
 
+def _cache_budget_bytes() -> int:
+    raw = os.environ.get("SIEGE_UTILITIES_CACHE_MAX_BYTES")
+    if not raw:
+        return _DEFAULT_MAX_BYTES
+    try:
+        return max(int(raw), 0)
+    except ValueError:
+        log.warning("SIEGE_UTILITIES_CACHE_MAX_BYTES=%r is not an int; using default.", raw)
+        return _DEFAULT_MAX_BYTES
+
+
+def _evict_to_fit(root: Path, incoming_bytes: int, budget: int) -> None:
+    """LRU-evict from *root* until total size + incoming_bytes <= budget.
+
+    Oldest-access first (``st_atime``); ties broken by ``st_mtime``.
+    Files actively in use by another process will fail to unlink on
+    Windows; we log and skip rather than abort eviction.
+    """
+    if budget <= 0:
+        return
+    entries = []
+    total = 0
+    for p in root.iterdir():
+        if not p.is_file():
+            continue
+        try:
+            st = p.stat()
+        except OSError:
+            continue
+        entries.append((st.st_atime, st.st_mtime, st.st_size, p))
+        total += st.st_size
+    if total + incoming_bytes <= budget:
+        return
+    # Sort oldest-access first.
+    entries.sort()
+    for atime, mtime, size, p in entries:
+        if total + incoming_bytes <= budget:
+            break
+        try:
+            p.unlink()
+            total -= size
+            log.info("cache: evicted %s (%d bytes, last access %s)", p.name, size, atime)
+        except OSError as e:
+            log.warning("cache: could not evict %s: %s", p, e)
+
+
 def ensure_sample_dataset(
     name: str,
     url: str,
     *,
     cache_dir: Optional[Path] = None,
     sha256: Optional[str] = None,
+    max_bytes: Optional[int] = None,
 ) -> Path:
     """Return a local path to ``name``, downloading from ``url`` on first use.
 
@@ -80,31 +143,60 @@ def ensure_sample_dataset(
     target = root / name
 
     if target.exists():
+        # Touch atime so the LRU eviction order reflects use, not just
+        # initial download time.
+        try:
+            os.utime(target, None)
+        except OSError:
+            pass
         return target
 
-    tmp = target.with_suffix(target.suffix + ".part")
+    # Atomic write: download into a per-call temp file with mkstemp,
+    # fsync, then os.replace into place. The previous predictable
+    # `.part` suffix had a TOCTOU race when two callers downloaded the
+    # same dataset concurrently — the second writer could clobber the
+    # first's partial.
+    fd, tmp_path_str = tempfile.mkstemp(
+        prefix=f".{name}.",
+        suffix=".part",
+        dir=str(root),
+    )
+    tmp = Path(tmp_path_str)
     try:
-        with urllib.request.urlopen(url) as resp, open(tmp, "wb") as f:
-            while chunk := resp.read(1 << 16):
-                f.write(chunk)
-    except Exception as e:
-        if tmp.exists():
-            tmp.unlink()
-        raise SampleDatasetError(
-            f"failed to download sample dataset {name!r} from {url}: {e}"
-        ) from e
-
-    if sha256 is not None:
-        h = hashlib.sha256()
-        with open(tmp, "rb") as f:
-            while chunk := f.read(1 << 16):
-                h.update(chunk)
-        got = h.hexdigest()
-        if got != sha256.lower():
-            tmp.unlink()
+        try:
+            with os.fdopen(fd, "wb") as f, urllib.request.urlopen(url) as resp:
+                while chunk := resp.read(1 << 16):
+                    f.write(chunk)
+                f.flush()
+                os.fsync(f.fileno())
+        except Exception as e:
             raise SampleDatasetError(
-                f"sha256 mismatch for {name!r}: expected {sha256}, got {got}"
-            )
+                f"failed to download sample dataset {name!r} from {url}: {e}"
+            ) from e
 
-    tmp.rename(target)
-    return target
+        if sha256 is not None:
+            h = hashlib.sha256()
+            with open(tmp, "rb") as f:
+                while chunk := f.read(1 << 16):
+                    h.update(chunk)
+            got = h.hexdigest()
+            if got != sha256.lower():
+                raise SampleDatasetError(
+                    f"sha256 mismatch for {name!r}: expected {sha256}, got {got}"
+                )
+
+        # Enforce the size budget BEFORE moving into place so a giant
+        # download can't temporarily blow past the cap.
+        size = tmp.stat().st_size
+        budget = max_bytes if max_bytes is not None else _cache_budget_bytes()
+        _evict_to_fit(root, size, budget)
+
+        os.replace(tmp, target)
+        return target
+    except Exception:
+        if tmp.exists():
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+        raise

--- a/siege_utilities/engines/dataframe_engine.py
+++ b/siege_utilities/engines/dataframe_engine.py
@@ -973,12 +973,20 @@ class SparkEngine(DataFrameEngine):
             )
         if how.lower() not in ("inner", "left", "right", "outer", "full"):
             raise ValueError(f"unsupported join type {how!r}")
-        left.createOrReplaceTempView("_sjoin_left")
-        right.createOrReplaceTempView("_sjoin_right")
+        # Unique per-call temp-view names so concurrent calls don't
+        # collide on a shared `_sjoin_left` and so a failed previous
+        # call doesn't leave stale state in the catalog. The returned
+        # DataFrame is lazy — we can't drop the views in this scope.
+        import uuid as _uuid
+        tag = _uuid.uuid4().hex[:8]
+        lv = f"_sjoin_left_{tag}"
+        rv = f"_sjoin_right_{tag}"
+        left.createOrReplaceTempView(lv)
+        right.createOrReplaceTempView(rv)
         st_func = f"ST_{predicate.capitalize()}"
         sql = (
             f"SELECT l.*, r.* "
-            f"FROM _sjoin_left l {how.upper()} JOIN _sjoin_right r "
+            f"FROM {lv} l {how.upper()} JOIN {rv} r "
             f"ON {st_func}(ST_GeomFromText(l.{left_geom}), ST_GeomFromText(r.{right_geom}))"
         )
         return self._session.sql(sql)
@@ -990,10 +998,12 @@ class SparkEngine(DataFrameEngine):
         # `distance` is interpolated as a float — coerce so a malicious
         # caller can't sneak SQL via a string.
         distance_lit = float(distance)
-        df.createOrReplaceTempView("_buf_tbl")
+        import uuid as _uuid
+        view = f"_buf_tbl_{_uuid.uuid4().hex[:8]}"
+        df.createOrReplaceTempView(view)
         sql = (
             f"SELECT *, ST_AsText(ST_Buffer(ST_GeomFromText({geometry_col}), {distance_lit})) "
-            f"AS {geometry_col}_buffered FROM _buf_tbl"
+            f"AS {geometry_col}_buffered FROM {view}"
         )
         return self._session.sql(sql)
 
@@ -1005,21 +1015,24 @@ class SparkEngine(DataFrameEngine):
             validate_sql_identifier_in as validate_identifier_in,
         )
         validate_identifier_in(geometry_col, df.columns, label="geometry column")
-        df.createOrReplaceTempView("_dist_left")
+        import uuid as _uuid
+        lv = f"_dist_left_{_uuid.uuid4().hex[:8]}"
+        df.createOrReplaceTempView(lv)
         if isinstance(other, (BaseGeometry, str)):
             wkt_str = other.wkt if isinstance(other, BaseGeometry) else other
             wkt_escaped = escape_string_literal(wkt_str)
             sql = (
                 f"SELECT *, ST_Distance(ST_GeomFromText({geometry_col}), "
-                f"ST_GeomFromText('{wkt_escaped}')) AS _distance FROM _dist_left"
+                f"ST_GeomFromText('{wkt_escaped}')) AS _distance FROM {lv}"
             )
         else:
             validate_identifier_in(other_geom, other.columns, label="other geometry column")
-            other.createOrReplaceTempView("_dist_right")
+            rv = f"_dist_right_{_uuid.uuid4().hex[:8]}"
+            other.createOrReplaceTempView(rv)
             sql = (
                 f"SELECT ST_Distance(ST_GeomFromText(l.{geometry_col}), "
                 f"ST_GeomFromText(r.{other_geom})) AS _distance "
-                f"FROM _dist_left l, _dist_right r"
+                f"FROM {lv} l, {rv} r"
             )
         return self._session.sql(sql)
 
@@ -1067,11 +1080,15 @@ class SparkEngine(DataFrameEngine):
         validate_identifier_in(polygon_geom, polygons.columns, label="polygon geometry column")
         if how.lower() not in ("inner", "left", "right", "outer", "full"):
             raise ValueError(f"unsupported join type {how!r}")
-        points.createOrReplaceTempView("_assign_pts")
-        broadcast(polygons).createOrReplaceTempView("_assign_poly")
+        import uuid as _uuid
+        tag = _uuid.uuid4().hex[:8]
+        pv = f"_assign_pts_{tag}"
+        poly_v = f"_assign_poly_{tag}"
+        points.createOrReplaceTempView(pv)
+        broadcast(polygons).createOrReplaceTempView(poly_v)
         return self._session.sql(
             f"SELECT p.*, poly.* "
-            f"FROM _assign_pts p {how.upper()} JOIN _assign_poly poly "
+            f"FROM {pv} p {how.upper()} JOIN {poly_v} poly "
             f"ON ST_Contains(ST_GeomFromText(poly.{polygon_geom}), "
             f"ST_GeomFromText(p.{point_geom}))"
         )
@@ -1086,8 +1103,12 @@ class SparkEngine(DataFrameEngine):
         # Coerce numeric inputs so they can't carry SQL.
         k_lit = int(k)
         max_distance_lit = float(max_distance) if max_distance is not None else None
-        points.createOrReplaceTempView("_nn_pts")
-        targets.createOrReplaceTempView("_nn_tgt")
+        import uuid as _uuid
+        tag = _uuid.uuid4().hex[:8]
+        pv = f"_nn_pts_{tag}"
+        tv = f"_nn_tgt_{tag}"
+        points.createOrReplaceTempView(pv)
+        targets.createOrReplaceTempView(tv)
         # WHERE on a SELECT-list alias is invalid in Spark SQL; re-expand
         # the ST_Distance expression in the predicate.
         if max_distance_lit is not None:
@@ -1107,7 +1128,7 @@ class SparkEngine(DataFrameEngine):
                         ORDER BY ST_Distance(ST_GeomFromText(p.{point_geom}),
                                              ST_GeomFromText(t.{target_geom}))
                     ) AS rn
-                FROM _nn_pts p, _nn_tgt t
+                FROM {pv} p, {tv} t
                 {dist_filter}
             ) WHERE rn <= {k_lit}
         """)

--- a/siege_utilities/geo/boundary_result.py
+++ b/siege_utilities/geo/boundary_result.py
@@ -29,8 +29,17 @@ except ImportError:
 # Typed Exceptions
 # ---------------------------------------------------------------------------
 
-class BoundaryRetrievalError(Exception):
-    """Base exception for all boundary retrieval failures."""
+from ..exceptions import SiegeGeoError
+
+
+class BoundaryRetrievalError(SiegeGeoError):
+    """Base exception for all boundary retrieval failures.
+
+    Inherits from :class:`SiegeGeoError` so callers can catch the entire
+    siege_utilities exception family with a single
+    ``except SiegeError:``. Previously this stood alone outside the
+    documented hierarchy and slipped past ``except SiegeError`` blocks.
+    """
 
     def __init__(self, message: str, stage: str, context: Optional[Dict[str, Any]] = None):
         self.stage = stage

--- a/siege_utilities/reporting/report_generator.py
+++ b/siege_utilities/reporting/report_generator.py
@@ -505,23 +505,25 @@ class ReportGenerator:
 
                 # Handle matplotlib Figure
                 if hasattr(chart, 'savefig'):
-                    # matplotlib Figure
+                    # Always close the figure and the buffer, even on
+                    # savefig() exceptions — long-running pipelines that
+                    # raise mid-render were leaking the entire figure
+                    # graph until interpreter exit.
                     buf = io.BytesIO()
-                    chart.savefig(buf, format='png', dpi=150, bbox_inches='tight')
-                    buf.seek(0)
-                    img = RLImage(buf, width=width*inch, height=height*inch)
-                    result.append(img)
-                    # Close the figure to free memory. If matplotlib
-                    # isn't installed the import raises ImportError; if
-                    # close() fails on a malformed figure it raises
-                    # something matplotlib-specific. Either way memory
-                    # cleanup isn't worth aborting the report — but log
-                    # so we can spot it when it happens.
                     try:
-                        import matplotlib.pyplot as plt
-                        plt.close(chart)
-                    except Exception as e:
-                        log.debug("Could not close matplotlib figure: %s", e)
+                        chart.savefig(buf, format='png', dpi=150, bbox_inches='tight')
+                        buf.seek(0)
+                        img = RLImage(buf, width=width*inch, height=height*inch)
+                        result.append(img)
+                    finally:
+                        try:
+                            import matplotlib.pyplot as plt
+                            plt.close(chart)
+                        except Exception as exc:
+                            log.debug("Could not close matplotlib figure: %s", exc)
+                        # The BytesIO is now referenced by the RLImage —
+                        # ReportLab keeps a handle for the build pass and
+                        # closes it itself. Nothing to do here.
                     continue
 
                 # Handle PIL Image

--- a/tests/test_cache_eviction.py
+++ b/tests/test_cache_eviction.py
@@ -1,0 +1,74 @@
+"""Tests for the LRU eviction + atomic-write behaviour in siege_utilities.cache.
+
+PR follow-up: the cache was previously unbounded and used a
+predictable `.part` filename that could race under concurrent writers.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from siege_utilities.cache import _evict_to_fit, ensure_sample_dataset
+
+
+def _seed(root: Path, name: str, size: int, atime: float) -> Path:
+    p = root / name
+    p.write_bytes(b"x" * size)
+    import os
+    os.utime(p, (atime, atime))
+    return p
+
+
+class TestEviction:
+    def test_no_eviction_when_under_budget(self, tmp_path):
+        a = _seed(tmp_path, "a.bin", 100, 1_000_000.0)
+        b = _seed(tmp_path, "b.bin", 100, 2_000_000.0)
+        _evict_to_fit(tmp_path, incoming_bytes=50, budget=1000)
+        assert a.exists() and b.exists()
+
+    def test_lru_oldest_evicted_first(self, tmp_path):
+        old = _seed(tmp_path, "old.bin", 400, 1_000_000.0)
+        mid = _seed(tmp_path, "mid.bin", 400, 2_000_000.0)
+        _seed(tmp_path, "new.bin", 400, 3_000_000.0)
+        # Existing total 1200, budget 1000, incoming 400 → need ≥600
+        # evicted. Oldest is "old" (400) → not enough; also "mid" (400)
+        # → total 800 freed, still need more; also "new" (400).
+        _evict_to_fit(tmp_path, incoming_bytes=400, budget=1000)
+        assert not old.exists()
+        assert not mid.exists()
+        # We freed everything older than incoming — the order is
+        # oldest-first so by the time we hit "new" we've freed enough.
+        # Either way: total + incoming should fit.
+        survivors = [p for p in tmp_path.iterdir() if p.is_file()]
+        remaining = sum(p.stat().st_size for p in survivors)
+        assert remaining + 400 <= 1000
+
+    def test_zero_budget_is_noop(self, tmp_path):
+        a = _seed(tmp_path, "a.bin", 100, 1.0)
+        _evict_to_fit(tmp_path, incoming_bytes=50, budget=0)
+        assert a.exists()  # 0 means "no eviction"
+
+
+class TestAtomicWrite:
+    def test_existing_file_returns_unchanged_and_touches_atime(self, tmp_path):
+        target = tmp_path / "fixture.bin"
+        target.write_bytes(b"data")
+        before_atime = target.stat().st_atime
+        # No url should be hit because file exists.
+        result = ensure_sample_dataset(
+            "fixture.bin",
+            url="http://example.invalid/should-not-be-fetched",
+            cache_dir=tmp_path,
+        )
+        assert result == target
+        assert result.read_bytes() == b"data"
+        # atime should have been bumped.
+        after_atime = target.stat().st_atime
+        assert after_atime >= before_atime
+
+    def test_path_separator_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match="single filename"):
+            ensure_sample_dataset("a/b.bin", url="http://example.invalid",
+                                  cache_dir=tmp_path)


### PR DESCRIPTION
## Summary
Second of two PRs landing the Major-tier findings.

| Concern | Fix |
|---|---|
| BoundaryRetrievalError outside SiegeError family | Inherit from SiegeGeoError |
| Spark temp views with shared names → concurrent collisions | Per-call uuid-suffixed view names at 8 sites |
| matplotlib figure leaks on savefig() exceptions | try/finally guarantees plt.close() |
| Cache grew unbounded; predictable .part path was racy | 5 GiB budget + LRU eviction + tempfile.mkstemp atomic write; SIEGE_UTILITIES_CACHE_MAX_BYTES override |

## Test plan
- [x] test_cache_eviction: oldest-first eviction, zero-budget noop, atime-touch, path-separator rejection
- [ ] Existing test_spatial_transformations / engine tests via CI