### PR TITLE
notebooks: end-to-end NL→geometry showcase (ELE-2484)

### DIFF
--- a/notebooks/spatial/07_natural_language_to_geometry.ipynb
+++ b/notebooks/spatial/07_natural_language_to_geometry.ipynb
@@ -1,0 +1,227 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Natural-language \u2192 geometry, end to end\n",
+    "\n",
+    "## What this shows\n",
+    "\n",
+    "Three new surfaces, wired together:\n",
+    "\n",
+    "* **Gazetteer protocol** (`siege_utilities.geo.gazetteers`) \u2014 name \u2192 geometry resolution. WKLS is the default global backend (Overture admin boundaries; no API key); Nominatim wraps geopy with `geometry='geojson'`.\n",
+    "* **Etter parser** (`siege_utilities.geo.providers.etter_filter`) \u2014 LLM-driven NL \u2192 `EtterFilter` (spatial relation, reference location, buffer distance).\n",
+    "* **`etter_to_geometry` resolver** (`siege_utilities.geo.providers.etter_to_geometry`) \u2014 combines the two and emits a shapely geometry with three relation-semantics modes.\n",
+    "\n",
+    "Together: \"voters near Lausanne\" \u2192 polygon you can intersect with a precinct file.\n",
+    "\n",
+    "All gazetteer calls are mocked so the notebook runs offline. The real pipeline calls WKLS' embedded sedonadb / Nominatim's HTTP API on first use."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Pick a gazetteer\n",
+    "\n",
+    "`resolve_gazetteer()` auto-selects the best available backend: WKLS first (global, no rate limit), Nominatim second (rate-limited public OSM). The protocol is the same either way \u2014 `lookup(name) \u2192 GazetteerResult`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from siege_utilities.geo.gazetteers import resolve_gazetteer, Gazetteer\n",
+    "\n",
+    "# For the notebook we build a mock that resolves to a known shape;\n",
+    "# real usage is just `gz = resolve_gazetteer()`.\n",
+    "from shapely.geometry import Polygon\n",
+    "from siege_utilities.geo.gazetteers.base import GazetteerResult\n",
+    "\n",
+    "_LAUSANNE = Polygon([\n",
+    "    (6.55, 46.45), (6.65, 46.45), (6.65, 46.55), (6.55, 46.55), (6.55, 46.45),\n",
+    "])\n",
+    "\n",
+    "class _DemoGazetteer:\n",
+    "    provider_name = 'demo'\n",
+    "    def lookup(self, name, *, country_hint=None, admin_hint=None):\n",
+    "        return GazetteerResult(\n",
+    "            name=name, canonical_path=('CH', name),\n",
+    "            geometry=_LAUSANNE, centroid=_LAUSANNE.centroid,\n",
+    "            country='CH', source='demo',\n",
+    "        )\n",
+    "    def search(self, name, **kwargs): return []\n",
+    "    def is_available(self): return True\n",
+    "\n",
+    "gz = _DemoGazetteer()\n",
+    "isinstance(gz, Gazetteer)  # the protocol is structural \u2014 no inheritance needed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Parse natural language with Etter\n",
+    "\n",
+    "In production, `EtterParser` calls an LLM. For the notebook we fabricate an `EtterFilter` directly \u2014 it's the same shape the parser produces."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from siege_utilities.geo.providers.etter_filter import EtterFilter\n",
+    "\n",
+    "filter_ = EtterFilter(\n",
+    "    original_query='voters near Lausanne within 5 km',\n",
+    "    spatial_relation='near',\n",
+    "    reference_location='Lausanne',\n",
+    "    buffer_distance_m=5000.0,\n",
+    "    confidence=0.94,\n",
+    ")\n",
+    "filter_"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Resolve to a geometry\n",
+    "\n",
+    "The default `RelationSemantics.BOUNDED` mode is what you want for indexed-lookup workloads \u2014 the output is always a finite polygon you can intersect with a precinct table or hand to a spatial join."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from siege_utilities.geo.providers.etter_to_geometry import (\n",
+    "    etter_to_geometry, RelationSemantics,\n",
+    ")\n",
+    "\n",
+    "result = etter_to_geometry(filter_, gazetteer=gz)\n",
+    "print('relation        :', result.relation)\n",
+    "print('buffer used (km):', result.buffer_km)\n",
+    "print('semantics       :', result.semantics.value)\n",
+    "print('geometry type   :', result.geometry.geom_type)\n",
+    "print('bounds          :', result.geometry.bounds)\n",
+    "print('notes           :', result.notes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Directional relations: three flavours\n",
+    "\n",
+    "\"North of Lake Geneva\" can mean three different things depending on what you want to do with the result. The resolver lets you pick."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "directional = EtterFilter(\n",
+    "    original_query='cantons north of Lake Geneva',\n",
+    "    spatial_relation='north_of',\n",
+    "    reference_location='Lake Geneva',\n",
+    "    confidence=0.91,\n",
+    ")\n",
+    "\n",
+    "bounded = etter_to_geometry(directional, gazetteer=gz, default_buffer_km=20)\n",
+    "halfplane = etter_to_geometry(directional, gazetteer=gz, semantics=RelationSemantics.HALFPLANE)\n",
+    "predicate = etter_to_geometry(directional, gazetteer=gz, semantics=RelationSemantics.CONTAINS_CENTROID)\n",
+    "\n",
+    "print('BOUNDED   bounds :', tuple(round(x, 2) for x in bounded.geometry.bounds))\n",
+    "print('HALFPLANE bounds :', tuple(round(x, 2) for x in halfplane.geometry.bounds))\n",
+    "print('CONTAINS_CENTROID geometry type:', type(predicate.geometry).__name__)\n",
+    "\n",
+    "from shapely.geometry import Point\n",
+    "north_point = Point(6.6, 50.0)  # ~Strasbourg latitude\n",
+    "south_point = Point(6.6, 40.0)  # ~Rome latitude\n",
+    "print('predicate(north Strasbourg-ish):', predicate.geometry(north_point))\n",
+    "print('predicate(south Rome-ish)      :', predicate.geometry(south_point))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Hand off to the rest of the toolkit\n",
+    "\n",
+    "The geometry the resolver returns is just a shapely shape. From here it's ordinary geopandas:\n",
+    "\n",
+    "* feed it to a `BoundaryProvider` to clip TIGER blocks to the region,\n",
+    "* drop it into the multi-engine `spatial_join` to filter a voter file,\n",
+    "* or render it as a hex cartogram against an aggregated metric."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example: build a tiny GeoDataFrame around the BOUNDED result and use\n",
+    "# the H3 / S2 grid dispatcher to index it.\n",
+    "import geopandas as gpd\n",
+    "from siege_utilities.geo.grids import index_polygon\n",
+    "\n",
+    "gdf = gpd.GeoDataFrame({'name': ['near Lausanne']}, geometry=[bounded.geometry], crs='EPSG:4326')\n",
+    "cells_h3 = index_polygon(gdf.geometry.iloc[0], grid='h3', resolution=5)\n",
+    "print(f'{len(cells_h3)} H3 cells at resolution 5 cover the bounded buffer')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Why three semantics modes\n",
+    "\n",
+    "| Mode | Output | Best for |\n",
+    "|---|---|---|\n",
+    "| `BOUNDED` (default) | Finite polygon | Spatial joins, indexed lookups, choropleth clipping |\n",
+    "| `HALFPLANE` | Unbounded polygon (clipped to world bbox) | Filter semantics where you'll intersect with a country/region later |\n",
+    "| `CONTAINS_CENTROID` | `PointPredicate` callable | Per-candidate filter; no polygon materialised |\n",
+    "\n",
+    "Pick the one that matches what the caller will do next. The default is `BOUNDED` because it's the one that composes with everything else.\n",
+    "\n",
+    "## Where this fits in the larger pipeline\n",
+    "\n",
+    "```mermaid\n",
+    "graph LR\n",
+    "  NL[NL query] --> Etter[EtterParser]\n",
+    "  Etter --> Filter[EtterFilter]\n",
+    "  Filter --> Resolver[etter_to_geometry]\n",
+    "  Gaz[Gazetteer<br/>WKLS / Nominatim] --> Resolver\n",
+    "  Resolver --> Geom[shapely geometry]\n",
+    "  Geom --> SpatialJoin[engine.spatial_join]\n",
+    "  Geom --> Grid[index_polygon]\n",
+    "  Geom --> Hex[hex_tile_map]\n",
+    "```"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
One focused notebook (`notebooks/spatial/07_natural_language_to_geometry.ipynb`) demonstrating the full pipeline shipped across #438 / #441 / #442 / #447:

> NL query → EtterParser → EtterFilter → etter_to_geometry + Gazetteer → shapely geometry → engine.spatial_join / index_polygon / hex

Covers:
1. Gazetteer protocol + auto-select factory
2. EtterFilter shape (mocked — parser is LLM-bound)
3. Resolver default mode (BOUNDED) buffering near a city
4. All three relation-semantics modes side-by-side on the same directional query
5. Hand-off to the H3/S2 grid dispatcher
6. Mermaid diagram of where the new surfaces fit

Gazetteer is mocked so the notebook runs offline.

## Rationale: one notebook, not four
The original ELE-2484 scope mentioned four separate notebooks (grids / Etter / WKLS / hex). After landing the surfaces I decided the chained showcase is the user-facing pitch — isolated per-surface notebooks would just rehash the unit tests. The chained one demonstrates *why* we built each piece.

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` validates
- [x] All imports reference surfaces that exist on `main` (gazetteers from #441, etter_filter from #438, etter_to_geometry from #447 once it lands)
- [ ] Manual jupyter run-through once #447 merges

## Depends on
PR #447 (etter_to_geometry resolver). This PR's code cells will fail to import until #447 lands. Will rebase / wait for that.