### PR TITLE
sprint B: Snowflake connector tests + credentials scaffolding (refs #453)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,10 @@ celerybeat.pid
 *credentials*.json
 *service_account*.json
 *token*.json
+# Sprint B (issue #453) developer-local connector test credentials —
+# never commit, never expand into CI. See docs/testing/sprint-b-credentials.md.
+.siege-test-credentials.yaml
+siege-test-credentials.yaml
 *client_secret*.json
 *.pem
 !tests/fixtures/**

--- a/docs/testing/sprint-b-credentials.md
+++ b/docs/testing/sprint-b-credentials.md
@@ -1,0 +1,83 @@
+# Connector live-API credentials
+
+Sprint B (issue #453) adds connector test coverage in two phases:
+
+- **Phase 1 — mock unit tests.** No credentials required. Run on every CI build.
+- **Phase 2 — live-API smoke tests.** Marked `@pytest.mark.requires_api_key`. Skipped by default. Run manually when you want to prove the real API contract still holds.
+
+This document covers Phase 2 only.
+
+## Strategy
+
+Developer-local credentials in **`~/.siege-test-credentials.yaml`** (or the path in `SIEGE_TEST_CREDENTIALS`). The file is **not** read by CI; CI runs the mock path only. If/when external contributors land, we may layer GitHub Actions secrets + a gated `live-api` environment on top — see #453 for context.
+
+The file is gitignored at the repo root; the test fixture skips when it's absent. **Never commit a credentials file**, even partially redacted.
+
+## Schema
+
+```yaml
+snowflake:
+  account: xy12345.us-east-1
+  user: TESTUSER
+  password: ...           # or use private_key_file
+  warehouse: COMPUTE_WH
+  database: TEST_DB
+  schema: TEST_SCHEMA
+  role: TEST_ROLE
+
+facebook_business:
+  access_token: ...
+  app_id: ...
+  app_secret: ...
+  ad_account_id: act_...
+
+datadotworld:
+  api_token: ...
+  dataset_owner: my-org
+  dataset_id: test-dataset
+
+google_analytics:
+  property_id: "12345678"
+  # Auth comes from a service-account JSON; set GOOGLE_APPLICATION_CREDENTIALS
+  # or point at it explicitly:
+  service_account_json: /path/to/sa.json
+
+google_workspace:
+  customer_id: C0123abcd
+  admin_email: admin@example.com
+  service_account_json: /path/to/sa.json
+
+google_search:
+  api_key: ...
+  search_engine_id: ...
+
+vista_social:
+  api_token: ...
+  account_id: ...
+
+polling_analyzer:
+  # No external credentials — polling_analyzer is data-only.
+  # Listed here for completeness; tests will not consume this fixture.
+```
+
+## Running the live-API tests
+
+```bash
+# All connectors with creds available
+pytest -m requires_api_key
+
+# A specific connector
+pytest -m requires_api_key tests/test_snowflake_connector.py
+
+# Combined with the standard mock suite (full coverage):
+pytest -m "not requires_api_key or requires_api_key"  # not how -m works; see note below
+```
+
+Note: `requires_api_key` is the **only** marker that disables the test by default. Standard `pytest` (no `-m`) skips it via the fixture's `pytest.skip()`, not via `-m "not requires_api_key"`. This means the test still appears in the report as `SKIPPED` with the reason "no credentials file at X" — which is the signal you want when you're trying to figure out why a connector isn't being exercised.
+
+## Failure modes
+
+- **Credentials file missing** → `SKIPPED` with the path it expected. Create the file.
+- **Section missing** → the per-connector test sub-skips with which key is missing.
+- **Credentials wrong / expired** → real API error from the connector. Fix the value and re-run.
+- **Test passes locally but fails on someone else's machine** → schemas drift. Re-read this doc; if the schema has changed, update both this doc AND the relevant tests in the same commit.

--- a/docs/testing/sprint-b-credentials.md
+++ b/docs/testing/sprint-b-credentials.md
@@ -63,17 +63,17 @@ polling_analyzer:
 ## Running the live-API tests
 
 ```bash
-# All connectors with creds available
+# All connectors with creds available — runs only the marked tests
 pytest -m requires_api_key
 
 # A specific connector
 pytest -m requires_api_key tests/test_snowflake_connector.py
 
-# Combined with the standard mock suite (full coverage):
-pytest -m "not requires_api_key or requires_api_key"  # not how -m works; see note below
+# Full suite (mocks + live API in one pass) — no -m needed
+pytest
 ```
 
-Note: `requires_api_key` is the **only** marker that disables the test by default. Standard `pytest` (no `-m`) skips it via the fixture's `pytest.skip()`, not via `-m "not requires_api_key"`. This means the test still appears in the report as `SKIPPED` with the reason "no credentials file at X" — which is the signal you want when you're trying to figure out why a connector isn't being exercised.
+Note: `requires_api_key` does not disable tests by default at the pytest-marker level — the suite runs them on every `pytest` invocation. The skip happens inside the `api_credentials` fixture when the credentials file is missing. So a plain `pytest` run shows the live tests as `SKIPPED` with the reason "no credentials file at X" — exactly the signal you want when figuring out why a connector isn't being exercised. Use `pytest -m requires_api_key` when you want to *isolate* the live path.
 
 ## Failure modes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -303,6 +303,7 @@ markers = [
     "smoke: quick validation tests for critical paths (no network, no GDAL)",
     "slow: tests that take >10s (network, large data)",
     "databricks: tests requiring Databricks runtime or SDK",
+    "requires_api_key: connector smoke tests that hit a live external API; require ~/.siege-test-credentials.yaml. Skipped by default; opt in with `pytest -m requires_api_key`.",
 ]
 
 [tool.coverage.report]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,8 +112,18 @@ def api_credentials():
             "Create one with the per-connector keys you want to exercise; "
             "see docs/testing/sprint-b-credentials.md for the schema."
         )
-    with open(path) as f:
-        return yaml.safe_load(f) or {}
+    try:
+        with open(path) as f:
+            return yaml.safe_load(f) or {}
+    except yaml.YAMLError as exc:
+        # A malformed file is a real configuration error, not a missing
+        # one — surface it as a skip with the parser error so the
+        # developer fixes the file rather than chasing an opaque
+        # uncaught exception during fixture setup.
+        pytest.skip(
+            f"requires_api_key: credentials file at {path} is not valid "
+            f"YAML — {exc}. Fix the syntax and re-run."
+        )
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,6 +86,37 @@ def _siege_test_directories():
 
 
 @pytest.fixture
+def api_credentials():
+    """Load connector API credentials from a developer-local YAML file.
+
+    Looked up at ``~/.siege-test-credentials.yaml`` (or the path in the
+    ``SIEGE_TEST_CREDENTIALS`` env var). When the file is absent, tests
+    decorated with ``@pytest.mark.requires_api_key`` and consuming this
+    fixture are skipped — by design, Sprint B's strategy is
+    developer-local creds, not CI secrets. CI is expected to run only
+    the mock unit tests; the live-API path is opt-in via
+    ``pytest -m requires_api_key``.
+
+    Returns the parsed dict; individual connectors look up their own
+    sub-keys (e.g. ``creds["snowflake"]["account"]``) and skip if
+    their section is missing.
+    """
+    import yaml  # local import — yaml is in extras_require, not core
+
+    path = os.environ.get("SIEGE_TEST_CREDENTIALS") or os.path.expanduser(
+        "~/.siege-test-credentials.yaml"
+    )
+    if not os.path.exists(path):
+        pytest.skip(
+            f"requires_api_key: no credentials file at {path}. "
+            "Create one with the per-connector keys you want to exercise; "
+            "see docs/testing/sprint-b-credentials.md for the schema."
+        )
+    with open(path) as f:
+        return yaml.safe_load(f) or {}
+
+
+@pytest.fixture
 def mock_spark_session():
     """Mock Spark session for distributed computing tests."""
     mock_spark = Mock()

--- a/tests/test_snowflake_connector.py
+++ b/tests/test_snowflake_connector.py
@@ -1,0 +1,160 @@
+"""Tests for siege_utilities.analytics.snowflake_connector.
+
+Phase-1 mock tests (no creds required) pin the connector's public
+behavior against the canonical snowflake.connector API; Phase-2 marks
+a real connect/disconnect smoke run that's skipped unless
+~/.siege-test-credentials.yaml has a ``snowflake:`` section.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — mock unit tests
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def _patch_snowflake(monkeypatch):
+    """Stand in for snowflake.connector at module level so __init__ doesn't
+    raise ImportError on machines without snowflake-connector-python installed.
+    Returns the mock module so tests can assert on connect() calls.
+    """
+    from siege_utilities.analytics import snowflake_connector as mod
+
+    fake = MagicMock()
+    monkeypatch.setattr(mod, "SNOWFLAKE_AVAILABLE", True)
+    monkeypatch.setattr(mod, "snowflake", fake, raising=False)
+    # write_pandas is referenced directly; patch the symbol the module imports.
+    monkeypatch.setattr(mod, "write_pandas", MagicMock(return_value=(True, 1, 5, None)), raising=False)
+    return fake
+
+
+def test_init_rejects_when_snowflake_not_installed(monkeypatch):
+    """The constructor must raise ImportError, not silently produce a
+    half-built object that fails later with a confusing AttributeError."""
+    from siege_utilities.analytics import snowflake_connector as mod
+
+    monkeypatch.setattr(mod, "SNOWFLAKE_AVAILABLE", False)
+    with pytest.raises(ImportError, match="snowflake-connector-python"):
+        mod.SnowflakeConnector(account="x", user="y")
+
+
+def test_init_records_connection_params(_patch_snowflake):
+    from siege_utilities.analytics.snowflake_connector import SnowflakeConnector
+
+    c = SnowflakeConnector(
+        account="acc", user="u", password="p",
+        warehouse="WH", database="DB", schema="SCH", role="R",
+    )
+    assert (c.account, c.user, c.warehouse, c.database, c.schema, c.role) == (
+        "acc", "u", "WH", "DB", "SCH", "R"
+    )
+    # connection is lazy
+    assert c.connection is None
+
+
+def test_load_config_overlays_json_values(tmp_path, _patch_snowflake):
+    """A config file value must override the constructor None defaults
+    but not stomp explicitly-passed values."""
+    from siege_utilities.analytics.snowflake_connector import SnowflakeConnector
+
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text(json.dumps({"warehouse": "FROM_FILE", "database": "FROM_FILE_DB"}))
+
+    c = SnowflakeConnector(account="acc", user="u", password="p", config_file=cfg)
+    assert c.warehouse == "FROM_FILE"
+    assert c.database == "FROM_FILE_DB"
+
+
+def test_load_config_missing_file_raises(_patch_snowflake, tmp_path):
+    from siege_utilities.analytics.snowflake_connector import SnowflakeConnector
+
+    with pytest.raises(FileNotFoundError):
+        SnowflakeConnector(
+            account="a", user="u", password="p",
+            config_file=tmp_path / "does_not_exist.json",
+        )
+
+
+def test_connect_passes_only_non_none_params(_patch_snowflake):
+    """``snowflake.connector.connect`` should never see warehouse=None /
+    database=None — those are best omitted so Snowflake falls back to
+    user defaults instead of erroring on empty values."""
+    from siege_utilities.analytics.snowflake_connector import SnowflakeConnector
+
+    c = SnowflakeConnector(account="acc", user="u", password="p", warehouse=None)
+    assert c.connect() is True
+
+    _patch_snowflake.connector.connect.assert_called_once()
+    kwargs = _patch_snowflake.connector.connect.call_args.kwargs
+    assert "warehouse" not in kwargs
+    assert kwargs["account"] == "acc"
+    assert kwargs["password"] == "p"
+
+
+def test_execute_query_returns_none_on_driver_error(_patch_snowflake):
+    """Driver-side failures must be translated to ``None``, not propagate
+    a raw snowflake.connector exception — callers expect Optional[list]."""
+    from siege_utilities.analytics.snowflake_connector import SnowflakeConnector
+
+    c = SnowflakeConnector(account="acc", user="u", password="p")
+    cursor = MagicMock()
+    cursor.execute.side_effect = RuntimeError("boom")
+    c.connection = MagicMock()
+    c.cursor = cursor
+
+    assert c.execute_query("SELECT 1") is None
+
+
+def test_upload_dataframe_validates_table_identifier(_patch_snowflake):
+    """SQL-injection guardrail: bad identifiers must fail before any
+    cursor.execute or write_pandas call — the v3.15.0 hardening landed
+    siege_utilities.core.sql_safety.validate_sql_identifier on this path."""
+    pd = pytest.importorskip("pandas")
+    from siege_utilities.analytics.snowflake_connector import SnowflakeConnector
+
+    c = SnowflakeConnector(account="acc", user="u", password="p")
+    c.connection = MagicMock()
+    c.cursor = MagicMock()
+
+    df = pd.DataFrame({"a": [1]})
+    with pytest.raises(ValueError):
+        c.upload_dataframe(df, table_name="bad; DROP TABLE users;--")
+
+
+def test_context_manager_connects_and_disconnects(_patch_snowflake):
+    from siege_utilities.analytics.snowflake_connector import SnowflakeConnector
+
+    with SnowflakeConnector(account="a", user="u", password="p") as c:
+        assert c.connection is not None
+    # disconnect closes both cursor and connection
+    c.connection.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — live API smoke (skipped without credentials)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.requires_api_key
+def test_snowflake_live_connect_disconnect(api_credentials):
+    pytest.importorskip("snowflake.connector")
+    from siege_utilities.analytics.snowflake_connector import SnowflakeConnector
+
+    creds = api_credentials.get("snowflake")
+    if not creds:
+        pytest.skip("no 'snowflake:' section in credentials file")
+
+    c = SnowflakeConnector(**{k: creds.get(k) for k in (
+        "account", "user", "password", "warehouse", "database", "schema", "role"
+    )})
+    assert c.connect() is True
+    try:
+        result = c.execute_query("SELECT CURRENT_VERSION()")
+        assert result and len(result) == 1
+    finally:
+        c.disconnect()


### PR DESCRIPTION
## Summary

First connector under **Sprint B** (#453). Lands the shared test infrastructure for the rest of the sprint along with the `snowflake_connector` test module.

Per the #453 decision: developer-local credentials at `~/.siege-test-credentials.yaml`; CI runs Phase-1 mock tests only, Phase-2 live-API tests skip when the file is absent.

## What's in this PR

**Shared scaffolding (one-time):**
- `pyproject.toml` — register `requires_api_key` pytest marker.
- `tests/conftest.py` — `api_credentials` fixture loads `~/.siege-test-credentials.yaml`, skips when absent.
- `.gitignore` — belt-and-suspenders on the credentials filename.
- `docs/testing/sprint-b-credentials.md` — schema + run instructions for all 8 connectors.

**Snowflake tests:**
- `tests/test_snowflake_connector.py` — 7 mock tests (init guard, config overlay, missing-file, connect-param-cleaning, error translation, SQL-injection guardrail on upload, context-manager lifecycle) + 1 live-API smoke gated by `requires_api_key`.

## Test plan

- [ ] CI green (mock tests run; live-API test skips with "no credentials file" message)
- [ ] Locally with creds: `pytest -m requires_api_key tests/test_snowflake_connector.py` passes

## Sprint B progress

- [x] Snowflake (this PR)
- [ ] facebook_business
- [ ] datadotworld_connector
- [ ] google_analytics (top up)
- [ ] vista_social
- [ ] google_workspace
- [ ] polling_analyzer
- [ ] google_search

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Sprint B connector testing guide covering developer-local credential setup, how to run optional live API smoke tests, and failure-mode guidance.

* **Tests**
  * Added comprehensive Snowflake connector test suite with mock unit tests and an opt-in live API smoke test (run via new pytest marker).
  * Added a test fixture that loads developer-local credentials and skips live tests when absent or invalid.

* **Chores**
  * Ignored local connector credential files to prevent accidental commits.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siege-analytics/siege_utilities/pull/459)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->