### PR TITLE
sprint B: bulk connector tests (facebook + dataworld + vista + workspace + GA smoke) (refs #453)

### DIFF
--- a/tests/test_datadotworld_connector.py
+++ b/tests/test_datadotworld_connector.py
@@ -1,0 +1,89 @@
+"""Tests for siege_utilities.analytics.datadotworld_connector."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def _patch_dw(monkeypatch):
+    from siege_utilities.analytics import datadotworld_connector as mod
+
+    fake = MagicMock()
+    monkeypatch.setattr(mod, "DATADOTWORLD_AVAILABLE", True)
+    monkeypatch.setattr(mod, "dw", fake, raising=False)
+    return fake
+
+
+def test_init_rejects_when_dw_not_installed(monkeypatch):
+    from siege_utilities.analytics import datadotworld_connector as mod
+
+    monkeypatch.setattr(mod, "DATADOTWORLD_AVAILABLE", False)
+    with pytest.raises(ImportError, match="datadotworld"):
+        mod.DataDotWorldConnector(api_token="t")
+
+
+def test_init_with_explicit_token_uses_authenticated_client(_patch_dw):
+    from siege_utilities.analytics.datadotworld_connector import DataDotWorldConnector
+
+    c = DataDotWorldConnector(api_token="tok-123")
+    _patch_dw.api_client.assert_called_once_with("tok-123")
+    assert c.client is not None
+
+
+def test_init_falls_back_to_env_var(monkeypatch, _patch_dw):
+    """If no token and no config are provided, the env var
+    DATADOTWORLD_API_TOKEN should be the next try — otherwise the
+    integration silently falls into anonymous mode, which has
+    extremely different access rules and is a surprising default."""
+    from siege_utilities.analytics.datadotworld_connector import DataDotWorldConnector
+
+    monkeypatch.setenv("DATADOTWORLD_API_TOKEN", "from-env")
+    DataDotWorldConnector()
+    _patch_dw.api_client.assert_called_once_with("from-env")
+
+
+def test_init_anonymous_when_no_token_and_no_env(monkeypatch, _patch_dw):
+    monkeypatch.delenv("DATADOTWORLD_API_TOKEN", raising=False)
+    DataDotWorldConnector_local = __import__(
+        "siege_utilities.analytics.datadotworld_connector",
+        fromlist=["DataDotWorldConnector"],
+    ).DataDotWorldConnector
+    DataDotWorldConnector_local()
+    # api_client called with no args = anonymous
+    _patch_dw.api_client.assert_called_once_with()
+
+
+def test_load_config_overrides_constructor_token(tmp_path, _patch_dw):
+    from siege_utilities.analytics.datadotworld_connector import DataDotWorldConnector
+
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text(json.dumps({"api_token": "from-file"}))
+
+    c = DataDotWorldConnector(api_token="from-arg", config_file=cfg)
+    # File wins because _load_config runs after constructor assignment
+    assert c.api_token == "from-file"
+
+
+def test_load_config_missing_file_raises(_patch_dw, tmp_path):
+    from siege_utilities.analytics.datadotworld_connector import DataDotWorldConnector
+
+    with pytest.raises(FileNotFoundError):
+        DataDotWorldConnector(config_file=tmp_path / "missing.json")
+
+
+@pytest.mark.requires_api_key
+def test_dataworld_live_search(api_credentials):
+    pytest.importorskip("datadotworld")
+    from siege_utilities.analytics.datadotworld_connector import DataDotWorldConnector
+
+    creds = api_credentials.get("datadotworld")
+    if not creds:
+        pytest.skip("no 'datadotworld:' section in credentials file")
+    c = DataDotWorldConnector(api_token=creds["api_token"])
+    # smoke: search returns a (possibly empty) list, not a traceback
+    result = c.search_datasets("census", limit=1)
+    assert result is None or isinstance(result, list)

--- a/tests/test_facebook_business_connector.py
+++ b/tests/test_facebook_business_connector.py
@@ -1,0 +1,98 @@
+"""Tests for siege_utilities.analytics.facebook_business.
+
+Phase-1 mock tests pin init / auth-init / error translation paths;
+Phase-2 live smoke test exercises a real ``get_ad_accounts`` call
+when ``~/.siege-test-credentials.yaml`` has a ``facebook_business``
+section.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def _patch_fb(monkeypatch):
+    from siege_utilities.analytics import facebook_business as mod
+
+    fake_api = MagicMock()
+    fake_pkg = MagicMock()
+    monkeypatch.setattr(mod, "FACEBOOK_BUSINESS_AVAILABLE", True)
+    monkeypatch.setattr(mod, "FacebookAdsApi", fake_api, raising=False)
+    monkeypatch.setattr(mod, "facebook_business", fake_pkg, raising=False)
+    fake_pkg.adobjects.user.User = MagicMock()
+    return {"api": fake_api, "pkg": fake_pkg}
+
+
+def test_init_rejects_when_facebook_not_installed(monkeypatch):
+    from siege_utilities.analytics import facebook_business as mod
+
+    monkeypatch.setattr(mod, "FACEBOOK_BUSINESS_AVAILABLE", False)
+    with pytest.raises(ImportError, match="facebook-business"):
+        mod.FacebookBusinessConnector(access_token="x")
+
+
+def test_init_uses_app_id_secret_when_provided(_patch_fb):
+    from siege_utilities.analytics.facebook_business import FacebookBusinessConnector
+
+    FacebookBusinessConnector(access_token="tok", app_id="app", app_secret="sec")
+    _patch_fb["api"].init.assert_called_once_with("app", "sec", "tok")
+
+
+def test_init_falls_back_to_token_only(_patch_fb):
+    """When app_id/app_secret aren't supplied, the SDK is initialized
+    with just the access token (the supported token-only auth path)."""
+    from siege_utilities.analytics.facebook_business import FacebookBusinessConnector
+
+    FacebookBusinessConnector(access_token="tok")
+    _patch_fb["api"].init.assert_called_once_with(access_token="tok")
+
+
+def test_get_ad_accounts_translates_errors_to_empty_list(_patch_fb):
+    """Errors during ``me.get_ad_accounts()`` must translate to ``[]``
+    not propagate raw facebook_business exceptions to callers — the
+    rest of the codebase assumes List[Dict] from this method."""
+    from siege_utilities.analytics.facebook_business import FacebookBusinessConnector
+
+    user_inst = MagicMock()
+    user_inst.get_ad_accounts.side_effect = RuntimeError("rate limited")
+    _patch_fb["pkg"].adobjects.user.User.return_value = user_inst
+
+    c = FacebookBusinessConnector(access_token="tok")
+    assert c.get_ad_accounts() == []
+
+
+def test_get_ad_accounts_maps_sdk_records_to_dicts(_patch_fb):
+    from siege_utilities.analytics.facebook_business import FacebookBusinessConnector
+
+    fake_account = {
+        "id": "act_123", "name": "Test", "account_status": 1,
+        "currency": "USD", "timezone_name": "America/Chicago",
+    }
+    user_inst = MagicMock()
+    user_inst.get_ad_accounts.return_value = [fake_account]
+    _patch_fb["pkg"].adobjects.user.User.return_value = user_inst
+
+    c = FacebookBusinessConnector(access_token="tok")
+    accounts = c.get_ad_accounts()
+    assert accounts == [fake_account]
+
+
+@pytest.mark.requires_api_key
+def test_facebook_live_get_ad_accounts(api_credentials):
+    pytest.importorskip("facebook_business")
+    from siege_utilities.analytics.facebook_business import FacebookBusinessConnector
+
+    creds = api_credentials.get("facebook_business")
+    if not creds:
+        pytest.skip("no 'facebook_business:' section in credentials file")
+
+    c = FacebookBusinessConnector(
+        access_token=creds["access_token"],
+        app_id=creds.get("app_id"),
+        app_secret=creds.get("app_secret"),
+    )
+    accounts = c.get_ad_accounts()
+    assert isinstance(accounts, list)

--- a/tests/test_google_analytics_connector.py
+++ b/tests/test_google_analytics_connector.py
@@ -255,3 +255,41 @@ class TestGA4ResponseParsing:
         # Should return empty DataFrame, not raise
         assert isinstance(df, pd.DataFrame)
         assert len(df) == 0
+
+
+# ---------------------------------------------------------------------------
+# Sprint B Phase-2 live-API smoke (skipped without credentials)
+# ---------------------------------------------------------------------------
+
+import pytest
+
+
+@pytest.mark.requires_api_key
+def test_ga4_live_minimum_query(api_credentials):
+    pytest.importorskip("google.analytics.data_v1beta")
+    from siege_utilities.analytics.google_analytics import GoogleAnalyticsConnector
+
+    creds = api_credentials.get("google_analytics")
+    if not creds or not creds.get("property_id"):
+        pytest.skip("no 'google_analytics.property_id' in credentials file")
+    sa_json = creds.get("service_account_json")
+    if not sa_json:
+        pytest.skip("no 'google_analytics.service_account_json' in credentials")
+
+    import json
+    with open(sa_json) as f:
+        sa_data = json.load(f)
+    conn = GoogleAnalyticsConnector(
+        auth_method="service_account",
+        service_account_data=sa_data,
+    )
+    assert conn.authenticate() is True
+
+    df = conn.get_ga4_data(
+        property_id=str(creds["property_id"]),
+        start_date="7daysAgo",
+        end_date="today",
+        metrics=["sessions"],
+    )
+    # An empty result is legal (e.g. zero traffic); the shape is what we pin.
+    assert df is not None

--- a/tests/test_google_workspace_client.py
+++ b/tests/test_google_workspace_client.py
@@ -1,0 +1,107 @@
+"""Tests for siege_utilities.analytics.google_workspace.GoogleWorkspaceClient.
+
+Pins service-cache behavior, URL helpers, and the batch-update
+wrappers' SDK call shape; live smoke test exercises a real
+``sheets_service().spreadsheets().get()`` against a fixture
+spreadsheet ID.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def _patch_google(monkeypatch):
+    from siege_utilities.analytics import google_workspace as mod
+
+    fake_build = MagicMock()
+    monkeypatch.setattr(mod, "_GOOGLE_AVAILABLE", True)
+    monkeypatch.setattr(mod, "build", fake_build, raising=False)
+    return fake_build
+
+
+def test_require_google_raises_when_unavailable(monkeypatch):
+    from siege_utilities.analytics import google_workspace as mod
+
+    monkeypatch.setattr(mod, "_GOOGLE_AVAILABLE", False)
+    with pytest.raises(ImportError, match="Google API libraries"):
+        mod._require_google()
+
+
+def test_service_cache_reuses_builds(_patch_google):
+    """build() is expensive; calling sheets_service() twice must
+    not re-build. Verifies the ``self._services`` cache."""
+    from siege_utilities.analytics.google_workspace import GoogleWorkspaceClient
+
+    client = GoogleWorkspaceClient(credentials=MagicMock())
+    s1 = client.sheets_service()
+    s2 = client.sheets_service()
+    assert s1 is s2
+    _patch_google.assert_called_once()
+
+
+def test_different_services_built_independently(_patch_google):
+    from siege_utilities.analytics.google_workspace import GoogleWorkspaceClient
+
+    _patch_google.side_effect = lambda *a, **kw: MagicMock(name=f"{a[0]}-{a[1]}")
+    client = GoogleWorkspaceClient(credentials=MagicMock())
+    client.sheets_service()
+    client.docs_service()
+    client.slides_service()
+    # 3 distinct (api, version) pairs → 3 build() calls
+    assert _patch_google.call_count == 3
+
+
+def test_url_helpers_return_canonical_urls():
+    from siege_utilities.analytics.google_workspace import GoogleWorkspaceClient
+
+    assert GoogleWorkspaceClient.spreadsheet_url("ABC123") == (
+        "https://docs.google.com/spreadsheets/d/ABC123"
+    )
+    assert GoogleWorkspaceClient.document_url("DEF456") == (
+        "https://docs.google.com/document/d/DEF456"
+    )
+    assert GoogleWorkspaceClient.presentation_url("GHI789") == (
+        "https://docs.google.com/presentation/d/GHI789"
+    )
+
+
+def test_batch_update_spreadsheet_passes_requests_through(_patch_google):
+    from siege_utilities.analytics.google_workspace import GoogleWorkspaceClient
+
+    fake_service = MagicMock()
+    _patch_google.return_value = fake_service
+
+    client = GoogleWorkspaceClient(credentials=MagicMock())
+    req = [{"updateCells": {"range": {}, "fields": "*"}}]
+    client.batch_update_spreadsheet("sheet-id", req)
+
+    fake_service.spreadsheets.return_value.batchUpdate.assert_called_once_with(
+        spreadsheetId="sheet-id", body={"requests": req},
+    )
+
+
+@pytest.mark.requires_api_key
+def test_google_workspace_live_sheets_get(api_credentials):
+    pytest.importorskip("googleapiclient.discovery")
+    from siege_utilities.analytics.google_workspace import GoogleWorkspaceClient
+
+    creds = api_credentials.get("google_workspace")
+    if not creds or not creds.get("service_account_json"):
+        pytest.skip("no 'google_workspace.service_account_json' in credentials")
+    if not creds.get("spreadsheet_id"):
+        pytest.skip("no 'google_workspace.spreadsheet_id' fixture in credentials")
+
+    client = GoogleWorkspaceClient.from_service_account(
+        service_account_file=creds["service_account_json"],
+    )
+    result = (
+        client.sheets_service()
+        .spreadsheets()
+        .get(spreadsheetId=creds["spreadsheet_id"])
+        .execute()
+    )
+    assert "spreadsheetId" in result

--- a/tests/test_vista_social_connector.py
+++ b/tests/test_vista_social_connector.py
@@ -1,0 +1,136 @@
+"""Tests for siege_utilities.analytics.vista_social.
+
+The connector ships against an undocumented public API; these tests
+pin the well-tested ``_request`` plumbing and the auth / rate-limit
+/ error-translation behavior — that's the part that's correct
+regardless of which endpoint paths Vista Social actually exposes.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def _patch_requests(monkeypatch):
+    from siege_utilities.analytics import vista_social as mod
+
+    fake_requests = MagicMock()
+    fake_session = MagicMock()
+    fake_session.headers = {}
+    fake_requests.Session.return_value = fake_session
+    # Real exception classes so isinstance checks work
+    fake_requests.exceptions.RequestException = Exception
+    monkeypatch.setattr(mod, "requests", fake_requests, raising=False)
+    monkeypatch.setattr(mod, "REQUESTS_AVAILABLE", True)
+    return {"requests": fake_requests, "session": fake_session}
+
+
+def test_init_requires_api_token():
+    from siege_utilities.analytics.vista_social import VistaSocialConnector
+
+    with pytest.raises(ValueError, match="api_token"):
+        VistaSocialConnector(api_token="")
+
+
+def test_init_sets_bearer_header(_patch_requests):
+    from siege_utilities.analytics.vista_social import VistaSocialConnector
+
+    VistaSocialConnector(api_token="tok")
+    headers = _patch_requests["session"].headers
+    assert headers["Authorization"] == "Bearer tok"
+    assert headers["Accept"] == "application/json"
+
+
+def test_401_raises_auth_error_no_retry(_patch_requests):
+    """401/403 are credential failures — retrying would just waste
+    quota and risk a rate-limit ban. Must raise immediately."""
+    from siege_utilities.analytics.vista_social import (
+        VistaSocialConnector, VistaSocialAuthError,
+    )
+
+    resp = MagicMock(status_code=401, content=b"", text="unauthorized", headers={})
+    _patch_requests["session"].request.return_value = resp
+
+    c = VistaSocialConnector(api_token="bad-tok", retry_attempts=5)
+    with pytest.raises(VistaSocialAuthError):
+        c.list_accounts()
+    # Called exactly once — never retried.
+    assert _patch_requests["session"].request.call_count == 1
+
+
+def test_429_raises_rate_limit_error(_patch_requests):
+    """429 surfaces a typed exception so callers can back off
+    explicitly rather than have our retry loop double-stack into
+    a longer ban."""
+    from siege_utilities.analytics.vista_social import (
+        VistaSocialConnector, VistaSocialRateLimitError,
+    )
+
+    resp = MagicMock(
+        status_code=429, content=b"", text="rate limited",
+        headers={"Retry-After": "30"},
+    )
+    _patch_requests["session"].request.return_value = resp
+
+    c = VistaSocialConnector(api_token="tok", retry_attempts=3)
+    with pytest.raises(VistaSocialRateLimitError, match="Retry-After: 30"):
+        c.list_accounts()
+    assert _patch_requests["session"].request.call_count == 1
+
+
+def test_5xx_retries_then_succeeds(_patch_requests, monkeypatch):
+    """Transient 5xxs should retry with backoff and eventually
+    return a successful 2xx response. Verifies the retry loop
+    actually loops — not just runs once."""
+    from siege_utilities.analytics import vista_social as mod
+    from siege_utilities.analytics.vista_social import VistaSocialConnector
+
+    monkeypatch.setattr(mod.time, "sleep", lambda *_: None)
+    fail = MagicMock(status_code=503, content=b"", text="upstream gone", headers={})
+    ok = MagicMock(status_code=200, content=b'{"data":[{"id":"a"}]}', headers={})
+    ok.json.return_value = {"data": [{"id": "a"}]}
+    _patch_requests["session"].request.side_effect = [fail, fail, ok]
+
+    c = VistaSocialConnector(api_token="tok", retry_attempts=3, retry_backoff=1.0)
+    accounts = c.list_accounts()
+    assert accounts == [{"id": "a"}]
+    assert _patch_requests["session"].request.call_count == 3
+
+
+def test_4xx_other_raises_without_retry(_patch_requests):
+    """A 400/404/etc is the caller's fault, not transient — must
+    surface immediately without burning retry budget."""
+    from siege_utilities.analytics.vista_social import (
+        VistaSocialConnector, VistaSocialError,
+    )
+
+    resp = MagicMock(status_code=404, content=b"", text="not found", headers={})
+    _patch_requests["session"].request.return_value = resp
+
+    c = VistaSocialConnector(api_token="tok", retry_attempts=3)
+    with pytest.raises(VistaSocialError, match="404"):
+        c.list_accounts()
+    assert _patch_requests["session"].request.call_count == 1
+
+
+def test_list_profiles_requires_account_id(_patch_requests):
+    from siege_utilities.analytics.vista_social import VistaSocialConnector
+
+    c = VistaSocialConnector(api_token="tok")
+    with pytest.raises(ValueError, match="account_id"):
+        c.list_profiles("")
+
+
+@pytest.mark.requires_api_key
+def test_vista_social_live_list_accounts(api_credentials):
+    from siege_utilities.analytics.vista_social import VistaSocialConnector
+
+    creds = api_credentials.get("vista_social")
+    if not creds:
+        pytest.skip("no 'vista_social:' section in credentials file")
+    c = VistaSocialConnector(api_token=creds["api_token"])
+    accounts = c.list_accounts()
+    assert isinstance(accounts, list)


### PR DESCRIPTION
## Summary

Bulk follow-up to PR #459. Lands the remaining Sprint B connector coverage in one PR, stacked on the scaffolding from #459.

**Stacked on #459** — base is \`feature/sprint-b-snowflake-tests\`. After #459 merges to main, the GitHub UI will auto-rebase this PR's base to main.

## Coverage added

| Connector | Mock tests | Live smoke |
|-----------|:---:|:---:|
| facebook_business | 4 | 1 |
| datadotworld_connector | 5 | 1 |
| vista_social | 7 | 1 |
| google_workspace | 5 | 1 |
| google_analytics | (9 in tree) | +1 |

All live-API tests gated by \`@pytest.mark.requires_api_key\` and the \`api_credentials\` fixture from #459. They skip cleanly when \`~/.siege-test-credentials.yaml\` is absent.

## Notes on issue scope

Sprint B (#453) lists \`polling_analyzer.py\` and \`google_search.py\`. Neither file exists in \`siege_utilities/analytics/\`. I'll edit #453 to drop them once this is merged; flagging now so the next reviewer doesn't search for them.

## Test plan

- [ ] CI green on top of #459
- [ ] Live smoke tests pass locally once creds are in place
- [ ] After #459 merges, GitHub rebases this PR's base; re-run CI