### PR TITLE
sprint E phase 1: cross-engine invariants design doc + skeleton (refs #456)

### DIFF
--- a/docs/engines/INVARIANTS.md
+++ b/docs/engines/INVARIANTS.md
@@ -1,0 +1,104 @@
+# Cross-backend engine invariants
+
+Working design document for **Sprint E** (issue #456), Phase 1.
+
+The `DataFrameEngine` premise — consumer code should not branch on backend — is unverified. `PandasEngine`, `DuckDBEngine`, `SparkEngine`, and `PostGISEngine` ship today with subtle divergences in edge cases: empty inputs, NaN propagation, sort stability, identifier validation. This doc pins down what *must* be the same and what is allowed to differ.
+
+The output of Phase 1 (this doc) feeds directly into Phase 2 (Hypothesis strategies in `tests/property/`) and Phase 3 (reactive bug fixes). Phases 2 and 3 are filed as separate follow-up issues.
+
+## How to read this doc
+
+Each operation has:
+
+- **Required input shape** — what the caller is responsible for providing.
+- **Required output shape** — what the engine guarantees in return.
+- **Tolerances** — where each engine is allowed to differ, with the rationale.
+- **Open question** — anything still TBD; a Phase-1 deliverable is converting these to decisions.
+
+The granularity is operation-level, not backend-level. If an engine can't meet an invariant, that's a Phase-3 bug fix — not a reason to weaken the invariant.
+
+## Universal invariants (apply to every operation)
+
+1. **Empty input → empty output, never raise.** A 0-row DataFrame in must yield a 0-row DataFrame out, with the correct schema. Engines that currently raise on empty input (Spark's groupby occasionally; PostGIS on aggregations) are bugs.
+2. **Schema invariance.** Output column names + dtypes are reproducible from `(operation, input_schema)`. No engine may add a backend-specific metadata column.
+3. **No silent NaN coercion across backends.** If pandas produces `NaN`, the other engines must produce their backend-native missing value (`None` for DuckDB/PostGIS, `null` for Spark), and `to_pandas()` must round-trip it back to `NaN`.
+4. **Identifier validation happens at the engine boundary.** All four engines must reject identifiers that fail `siege_utilities.core.sql_safety.validate_sql_identifier`. (Pandas previously passed them through; DuckDB/PostGIS/Spark exec'd them — the v3.15.0 sweep aligned this. Property tests pin it.)
+
+## Per-operation invariants
+
+### `read_csv(path, *, schema=None)`
+
+- **Input:** UTF-8 CSV file at *path*. Optional schema dict; when present, engines must coerce dtypes to match.
+- **Output:** DataFrame with header row as columns, all subsequent rows as data.
+- **Tolerance:**
+  - Spark may infer numeric columns as `LongType` where pandas picks `Int64` — equivalent under `to_pandas()`.
+  - PostGIS reads via `COPY FROM`; identifier rules apply.
+- **Open question:** behavior on malformed UTF-8 — fail fast vs. replace.
+
+### `read_parquet(path)`
+
+- **Input:** Parquet file at *path* (single-file or directory of part-files).
+- **Output:** DataFrame with the parquet schema.
+- **Tolerance:** none — parquet is self-describing. Divergences are bugs.
+
+### `groupby_agg(by, agg_dict)`
+
+- **Input:** `by` is a column or list of columns; `agg_dict` maps `column → agg_name` where `agg_name ∈ {sum, mean, count, min, max, first, last, stddev, variance, approx_count_distinct}`.
+- **Output:** One row per unique `by` tuple, with one column per `agg_dict` entry named `{column}_{agg_name}` (or the input column name if `agg_name == "first"`). Plus the `by` columns.
+- **Tolerance:**
+  - **Sort order is NOT guaranteed.** Caller must `.sort_values()` if order matters. Tests assert set-equality over rows, not list-equality.
+  - `mean` ignores NaN; `count` excludes NaN; `sum` of all-NaN is 0.0 (not NaN). All four engines must agree on this.
+- **Bug currently:** Spark `groupby_agg` raises `AttributeError` on unknown agg names — fixed in Sprint A (#452, item 2) by validating against a known set. Pin with a property test.
+
+### `filter(condition)`
+
+- **Input:** boolean Series or expression string.
+- **Output:** DataFrame containing only rows where `condition` is True.
+- **Tolerance:** NaN in the condition is treated as False on every backend. (PostGIS treats it as `UNKNOWN` natively; the engine must coerce to False before applying.)
+
+### `join(other, on, how)`
+
+- **Input:** another DataFrame; `on` is column or list; `how ∈ {inner, left, right, outer}`.
+- **Output:** Join semantics per `how`. Column collision is resolved by appending `_left` / `_right` suffixes (pandas default behavior — other engines must match).
+- **Tolerance:**
+  - Row order on `outer` is not guaranteed.
+  - PostGIS may not support arbitrary join keys (must be indexable); the engine raises `NotImplementedError` on the unsupported key types rather than silently coercing.
+- **Open question:** what is the canonical behavior when the same join key has duplicates on both sides? Pandas cross-product; Spark same; PostGIS same. Confirm and pin.
+
+### `spatial_join(other, predicate)`
+
+- **Input:** two GeoDataFrames; `predicate ∈ {intersects, contains, within}`.
+- **Output:** rows from the left side, joined with the matching rows from the right side, indexed by `(left_idx, right_idx)`.
+- **Tolerance:**
+  - **Relation semantics modes** (BOUNDED / HALFPLANE / CONTAINS_CENTROID, the v3.15.0 hardening) are an explicit parameter; engines must respect it identically.
+  - Sort order is not guaranteed.
+- **Bug surface:** SparkEngine's spatial_join goes through Sedona; geometry SRIDs must match before the join — pandas would auto-reproject, Sedona will silently produce nothing. The engine must reproject explicitly; property test should pin this.
+
+### `to_geodataframe(geometry_column="geometry")`
+
+- **Input:** DataFrame with a column of either WKT strings or GeoJSON dicts.
+- **Output:** GeoDataFrame with that column converted to shapely geometries.
+- **Tolerance:**
+  - Missing column → `ValueError` with the column name in the message.
+  - Mixed-type column (some WKT, some GeoJSON) → `ValueError`, not silent partial conversion.
+- **Bug currently:** PandasEngine raises `KeyError` (not `ValueError`) when the column is missing. Phase-3 fix.
+
+### `index_points(grid, resolution)` / `index_polygon(grid, resolution)`
+
+- **Input:** GeoDataFrame; `grid ∈ {h3, s2}`; `resolution` int.
+- **Output:** Original frame + an `{grid}_id` column (e.g. `h3_id` string or `s2_id` int64).
+- **Tolerance:**
+  - **`index_points`**: one cell ID per row. Deterministic across backends.
+  - **`index_polygon`**: zero, one, or many cell IDs per row (the polygon may overlap multiple cells). Output is a new row per `(input_row, cell_id)` pair. Number of cells per input row must match across backends within a `±1` tolerance at cell boundaries (this is the H3/S2 library's edge-case difference; pin the tolerance, don't try to eliminate it).
+
+## Acceptance for Phase 1
+
+- [x] This doc lands in `docs/engines/INVARIANTS.md`.
+- [ ] A skeleton property test in `tests/property/test_engine_invariants_skeleton.py` demonstrating the Hypothesis pattern (input strategy → run on every available engine → assert equivalence). Concrete strategies for the full operation matrix are Phase 2.
+- [ ] Follow-up issues filed for Phase 2 (Hypothesis strategies) and Phase 3 (reactive bug fixes).
+
+## What this doc deliberately doesn't decide
+
+- **Performance invariants.** Sprint D handles hot-path perf separately; this doc is about correctness only.
+- **API surface.** We're testing the existing public surface, not redesigning it. Anything that would require a new method on `DataFrameEngine` is out of scope.
+- **Cross-engine optimization.** No "we will detect that PandasEngine and DuckDBEngine produce equivalent output and skip one" tricks. The point of property testing is to *find* divergences, not paper over them.

--- a/docs/engines/INVARIANTS.md
+++ b/docs/engines/INVARIANTS.md
@@ -44,7 +44,7 @@ The granularity is operation-level, not backend-level. If an engine can't meet a
 ### `groupby_agg(by, agg_dict)`
 
 - **Input:** `by` is a column or list of columns; `agg_dict` maps `column → agg_name` where `agg_name ∈ {sum, mean, count, min, max, first, last, stddev, variance, approx_count_distinct}`.
-- **Output:** One row per unique `by` tuple, with one column per `agg_dict` entry named `{column}_{agg_name}` (or the input column name if `agg_name == "first"`). Plus the `by` columns.
+- **Output:** One row per unique `by` tuple, with one column per `agg_dict` entry. The output column name **equals the input column name** (pandas `df.groupby(...).agg({col: fn}).reset_index()` convention — the aggregated value replaces the original column with no suffix). Non-pandas engines must match this, not append `_{agg_name}`. Plus the `by` columns.
 - **Tolerance:**
   - **Sort order is NOT guaranteed.** Caller must `.sort_values()` if order matters. Tests assert set-equality over rows, not list-equality.
   - `mean` ignores NaN; `count` excludes NaN; `sum` of all-NaN is 0.0 (not NaN). All four engines must agree on this.

--- a/tests/property/test_engine_invariants_skeleton.py
+++ b/tests/property/test_engine_invariants_skeleton.py
@@ -1,0 +1,145 @@
+"""Skeleton Hypothesis-based property tests for cross-engine invariants.
+
+Demonstrates the pattern that Phase 2 of Sprint E (#456) will scale
+out across the full operation matrix from docs/engines/INVARIANTS.md.
+Two concrete invariants are pinned here so the testing approach is
+verifiable today; the rest is a follow-up.
+
+The pattern:
+
+    1. Hypothesis strategy generates a valid input frame.
+    2. Run the operation through every available engine.
+    3. Convert each engine's output back to pandas (the canonical
+       reference) and assert equivalence under documented tolerances.
+
+Engines whose deps aren't installed are skipped per-test via
+``pytest.importorskip`` — CI matrices that don't ship DuckDB / Spark
+won't fail; they just exercise fewer backends.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+hypothesis = pytest.importorskip("hypothesis")
+hyp_strategies = pytest.importorskip("hypothesis.strategies")
+
+from hypothesis import HealthCheck, given, settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Hypothesis strategies — minimal set for the skeleton
+# ---------------------------------------------------------------------------
+
+# Small range so the test runs fast and Hypothesis can shrink effectively.
+_SAFE_INTS = st.integers(min_value=-1000, max_value=1000)
+_SAFE_FLOATS = st.floats(
+    min_value=-1e6, max_value=1e6, allow_nan=False, allow_infinity=False,
+)
+
+
+@st.composite
+def simple_int_frame(draw, max_rows: int = 50):
+    """Generate a small DataFrame with two int columns named ``group`` and ``value``.
+
+    Group keys are bounded so the property tests actually exercise
+    multi-row groups rather than degenerating into one-row-per-group.
+    """
+    n = draw(st.integers(min_value=0, max_value=max_rows))
+    groups = draw(st.lists(st.integers(min_value=0, max_value=5), min_size=n, max_size=n))
+    values = draw(st.lists(_SAFE_INTS, min_size=n, max_size=n))
+    return pd.DataFrame({"group": groups, "value": values})
+
+
+# ---------------------------------------------------------------------------
+# Engine probes — return None if the engine isn't available
+# ---------------------------------------------------------------------------
+
+def _pandas_engine():
+    from siege_utilities.engines.dataframe_engine import PandasEngine
+    return PandasEngine()
+
+
+def _duckdb_engine():
+    """Construct DuckDBEngine or return None if DuckDB isn't installed."""
+    try:
+        from siege_utilities.engines.dataframe_engine import DuckDBEngine
+        return DuckDBEngine()
+    except ImportError:
+        return None
+
+
+# Spark + PostGIS are heavier to spin up. Phase 2 will add probes that
+# share a single fixture-scoped session; for the skeleton we exercise
+# pandas + DuckDB which run reliably in CI without external services.
+
+_AVAILABLE_ENGINES = [
+    ("pandas", _pandas_engine),
+    ("duckdb", _duckdb_engine),
+]
+
+
+# ---------------------------------------------------------------------------
+# Invariant 1: empty input → empty output, schema preserved
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("engine_name,engine_factory", _AVAILABLE_ENGINES)
+def test_groupby_agg_empty_input_returns_empty(engine_name, engine_factory):
+    """INVARIANTS.md Universal #1: empty input → empty output, never raise."""
+    engine = engine_factory()
+    if engine is None:
+        pytest.skip(f"{engine_name} engine not available")
+
+    empty = pd.DataFrame({"group": [], "value": []}).astype(
+        {"group": "int64", "value": "int64"}
+    )
+    result = engine.groupby_agg(empty, group_cols=["group"], agg_dict={"value": "sum"})
+
+    # Convert back to pandas — engines that return a native handle (e.g.
+    # DuckDBPyRelation) materialize via to_pandas in Phase 2 strategies.
+    if not isinstance(result, pd.DataFrame):
+        result = result.to_pandas() if hasattr(result, "to_pandas") else pd.DataFrame(result)
+
+    assert len(result) == 0
+
+
+# ---------------------------------------------------------------------------
+# Invariant 2: groupby_agg sum is set-equal across engines (sort-tolerant)
+# ---------------------------------------------------------------------------
+
+@given(df=simple_int_frame())
+@settings(
+    max_examples=25,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_groupby_sum_agrees_across_engines(df):
+    """INVARIANTS.md groupby_agg: sum is identical (as a set of rows)
+    across every available backend. Phase 2 will broaden this to all
+    agg names and add float / NaN / count variants."""
+    expected_engine = _pandas_engine()
+    expected = expected_engine.groupby_agg(
+        df, group_cols=["group"], agg_dict={"value": "sum"},
+    )
+    expected_set = frozenset(
+        (int(r.group), int(r.value_sum)) for r in expected.itertuples()
+    )
+
+    for engine_name, factory in _AVAILABLE_ENGINES:
+        if engine_name == "pandas":
+            continue
+        engine = factory()
+        if engine is None:
+            continue
+        got = engine.groupby_agg(df, group_cols=["group"], agg_dict={"value": "sum"})
+        if not isinstance(got, pd.DataFrame):
+            got = got.to_pandas() if hasattr(got, "to_pandas") else pd.DataFrame(got)
+        got_set = frozenset(
+            (int(r.group), int(r.value_sum)) for r in got.itertuples()
+        )
+        assert got_set == expected_set, (
+            f"{engine_name} disagrees with pandas: "
+            f"{got_set - expected_set} extra, {expected_set - got_set} missing"
+        )

--- a/tests/property/test_engine_invariants_skeleton.py
+++ b/tests/property/test_engine_invariants_skeleton.py
@@ -124,7 +124,7 @@ def test_groupby_sum_agrees_across_engines(df):
         df, group_cols=["group"], agg_dict={"value": "sum"},
     )
     expected_set = frozenset(
-        (int(r.group), int(r.value_sum)) for r in expected.itertuples()
+        (int(r.group), int(r.value)) for r in expected.itertuples()
     )
 
     for engine_name, factory in _AVAILABLE_ENGINES:
@@ -137,7 +137,7 @@ def test_groupby_sum_agrees_across_engines(df):
         if not isinstance(got, pd.DataFrame):
             got = got.to_pandas() if hasattr(got, "to_pandas") else pd.DataFrame(got)
         got_set = frozenset(
-            (int(r.group), int(r.value_sum)) for r in got.itertuples()
+            (int(r.group), int(r.value)) for r in got.itertuples()
         )
         assert got_set == expected_set, (
             f"{engine_name} disagrees with pandas: "


### PR DESCRIPTION
## Summary

Sprint E (#456) is a multi-week, multi-PR arc per the issue itself. This PR lands **Phase 1 only**: the working design document that pins down which operations must be cross-backend identical, plus a skeleton Hypothesis test that demonstrates the testing pattern.

Phase 2 (full operation matrix of Hypothesis strategies) and Phase 3 (reactive bug fixes for divergences found) will be filed as follow-up issues once this lands.

## What's in here

- **`docs/engines/INVARIANTS.md`** — the design doc. Universal invariants (empty handling, schema invariance, NaN policy, identifier validation) plus per-operation invariants for `read_csv`, `read_parquet`, `groupby_agg`, `filter`, `join`, `spatial_join`, `to_geodataframe`, `index_points`/`index_polygon`. Explicit out-of-scope list at the bottom.

- **`tests/property/test_engine_invariants_skeleton.py`** — Hypothesis-based skeleton. Two invariants pinned today (empty-input handling, groupby_agg sum equivalence). Spark / PostGIS probes deferred to Phase 2 because they need fixture-scoped session setup.

## Why split it like this

The issue itself says "design heavy" for Phase 1. Landing the design doc as a reviewable artifact lets the next round of work proceed against a fixed target instead of inventing invariants on the fly. The skeleton test verifies the testing pattern works *today* against two real engines (pandas + DuckDB), so Phase 2 isn't starting from zero.

## Test plan

- [ ] CI green (skeleton runs against pandas + DuckDB; skips engines whose deps aren't installed)
- [ ] Reviewer agrees the invariant tolerances are right (this is the actual decision point — the code is mechanical follow-up)