### PR TITLE
fix: address hostile-review findings on the v3.15.1+ work

### DIFF
--- a/docs/engines/INVARIANTS.md
+++ b/docs/engines/INVARIANTS.md
@@ -1,10 +1,6 @@
 # Cross-backend engine invariants
 
-Working design document for **Sprint E** (issue #456), Phase 1.
-
-The `DataFrameEngine` premise — consumer code should not branch on backend — is unverified. `PandasEngine`, `DuckDBEngine`, `SparkEngine`, and `PostGISEngine` ship today with subtle divergences in edge cases: empty inputs, NaN propagation, sort stability, identifier validation. This doc pins down what *must* be the same and what is allowed to differ.
-
-The output of Phase 1 (this doc) feeds directly into Phase 2 (Hypothesis strategies in `tests/property/`) and Phase 3 (reactive bug fixes). Phases 2 and 3 are filed as separate follow-up issues.
+The `DataFrameEngine` premise — consumer code should not branch on backend — is unverified. `PandasEngine`, `DuckDBEngine`, `SparkEngine`, and `PostGISEngine` diverge in edge cases: empty inputs, NaN propagation, sort stability, identifier validation. This doc pins down what *must* be the same and what is allowed to differ.
 
 ## How to read this doc
 
@@ -13,16 +9,16 @@ Each operation has:
 - **Required input shape** — what the caller is responsible for providing.
 - **Required output shape** — what the engine guarantees in return.
 - **Tolerances** — where each engine is allowed to differ, with the rationale.
-- **Open question** — anything still TBD; a Phase-1 deliverable is converting these to decisions.
+- **Open question** — anything still TBD.
 
-The granularity is operation-level, not backend-level. If an engine can't meet an invariant, that's a Phase-3 bug fix — not a reason to weaken the invariant.
+The granularity is operation-level, not backend-level. If an engine can't meet an invariant, that's a bug fix, not a reason to weaken the invariant.
 
 ## Universal invariants (apply to every operation)
 
 1. **Empty input → empty output, never raise.** A 0-row DataFrame in must yield a 0-row DataFrame out, with the correct schema. Engines that currently raise on empty input (Spark's groupby occasionally; PostGIS on aggregations) are bugs.
 2. **Schema invariance.** Output column names + dtypes are reproducible from `(operation, input_schema)`. No engine may add a backend-specific metadata column.
 3. **No silent NaN coercion across backends.** If pandas produces `NaN`, the other engines must produce their backend-native missing value (`None` for DuckDB/PostGIS, `null` for Spark), and `to_pandas()` must round-trip it back to `NaN`.
-4. **Identifier validation happens at the engine boundary.** All four engines must reject identifiers that fail `siege_utilities.core.sql_safety.validate_sql_identifier`. (Pandas previously passed them through; DuckDB/PostGIS/Spark exec'd them — the v3.15.0 sweep aligned this. Property tests pin it.)
+4. **Identifier validation at the engine boundary.** _Aspiration, not current behavior._ Today only the upload/DDL paths in `SnowflakeConnector` and `spatial_transformations` call `validate_sql_identifier`; the engine-level operations (`groupby_agg`, `filter`, `join`) do not. Listed here so property-test work can pin the invariant once the engines route through validation.
 
 ## Per-operation invariants
 
@@ -48,7 +44,7 @@ The granularity is operation-level, not backend-level. If an engine can't meet a
 - **Tolerance:**
   - **Sort order is NOT guaranteed.** Caller must `.sort_values()` if order matters. Tests assert set-equality over rows, not list-equality.
   - `mean` ignores NaN; `count` excludes NaN; `sum` of all-NaN is 0.0 (not NaN). All four engines must agree on this.
-- **Bug currently:** Spark `groupby_agg` raises `AttributeError` on unknown agg names — fixed in Sprint A (#452, item 2) by validating against a known set. Pin with a property test.
+- **Known divergence to pin:** Spark `groupby_agg` validates against a known agg-name set; unknown names raise `ValueError` (not `AttributeError`). Property tests should assert all four engines raise the same exception type on unknown names.
 
 ### `filter(condition)`
 
@@ -70,7 +66,7 @@ The granularity is operation-level, not backend-level. If an engine can't meet a
 - **Input:** two GeoDataFrames; `predicate ∈ {intersects, contains, within}`.
 - **Output:** rows from the left side, joined with the matching rows from the right side, indexed by `(left_idx, right_idx)`.
 - **Tolerance:**
-  - **Relation semantics modes** (BOUNDED / HALFPLANE / CONTAINS_CENTROID, the v3.15.0 hardening) are an explicit parameter; engines must respect it identically.
+  - **Relation semantics modes** (BOUNDED / HALFPLANE / CONTAINS_CENTROID) are an explicit parameter; engines must respect it identically.
   - Sort order is not guaranteed.
 - **Bug surface:** SparkEngine's spatial_join goes through Sedona; geometry SRIDs must match before the join — pandas would auto-reproject, Sedona will silently produce nothing. The engine must reproject explicitly; property test should pin this.
 
@@ -81,7 +77,7 @@ The granularity is operation-level, not backend-level. If an engine can't meet a
 - **Tolerance:**
   - Missing column → `ValueError` with the column name in the message.
   - Mixed-type column (some WKT, some GeoJSON) → `ValueError`, not silent partial conversion.
-- **Bug currently:** PandasEngine raises `KeyError` (not `ValueError`) when the column is missing. Phase-3 fix.
+- **Known divergence to pin:** PandasEngine raises `KeyError` (not `ValueError`) when the column is missing; this should be normalised to `ValueError`.
 
 ### `index_points(grid, resolution)` / `index_polygon(grid, resolution)`
 
@@ -91,14 +87,8 @@ The granularity is operation-level, not backend-level. If an engine can't meet a
   - **`index_points`**: one cell ID per row. Deterministic across backends.
   - **`index_polygon`**: zero, one, or many cell IDs per row (the polygon may overlap multiple cells). Output is a new row per `(input_row, cell_id)` pair. Number of cells per input row must match across backends within a `±1` tolerance at cell boundaries (this is the H3/S2 library's edge-case difference; pin the tolerance, don't try to eliminate it).
 
-## Acceptance for Phase 1
-
-- [x] This doc lands in `docs/engines/INVARIANTS.md`.
-- [ ] A skeleton property test in `tests/property/test_engine_invariants_skeleton.py` demonstrating the Hypothesis pattern (input strategy → run on every available engine → assert equivalence). Concrete strategies for the full operation matrix are Phase 2.
-- [ ] Follow-up issues filed for Phase 2 (Hypothesis strategies) and Phase 3 (reactive bug fixes).
-
 ## What this doc deliberately doesn't decide
 
-- **Performance invariants.** Sprint D handles hot-path perf separately; this doc is about correctness only.
+- **Performance invariants.** Hot-path perf lives in `tests/perf/`; this doc is about correctness only.
 - **API surface.** We're testing the existing public surface, not redesigning it. Anything that would require a new method on `DataFrameEngine` is out of scope.
 - **Cross-engine optimization.** No "we will detect that PandasEngine and DuckDBEngine produce equivalent output and skip one" tricks. The point of property testing is to *find* divergences, not paper over them.

--- a/siege_utilities/geo/django/services/nces_service.py
+++ b/siege_utilities/geo/django/services/nces_service.py
@@ -81,6 +81,7 @@ class NCESPopulationService:
             NCESPopulationResult with statistics.
         """
         from django.contrib.gis.geos import GEOSGeometry, MultiPolygon
+        from django.utils import timezone
 
         from siege_utilities.conf import settings
 
@@ -96,27 +97,24 @@ class NCESPopulationService:
             result.errors.append(str(e))
             return result
 
-        # Pre-fetch all existing rows for this year in one query. The
-        # previous per-row ``.filter(...).first()`` issued one SELECT per
-        # input row — ~10K SELECTs for a typical year before any
-        # bulk_create touched disk. The dict lookup below is O(1) and
-        # the query count drops to 1 + ceil(N/batch_size).
-        existing_by_code = {
-            obj.locale_code: obj
+        existing_by_key = {
+            (obj.locale_code, obj.nces_year): obj
             for obj in NCESLocaleBoundary.objects.filter(nces_year=year)
         }
 
         objects_to_create: list = []
         objects_to_update: list = []
+        # bulk_update bypasses auto_now=True; set updated_at explicitly.
+        now = timezone.now()
         _UPDATE_FIELDS = (
             "locale_category", "locale_subcategory", "name",
-            "vintage_year", "geometry", "source",
+            "vintage_year", "geometry", "source", "updated_at",
         )
 
         for idx, row in gdf.iterrows():
             try:
                 locale_code = int(row["locale_code"])
-                existing = existing_by_code.get(locale_code)
+                existing = existing_by_key.get((locale_code, year))
 
                 if existing and not update_existing:
                     result.records_skipped += 1
@@ -140,6 +138,7 @@ class NCESPopulationService:
                 if existing:
                     for key, value in kwargs.items():
                         setattr(existing, key, value)
+                    existing.updated_at = now
                     objects_to_update.append(existing)
                 else:
                     objects_to_create.append(NCESLocaleBoundary(**kwargs))
@@ -160,8 +159,6 @@ class NCESPopulationService:
             )
             result.records_created += len(objects_to_create)
 
-        # Single bulk_update replaces the per-row ``.save()`` loop —
-        # one round-trip rather than one per row.
         if objects_to_update:
             NCESLocaleBoundary.objects.bulk_update(
                 objects_to_update, list(_UPDATE_FIELDS), batch_size=batch_size,
@@ -194,6 +191,7 @@ class NCESPopulationService:
             NCESPopulationResult with statistics.
         """
         from django.contrib.gis.geos import Point
+        from django.utils import timezone
 
         from ..models import SchoolLocation, State
 
@@ -226,20 +224,18 @@ class NCESPopulationService:
             if hasattr(st, "abbreviation"):
                 state_cache[st.abbreviation] = st
 
-        # Pre-fetch existing SchoolLocation rows for this vintage in a
-        # single query so the per-row check below is O(1) dict lookup
-        # rather than O(N) SELECTs.
-        existing_by_ncessch = {
-            obj.ncessch: obj
+        existing_by_key = {
+            (obj.ncessch, obj.vintage_year): obj
             for obj in SchoolLocation.objects.filter(vintage_year=year)
         }
 
         objects_to_create: list = []
         objects_to_update: list = []
+        now = timezone.now()
         _UPDATE_FIELDS = (
             "school_name", "lea_id", "state", "locale_code",
             "locale_category", "locale_subcategory", "name",
-            "vintage_year", "geometry", "source",
+            "vintage_year", "geometry", "source", "updated_at",
         )
 
         for idx, row in gdf.iterrows():
@@ -249,7 +245,7 @@ class NCESPopulationService:
                     result.records_skipped += 1
                     continue
 
-                existing = existing_by_ncessch.get(ncessch)
+                existing = existing_by_key.get((ncessch, year))
 
                 if existing and not update_existing:
                     result.records_skipped += 1
@@ -292,6 +288,7 @@ class NCESPopulationService:
                 if existing:
                     for key, value in kwargs.items():
                         setattr(existing, key, value)
+                    existing.updated_at = now
                     objects_to_update.append(existing)
                 else:
                     objects_to_create.append(SchoolLocation(**kwargs))
@@ -342,6 +339,8 @@ class NCESPopulationService:
         Returns:
             NCESPopulationResult with statistics.
         """
+        from django.utils import timezone
+
         from ..models import (
             SchoolDistrictElementary,
             SchoolDistrictSecondary,
@@ -358,10 +357,7 @@ class NCESPopulationService:
             result.errors.append(str(e))
             return result
 
-        # Build lookup: lea_id → locale info. Vectorised: filter the
-        # frame to rows with non-empty lea_id and a locale_code, then
-        # zip the columns into a dict. Avoids row-at-a-time iteration
-        # over a DataFrame that has tens of thousands of rows.
+        # Build lookup: lea_id → locale info.
         if {"lea_id", "locale_code"}.issubset(df.columns):
             mask = df["lea_id"].astype(str).str.len().gt(0) & df["locale_code"].notna()
             sub = df.loc[mask, ["lea_id", "locale_code", "locale_category", "locale_subcategory"]].fillna("")
@@ -379,11 +375,11 @@ class NCESPopulationService:
         else:
             locale_lookup = {}
 
-        # Update each district model type. bulk_update replaces the
-        # per-row ``.save()`` that previously issued one UPDATE per
-        # district — easily 30K UPDATEs across the three district
-        # types for a full national run.
-        _UPDATE_FIELDS = ("locale_code", "locale_category", "locale_subcategory")
+        # bulk_update bypasses auto_now=True; set updated_at explicitly.
+        now = timezone.now()
+        _UPDATE_FIELDS = (
+            "locale_code", "locale_category", "locale_subcategory", "updated_at",
+        )
         _BATCH = 500
 
         for model_cls in (
@@ -402,6 +398,7 @@ class NCESPopulationService:
                     district.locale_code = locale_info["locale_code"]
                     district.locale_category = locale_info["locale_category"]
                     district.locale_subcategory = locale_info["locale_subcategory"]
+                    district.updated_at = now
                     to_update.append(district)
                     if len(to_update) >= _BATCH:
                         model_cls.objects.bulk_update(to_update, list(_UPDATE_FIELDS))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,9 +92,8 @@ def api_credentials():
     Looked up at ``~/.siege-test-credentials.yaml`` (or the path in the
     ``SIEGE_TEST_CREDENTIALS`` env var). When the file is absent, tests
     decorated with ``@pytest.mark.requires_api_key`` and consuming this
-    fixture are skipped — by design, Sprint B's strategy is
-    developer-local creds, not CI secrets. CI is expected to run only
-    the mock unit tests; the live-API path is opt-in via
+    fixture are skipped — credentials are developer-local, not in CI.
+    CI runs the mock unit tests; the live-API path is opt-in via
     ``pytest -m requires_api_key``.
 
     Returns the parsed dict; individual connectors look up their own

--- a/tests/perf/test_iterrows_regressions.py
+++ b/tests/perf/test_iterrows_regressions.py
@@ -1,120 +1,79 @@
-"""Performance regression guards for the Sprint D vectorisation pass.
+"""Correctness checks for the vectorised hot paths.
 
-Each test runs a vectorised path and an "old style" .iterrows()
-equivalent against the same synthetic input, then asserts the
-vectorised path is no more than 2× slower than the baseline — i.e.,
-catches *regressions* if someone reverts the refactor or reintroduces
-a row-at-a-time loop. We don't pin absolute timings (CI noise);
-we pin the *relative* speedup that motivated the refactor.
+These don't pin timings — single-shot ``perf_counter`` on small frames
+is too noisy to be useful in CI. Instead they assert the vectorised
+output is byte-identical to the row-at-a-time baseline, so a future
+refactor that produces subtly different output (escaping, type
+coercion, NaN handling) gets caught.
 
-The 2× ratio is deliberately loose for CI noise. On a quiet
-machine the vectorised paths are typically 10-50× faster; the test
-fails only when something has gone catastrophically wrong.
+The actual perf win is measured offline with much larger inputs;
+that's not a CI test.
 """
 
 from __future__ import annotations
-
-import time
 
 import pytest
 
 pd = pytest.importorskip("pandas")
 
 
-def _time(fn) -> float:
-    start = time.perf_counter()
-    fn()
-    return time.perf_counter() - start
-
-
-def test_wkt_sql_generation_vectorised_beats_iterrows():
-    """Mirrors siege_utilities.geo.spatial_transformations._convert_to_postgis
-    hot loop — generating one INSERT line per geometry. The old
-    code called ``escape_string_literal(row.geometry.wkt)`` inside
-    iterrows; the new code uses ``gdf.geometry.apply(...)`` + string
-    concat on the Series.
-    """
+def test_wkt_sql_generation_output_matches_iterrows():
+    """Same call shape as siege_utilities.geo.spatial_transformations
+    ._convert_to_postgis — including the ``escape_string_literal``
+    call that the production path uses."""
     shapely = pytest.importorskip("shapely.geometry")
-    n = 5000
+    from siege_utilities.core.sql_safety import escape_sql_string_literal as escape
+
     df = pd.DataFrame({
-        "geometry": [shapely.Point(i, i) for i in range(n)],
+        "geometry": [shapely.Point(i, i) for i in range(200)],
     })
 
-    def baseline_iterrows() -> str:
-        out = []
-        for _, row in df.iterrows():
-            wkt = row["geometry"].wkt
-            out.append(f"INSERT INTO t (geom) VALUES (ST_GeomFromText('{wkt}'));")
-        return "\n".join(out)
-
-    def vectorised() -> str:
-        wkt_series = df["geometry"].apply(lambda g: g.wkt)
-        lines = (
-            "INSERT INTO t (geom) VALUES (ST_GeomFromText('"
-            + wkt_series
-            + "'));"
-        )
-        return "\n".join(lines)
-
-    # Sanity: both produce identical output.
-    assert baseline_iterrows() == vectorised()
-
-    t_base = _time(baseline_iterrows)
-    t_vec = _time(vectorised)
-    # Vectorised must be at most 2× the baseline (i.e., not worse).
-    # In practice it's much faster — this just guards regression.
-    assert t_vec <= 2.0 * t_base, (
-        f"Vectorised WKT generation regressed: vec={t_vec:.4f}s, base={t_base:.4f}s. "
-        "Did someone reintroduce iterrows in spatial_transformations._convert_to_postgis?"
+    baseline = "\n".join(
+        f"INSERT INTO spatial_table (geom) VALUES (ST_GeomFromText('{escape(row['geometry'].wkt)}'));"
+        for _, row in df.iterrows()
     )
 
+    wkt_series = df["geometry"].apply(lambda g: escape(g.wkt))
+    vectorised = "\n".join(
+        "INSERT INTO spatial_table (geom) VALUES (ST_GeomFromText('"
+        + wkt_series
+        + "'));"
+    )
 
-def test_lookup_dict_build_vectorised_beats_iterrows():
-    """Mirrors the nces_service.enrich_districts lookup-dict build.
-    The old code iterated rows; the new code masks + zips columns.
-    """
-    n = 20_000
+    assert baseline == vectorised
+
+
+def test_lookup_dict_build_matches_iterrows():
+    """Same call shape as nces_service.enrich_districts lookup build."""
     df = pd.DataFrame({
-        "lea_id": [f"{i:07d}" for i in range(n)],
-        "locale_code": [i % 50 for i in range(n)],
-        "locale_category": ["city"] * n,
-        "locale_subcategory": ["large"] * n,
+        "lea_id": [f"{i:07d}" for i in range(200)],
+        "locale_code": [i % 50 for i in range(200)],
+        "locale_category": ["city"] * 200,
+        "locale_subcategory": ["large"] * 200,
     })
 
-    def baseline_iterrows() -> dict:
-        out: dict = {}
-        for _, row in df.iterrows():
-            lea = str(row.get("lea_id", ""))
-            if lea and row.get("locale_code") is not None:
-                out[lea] = {
-                    "locale_code": str(int(row["locale_code"])),
-                    "locale_category": str(row.get("locale_category", "")),
-                    "locale_subcategory": str(row.get("locale_subcategory", "")),
-                }
-        return out
-
-    def vectorised() -> dict:
-        mask = df["lea_id"].astype(str).str.len().gt(0) & df["locale_code"].notna()
-        sub = df.loc[mask, ["lea_id", "locale_code", "locale_category", "locale_subcategory"]].fillna("")
-        return {
-            str(lea): {
-                "locale_code": str(int(code)),
-                "locale_category": str(cat),
-                "locale_subcategory": str(s),
+    baseline: dict = {}
+    for _, row in df.iterrows():
+        lea = str(row.get("lea_id", ""))
+        if lea and row.get("locale_code") is not None:
+            baseline[lea] = {
+                "locale_code": str(int(row["locale_code"])),
+                "locale_category": str(row.get("locale_category", "")),
+                "locale_subcategory": str(row.get("locale_subcategory", "")),
             }
-            for lea, code, cat, s in zip(
-                sub["lea_id"], sub["locale_code"],
-                sub["locale_category"], sub["locale_subcategory"],
-            )
+
+    mask = df["lea_id"].astype(str).str.len().gt(0) & df["locale_code"].notna()
+    sub = df.loc[mask, ["lea_id", "locale_code", "locale_category", "locale_subcategory"]].fillna("")
+    vectorised = {
+        str(lea): {
+            "locale_code": str(int(code)),
+            "locale_category": str(cat),
+            "locale_subcategory": str(s),
         }
+        for lea, code, cat, s in zip(
+            sub["lea_id"], sub["locale_code"],
+            sub["locale_category"], sub["locale_subcategory"],
+        )
+    }
 
-    a = baseline_iterrows()
-    b = vectorised()
-    assert a == b
-
-    t_base = _time(baseline_iterrows)
-    t_vec = _time(vectorised)
-    assert t_vec <= 2.0 * t_base, (
-        f"Vectorised lookup-dict build regressed: vec={t_vec:.4f}s, base={t_base:.4f}s. "
-        "Did someone reintroduce iterrows in nces_service.enrich_districts?"
-    )
+    assert baseline == vectorised

--- a/tests/property/test_engine_invariants_skeleton.py
+++ b/tests/property/test_engine_invariants_skeleton.py
@@ -47,6 +47,9 @@ def test_pandas_groupby_sum_empty_input_returns_empty():
     )
     result = engine.groupby_agg(empty, group_cols=["group"], agg_dict={"value": "sum"})
     assert len(result) == 0
+    assert list(result.columns) == ["group", "value"]
+    assert result["group"].dtype == "int64"
+    assert result["value"].dtype == "int64"
 
 
 @given(df=simple_int_frame())
@@ -64,10 +67,12 @@ def test_pandas_engine_agrees_with_raw_duckdb_sql(df):
     """
     duckdb = pytest.importorskip("duckdb")
 
+    from collections import Counter
+
     pandas_result = _pandas_engine().groupby_agg(
         df, group_cols=["group"], agg_dict={"value": "sum"},
     )
-    pandas_set = frozenset(
+    pandas_rows = Counter(
         (int(r.group), int(r.value)) for r in pandas_result.itertuples()
     )
 
@@ -80,11 +85,11 @@ def test_pandas_engine_agrees_with_raw_duckdb_sql(df):
     finally:
         con.close()
 
-    sql_set = frozenset(
+    sql_rows = Counter(
         (int(r.group), int(r.value)) for r in sql_result.itertuples()
     )
 
-    assert pandas_set == sql_set, (
+    assert pandas_rows == sql_rows, (
         f"Pandas engine and DuckDB SQL disagree: "
-        f"pandas-only={pandas_set - sql_set}, sql-only={sql_set - pandas_set}"
+        f"pandas-only={pandas_rows - sql_rows}, sql-only={sql_rows - pandas_rows}"
     )

--- a/tests/property/test_engine_invariants_skeleton.py
+++ b/tests/property/test_engine_invariants_skeleton.py
@@ -1,20 +1,15 @@
 """Skeleton Hypothesis-based property tests for cross-engine invariants.
 
-Demonstrates the pattern that Phase 2 of Sprint E (#456) will scale
-out across the full operation matrix from docs/engines/INVARIANTS.md.
-Two concrete invariants are pinned here so the testing approach is
-verifiable today; the rest is a follow-up.
+DuckDBEngine.groupby_agg currently dispatches to pandas when handed a
+pandas DataFrame, so comparing the two engines via the engine API
+proves nothing — both branches run the same pandas code. To actually
+exercise a different backend, this skeleton drops down to raw DuckDB
+SQL via the duckdb python API and compares the SQL result to the
+pandas reference.
 
-The pattern:
-
-    1. Hypothesis strategy generates a valid input frame.
-    2. Run the operation through every available engine.
-    3. Convert each engine's output back to pandas (the canonical
-       reference) and assert equivalence under documented tolerances.
-
-Engines whose deps aren't installed are skipped per-test via
-``pytest.importorskip`` — CI matrices that don't ship DuckDB / Spark
-won't fail; they just exercise fewer backends.
+Phase 2 of #456 will scale this pattern across the operation matrix in
+docs/engines/INVARIANTS.md and replace the raw-SQL probe with a proper
+DuckDBEngine SQL path once that exists.
 """
 
 from __future__ import annotations
@@ -29,85 +24,30 @@ from hypothesis import HealthCheck, given, settings  # noqa: E402
 from hypothesis import strategies as st  # noqa: E402
 
 
-# ---------------------------------------------------------------------------
-# Hypothesis strategies — minimal set for the skeleton
-# ---------------------------------------------------------------------------
-
-# Small range so the test runs fast and Hypothesis can shrink effectively.
 _SAFE_INTS = st.integers(min_value=-1000, max_value=1000)
-_SAFE_FLOATS = st.floats(
-    min_value=-1e6, max_value=1e6, allow_nan=False, allow_infinity=False,
-)
 
 
 @st.composite
 def simple_int_frame(draw, max_rows: int = 50):
-    """Generate a small DataFrame with two int columns named ``group`` and ``value``.
-
-    Group keys are bounded so the property tests actually exercise
-    multi-row groups rather than degenerating into one-row-per-group.
-    """
     n = draw(st.integers(min_value=0, max_value=max_rows))
     groups = draw(st.lists(st.integers(min_value=0, max_value=5), min_size=n, max_size=n))
     values = draw(st.lists(_SAFE_INTS, min_size=n, max_size=n))
     return pd.DataFrame({"group": groups, "value": values})
 
 
-# ---------------------------------------------------------------------------
-# Engine probes — return None if the engine isn't available
-# ---------------------------------------------------------------------------
-
 def _pandas_engine():
     from siege_utilities.engines.dataframe_engine import PandasEngine
     return PandasEngine()
 
 
-def _duckdb_engine():
-    """Construct DuckDBEngine or return None if DuckDB isn't installed."""
-    try:
-        from siege_utilities.engines.dataframe_engine import DuckDBEngine
-        return DuckDBEngine()
-    except ImportError:
-        return None
-
-
-# Spark + PostGIS are heavier to spin up. Phase 2 will add probes that
-# share a single fixture-scoped session; for the skeleton we exercise
-# pandas + DuckDB which run reliably in CI without external services.
-
-_AVAILABLE_ENGINES = [
-    ("pandas", _pandas_engine),
-    ("duckdb", _duckdb_engine),
-]
-
-
-# ---------------------------------------------------------------------------
-# Invariant 1: empty input → empty output, schema preserved
-# ---------------------------------------------------------------------------
-
-@pytest.mark.parametrize("engine_name,engine_factory", _AVAILABLE_ENGINES)
-def test_groupby_agg_empty_input_returns_empty(engine_name, engine_factory):
-    """INVARIANTS.md Universal #1: empty input → empty output, never raise."""
-    engine = engine_factory()
-    if engine is None:
-        pytest.skip(f"{engine_name} engine not available")
-
+def test_pandas_groupby_sum_empty_input_returns_empty():
+    engine = _pandas_engine()
     empty = pd.DataFrame({"group": [], "value": []}).astype(
         {"group": "int64", "value": "int64"}
     )
     result = engine.groupby_agg(empty, group_cols=["group"], agg_dict={"value": "sum"})
-
-    # Convert back to pandas — engines that return a native handle (e.g.
-    # DuckDBPyRelation) materialize via to_pandas in Phase 2 strategies.
-    if not isinstance(result, pd.DataFrame):
-        result = result.to_pandas() if hasattr(result, "to_pandas") else pd.DataFrame(result)
-
     assert len(result) == 0
 
-
-# ---------------------------------------------------------------------------
-# Invariant 2: groupby_agg sum is set-equal across engines (sort-tolerant)
-# ---------------------------------------------------------------------------
 
 @given(df=simple_int_frame())
 @settings(
@@ -115,31 +55,36 @@ def test_groupby_agg_empty_input_returns_empty(engine_name, engine_factory):
     deadline=None,
     suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
 )
-def test_groupby_sum_agrees_across_engines(df):
-    """INVARIANTS.md groupby_agg: sum is identical (as a set of rows)
-    across every available backend. Phase 2 will broaden this to all
-    agg names and add float / NaN / count variants."""
-    expected_engine = _pandas_engine()
-    expected = expected_engine.groupby_agg(
+def test_pandas_engine_agrees_with_raw_duckdb_sql(df):
+    """PandasEngine.groupby_agg sum agrees with the same query
+    executed through raw DuckDB SQL on the identical input.
+
+    This is the only place in the property suite that currently
+    crosses a real engine boundary; phase 2 will broaden it.
+    """
+    duckdb = pytest.importorskip("duckdb")
+
+    pandas_result = _pandas_engine().groupby_agg(
         df, group_cols=["group"], agg_dict={"value": "sum"},
     )
-    expected_set = frozenset(
-        (int(r.group), int(r.value)) for r in expected.itertuples()
+    pandas_set = frozenset(
+        (int(r.group), int(r.value)) for r in pandas_result.itertuples()
     )
 
-    for engine_name, factory in _AVAILABLE_ENGINES:
-        if engine_name == "pandas":
-            continue
-        engine = factory()
-        if engine is None:
-            continue
-        got = engine.groupby_agg(df, group_cols=["group"], agg_dict={"value": "sum"})
-        if not isinstance(got, pd.DataFrame):
-            got = got.to_pandas() if hasattr(got, "to_pandas") else pd.DataFrame(got)
-        got_set = frozenset(
-            (int(r.group), int(r.value)) for r in got.itertuples()
-        )
-        assert got_set == expected_set, (
-            f"{engine_name} disagrees with pandas: "
-            f"{got_set - expected_set} extra, {expected_set - got_set} missing"
-        )
+    con = duckdb.connect(":memory:")
+    try:
+        con.register("input_df", df)
+        sql_result = con.sql(
+            "SELECT \"group\", SUM(value) AS value FROM input_df GROUP BY \"group\""
+        ).to_df()
+    finally:
+        con.close()
+
+    sql_set = frozenset(
+        (int(r.group), int(r.value)) for r in sql_result.itertuples()
+    )
+
+    assert pandas_set == sql_set, (
+        f"Pandas engine and DuckDB SQL disagree: "
+        f"pandas-only={pandas_set - sql_set}, sql-only={sql_set - pandas_set}"
+    )

--- a/tests/test_datadotworld_connector.py
+++ b/tests/test_datadotworld_connector.py
@@ -46,15 +46,16 @@ def test_init_falls_back_to_env_var(monkeypatch, _patch_dw):
     _patch_dw.api_client.assert_called_once_with("from-env")
 
 
-def test_init_anonymous_when_no_token_and_no_env(monkeypatch, _patch_dw):
+def test_init_anonymous_when_no_token_and_no_env(monkeypatch, caplog, _patch_dw):
+    from siege_utilities.analytics.datadotworld_connector import DataDotWorldConnector
+
     monkeypatch.delenv("DATADOTWORLD_API_TOKEN", raising=False)
-    DataDotWorldConnector_local = __import__(
-        "siege_utilities.analytics.datadotworld_connector",
-        fromlist=["DataDotWorldConnector"],
-    ).DataDotWorldConnector
-    DataDotWorldConnector_local()
-    # api_client called with no args = anonymous
+    with caplog.at_level("WARNING", logger="siege_utilities.analytics.datadotworld_connector"):
+        DataDotWorldConnector()
     _patch_dw.api_client.assert_called_once_with()
+    assert any("anonymous" in r.message.lower() for r in caplog.records), (
+        "expected anonymous-access warning to be logged"
+    )
 
 
 def test_load_config_overrides_constructor_token(tmp_path, _patch_dw):

--- a/tests/test_facebook_business_connector.py
+++ b/tests/test_facebook_business_connector.py
@@ -1,7 +1,7 @@
 """Tests for siege_utilities.analytics.facebook_business.
 
-Phase-1 mock tests pin init / auth-init / error translation paths;
-Phase-2 live smoke test exercises a real ``get_ad_accounts`` call
+Mock tests pin init / auth-init / error translation. The
+``requires_api_key`` smoke test hits the live Facebook Business API
 when ``~/.siege-test-credentials.yaml`` has a ``facebook_business``
 section.
 """

--- a/tests/test_google_analytics_connector.py
+++ b/tests/test_google_analytics_connector.py
@@ -258,7 +258,7 @@ class TestGA4ResponseParsing:
 
 
 # ---------------------------------------------------------------------------
-# Sprint B Phase-2 live-API smoke (skipped without credentials)
+# Live-API smoke (skipped without credentials)
 # ---------------------------------------------------------------------------
 
 import pytest

--- a/tests/test_nces_service_bulk_update_timestamp.py
+++ b/tests/test_nces_service_bulk_update_timestamp.py
@@ -1,0 +1,95 @@
+"""Regression test for the bulk_update timestamp fix.
+
+Django's auto_now=True does not fire under bulk_update. The
+NCESPopulationService methods now set ``updated_at`` explicitly and
+include it in the bulk_update field list; this test verifies the
+existing-row path actually advances ``updated_at``.
+
+Requires PostGIS test DB; skips when GDAL is absent.
+"""
+
+from datetime import datetime, timedelta, timezone as dt_timezone
+from unittest.mock import patch
+
+import pytest
+
+try:
+    from django.contrib.gis.geos import MultiPolygon, Polygon
+
+    HAS_GDAL = True
+except Exception:
+    HAS_GDAL = False
+
+pytestmark = [
+    pytest.mark.django_db,
+    pytest.mark.requires_gdal,
+    pytest.mark.skipif(not HAS_GDAL, reason="GDAL/PostGIS not available"),
+]
+
+
+def _make_polygon():
+    return MultiPolygon(Polygon(((0, 0), (1, 0), (1, 1), (0, 1), (0, 0))))
+
+
+def test_populate_locale_boundaries_advances_updated_at_on_update(db):
+    """If a NCESLocaleBoundary already exists for (locale_code, year),
+    re-running populate with update_existing=True must bump
+    ``updated_at`` to reflect the rewrite. bulk_update bypasses
+    auto_now=True, so the service has to set it explicitly. If anyone
+    removes that explicit assignment, this test goes red."""
+    import geopandas as gpd
+
+    from siege_utilities.geo.django.models import NCESLocaleBoundary
+    from siege_utilities.geo.django.services.nces_service import (
+        NCESPopulationService,
+    )
+
+    year = 2099
+    stale_time = datetime(2020, 1, 1, tzinfo=dt_timezone.utc)
+
+    existing = NCESLocaleBoundary.objects.create(
+        feature_id=f"nces_locale_11_{year}",
+        locale_code=11,
+        locale_category="city_old",
+        locale_subcategory="city_large_old",
+        nces_year=year,
+        vintage_year=year,
+        name="Old Name",
+        geometry=_make_polygon(),
+        source="NCES EDGE",
+    )
+    NCESLocaleBoundary.objects.filter(pk=existing.pk).update(
+        updated_at=stale_time,
+    )
+    existing.refresh_from_db()
+    assert existing.updated_at == stale_time
+
+    gdf = gpd.GeoDataFrame(
+        {
+            "locale_code": [11],
+            "locale_category": ["city"],
+            "locale_subcategory": ["city_large"],
+            "name": ["New Name"],
+        },
+        geometry=[_make_polygon()],
+        crs="EPSG:4326",
+    )
+
+    service = NCESPopulationService()
+    with patch.object(service, "_get_downloader") as mock_get:
+        mock_get.return_value.download_locale_boundaries.return_value = gdf
+        result = service.populate_locale_boundaries(
+            year=year, update_existing=True,
+        )
+
+    assert result.records_updated == 1
+    existing.refresh_from_db()
+    assert existing.updated_at > stale_time, (
+        "bulk_update did not advance updated_at; "
+        "auto_now=True does not fire under bulk_update and the service "
+        "must set the field explicitly."
+    )
+    assert existing.updated_at > datetime.now(dt_timezone.utc) - timedelta(
+        minutes=5,
+    )
+    assert existing.name == "New Name"

--- a/tests/test_snowflake_connector.py
+++ b/tests/test_snowflake_connector.py
@@ -1,9 +1,9 @@
 """Tests for siege_utilities.analytics.snowflake_connector.
 
-Phase-1 mock tests (no creds required) pin the connector's public
-behavior against the canonical snowflake.connector API; Phase-2 marks
-a real connect/disconnect smoke run that's skipped unless
-~/.siege-test-credentials.yaml has a ``snowflake:`` section.
+Mock tests run on every CI build. The ``requires_api_key``-marked
+smoke test at the bottom hits Snowflake for real and is skipped
+unless ``~/.siege-test-credentials.yaml`` has a ``snowflake:``
+section.
 """
 
 from __future__ import annotations
@@ -112,9 +112,8 @@ def test_execute_query_returns_none_on_driver_error(_patch_snowflake):
 
 
 def test_upload_dataframe_validates_table_identifier(_patch_snowflake):
-    """SQL-injection guardrail: bad identifiers must fail before any
-    cursor.execute or write_pandas call — the v3.15.0 hardening landed
-    siege_utilities.core.sql_safety.validate_sql_identifier on this path."""
+    """Bad identifiers must fail before any cursor.execute or
+    write_pandas call. validate_sql_identifier guards this path."""
     pd = pytest.importorskip("pandas")
     from siege_utilities.analytics.snowflake_connector import SnowflakeConnector
 


### PR DESCRIPTION
## Summary

Self-review caught several real problems in PRs #459, #461, #462, #463. Fixing them in one shot rather than splitting across four small PRs.

### Critical

- **bulk_update timestamp regression in `nces_service`.** Switching to `bulk_update` bypasses Django's `auto_now=True` on `updated_at` (inherited from `TemporalBoundary` at `base.py:73`). All three call sites now set `updated_at = timezone.now()` explicitly and include it in the `bulk_update` field list. Without this fix, populate runs would silently leave `updated_at` stale on existing rows.

- **Cross-engine property test was fraudulent.** The skeleton compared `PandasEngine` to `DuckDBEngine`, but `DuckDBEngine.groupby_agg` passes pandas DataFrames straight to pandas (`dataframe_engine.py:723-730`). The test could never detect a divergence because both branches ran identical code. Replaced with a comparison against raw `duckdb.connect(":memory:")` SQL — that actually crosses an engine boundary.

### Major

- **`existing_by_*` dict keys**: now `(locale_code, nces_year)` and `(ncessch, vintage_year)` rather than single-column. Year is fixed inside the function today so the bug was latent, but the explicit key documents the invariant.

- **Perf "regression tests" → correctness tests**: the iterrows benchmarks omitted `escape_string_literal` (the actual hot call) and the 2× timing assertion was flaky. Reframed as byte-equality checks between the vectorised and iterrows paths.

- **datadotworld anonymous-init test now asserts the warning is logged** via `caplog`, not just that `api_client()` was called.

### Minor

- `INVARIANTS.md` identifier-validation universal was aspirational, not current; relabelled.
- Stripped Sprint/Phase/PR meta-narration from doc body, section headers, test docstrings.

## Test plan

- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured consistent timestamp updates during bulk data operations in population and enrichment services.
  * Enhanced validation for connector initialization in anonymous mode.

* **Tests**
  * Refactored regression tests to verify output correctness instead of performance metrics.
  * Restructured cross-backend invariant tests with simplified validation approach.
  * Updated connector test coverage documentation.

* **Documentation**
  * Clarified engine invariant documentation for property testing and cross-backend behavior.
  * Updated test docstrings and comments for accuracy.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siege-analytics/siege_utilities/pull/464)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->