### PR TITLE
task: Sprint E Phase 2 -- cross-engine property tests for filter / join / to_geodataframe (refs #456)

### DIFF
--- a/tests/property/test_filter_invariants.py
+++ b/tests/property/test_filter_invariants.py
@@ -1,0 +1,89 @@
+"""Cross-engine property tests for DataFrameEngine.filter.
+
+Currently exercises PandasEngine against raw DuckDB SQL since
+DuckDBEngine.filter passes pandas DataFrames straight through to
+pandas. SparkEngine / PostGISEngine probes belong in a Spark-marked
+follow-up because they need fixture-scoped session setup.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+hypothesis = pytest.importorskip("hypothesis")
+
+from hypothesis import HealthCheck, given, settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+
+@st.composite
+def filterable_frame(draw, max_rows: int = 40):
+    n = draw(st.integers(min_value=0, max_value=max_rows))
+    group = draw(st.lists(st.integers(min_value=0, max_value=4), min_size=n, max_size=n))
+    value = draw(st.lists(st.integers(min_value=-50, max_value=50), min_size=n, max_size=n))
+    return pd.DataFrame({"group": group, "value": value})
+
+
+def _pandas_engine():
+    from siege_utilities.engines.dataframe_engine import PandasEngine
+    return PandasEngine()
+
+
+def _duckdb_filter_sql(df, sql_predicate: str) -> "pd.DataFrame":
+    duckdb = pytest.importorskip("duckdb")
+    con = duckdb.connect(":memory:")
+    try:
+        con.register("input_df", df)
+        return con.sql(
+            f"SELECT * FROM input_df WHERE {sql_predicate}"
+        ).to_df()
+    finally:
+        con.close()
+
+
+def _rows_as_counter(df) -> Counter:
+    return Counter((int(r.group), int(r.value)) for r in df.itertuples())
+
+
+def test_filter_empty_input_returns_empty_with_schema():
+    empty = pd.DataFrame({"group": [], "value": []}).astype(
+        {"group": "int64", "value": "int64"}
+    )
+    result = _pandas_engine().filter(empty, empty["value"] > 0)
+    assert len(result) == 0
+    assert list(result.columns) == ["group", "value"]
+
+
+@given(df=filterable_frame())
+@settings(
+    max_examples=25,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_filter_value_gt_zero_agrees_with_duckdb(df):
+    pandas_result = _pandas_engine().filter(df, df["value"] > 0)
+    sql_result = _duckdb_filter_sql(df, "value > 0")
+    assert _rows_as_counter(pandas_result) == _rows_as_counter(sql_result)
+
+
+@given(df=filterable_frame())
+@settings(
+    max_examples=25,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_filter_group_eq_zero_agrees_with_duckdb(df):
+    pandas_result = _pandas_engine().filter(df, df["group"] == 0)
+    sql_result = _duckdb_filter_sql(df, "\"group\" = 0")
+    assert _rows_as_counter(pandas_result) == _rows_as_counter(sql_result)
+
+
+def test_filter_resets_index():
+    """The PandasEngine docs imply ordered, contiguous integer index
+    on output (`.reset_index(drop=True)` in the impl). Pin it."""
+    df = pd.DataFrame({"group": [0, 1, 2, 3, 4], "value": [10, 20, 30, 40, 50]})
+    result = _pandas_engine().filter(df, df["value"] > 25)
+    assert list(result.index) == list(range(len(result)))

--- a/tests/property/test_grid_invariants.py
+++ b/tests/property/test_grid_invariants.py
@@ -1,0 +1,108 @@
+"""Determinism property tests for index_points / index_polygon.
+
+INVARIANTS.md says index_points is deterministic across backends:
+one cell ID per row, same value for the same (lat, lon, grid,
+resolution) tuple. index_polygon may produce zero / one / many cell
+IDs per row, but the cell set for a given polygon at a given
+resolution must be deterministic.
+
+These tests don't compare engine to engine yet -- the
+DataFrameEngine.index_points implementation round-trips through
+pandas, so single-engine determinism is what's pinned. Engine
+divergence comes in Phase 3 once SparkEngine has a native override.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+hypothesis = pytest.importorskip("hypothesis")
+
+from hypothesis import HealthCheck, given, settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+
+_LAT = st.floats(min_value=-85.0, max_value=85.0, allow_nan=False, allow_infinity=False)
+_LON = st.floats(min_value=-180.0, max_value=180.0, allow_nan=False, allow_infinity=False)
+
+
+@st.composite
+def points_frame(draw, max_rows: int = 30):
+    n = draw(st.integers(min_value=1, max_value=max_rows))
+    lats = draw(st.lists(_LAT, min_size=n, max_size=n))
+    lons = draw(st.lists(_LON, min_size=n, max_size=n))
+    return pd.DataFrame({"lat": lats, "lon": lons})
+
+
+@given(df=points_frame())
+@settings(
+    max_examples=15,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_h3_index_points_deterministic(df):
+    pytest.importorskip("h3")
+    from siege_utilities.geo.grids import index_points
+
+    first = index_points(df, "lat", "lon", resolution=8)
+    second = index_points(df, "lat", "lon", resolution=8)
+    assert list(first) == list(second), (
+        "h3 index_points must be deterministic for the same (lat,lon,resolution)"
+    )
+
+
+@given(df=points_frame())
+@settings(
+    max_examples=15,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_s2_index_points_deterministic(df):
+    pytest.importorskip("s2sphere")
+    from siege_utilities.geo.grids import index_points
+
+    first = index_points(df, "lat", "lon", level=12)
+    second = index_points(df, "lat", "lon", level=12)
+    assert list(first) == list(second), (
+        "s2 index_points must be deterministic for the same (lat,lon,level)"
+    )
+
+
+def test_h3_index_points_one_cell_per_row():
+    pytest.importorskip("h3")
+    from siege_utilities.geo.grids import index_points
+
+    df = pd.DataFrame({
+        "lat": [37.7749, 40.7128, 51.5074],
+        "lon": [-122.4194, -74.0060, -0.1278],
+    })
+    result = index_points(df, "lat", "lon", resolution=8)
+    assert len(result) == len(df), "exactly one cell ID per row"
+    assert result.notna().all(), "no row maps to no cell"
+
+
+def test_h3_resolution_changes_cell_id():
+    """Different resolutions produce different cell IDs for the same
+    point. Pin the property the docs imply when they say resolution
+    is part of the (point, grid, resolution) key."""
+    pytest.importorskip("h3")
+    from siege_utilities.geo.grids import index_points
+
+    df = pd.DataFrame({"lat": [37.7749], "lon": [-122.4194]})
+    res_6 = index_points(df, "lat", "lon", resolution=6)
+    res_9 = index_points(df, "lat", "lon", resolution=9)
+    assert res_6.iloc[0] != res_9.iloc[0]
+
+
+def test_index_polygon_is_deterministic():
+    pytest.importorskip("h3")
+    shapely = pytest.importorskip("shapely.geometry")
+    from siege_utilities.geo.grids import index_polygon
+
+    # A 1-degree square; covers a stable cell set at any given resolution.
+    poly = shapely.Polygon([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)])
+    first = list(index_polygon(poly, grid="h3", resolution=6))
+    second = list(index_polygon(poly, grid="h3", resolution=6))
+    assert first == second
+    assert len(first) > 0, "a 1-deg square at h3 res 6 must cover at least one cell"

--- a/tests/property/test_join_invariants.py
+++ b/tests/property/test_join_invariants.py
@@ -1,0 +1,107 @@
+"""Cross-engine property tests for DataFrameEngine.join.
+
+Exercises all four `how` values (inner / left / right / outer)
+against raw DuckDB SQL with the same JOIN semantics. Sort order is
+not asserted; multiset comparison via Counter.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+hypothesis = pytest.importorskip("hypothesis")
+
+from hypothesis import HealthCheck, given, settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+
+@st.composite
+def joinable_frames(draw, max_rows: int = 20):
+    """Build a left/right pair sharing a `key` column."""
+    left_n = draw(st.integers(min_value=0, max_value=max_rows))
+    right_n = draw(st.integers(min_value=0, max_value=max_rows))
+    left_keys = draw(st.lists(st.integers(min_value=0, max_value=8), min_size=left_n, max_size=left_n))
+    right_keys = draw(st.lists(st.integers(min_value=0, max_value=8), min_size=right_n, max_size=right_n))
+    left_vals = draw(st.lists(st.integers(min_value=-30, max_value=30), min_size=left_n, max_size=left_n))
+    right_vals = draw(st.lists(st.integers(min_value=-30, max_value=30), min_size=right_n, max_size=right_n))
+    left = pd.DataFrame({"key": left_keys, "left_value": left_vals})
+    right = pd.DataFrame({"key": right_keys, "right_value": right_vals})
+    return left, right
+
+
+def _pandas_engine():
+    from siege_utilities.engines.dataframe_engine import PandasEngine
+    return PandasEngine()
+
+
+def _duckdb_join(left, right, how: str) -> "pd.DataFrame":
+    duckdb = pytest.importorskip("duckdb")
+    sql_join = {
+        "inner": "INNER JOIN",
+        "left": "LEFT JOIN",
+        "right": "RIGHT JOIN",
+        "outer": "FULL OUTER JOIN",
+    }[how]
+    con = duckdb.connect(":memory:")
+    try:
+        con.register("L", left)
+        con.register("R", right)
+        # Use COALESCE on the join key to mirror pandas' behaviour: when
+        # the key is absent on a side (left/right/outer), pandas keeps
+        # it as the value from the present side. SQL's natural USING
+        # gives the same result via the consolidated key.
+        return con.sql(
+            f"SELECT COALESCE(L.key, R.key) AS key, "
+            f"L.left_value AS left_value, "
+            f"R.right_value AS right_value "
+            f"FROM L {sql_join} R ON L.key = R.key"
+        ).to_df()
+    finally:
+        con.close()
+
+
+def _rows_as_counter(df) -> Counter:
+    def _cell(v):
+        if pd.isna(v):
+            return None
+        return int(v) if isinstance(v, (int, float)) and not isinstance(v, bool) else v
+    return Counter(
+        (_cell(r.key), _cell(r.left_value), _cell(r.right_value))
+        for r in df.itertuples()
+    )
+
+
+@pytest.mark.parametrize("how", ["inner", "left", "right", "outer"])
+def test_join_empty_inputs_return_empty(how):
+    empty_left = pd.DataFrame({"key": [], "left_value": []}).astype(
+        {"key": "int64", "left_value": "int64"}
+    )
+    empty_right = pd.DataFrame({"key": [], "right_value": []}).astype(
+        {"key": "int64", "right_value": "int64"}
+    )
+    result = _pandas_engine().join(empty_left, empty_right, on="key", how=how)
+    assert len(result) == 0
+    assert set(result.columns) == {"key", "left_value", "right_value"}
+
+
+@pytest.mark.parametrize("how", ["inner", "left", "right", "outer"])
+@given(frames=joinable_frames())
+@settings(
+    max_examples=15,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_join_agrees_with_duckdb(how, frames):
+    """For each how value, pandas merge and DuckDB JOIN produce the
+    same multiset of rows."""
+    left, right = frames
+    pandas_result = _pandas_engine().join(left, right, on="key", how=how)
+    sql_result = _duckdb_join(left, right, how)
+    assert _rows_as_counter(pandas_result) == _rows_as_counter(sql_result), (
+        f"how={how} pandas != duckdb:\n"
+        f"  left=\n{left}\n  right=\n{right}\n"
+        f"  pandas=\n{pandas_result}\n  duckdb=\n{sql_result}"
+    )

--- a/tests/property/test_read_invariants.py
+++ b/tests/property/test_read_invariants.py
@@ -1,0 +1,113 @@
+"""Round-trip property tests for read_csv / read_parquet.
+
+INVARIANTS.md says read_parquet has no tolerance (parquet is
+self-describing; divergences are bugs). read_csv has documented
+tolerance for numeric dtype inference but the column set and row
+contents must round-trip identically.
+
+These tests write a Hypothesis-generated frame to disk via pandas,
+read it back via each engine, and assert equivalence after a
+to_pandas() normalisation.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+hypothesis = pytest.importorskip("hypothesis")
+
+from hypothesis import HealthCheck, given, settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+
+@st.composite
+def simple_frame(draw, max_rows: int = 20):
+    n = draw(st.integers(min_value=0, max_value=max_rows))
+    ids = draw(st.lists(st.integers(min_value=0, max_value=1000), min_size=n, max_size=n))
+    values = draw(st.lists(
+        st.floats(min_value=-1e6, max_value=1e6, allow_nan=False, allow_infinity=False),
+        min_size=n, max_size=n,
+    ))
+    return pd.DataFrame({"id": ids, "value": values})
+
+
+def _pandas_engine():
+    from siege_utilities.engines.dataframe_engine import PandasEngine
+    return PandasEngine()
+
+
+def _duckdb_engine_or_skip():
+    try:
+        from siege_utilities.engines.dataframe_engine import DuckDBEngine
+        return DuckDBEngine()
+    except ImportError:
+        pytest.skip("DuckDB not installed")
+
+
+def _rows_as_counter(df) -> Counter:
+    return Counter(
+        (int(r.id), round(float(r.value), 6)) for r in df.itertuples()
+    )
+
+
+@given(df=simple_frame())
+@settings(
+    max_examples=15,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_read_csv_pandas_round_trip(df, tmp_path):
+    path = tmp_path / "rt.csv"
+    df.to_csv(path, index=False)
+
+    pandas_back = _pandas_engine().read_csv(str(path))
+    assert _rows_as_counter(pandas_back) == _rows_as_counter(df)
+
+
+@given(df=simple_frame())
+@settings(
+    max_examples=15,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_read_parquet_pandas_round_trip(df, tmp_path):
+    pytest.importorskip("pyarrow")
+    path = tmp_path / "rt.parquet"
+    df.to_parquet(path, index=False)
+
+    pandas_back = _pandas_engine().read_parquet(str(path))
+    assert _rows_as_counter(pandas_back) == _rows_as_counter(df)
+
+
+@given(df=simple_frame())
+@settings(
+    max_examples=15,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_read_csv_pandas_and_duckdb_agree(df, tmp_path):
+    """The two engines must read the same CSV to the same row set
+    after a to_pandas() normalisation. Sort order is not asserted."""
+    path = tmp_path / "rt.csv"
+    df.to_csv(path, index=False)
+
+    pandas_engine = _pandas_engine()
+    duckdb_engine = _duckdb_engine_or_skip()
+
+    pandas_back = pandas_engine.read_csv(str(path))
+    duckdb_back = duckdb_engine.to_pandas(duckdb_engine.read_csv(str(path)))
+    assert _rows_as_counter(pandas_back) == _rows_as_counter(duckdb_back)
+
+
+def test_read_csv_empty_file_returns_empty_frame(tmp_path):
+    """A CSV with only a header must read back as a zero-row frame
+    with the right column set, not raise."""
+    path = tmp_path / "empty.csv"
+    path.write_text("id,value\n")
+
+    pandas_back = _pandas_engine().read_csv(str(path))
+    assert len(pandas_back) == 0
+    assert list(pandas_back.columns) == ["id", "value"]

--- a/tests/property/test_spatial_join_invariants.py
+++ b/tests/property/test_spatial_join_invariants.py
@@ -1,0 +1,92 @@
+"""Property tests for DataFrameEngine.spatial_join.
+
+INVARIANTS.md spatial_join section: predicates intersects / contains /
+within, output keyed by (left_idx, right_idx). The Pandas/Sedona
+divergence (auto-reproject vs. silent empty on mismatched SRIDs) is
+the canonical bug surface but cannot be pinned without Spark; covered
+here for PandasEngine only. Spark side belongs in Phase 3.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+gpd = pytest.importorskip("geopandas")
+shapely = pytest.importorskip("shapely.geometry")
+
+
+def _pandas_engine():
+    from siege_utilities.engines.dataframe_engine import PandasEngine
+    return PandasEngine()
+
+
+@pytest.fixture
+def overlapping_squares():
+    left = gpd.GeoDataFrame(
+        {"lid": [1, 2]},
+        geometry=[
+            shapely.Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]),
+            shapely.Polygon([(10, 10), (12, 10), (12, 12), (10, 12)]),
+        ],
+        crs="EPSG:4326",
+    )
+    right = gpd.GeoDataFrame(
+        {"rid": [10, 20]},
+        geometry=[
+            shapely.Polygon([(1, 1), (3, 1), (3, 3), (1, 3)]),  # overlaps left[0]
+            shapely.Polygon([(100, 100), (101, 100), (101, 101), (100, 101)]),  # disjoint
+        ],
+        crs="EPSG:4326",
+    )
+    return left, right
+
+
+def test_spatial_join_intersects_picks_overlap(overlapping_squares):
+    left, right = overlapping_squares
+    result = _pandas_engine().spatial_join(left, right, predicate="intersects")
+    # left[0] intersects right[0]; left[1] intersects nothing
+    assert len(result) == 1
+    assert result["lid"].iloc[0] == 1
+    assert result["rid"].iloc[0] == 10
+
+
+def test_spatial_join_empty_left_returns_empty(overlapping_squares):
+    _, right = overlapping_squares
+    empty_left = gpd.GeoDataFrame(
+        {"lid": []}, geometry=[], crs="EPSG:4326",
+    )
+    result = _pandas_engine().spatial_join(empty_left, right, predicate="intersects")
+    assert len(result) == 0
+
+
+def test_spatial_join_within_predicate():
+    inner = gpd.GeoDataFrame(
+        {"iid": [1]},
+        geometry=[shapely.Polygon([(1, 1), (2, 1), (2, 2), (1, 2)])],
+        crs="EPSG:4326",
+    )
+    outer = gpd.GeoDataFrame(
+        {"oid": [10]},
+        geometry=[shapely.Polygon([(0, 0), (5, 0), (5, 5), (0, 5)])],
+        crs="EPSG:4326",
+    )
+    result = _pandas_engine().spatial_join(inner, outer, predicate="within")
+    assert len(result) == 1
+    assert result["iid"].iloc[0] == 1
+    assert result["oid"].iloc[0] == 10
+
+
+def test_spatial_join_disjoint_geometries_produce_no_rows():
+    a = gpd.GeoDataFrame(
+        {"aid": [1]},
+        geometry=[shapely.Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])],
+        crs="EPSG:4326",
+    )
+    b = gpd.GeoDataFrame(
+        {"bid": [10]},
+        geometry=[shapely.Polygon([(10, 10), (11, 10), (11, 11), (10, 11)])],
+        crs="EPSG:4326",
+    )
+    result = _pandas_engine().spatial_join(a, b, predicate="intersects")
+    assert len(result) == 0

--- a/tests/property/test_to_geodataframe_invariants.py
+++ b/tests/property/test_to_geodataframe_invariants.py
@@ -32,9 +32,12 @@ def _duckdb_engine_or_skip():
 
 
 def _postgis_engine_or_skip():
+    """to_geodataframe is pure-pandas and never touches the connection,
+    so a placeholder DSN is fine. PostGISEngine requires a
+    connection_string at construct time though."""
     try:
         from siege_utilities.engines.dataframe_engine import PostGISEngine
-        return PostGISEngine()
+        return PostGISEngine("postgresql://placeholder@invalid:5432/none")
     except ImportError:
         pytest.skip("psycopg2 / SQLAlchemy not installed")
 

--- a/tests/property/test_to_geodataframe_invariants.py
+++ b/tests/property/test_to_geodataframe_invariants.py
@@ -1,0 +1,68 @@
+"""Cross-engine tests for the to_geodataframe error contract.
+
+INVARIANTS.md says every engine must raise `ValueError` when the
+geometry column is missing. Pin this on every engine whose constructor
+works without external dependencies (PandasEngine, DuckDBEngine,
+PostGISEngine; SparkEngine deferred because it requires a session).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+
+@pytest.fixture
+def df_without_geometry():
+    return pd.DataFrame({"id": [1, 2, 3], "name": ["a", "b", "c"]})
+
+
+def _pandas_engine():
+    from siege_utilities.engines.dataframe_engine import PandasEngine
+    return PandasEngine()
+
+
+def _duckdb_engine_or_skip():
+    try:
+        from siege_utilities.engines.dataframe_engine import DuckDBEngine
+        return DuckDBEngine()
+    except ImportError:
+        pytest.skip("DuckDB not installed")
+
+
+def _postgis_engine_or_skip():
+    try:
+        from siege_utilities.engines.dataframe_engine import PostGISEngine
+        return PostGISEngine()
+    except ImportError:
+        pytest.skip("psycopg2 / SQLAlchemy not installed")
+
+
+def test_pandas_to_geodataframe_missing_column_raises_value_error(df_without_geometry):
+    pytest.importorskip("geopandas")
+    with pytest.raises(ValueError, match="geometry"):
+        _pandas_engine().to_geodataframe(df_without_geometry, geometry_col="geometry")
+
+
+def test_duckdb_to_geodataframe_missing_column_raises_value_error(df_without_geometry):
+    pytest.importorskip("geopandas")
+    engine = _duckdb_engine_or_skip()
+    with pytest.raises(ValueError, match="geometry"):
+        engine.to_geodataframe(df_without_geometry, geometry_col="geometry")
+
+
+def test_postgis_to_geodataframe_missing_column_raises_value_error(df_without_geometry):
+    pytest.importorskip("geopandas")
+    engine = _postgis_engine_or_skip()
+    with pytest.raises(ValueError, match="geometry"):
+        engine.to_geodataframe(df_without_geometry, geometry_col="geometry")
+
+
+def test_pandas_to_geodataframe_custom_column_name_in_message(df_without_geometry):
+    """The custom column name appears in the error message verbatim
+    so users can find the typo quickly. The current message format is
+    `Cannot construct GeoDataFrame: column 'X' not found`."""
+    pytest.importorskip("geopandas")
+    with pytest.raises(ValueError, match="'geom_typo' not found"):
+        _pandas_engine().to_geodataframe(df_without_geometry, geometry_col="geom_typo")


### PR DESCRIPTION
## Summary

Sprint E Phase 2 lands the property-test scaffolding for the operations documented in \`docs/engines/INVARIANTS.md\`. Each test compares PandasEngine output to raw DuckDB SQL with the same semantics, using a Hypothesis-generated frame as input and \`collections.Counter\` for the sort-tolerant multiset comparison the invariants doc requires.

## Coverage

| Operation | What's pinned |
|---|---|
| \`filter\` | empty-input schema preservation, two parametrised predicates against DuckDB, \`reset_index\` output convention |
| \`join\` | all four \`how\` values (inner, left, right, outer) against DuckDB INNER/LEFT/RIGHT/FULL OUTER JOIN, empty input across all four |
| \`to_geodataframe\` | ValueError contract on missing column for PandasEngine, DuckDBEngine, PostGISEngine |

SparkEngine probes are out of scope for this PR -- they need fixture-scoped session setup. Phase 3 will pick them up.

## Phase 3

Filed as #467. As property tests run on real data, divergences across the four engines surface and either get fixed or get baselined as documented intentional deviations.

## Test plan

- [ ] CI green
- [ ] Property tests run cleanly against pandas + DuckDB on every push