### PR TITLE
task: Sprint E Phase 3 increment -- SparkEngine groupby_agg probe + spatial_join doc fix (refs #467)

### DIFF
--- a/docs/engines/INVARIANTS.md
+++ b/docs/engines/INVARIANTS.md
@@ -68,7 +68,7 @@ The granularity is operation-level, not backend-level. If an engine can't meet a
 - **Tolerance:**
   - **Relation semantics modes** (BOUNDED / HALFPLANE / CONTAINS_CENTROID) are an explicit parameter; engines must respect it identically.
   - Sort order is not guaranteed.
-- SparkEngine's spatial_join goes through Sedona; geometry SRIDs must match before the join. Pandas auto-reprojects; Sedona silently returns nothing on mismatched SRIDs. The engine reprojects before the join. Property test should pin this.
+- **Caller-aligned CRS contract.** Both inputs must already be in the same CRS at call time. Engines do not inspect, validate, or reproject the geometry columns. PandasEngine routes through `gpd.sjoin`, which works on whatever the inputs report as CRS; SparkEngine routes through Sedona's `ST_GeomFromText`, which strips SRID at parse time and runs the predicate on raw coordinates. Two frames in different CRSes will produce wrong results, not a clear error. The right place to handle this is upstream of the call: reproject to a shared CRS before calling, or attach an explicit CRS check to whatever surface fronts the engine. A future engine helper that takes a `crs=` kwarg and reprojects can fix this at the boundary; tracked in #467.
 
 ### `to_geodataframe(geometry_column="geometry")`
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,6 +125,36 @@ def api_credentials():
             )
 
 
+@pytest.fixture(scope="session")
+def real_spark_session():
+    """Real SparkSession for cross-engine property tests.
+
+    Skips the requesting test cleanly when pyspark isn't installed.
+    Session-scoped so the JVM startup cost (5-10 seconds) only happens
+    once per pytest run; tests share the session.
+
+    CI does not install pyspark, so this fixture skips there. The
+    user's Zsh builder makes Spark available locally, so Phase 3
+    property tests can be exercised against it.
+    """
+    pytest.importorskip("pyspark")
+    from pyspark.sql import SparkSession
+
+    spark = (
+        SparkSession.builder
+        .appName("siege_utilities_property_tests")
+        .master("local[2]")
+        .config("spark.sql.shuffle.partitions", "2")
+        .config("spark.default.parallelism", "2")
+        .config("spark.driver.memory", "1g")
+        .config("spark.ui.showConsoleProgress", "false")
+        .getOrCreate()
+    )
+    spark.sparkContext.setLogLevel("ERROR")
+    yield spark
+    spark.stop()
+
+
 @pytest.fixture
 def mock_spark_session():
     """Mock Spark session for distributed computing tests."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,11 +133,15 @@ def real_spark_session():
     Session-scoped so the JVM startup cost (5-10 seconds) only happens
     once per pytest run; tests share the session.
 
-    CI does not install pyspark, so this fixture skips there. The
-    user's Zsh builder makes Spark available locally, so Phase 3
-    property tests can be exercised against it.
+    Pins PYSPARK_PYTHON and PYSPARK_DRIVER_PYTHON to the running
+    interpreter so Spark workers don't pick up a different Python off
+    the PATH and fail with PYTHON_VERSION_MISMATCH. This bites pyenv
+    setups where homebrew's python3.14 is first on PATH but the
+    driver runs under pyenv's python3.11.
     """
     pytest.importorskip("pyspark")
+    os.environ.setdefault("PYSPARK_PYTHON", sys.executable)
+    os.environ.setdefault("PYSPARK_DRIVER_PYTHON", sys.executable)
     from pyspark.sql import SparkSession
 
     spark = (

--- a/tests/property/test_engine_invariants_skeleton.py
+++ b/tests/property/test_engine_invariants_skeleton.py
@@ -138,6 +138,56 @@ def test_count_excludes_nan_fixed_case():
     assert group_2_count == 0
 
 
+# ---------------------------------------------------------------------------
+# SparkEngine probes (skip cleanly without pyspark)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("agg", ["sum", "mean", "min", "max", "count"])
+def test_spark_engine_groupby_agg_agrees_with_pandas_fixed(agg, real_spark_session):
+    """Same input through PandasEngine and SparkEngine produces the
+    same multiset of output rows for each documented agg name.
+    Uses a fixed-case frame rather than Hypothesis so the test doesn't
+    repeatedly spin up Spark for each example."""
+    from siege_utilities.engines.dataframe_engine import SparkEngine
+
+    df = pd.DataFrame({
+        "group": [1, 1, 2, 2, 3, 3, 3],
+        "value": [10.0, 20.0, 5.0, 7.0, -1.0, 1.0, 100.0],
+    })
+
+    pandas_result = _pandas_engine().groupby_agg(
+        df, group_cols=["group"], agg_dict={"value": agg},
+    )
+    pandas_rows = _rows_as_counter(pandas_result)
+
+    spark_engine = SparkEngine(spark=real_spark_session)
+    sdf = real_spark_session.createDataFrame(df)
+    spark_result = spark_engine.groupby_agg(
+        sdf, group_cols=["group"], agg_dict={"value": agg},
+    ).toPandas()
+    spark_rows = _rows_as_counter(spark_result)
+
+    assert pandas_rows == spark_rows, (
+        f"agg={agg}: pandas != spark\n"
+        f"  pandas: {pandas_result.to_dict('records')}\n"
+        f"  spark : {spark_result.to_dict('records')}"
+    )
+
+
+def test_spark_engine_groupby_agg_rejects_unknown_name(real_spark_session):
+    """The shared _validate_agg_names invariant: every engine raises
+    ValueError on unknown agg names. Spark side specifically."""
+    from siege_utilities.engines.dataframe_engine import SparkEngine
+
+    spark_engine = SparkEngine(spark=real_spark_session)
+    sdf = real_spark_session.createDataFrame(
+        pd.DataFrame({"g": [1], "v": [1.0]})
+    )
+    with pytest.raises(ValueError, match="unsupported aggregation"):
+        spark_engine.groupby_agg(sdf, group_cols=["g"], agg_dict={"v": "median"})
+
+
 @pytest.mark.parametrize("agg", ["sum", "mean", "min", "max", "count"])
 @given(df=int_value_frame())
 @settings(


### PR DESCRIPTION
## Summary

First Phase 3 increment of Sprint E. Lands the Spark side of the property tests for operations that are on main today (groupby_agg from Phase 1, merged in v3.16.0). Filter / join / to_geodataframe / read / grid / spatial_join Spark probes will stack on top of #468 once that merges.

## What's in

- New session-scoped \`real_spark_session\` fixture in \`tests/conftest.py\`. Builds a local-mode SparkSession lazily; skips cleanly when pyspark isn't installed. CI does not install pyspark (the standard test job ignores it); the Zsh-builder local environment does.
- Two new tests in \`tests/property/test_engine_invariants_skeleton.py\`:
  - \`test_spark_engine_groupby_agg_agrees_with_pandas_fixed\` -- parametrised over sum / mean / min / max / count, fixed 7-row input to avoid paying SparkSession startup per Hypothesis example.
  - \`test_spark_engine_groupby_agg_rejects_unknown_name\` -- pins the shared \`_validate_agg_names\` ValueError on the Spark side.
- INVARIANTS.md spatial_join section rewritten to match what the code actually does. The previous claim that the engine reprojects before the join was aspiration, not current behavior. The honest description: both inputs must share a CRS at call time, engines do not inspect or reproject, callers are responsible. A future engine helper that takes \`crs=\` can fix this at the boundary; tracked in #467.

## Test plan

- [ ] CI green (Spark tests skip cleanly without pyspark)
- [ ] User verifies locally via Zsh-built environment that the Spark probes pass

## Follow-ups still in #467

- Spark probes for filter / join / to_geodataframe / read / spatial_join (stacks on #468)
- PostGIS probes for to_geodataframe (works without external service)
- Optional \`crs=\` kwarg on spatial_join + reprojection at the engine boundary
- read_csv dtype-equivalence claim (Spark LongType vs Pandas Int64) under \`to_pandas()\`
- H3/S2 cross-engine determinism with the ±1 tolerance INVARIANTS.md documents

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified spatial_join requirements: both input GeoDataFrames must already be in the same coordinate reference system (CRS). Engines will not validate, inspect, or reproject mismatched CRSes, and doing so will produce incorrect results rather than an error.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siege-analytics/siege_utilities/pull/469)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->