### PR TITLE
feature: Sprint C -- CensusGazetteer and WikidataGazetteer (closes #454)

### DIFF
--- a/siege_utilities/geo/gazetteers/__init__.py
+++ b/siege_utilities/geo/gazetteers/__init__.py
@@ -73,14 +73,12 @@ def resolve_gazetteer(
     if prefer == "nominatim":
         from .nominatim_gazetteer import NominatimGazetteer
         return NominatimGazetteer(cache_size=cache_size)
-    if prefer in ("census", "wikidata"):
-        raise NotImplementedError(
-            f"{prefer!r} gazetteer backend is queued for ELE-2483 PR-B2 — "
-            "Census uses an address-geocoder + TIGERWeb shape lookup and "
-            "Wikidata is SPARQL + OSM relation deref, both worth a focused "
-            "PR each. For now use prefer='wkls' (global) or "
-            "prefer='nominatim' (OSM)."
-        )
+    if prefer == "census":
+        from .census_gazetteer import CensusGazetteer
+        return CensusGazetteer(cache_size=cache_size)
+    if prefer == "wikidata":
+        from .wikidata_gazetteer import WikidataGazetteer
+        return WikidataGazetteer(cache_size=cache_size)
     if prefer is not None:
         raise ValueError(
             f"prefer must be one of 'wkls', 'nominatim', 'census', "

--- a/siege_utilities/geo/gazetteers/census_gazetteer.py
+++ b/siege_utilities/geo/gazetteers/census_gazetteer.py
@@ -194,10 +194,11 @@ class CensusGazetteer:
             raise GazetteerBackendError(
                 f"Census geocoder returned non-JSON for {name!r}"
             ) from exc
-        matches = (
-            data.get("result", {})
-            .get("addressMatches", [])
-        )
+        # `data.get("result", {})` only substitutes {} when the key is
+        # absent. The Census API also returns {"result": null, ...} on
+        # certain error envelopes; the `or {}` guard handles both.
+        result = data.get("result") or {}
+        matches = result.get("addressMatches") or []
         # Each match has a `geographies` dict keyed by layer name.
         # Counties is the canonical admin level we resolve here; consumers
         # who want state / tract can read raw.geographies themselves.

--- a/siege_utilities/geo/gazetteers/census_gazetteer.py
+++ b/siege_utilities/geo/gazetteers/census_gazetteer.py
@@ -1,0 +1,295 @@
+"""Census Geocoder + TIGERWeb gazetteer.
+
+US-only. Two upstreams chained:
+
+1. Census Geocoder's ``onelineaddress``-style endpoint accepts a place
+   name and returns matching geographies with FIPS codes (state +
+   county + place + tract).
+2. TIGERWeb ArcGIS REST returns the polygon for a given (layer, FIPS)
+   pair.
+
+The split exists because Census Geocoder is address-centric and only
+returns coords + FIPS for a place. The polygon comes from TIGER. We
+hand back a unified :class:`GazetteerResult` with shapely geometry,
+hiding the two-call shape from callers.
+
+Useful when the consumer already has a FIPS lookup pipeline downstream
+(electoral / NCES / Decennial workflows) and would prefer to skip the
+WKLS / Nominatim translation step.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+from typing import Any, Mapping, Optional
+from urllib.parse import urlencode
+
+from .base import (
+    GazetteerAmbiguousError,
+    GazetteerBackendError,
+    GazetteerCandidate,
+    GazetteerNotFoundError,
+    GazetteerResult,
+)
+
+log = logging.getLogger(__name__)
+
+try:
+    import requests
+    REQUESTS_AVAILABLE = True
+except ImportError:  # pragma: no cover - requests is a core dep
+    REQUESTS_AVAILABLE = False
+
+__all__ = ["CensusGazetteer", "REQUESTS_AVAILABLE"]
+
+
+_GEOCODER_BASE = "https://geocoding.geo.census.gov/geocoder/geographies/onelineaddress"
+_TIGERWEB_BASE = (
+    "https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/"
+    "State_County/MapServer"
+)
+_DEFAULT_BENCHMARK = "Public_AR_Current"
+_DEFAULT_VINTAGE = "Current_Current"
+_DEFAULT_TIMEOUT = 15.0
+
+# Map common-name admin layers in TIGERWeb. Layer IDs are stable in the
+# State_County MapServer; if Census ever renumbers we'll see test
+# failures, not silent geometry corruption.
+_LAYER_STATE = 0
+_LAYER_COUNTY = 1
+
+
+class CensusGazetteer:
+    """US Census-backed gazetteer with admin polygons from TIGER.
+
+    Args:
+        timeout: Per-request HTTP timeout (seconds).
+        cache_size: LRU cache size for the (name, hints) key.
+        benchmark / vintage: Census Geocoder benchmark/vintage strings.
+            Defaults pin to "current"; consumers stuck to a fixed
+            vintage (e.g. for reproducibility against a published
+            decennial roll) can override.
+    """
+
+    provider_name = "census"
+
+    def __init__(
+        self,
+        *,
+        timeout: float = _DEFAULT_TIMEOUT,
+        cache_size: int = 1024,
+        benchmark: str = _DEFAULT_BENCHMARK,
+        vintage: str = _DEFAULT_VINTAGE,
+    ) -> None:
+        if not REQUESTS_AVAILABLE:
+            raise ImportError(
+                "CensusGazetteer requires requests. It ships as a core "
+                "dependency; if it's missing the install is broken."
+            )
+        self._timeout = timeout
+        self._benchmark = benchmark
+        self._vintage = vintage
+        self._session = requests.Session()
+        self._session.headers.update({
+            "Accept": "application/json",
+            "User-Agent": "siege-utilities-gazetteer",
+        })
+        self._cached_lookup = functools.lru_cache(maxsize=cache_size)(
+            self._uncached_lookup
+        )
+
+    def is_available(self) -> bool:
+        return REQUESTS_AVAILABLE
+
+    # ------------------------------------------------------------------
+    # Gazetteer protocol
+    # ------------------------------------------------------------------
+
+    def lookup(
+        self,
+        name: str,
+        *,
+        country_hint: Optional[str] = None,
+        admin_hint: Optional[str] = None,
+    ) -> GazetteerResult:
+        if not name or not name.strip():
+            raise ValueError("CensusGazetteer.lookup: empty name")
+        if country_hint and country_hint.upper() not in ("US", "USA"):
+            raise GazetteerNotFoundError(
+                f"CensusGazetteer is US-only; country_hint={country_hint!r}"
+            )
+        rows = self._cached_lookup(name.strip(), (admin_hint or "").strip() or None)
+        if not rows:
+            raise GazetteerNotFoundError(
+                f"Census: no match for {name!r}"
+                + (f" (admin_hint={admin_hint!r})" if admin_hint else "")
+            )
+        if len(rows) > 1:
+            raise GazetteerAmbiguousError(
+                f"Census: {len(rows)} matches for {name!r}; "
+                "pass admin_hint or use search() and pick a candidate.",
+                candidates=[self._row_to_candidate(r) for r in rows],
+            )
+        return self._row_to_result(rows[0])
+
+    def search(
+        self,
+        name: str,
+        *,
+        country_hint: Optional[str] = None,
+        limit: int = 10,
+    ) -> list[GazetteerCandidate]:
+        if not name or not name.strip():
+            return []
+        if country_hint and country_hint.upper() not in ("US", "USA"):
+            return []
+        rows = self._cached_lookup(name.strip(), None)
+        return [self._row_to_candidate(r) for r in rows[:limit]]
+
+    # ------------------------------------------------------------------
+    # Internal: HTTP + translation
+    # ------------------------------------------------------------------
+
+    def _uncached_lookup(
+        self,
+        name: str,
+        admin_hint: Optional[str],
+    ) -> tuple[Mapping[str, Any], ...]:
+        query = name if not admin_hint else f"{name}, {admin_hint}"
+        params = {
+            "address": query,
+            "benchmark": self._benchmark,
+            "vintage": self._vintage,
+            "format": "json",
+        }
+        url = f"{_GEOCODER_BASE}?{urlencode(params)}"
+        try:
+            resp = self._session.get(url, timeout=self._timeout)
+        except requests.exceptions.RequestException as exc:
+            raise GazetteerBackendError(
+                f"Census geocoder request for {name!r} failed: {exc}"
+            ) from exc
+        if resp.status_code != 200:
+            raise GazetteerBackendError(
+                f"Census geocoder returned {resp.status_code} for "
+                f"{name!r}: {resp.text[:200]}"
+            )
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            raise GazetteerBackendError(
+                f"Census geocoder returned non-JSON for {name!r}"
+            ) from exc
+        matches = (
+            data.get("result", {})
+            .get("addressMatches", [])
+        )
+        # Each match has a `geographies` dict keyed by layer name.
+        # Counties is the canonical admin level we resolve here; consumers
+        # who want state / tract can read raw.geographies themselves.
+        rows = []
+        for m in matches:
+            geos = m.get("geographies", {}) or {}
+            counties = geos.get("Counties", []) or []
+            states = geos.get("States", []) or []
+            if not counties and not states:
+                continue
+            # Prefer county-level resolution; fall back to state.
+            target = counties[0] if counties else states[0]
+            layer = _LAYER_COUNTY if counties else _LAYER_STATE
+            rows.append({
+                "name": target.get("BASENAME") or target.get("NAME") or name,
+                "state_fips": target.get("STATE"),
+                "county_fips": target.get("COUNTY") if counties else None,
+                "lat": float(m.get("coordinates", {}).get("y", 0.0)),
+                "lon": float(m.get("coordinates", {}).get("x", 0.0)),
+                "_layer": layer,
+                "_geoid": target.get("GEOID"),
+                "raw": m,
+            })
+        return tuple(rows)
+
+    def _fetch_polygon(self, layer: int, geoid: str) -> Any:
+        """Fetch the polygon for a (layer, GEOID) pair from TIGERWeb."""
+        from shapely.geometry import shape as shapely_shape
+
+        params = {
+            "where": f"GEOID='{geoid}'",
+            "outFields": "GEOID,NAME",
+            "f": "geojson",
+            "returnGeometry": "true",
+        }
+        url = f"{_TIGERWEB_BASE}/{layer}/query?{urlencode(params)}"
+        try:
+            resp = self._session.get(url, timeout=self._timeout)
+        except requests.exceptions.RequestException as exc:
+            raise GazetteerBackendError(
+                f"TIGERWeb request for GEOID={geoid!r} failed: {exc}"
+            ) from exc
+        if resp.status_code != 200:
+            raise GazetteerBackendError(
+                f"TIGERWeb returned {resp.status_code} for GEOID={geoid!r}"
+            )
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            raise GazetteerBackendError(
+                f"TIGERWeb returned non-JSON for GEOID={geoid!r}"
+            ) from exc
+        features = data.get("features") or []
+        if not features:
+            raise GazetteerBackendError(
+                f"TIGERWeb returned no feature for GEOID={geoid!r}"
+            )
+        return shapely_shape(features[0]["geometry"])
+
+    def _row_to_candidate(self, row: Mapping[str, Any]) -> GazetteerCandidate:
+        admin: dict[str, str] = {}
+        if row.get("state_fips"):
+            admin["state_fips"] = str(row["state_fips"])
+        if row.get("county_fips"):
+            admin["county_fips"] = str(row["county_fips"])
+        path: tuple[str, ...] = ("US",)
+        if row.get("state_fips"):
+            path = path + (str(row["state_fips"]),)
+        if row.get("name"):
+            path = path + (str(row["name"]),)
+        return GazetteerCandidate(
+            name=str(row.get("name", "")),
+            canonical_path=path,
+            country="US",
+            admin_levels=admin,
+            source=self.provider_name,
+        )
+
+    def _row_to_result(self, row: Mapping[str, Any]) -> GazetteerResult:
+        from shapely.geometry import Point
+
+        geoid = row.get("_geoid")
+        if geoid:
+            geometry = self._fetch_polygon(int(row["_layer"]), str(geoid))
+            centroid = geometry.centroid
+        else:
+            geometry = Point(row["lon"], row["lat"])
+            centroid = geometry
+        admin: dict[str, str] = {}
+        if row.get("state_fips"):
+            admin["state_fips"] = str(row["state_fips"])
+        if row.get("county_fips"):
+            admin["county_fips"] = str(row["county_fips"])
+        path: tuple[str, ...] = ("US",)
+        if row.get("state_fips"):
+            path = path + (str(row["state_fips"]),)
+        if row.get("name"):
+            path = path + (str(row["name"]),)
+        return GazetteerResult(
+            name=str(row.get("name", "")),
+            canonical_path=path,
+            geometry=geometry,
+            centroid=centroid,
+            country="US",
+            admin_levels=admin,
+            source=self.provider_name,
+            raw=row.get("raw"),
+        )

--- a/siege_utilities/geo/gazetteers/census_gazetteer.py
+++ b/siege_utilities/geo/gazetteers/census_gazetteer.py
@@ -211,12 +211,21 @@ class CensusGazetteer:
                 continue
             target = counties[0] if counties else states[0]
             layer = _LAYER_COUNTY if counties else _LAYER_STATE
+            # Coordinates missing -> skip rather than silently emit
+            # (0.0, 0.0). A real match always carries x/y; the only way
+            # to get the fallback was an upstream malformed response,
+            # which should not produce a result at Null Island.
+            coords = m.get("coordinates") or {}
+            lat_raw = coords.get("y")
+            lon_raw = coords.get("x")
+            if lat_raw is None or lon_raw is None:
+                continue
             rows.append({
                 "name": target.get("BASENAME") or target.get("NAME") or name,
                 "state_fips": target.get("STATE"),
                 "county_fips": target.get("COUNTY") if counties else None,
-                "lat": float(m.get("coordinates", {}).get("y", 0.0)),
-                "lon": float(m.get("coordinates", {}).get("x", 0.0)),
+                "lat": float(lat_raw),
+                "lon": float(lon_raw),
                 "_layer": layer,
                 "_geoid": target.get("GEOID"),
                 "raw": m,

--- a/siege_utilities/geo/gazetteers/census_gazetteer.py
+++ b/siege_utilities/geo/gazetteers/census_gazetteer.py
@@ -41,7 +41,13 @@ try:
 except ImportError:  # pragma: no cover - requests is a core dep
     REQUESTS_AVAILABLE = False
 
-__all__ = ["CensusGazetteer", "REQUESTS_AVAILABLE"]
+try:
+    import shapely.geometry  # noqa: F401
+    SHAPELY_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    SHAPELY_AVAILABLE = False
+
+__all__ = ["CensusGazetteer", "REQUESTS_AVAILABLE", "SHAPELY_AVAILABLE"]
 
 
 _GEOCODER_BASE = "https://geocoding.geo.census.gov/geocoder/geographies/onelineaddress"
@@ -87,6 +93,11 @@ class CensusGazetteer:
                 "CensusGazetteer requires requests. It ships as a core "
                 "dependency; if it's missing the install is broken."
             )
+        if not SHAPELY_AVAILABLE:
+            raise ImportError(
+                "CensusGazetteer requires shapely to parse TIGER polygons. "
+                "Install with: pip install 'siege-utilities[geo]'."
+            )
         self._timeout = timeout
         self._benchmark = benchmark
         self._vintage = vintage
@@ -100,7 +111,7 @@ class CensusGazetteer:
         )
 
     def is_available(self) -> bool:
-        return REQUESTS_AVAILABLE
+        return REQUESTS_AVAILABLE and SHAPELY_AVAILABLE
 
     # ------------------------------------------------------------------
     # Gazetteer protocol
@@ -140,6 +151,8 @@ class CensusGazetteer:
         country_hint: Optional[str] = None,
         limit: int = 10,
     ) -> list[GazetteerCandidate]:
+        if limit < 0:
+            raise ValueError(f"CensusGazetteer.search: limit must be >= 0, got {limit}")
         if not name or not name.strip():
             return []
         if country_hint and country_hint.upper() not in ("US", "USA"):
@@ -195,7 +208,6 @@ class CensusGazetteer:
             states = geos.get("States", []) or []
             if not counties and not states:
                 continue
-            # Prefer county-level resolution; fall back to state.
             target = counties[0] if counties else states[0]
             layer = _LAYER_COUNTY if counties else _LAYER_STATE
             rows.append({
@@ -208,7 +220,21 @@ class CensusGazetteer:
                 "_geoid": target.get("GEOID"),
                 "raw": m,
             })
-        return tuple(rows)
+        # Census Geocoder returns one addressMatch per matching street
+        # range, but many ranges collapse to the same county or state
+        # GEOID. Without dedup, two addressMatches for the same county
+        # produce two rows and `lookup` raises GazetteerAmbiguousError
+        # for a single effective admin polygon. Collapse by (_layer,
+        # _geoid) keeping the first occurrence.
+        seen: set = set()
+        deduped: list = []
+        for row in rows:
+            key = (row["_layer"], row["_geoid"])
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(row)
+        return tuple(deduped)
 
     def _fetch_polygon(self, layer: int, geoid: str) -> Any:
         """Fetch the polygon for a (layer, GEOID) pair from TIGERWeb."""

--- a/siege_utilities/geo/gazetteers/wikidata_gazetteer.py
+++ b/siege_utilities/geo/gazetteers/wikidata_gazetteer.py
@@ -374,10 +374,17 @@ class WikidataGazetteer:
             if container_idx is not None:
                 holes_for[container_idx].append(inner_ring)
 
-        polys = [
-            Polygon(outer_rings[idx], holes_for[idx])
-            for idx in range(len(outer_rings))
-        ]
+        polys = []
+        for idx in range(len(outer_rings)):
+            poly = Polygon(outer_rings[idx], holes_for[idx])
+            # OSM data is user-edited and sometimes self-intersects;
+            # buffer(0) cleans non-self-intersecting topology errors
+            # without changing the polygon's shape meaningfully. This
+            # is the standard shapely defense for "almost-valid"
+            # external geometry.
+            if not poly.is_valid:
+                poly = poly.buffer(0)
+            polys.append(poly)
         return polys[0] if len(polys) == 1 else MultiPolygon(polys)
 
     @staticmethod
@@ -404,11 +411,27 @@ class WikidataGazetteer:
     def _row_to_result(self, row: Mapping[str, Any]) -> GazetteerResult:
         from shapely.geometry import Point
 
+        coord = self._parse_wkt_point(row.get("coord"))
+
         if row.get("osm_rel"):
-            geometry = self._fetch_osm_relation_geometry(row["osm_rel"])
-            centroid = geometry.centroid
+            try:
+                geometry = self._fetch_osm_relation_geometry(row["osm_rel"])
+                centroid = geometry.centroid
+            except GazetteerBackendError:
+                # Overpass failure on an entity with a P625 coordinate
+                # should fall back to the point rather than escalating
+                # to a hard error -- the caller asked for "where is X"
+                # and we have a usable answer.
+                if coord is None:
+                    raise
+                log.warning(
+                    "Wikidata: Overpass failed for relation %s; "
+                    "falling back to P625 point for %r",
+                    row.get("osm_rel"), row.get("name"),
+                )
+                geometry = Point(coord)
+                centroid = geometry
         else:
-            coord = self._parse_wkt_point(row.get("coord"))
             if coord is None:
                 raise GazetteerNotFoundError(
                     f"Wikidata: {row.get('name')!r} has neither OSM "

--- a/siege_utilities/geo/gazetteers/wikidata_gazetteer.py
+++ b/siege_utilities/geo/gazetteers/wikidata_gazetteer.py
@@ -36,7 +36,14 @@ try:
 except ImportError:  # pragma: no cover
     REQUESTS_AVAILABLE = False
 
-__all__ = ["WikidataGazetteer", "REQUESTS_AVAILABLE"]
+try:
+    import shapely.geometry  # noqa: F401
+    import shapely.ops  # noqa: F401
+    SHAPELY_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    SHAPELY_AVAILABLE = False
+
+__all__ = ["WikidataGazetteer", "REQUESTS_AVAILABLE", "SHAPELY_AVAILABLE"]
 
 
 _WIKIDATA_SPARQL_URL = "https://query.wikidata.org/sparql"
@@ -47,16 +54,24 @@ _USER_AGENT = "siege-utilities-gazetteer (https://github.com/siege-analytics/sie
 
 # Find entities matching `?name` (English label, exact or alias), pull
 # the OSM relation ID and coordinate location if either exists.
+# Optional country filter pushed into the WHERE clause so it runs
+# before LIMIT, preventing valid country-specific matches from being
+# dropped outside the first page for common names.
 _SPARQL_TEMPLATE = """
 SELECT ?item ?itemLabel ?countryLabel ?osmRel ?coord WHERE {
   ?item rdfs:label|skos:altLabel "%s"@en .
   OPTIONAL { ?item wdt:P17 ?country . }
+  %s
   OPTIONAL { ?item wdt:P402 ?osmRel . }
   OPTIONAL { ?item wdt:P625 ?coord . }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
 }
 LIMIT %d
 """
+# Country filter slot: empty when no hint, ISO-code match when hint given.
+# P297 is ISO 3166-1 alpha-2, P298 is alpha-3. Matching either lets
+# callers pass "US" or "USA" interchangeably.
+_SPARQL_COUNTRY_FILTER = '?country wdt:P297|wdt:P298 "%s" .'
 
 
 class WikidataGazetteer:
@@ -80,7 +95,14 @@ class WikidataGazetteer:
     ) -> None:
         if not REQUESTS_AVAILABLE:
             raise ImportError(
-                "WikidataGazetteer requires requests."
+                "WikidataGazetteer requires requests. Install with: "
+                "pip install 'requests>=2.28'."
+            )
+        if not SHAPELY_AVAILABLE:
+            raise ImportError(
+                "WikidataGazetteer requires shapely for geometry "
+                "assembly from OSM relations. Install with: "
+                "pip install 'siege-utilities[geo]'."
             )
         self._timeout = timeout
         self._sparql_url = sparql_url
@@ -95,7 +117,7 @@ class WikidataGazetteer:
         )
 
     def is_available(self) -> bool:
-        return REQUESTS_AVAILABLE
+        return REQUESTS_AVAILABLE and SHAPELY_AVAILABLE
 
     # ------------------------------------------------------------------
     # Gazetteer protocol
@@ -131,6 +153,8 @@ class WikidataGazetteer:
         country_hint: Optional[str] = None,
         limit: int = 10,
     ) -> list[GazetteerCandidate]:
+        if limit < 0:
+            raise ValueError(f"WikidataGazetteer.search: limit must be >= 0, got {limit}")
         if not name or not name.strip():
             return []
         rows = self._cached_lookup(
@@ -152,12 +176,18 @@ class WikidataGazetteer:
     ) -> tuple[Mapping[str, Any], ...]:
         # SPARQL injection guard: the place name lands inside a double-
         # quoted literal. Reject embedded quotes and backslashes outright;
-        # legitimate place names don't contain either.
+        # legitimate place names don't contain either. Same guard for
+        # country_hint since it also lands in a literal.
         if '"' in name or '\\' in name:
             raise ValueError(
                 f"WikidataGazetteer: name contains illegal character: {name!r}"
             )
-        query = _SPARQL_TEMPLATE % (name, limit)
+        if country and ('"' in country or '\\' in country):
+            raise ValueError(
+                f"WikidataGazetteer: country contains illegal character: {country!r}"
+            )
+        country_clause = (_SPARQL_COUNTRY_FILTER % country) if country else ""
+        query = _SPARQL_TEMPLATE % (name, country_clause, limit)
         try:
             resp = self._session.get(
                 self._sparql_url,
@@ -181,17 +211,13 @@ class WikidataGazetteer:
         bindings = data.get("results", {}).get("bindings", [])
         rows: list[Mapping[str, Any]] = []
         for b in bindings:
-            row = {
+            rows.append({
                 "item": b.get("item", {}).get("value"),
                 "name": b.get("itemLabel", {}).get("value") or name,
                 "country": b.get("countryLabel", {}).get("value"),
                 "osm_rel": b.get("osmRel", {}).get("value"),
                 "coord": b.get("coord", {}).get("value"),  # "Point(lon lat)"
-            }
-            if country and row["country"]:
-                if country.lower() not in row["country"].lower():
-                    continue
-            rows.append(row)
+            })
         return tuple(rows)
 
     def _fetch_osm_relation_geometry(self, osm_rel_id: str) -> Any:
@@ -231,38 +257,46 @@ class WikidataGazetteer:
                 f"Overpass returned non-JSON for relation {rel}"
             ) from exc
         # Overpass returns members with geometry inline when `out geom;`
-        # is used. Reassemble outer ways into a polygon. For full
-        # robustness we'd need to handle multipolygon roles; the simple
-        # case covers the majority of admin relations.
+        # is used. Many OSM admin relations split the exterior across
+        # multiple way segments that need to be stitched by shared
+        # endpoints to form the actual boundary. We do not yet
+        # implement that stitching; we accept closed rings (start ==
+        # end) only. Open segments raise a clear error so the consumer
+        # knows the limitation rather than getting a bogus polygon.
         elements = data.get("elements") or []
         if not elements:
             raise GazetteerBackendError(
                 f"Overpass returned no elements for relation {rel}"
             )
         relation = elements[0]
-        coords: list[list[tuple[float, float]]] = []
+        rings: list[list[tuple[float, float]]] = []
+        open_segments = 0
         for m in relation.get("members") or []:
             if m.get("role") != "outer":
                 continue
             geom = m.get("geometry") or []
-            if geom:
-                coords.append([(p["lon"], p["lat"]) for p in geom])
-        if not coords:
+            if len(geom) < 4:
+                continue
+            ring = [(p["lon"], p["lat"]) for p in geom]
+            if ring[0] != ring[-1]:
+                open_segments += 1
+                continue
+            rings.append(ring)
+        if not rings:
+            if open_segments:
+                raise GazetteerBackendError(
+                    f"OSM relation {rel} has {open_segments} unclosed outer "
+                    f"way segment(s) that need to be stitched into rings; "
+                    f"multipolygon assembly is not yet implemented. The "
+                    f"single-ring case works; file a follow-up if your "
+                    f"consumer needs split-segment support."
+                )
             raise GazetteerBackendError(
                 f"Overpass relation {rel} has no outer ring geometry"
             )
-        # Build via shapely Polygon for the single-ring case; multi-ring
-        # outer members get unioned. This is intentionally simple; if
-        # consumers need fuller multipolygon support, file a Phase-3
-        # follow-up rather than building it speculatively here.
         from shapely.geometry import Polygon
         from shapely.ops import unary_union
-
-        polys = [Polygon(ring) for ring in coords if len(ring) >= 4]
-        if not polys:
-            raise GazetteerBackendError(
-                f"Overpass relation {rel} outer rings are degenerate"
-            )
+        polys = [Polygon(ring) for ring in rings]
         return unary_union(polys) if len(polys) > 1 else polys[0]
 
     @staticmethod

--- a/siege_utilities/geo/gazetteers/wikidata_gazetteer.py
+++ b/siege_utilities/geo/gazetteers/wikidata_gazetteer.py
@@ -1,0 +1,314 @@
+"""Wikidata + OSM gazetteer.
+
+Two-step lookup:
+
+1. SPARQL query against Wikidata Query Service for an entity matching
+   the place name. Pull ``wdt:P402`` (OSM relation ID) and
+   ``wdt:P625`` (coordinate location) for each candidate.
+2. Deref the OSM relation ID against the Overpass API to get the
+   admin polygon.
+
+Useful for non-administrative places that WKLS / Nominatim's admin
+boundary indexes miss: cultural regions, historical entities,
+informal areas. The fallback path (when P402 is absent) returns the
+P625 point with no polygon.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+from typing import Any, Mapping, Optional
+
+from .base import (
+    GazetteerAmbiguousError,
+    GazetteerBackendError,
+    GazetteerCandidate,
+    GazetteerNotFoundError,
+    GazetteerResult,
+)
+
+log = logging.getLogger(__name__)
+
+try:
+    import requests
+    REQUESTS_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    REQUESTS_AVAILABLE = False
+
+__all__ = ["WikidataGazetteer", "REQUESTS_AVAILABLE"]
+
+
+_WIKIDATA_SPARQL_URL = "https://query.wikidata.org/sparql"
+_OVERPASS_URL = "https://overpass-api.de/api/interpreter"
+_DEFAULT_TIMEOUT = 30.0
+_USER_AGENT = "siege-utilities-gazetteer (https://github.com/siege-analytics/siege_utilities)"
+
+
+# Find entities matching `?name` (English label, exact or alias), pull
+# the OSM relation ID and coordinate location if either exists.
+_SPARQL_TEMPLATE = """
+SELECT ?item ?itemLabel ?countryLabel ?osmRel ?coord WHERE {
+  ?item rdfs:label|skos:altLabel "%s"@en .
+  OPTIONAL { ?item wdt:P17 ?country . }
+  OPTIONAL { ?item wdt:P402 ?osmRel . }
+  OPTIONAL { ?item wdt:P625 ?coord . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+}
+LIMIT %d
+"""
+
+
+class WikidataGazetteer:
+    """Wikidata SPARQL + OSM Overpass gazetteer.
+
+    Args:
+        timeout: Per-request HTTP timeout.
+        cache_size: LRU cache for the (name, country) key.
+        sparql_url / overpass_url: Override for self-hosted instances.
+    """
+
+    provider_name = "wikidata"
+
+    def __init__(
+        self,
+        *,
+        timeout: float = _DEFAULT_TIMEOUT,
+        cache_size: int = 1024,
+        sparql_url: str = _WIKIDATA_SPARQL_URL,
+        overpass_url: str = _OVERPASS_URL,
+    ) -> None:
+        if not REQUESTS_AVAILABLE:
+            raise ImportError(
+                "WikidataGazetteer requires requests."
+            )
+        self._timeout = timeout
+        self._sparql_url = sparql_url
+        self._overpass_url = overpass_url
+        self._session = requests.Session()
+        self._session.headers.update({
+            "Accept": "application/sparql-results+json",
+            "User-Agent": _USER_AGENT,
+        })
+        self._cached_lookup = functools.lru_cache(maxsize=cache_size)(
+            self._uncached_lookup
+        )
+
+    def is_available(self) -> bool:
+        return REQUESTS_AVAILABLE
+
+    # ------------------------------------------------------------------
+    # Gazetteer protocol
+    # ------------------------------------------------------------------
+
+    def lookup(
+        self,
+        name: str,
+        *,
+        country_hint: Optional[str] = None,
+        admin_hint: Optional[str] = None,
+    ) -> GazetteerResult:
+        if not name or not name.strip():
+            raise ValueError("WikidataGazetteer.lookup: empty name")
+        rows = self._cached_lookup(name.strip(), (country_hint or "").strip().upper() or None, 10)
+        if not rows:
+            raise GazetteerNotFoundError(
+                f"Wikidata: no match for {name!r}"
+                + (f" (country={country_hint!r})" if country_hint else "")
+            )
+        if len(rows) > 1:
+            raise GazetteerAmbiguousError(
+                f"Wikidata: {len(rows)} matches for {name!r}; "
+                "pass country_hint or use search() and pick a candidate.",
+                candidates=[self._row_to_candidate(r) for r in rows],
+            )
+        return self._row_to_result(rows[0])
+
+    def search(
+        self,
+        name: str,
+        *,
+        country_hint: Optional[str] = None,
+        limit: int = 10,
+    ) -> list[GazetteerCandidate]:
+        if not name or not name.strip():
+            return []
+        rows = self._cached_lookup(
+            name.strip(),
+            (country_hint or "").strip().upper() or None,
+            limit,
+        )
+        return [self._row_to_candidate(r) for r in rows]
+
+    # ------------------------------------------------------------------
+    # Internal: SPARQL + Overpass
+    # ------------------------------------------------------------------
+
+    def _uncached_lookup(
+        self,
+        name: str,
+        country: Optional[str],
+        limit: int,
+    ) -> tuple[Mapping[str, Any], ...]:
+        # SPARQL injection guard: the place name lands inside a double-
+        # quoted literal. Reject embedded quotes and backslashes outright;
+        # legitimate place names don't contain either.
+        if '"' in name or '\\' in name:
+            raise ValueError(
+                f"WikidataGazetteer: name contains illegal character: {name!r}"
+            )
+        query = _SPARQL_TEMPLATE % (name, limit)
+        try:
+            resp = self._session.get(
+                self._sparql_url,
+                params={"query": query, "format": "json"},
+                timeout=self._timeout,
+            )
+        except requests.exceptions.RequestException as exc:
+            raise GazetteerBackendError(
+                f"Wikidata SPARQL request for {name!r} failed: {exc}"
+            ) from exc
+        if resp.status_code != 200:
+            raise GazetteerBackendError(
+                f"Wikidata SPARQL returned {resp.status_code} for {name!r}"
+            )
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            raise GazetteerBackendError(
+                f"Wikidata SPARQL returned non-JSON for {name!r}"
+            ) from exc
+        bindings = data.get("results", {}).get("bindings", [])
+        rows: list[Mapping[str, Any]] = []
+        for b in bindings:
+            row = {
+                "item": b.get("item", {}).get("value"),
+                "name": b.get("itemLabel", {}).get("value") or name,
+                "country": b.get("countryLabel", {}).get("value"),
+                "osm_rel": b.get("osmRel", {}).get("value"),
+                "coord": b.get("coord", {}).get("value"),  # "Point(lon lat)"
+            }
+            if country and row["country"]:
+                if country.lower() not in row["country"].lower():
+                    continue
+            rows.append(row)
+        return tuple(rows)
+
+    def _fetch_osm_relation_geometry(self, osm_rel_id: str) -> Any:
+        """Pull an OSM relation polygon via Overpass."""
+        # Reject anything that isn't a positive integer relation ID;
+        # Overpass QL injection is a real concern even though the
+        # endpoint normally rejects malformed input.
+        try:
+            rel = int(osm_rel_id)
+        except (TypeError, ValueError) as exc:
+            raise GazetteerBackendError(
+                f"OSM relation id {osm_rel_id!r} is not numeric"
+            ) from exc
+        if rel <= 0:
+            raise GazetteerBackendError(
+                f"OSM relation id must be positive, got {osm_rel_id!r}"
+            )
+        ql = f"[out:json];relation({rel});out geom;"
+        try:
+            resp = self._session.post(
+                self._overpass_url,
+                data={"data": ql},
+                timeout=self._timeout,
+            )
+        except requests.exceptions.RequestException as exc:
+            raise GazetteerBackendError(
+                f"Overpass request for relation {rel} failed: {exc}"
+            ) from exc
+        if resp.status_code != 200:
+            raise GazetteerBackendError(
+                f"Overpass returned {resp.status_code} for relation {rel}"
+            )
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            raise GazetteerBackendError(
+                f"Overpass returned non-JSON for relation {rel}"
+            ) from exc
+        # Overpass returns members with geometry inline when `out geom;`
+        # is used. Reassemble outer ways into a polygon. For full
+        # robustness we'd need to handle multipolygon roles; the simple
+        # case covers the majority of admin relations.
+        elements = data.get("elements") or []
+        if not elements:
+            raise GazetteerBackendError(
+                f"Overpass returned no elements for relation {rel}"
+            )
+        relation = elements[0]
+        coords: list[list[tuple[float, float]]] = []
+        for m in relation.get("members") or []:
+            if m.get("role") != "outer":
+                continue
+            geom = m.get("geometry") or []
+            if geom:
+                coords.append([(p["lon"], p["lat"]) for p in geom])
+        if not coords:
+            raise GazetteerBackendError(
+                f"Overpass relation {rel} has no outer ring geometry"
+            )
+        # Build via shapely Polygon for the single-ring case; multi-ring
+        # outer members get unioned. This is intentionally simple; if
+        # consumers need fuller multipolygon support, file a Phase-3
+        # follow-up rather than building it speculatively here.
+        from shapely.geometry import Polygon
+        from shapely.ops import unary_union
+
+        polys = [Polygon(ring) for ring in coords if len(ring) >= 4]
+        if not polys:
+            raise GazetteerBackendError(
+                f"Overpass relation {rel} outer rings are degenerate"
+            )
+        return unary_union(polys) if len(polys) > 1 else polys[0]
+
+    @staticmethod
+    def _parse_wkt_point(point_wkt: Optional[str]) -> Optional[tuple[float, float]]:
+        if not point_wkt or not point_wkt.startswith("Point("):
+            return None
+        inside = point_wkt[len("Point("):].rstrip(")")
+        parts = inside.split()
+        if len(parts) != 2:
+            return None
+        try:
+            return (float(parts[0]), float(parts[1]))
+        except ValueError:
+            return None
+
+    def _row_to_candidate(self, row: Mapping[str, Any]) -> GazetteerCandidate:
+        return GazetteerCandidate(
+            name=str(row.get("name", "")),
+            canonical_path=(str(row["country"]),) if row.get("country") else (),
+            country=row.get("country"),
+            source=self.provider_name,
+        )
+
+    def _row_to_result(self, row: Mapping[str, Any]) -> GazetteerResult:
+        from shapely.geometry import Point
+
+        if row.get("osm_rel"):
+            geometry = self._fetch_osm_relation_geometry(row["osm_rel"])
+            centroid = geometry.centroid
+        else:
+            coord = self._parse_wkt_point(row.get("coord"))
+            if coord is None:
+                raise GazetteerNotFoundError(
+                    f"Wikidata: {row.get('name')!r} has neither OSM "
+                    f"relation (P402) nor coordinate (P625); cannot "
+                    f"resolve to geometry."
+                )
+            geometry = Point(coord)
+            centroid = geometry
+
+        return GazetteerResult(
+            name=str(row.get("name", "")),
+            canonical_path=(str(row["country"]),) if row.get("country") else (),
+            geometry=geometry,
+            centroid=centroid,
+            country=row.get("country"),
+            source=self.provider_name,
+            raw=dict(row),
+        )

--- a/siege_utilities/geo/gazetteers/wikidata_gazetteer.py
+++ b/siege_utilities/geo/gazetteers/wikidata_gazetteer.py
@@ -52,6 +52,71 @@ _DEFAULT_TIMEOUT = 30.0
 _USER_AGENT = "siege-utilities-gazetteer (https://github.com/siege-analytics/siege_utilities)"
 
 
+def _stitch_segments_into_rings(
+    segments: "list[list[tuple[float, float]]]",
+) -> "list[list[tuple[float, float]]]":
+    """Stitch a list of OSM way segments into closed rings.
+
+    OSM relations commonly split a boundary across multiple way
+    members. Each way has its own start and end coordinate; rings are
+    formed by chaining ways whose endpoints match (in either
+    direction). Already-closed segments (start == end) become rings
+    immediately. Open segments are walked greedily, reversing as
+    needed, until the current ring closes or no more matching segments
+    are found.
+
+    Returns the list of closed rings. Segments that cannot be closed
+    are dropped (they indicate a malformed relation rather than a
+    valid hole).
+    """
+    rings: list[list[tuple[float, float]]] = []
+    # Work on a queue we can pop from, preserving original lists.
+    remaining = [list(seg) for seg in segments]
+
+    # Pull off already-closed segments first; they are rings as-is.
+    closed_only: list[list[tuple[float, float]]] = []
+    open_only: list[list[tuple[float, float]]] = []
+    for seg in remaining:
+        if len(seg) >= 4 and seg[0] == seg[-1]:
+            closed_only.append(seg)
+        elif len(seg) >= 2:
+            open_only.append(seg)
+    rings.extend(closed_only)
+
+    # Greedy stitch on the remaining open segments.
+    while open_only:
+        current = open_only.pop(0)
+        progress = True
+        while progress and current[0] != current[-1]:
+            progress = False
+            for idx, candidate in enumerate(open_only):
+                if candidate[0] == current[-1]:
+                    current.extend(candidate[1:])
+                    open_only.pop(idx)
+                    progress = True
+                    break
+                if candidate[-1] == current[-1]:
+                    current.extend(reversed(candidate[:-1]))
+                    open_only.pop(idx)
+                    progress = True
+                    break
+                if candidate[-1] == current[0]:
+                    current[:0] = candidate[:-1]
+                    open_only.pop(idx)
+                    progress = True
+                    break
+                if candidate[0] == current[0]:
+                    current[:0] = list(reversed(candidate))[:-1]
+                    open_only.pop(idx)
+                    progress = True
+                    break
+        if current[0] == current[-1] and len(current) >= 4:
+            rings.append(current)
+        # else: dropped -- a malformed relation cannot close to a ring.
+
+    return rings
+
+
 # Find entities matching `?name` (English label, exact or alias), pull
 # the OSM relation ID and coordinate location if either exists.
 # Optional country filter pushed into the WHERE clause so it runs
@@ -257,47 +322,63 @@ class WikidataGazetteer:
                 f"Overpass returned non-JSON for relation {rel}"
             ) from exc
         # Overpass returns members with geometry inline when `out geom;`
-        # is used. Many OSM admin relations split the exterior across
-        # multiple way segments that need to be stitched by shared
-        # endpoints to form the actual boundary. We do not yet
-        # implement that stitching; we accept closed rings (start ==
-        # end) only. Open segments raise a clear error so the consumer
-        # knows the limitation rather than getting a bogus polygon.
+        # is used. OSM admin relations commonly split the exterior across
+        # multiple way segments that must be stitched by matching shared
+        # endpoints to form complete rings. Collect outer + inner
+        # segments separately, stitch each into closed rings, and build
+        # a (Multi)Polygon with holes.
         elements = data.get("elements") or []
         if not elements:
             raise GazetteerBackendError(
                 f"Overpass returned no elements for relation {rel}"
             )
         relation = elements[0]
-        rings: list[list[tuple[float, float]]] = []
-        open_segments = 0
+        outer_segments: list[list[tuple[float, float]]] = []
+        inner_segments: list[list[tuple[float, float]]] = []
         for m in relation.get("members") or []:
-            if m.get("role") != "outer":
+            role = m.get("role")
+            if role not in ("outer", "inner"):
                 continue
             geom = m.get("geometry") or []
-            if len(geom) < 4:
+            if len(geom) < 2:
                 continue
-            ring = [(p["lon"], p["lat"]) for p in geom]
-            if ring[0] != ring[-1]:
-                open_segments += 1
-                continue
-            rings.append(ring)
-        if not rings:
-            if open_segments:
-                raise GazetteerBackendError(
-                    f"OSM relation {rel} has {open_segments} unclosed outer "
-                    f"way segment(s) that need to be stitched into rings; "
-                    f"multipolygon assembly is not yet implemented. The "
-                    f"single-ring case works; file a follow-up if your "
-                    f"consumer needs split-segment support."
-                )
+            segment = [(p["lon"], p["lat"]) for p in geom]
+            (outer_segments if role == "outer" else inner_segments).append(segment)
+
+        outer_rings = _stitch_segments_into_rings(outer_segments)
+        inner_rings = _stitch_segments_into_rings(inner_segments)
+        if not outer_rings:
             raise GazetteerBackendError(
-                f"Overpass relation {rel} has no outer ring geometry"
+                f"OSM relation {rel} has no closeable outer ring geometry "
+                f"(received {len(outer_segments)} outer segment(s), none "
+                f"could be stitched into a closed ring)"
             )
-        from shapely.geometry import Polygon
-        from shapely.ops import unary_union
-        polys = [Polygon(ring) for ring in rings]
-        return unary_union(polys) if len(polys) > 1 else polys[0]
+
+        from shapely.geometry import MultiPolygon, Polygon
+
+        # Assign each inner (hole) to the smallest containing outer.
+        # Building shells first lets us run the contains() check on the
+        # polygon shell rather than re-implementing point-in-polygon.
+        shells = [Polygon(ring) for ring in outer_rings]
+        holes_for: list[list[list[tuple[float, float]]]] = [[] for _ in shells]
+        for inner_ring in inner_rings:
+            hole_poly = Polygon(inner_ring)
+            # Smallest containing shell wins (handles nested outer rings).
+            container_idx = None
+            container_area = None
+            for idx, shell in enumerate(shells):
+                if shell.covers(hole_poly):
+                    if container_area is None or shell.area < container_area:
+                        container_idx = idx
+                        container_area = shell.area
+            if container_idx is not None:
+                holes_for[container_idx].append(inner_ring)
+
+        polys = [
+            Polygon(outer_rings[idx], holes_for[idx])
+            for idx in range(len(outer_rings))
+        ]
+        return polys[0] if len(polys) == 1 else MultiPolygon(polys)
 
     @staticmethod
     def _parse_wkt_point(point_wkt: Optional[str]) -> Optional[tuple[float, float]]:

--- a/tests/test_census_gazetteer.py
+++ b/tests/test_census_gazetteer.py
@@ -1,0 +1,131 @@
+"""Tests for the CensusGazetteer backend.
+
+Mocks the two upstream HTTP services (Census Geocoder + TIGERWeb) so
+the tests run without network. Mirrors the existing pattern in
+test_nominatim_gazetteer.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def census_gaz():
+    from siege_utilities.geo.gazetteers.census_gazetteer import CensusGazetteer
+    return CensusGazetteer()
+
+
+def _fake_geocoder_response(matches):
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {"result": {"addressMatches": matches}}
+    return resp
+
+
+def _fake_tigerweb_response(features):
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {"features": features}
+    return resp
+
+
+def _county_match(*, name="Jefferson", state="01", county="073"):
+    return {
+        "coordinates": {"x": -86.802, "y": 33.521},
+        "geographies": {
+            "Counties": [{
+                "BASENAME": name,
+                "STATE": state,
+                "COUNTY": county,
+                "GEOID": state + county,
+            }],
+        },
+    }
+
+
+def _tigerweb_feature(geoid):
+    return {
+        "type": "Feature",
+        "properties": {"GEOID": geoid, "NAME": "Jefferson"},
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [[[-87, 33], [-86, 33], [-86, 34], [-87, 34], [-87, 33]]],
+        },
+    }
+
+
+def test_lookup_empty_name_raises(census_gaz):
+    with pytest.raises(ValueError, match="empty name"):
+        census_gaz.lookup("")
+
+
+def test_lookup_non_us_country_hint_raises(census_gaz):
+    from siege_utilities.geo.gazetteers.base import GazetteerNotFoundError
+
+    with pytest.raises(GazetteerNotFoundError, match="US-only"):
+        census_gaz.lookup("Toronto", country_hint="CA")
+
+
+def test_lookup_no_match_raises_not_found(census_gaz):
+    from siege_utilities.geo.gazetteers.base import GazetteerNotFoundError
+
+    with patch.object(
+        census_gaz._session, "get", return_value=_fake_geocoder_response([]),
+    ):
+        with pytest.raises(GazetteerNotFoundError, match="no match"):
+            census_gaz.lookup("Notarealplace, ZZ")
+
+
+def test_lookup_multiple_matches_raises_ambiguous(census_gaz):
+    from siege_utilities.geo.gazetteers.base import GazetteerAmbiguousError
+
+    matches = [
+        _county_match(name="Jefferson", state="01", county="073"),
+        _county_match(name="Jefferson", state="21", county="111"),
+    ]
+    with patch.object(
+        census_gaz._session, "get", return_value=_fake_geocoder_response(matches),
+    ):
+        with pytest.raises(GazetteerAmbiguousError) as ei:
+            census_gaz.lookup("Jefferson")
+        assert len(ei.value.candidates) == 2
+
+
+def test_lookup_single_match_fetches_polygon(census_gaz):
+    pytest.importorskip("shapely")
+    from siege_utilities.geo.gazetteers.base import GazetteerResult
+
+    geocoder_resp = _fake_geocoder_response([
+        _county_match(state="01", county="073"),
+    ])
+    tiger_resp = _fake_tigerweb_response([_tigerweb_feature("01073")])
+
+    with patch.object(census_gaz._session, "get") as mock_get:
+        # First call hits geocoder, second hits TIGERWeb.
+        mock_get.side_effect = [geocoder_resp, tiger_resp]
+        result = census_gaz.lookup("Birmingham, AL")
+
+    assert isinstance(result, GazetteerResult)
+    assert result.source == "census"
+    assert result.country == "US"
+    assert result.admin_levels["state_fips"] == "01"
+    assert result.admin_levels["county_fips"] == "073"
+    assert result.geometry.geom_type == "Polygon"
+
+
+def test_lookup_backend_error_on_500(census_gaz):
+    from siege_utilities.geo.gazetteers.base import GazetteerBackendError
+
+    bad = MagicMock(status_code=500, text="upstream error")
+    with patch.object(census_gaz._session, "get", return_value=bad):
+        with pytest.raises(GazetteerBackendError, match="500"):
+            census_gaz.lookup("Anywhere")
+
+
+def test_resolve_gazetteer_returns_census_when_preferred():
+    from siege_utilities.geo.gazetteers import resolve_gazetteer
+    from siege_utilities.geo.gazetteers.census_gazetteer import CensusGazetteer
+
+    gaz = resolve_gazetteer(prefer="census")
+    assert isinstance(gaz, CensusGazetteer)

--- a/tests/test_census_gazetteer.py
+++ b/tests/test_census_gazetteer.py
@@ -92,6 +92,53 @@ def test_lookup_multiple_matches_raises_ambiguous(census_gaz):
         assert len(ei.value.candidates) == 2
 
 
+def test_lookup_dedupes_matches_with_same_geoid(census_gaz):
+    """Census Geocoder returns one addressMatch per matching street
+    range; many ranges collapse to the same county. Two addressMatches
+    that both resolve to (state=01, county=073) must be treated as one
+    candidate, not two -- otherwise lookup() raises Ambiguous for what
+    is actually a single admin polygon."""
+    pytest.importorskip("shapely")
+    matches = [
+        _county_match(name="Jefferson", state="01", county="073"),
+        _county_match(name="Jefferson", state="01", county="073"),  # duplicate
+    ]
+    tiger_resp = _fake_tigerweb_response([_tigerweb_feature("01073")])
+    with patch.object(census_gaz._session, "get") as mock_get:
+        mock_get.side_effect = [_fake_geocoder_response(matches), tiger_resp]
+        result = census_gaz.lookup("Birmingham, AL")
+    assert result.admin_levels["county_fips"] == "073"
+
+
+def test_search_rejects_negative_limit(census_gaz):
+    with pytest.raises(ValueError, match="limit must be >= 0"):
+        census_gaz.search("anywhere", limit=-1)
+
+
+def test_lookup_state_only_fallback_when_no_counties(census_gaz):
+    """When Census Geocoder returns States but no Counties, lookup
+    falls back to state-level resolution. Covers the layer=_LAYER_STATE
+    branch."""
+    pytest.importorskip("shapely")
+    state_match = {
+        "coordinates": {"x": -86.802, "y": 33.521},
+        "geographies": {
+            "States": [{
+                "BASENAME": "Alabama",
+                "STATE": "01",
+                "GEOID": "01",
+            }],
+        },
+    }
+    geocoder_resp = _fake_geocoder_response([state_match])
+    tiger_resp = _fake_tigerweb_response([_tigerweb_feature("01")])
+    with patch.object(census_gaz._session, "get") as mock_get:
+        mock_get.side_effect = [geocoder_resp, tiger_resp]
+        result = census_gaz.lookup("Alabama")
+    assert result.admin_levels["state_fips"] == "01"
+    assert "county_fips" not in result.admin_levels
+
+
 def test_lookup_single_match_fetches_polygon(census_gaz):
     pytest.importorskip("shapely")
     from siege_utilities.geo.gazetteers.base import GazetteerResult

--- a/tests/test_census_gazetteer.py
+++ b/tests/test_census_gazetteer.py
@@ -170,6 +170,49 @@ def test_lookup_backend_error_on_500(census_gaz):
             census_gaz.lookup("Anywhere")
 
 
+def test_lookup_null_result_returns_not_found(census_gaz):
+    """data['result'] being null in the geocoder response must not crash
+    with AttributeError; it should fall through to 'no match' just like
+    an empty addressMatches list."""
+    from siege_utilities.geo.gazetteers.base import GazetteerNotFoundError
+
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {"result": None}
+    with patch.object(census_gaz._session, "get", return_value=resp):
+        with pytest.raises(GazetteerNotFoundError, match="no match"):
+            census_gaz.lookup("Anywhere")
+
+
+def test_lookup_tigerweb_backend_error(census_gaz):
+    """A successful geocoder call followed by a TIGERWeb 500 must
+    translate to GazetteerBackendError, not bubble as an unrelated
+    stack trace."""
+    pytest.importorskip("shapely")
+    from siege_utilities.geo.gazetteers.base import GazetteerBackendError
+
+    geocoder_resp = _fake_geocoder_response([_county_match(state="01", county="073")])
+    tiger_bad = MagicMock(status_code=500, text="tiger down")
+    with patch.object(census_gaz._session, "get") as mock_get:
+        mock_get.side_effect = [geocoder_resp, tiger_bad]
+        with pytest.raises(GazetteerBackendError, match="TIGERWeb"):
+            census_gaz.lookup("Birmingham, AL")
+
+
+def test_lookup_tigerweb_empty_features(census_gaz):
+    """TIGERWeb returning an empty features array (the geocoder
+    resolved the place but the polygon layer has nothing for that
+    GEOID) must translate to GazetteerBackendError."""
+    pytest.importorskip("shapely")
+    from siege_utilities.geo.gazetteers.base import GazetteerBackendError
+
+    geocoder_resp = _fake_geocoder_response([_county_match(state="01", county="073")])
+    tiger_empty = _fake_tigerweb_response([])
+    with patch.object(census_gaz._session, "get") as mock_get:
+        mock_get.side_effect = [geocoder_resp, tiger_empty]
+        with pytest.raises(GazetteerBackendError, match="no feature"):
+            census_gaz.lookup("Birmingham, AL")
+
+
 def test_resolve_gazetteer_returns_census_when_preferred():
     from siege_utilities.geo.gazetteers import resolve_gazetteer
     from siege_utilities.geo.gazetteers.census_gazetteer import CensusGazetteer

--- a/tests/test_gazetteers.py
+++ b/tests/test_gazetteers.py
@@ -289,12 +289,13 @@ class TestResolveGazetteer:
         gz = resolve_gazetteer(prefer="wkls")
         assert gz.provider_name == "wkls"
 
-    def test_prefer_unimplemented_backends_raise(self, fake_wkls):
-        # Nominatim shipped in PR-B; Census and Wikidata are still
-        # deferred to PR-B2.
-        for name in ("census", "wikidata"):
-            with pytest.raises(NotImplementedError):
-                resolve_gazetteer(prefer=name)
+    def test_prefer_census_returns_census_gazetteer(self, fake_wkls):
+        from siege_utilities.geo.gazetteers.census_gazetteer import CensusGazetteer
+        assert isinstance(resolve_gazetteer(prefer="census"), CensusGazetteer)
+
+    def test_prefer_wikidata_returns_wikidata_gazetteer(self, fake_wkls):
+        from siege_utilities.geo.gazetteers.wikidata_gazetteer import WikidataGazetteer
+        assert isinstance(resolve_gazetteer(prefer="wikidata"), WikidataGazetteer)
 
     def test_prefer_invalid_raises(self, fake_wkls):
         with pytest.raises(ValueError, match="prefer must be"):

--- a/tests/test_wikidata_gazetteer.py
+++ b/tests/test_wikidata_gazetteer.py
@@ -1,0 +1,162 @@
+"""Tests for the WikidataGazetteer backend.
+
+Mocks both upstream services (Wikidata SPARQL + Overpass). The
+backend is harder to test than Census because the SPARQL response
+shape is verbose; tests focus on the translation logic and the
+injection guard on `name`.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def wd_gaz():
+    from siege_utilities.geo.gazetteers.wikidata_gazetteer import WikidataGazetteer
+    return WikidataGazetteer()
+
+
+def _sparql_response(bindings):
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {"results": {"bindings": bindings}}
+    return resp
+
+
+def _binding(name, *, osm_rel=None, coord=None, country=None):
+    b: dict = {
+        "item": {"value": f"http://www.wikidata.org/entity/Q{abs(hash(name)) % 100000}"},
+        "itemLabel": {"value": name},
+    }
+    if osm_rel:
+        b["osmRel"] = {"value": str(osm_rel)}
+    if coord:
+        b["coord"] = {"value": f"Point({coord[0]} {coord[1]})"}
+    if country:
+        b["countryLabel"] = {"value": country}
+    return b
+
+
+def _overpass_response_with_polygon():
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {
+        "elements": [{
+            "type": "relation",
+            "members": [{
+                "type": "way",
+                "role": "outer",
+                "geometry": [
+                    {"lon": 0.0, "lat": 0.0},
+                    {"lon": 1.0, "lat": 0.0},
+                    {"lon": 1.0, "lat": 1.0},
+                    {"lon": 0.0, "lat": 1.0},
+                    {"lon": 0.0, "lat": 0.0},
+                ],
+            }],
+        }],
+    }
+    return resp
+
+
+def test_lookup_empty_name_raises(wd_gaz):
+    with pytest.raises(ValueError, match="empty name"):
+        wd_gaz.lookup("")
+
+
+def test_lookup_rejects_quote_in_name(wd_gaz):
+    """SPARQL injection guard: the name lands inside a double-quoted
+    SPARQL literal. Reject embedded quotes outright."""
+    with pytest.raises(ValueError, match="illegal character"):
+        wd_gaz.lookup('Foo" OR 1=1')
+
+
+def test_lookup_rejects_backslash_in_name(wd_gaz):
+    with pytest.raises(ValueError, match="illegal character"):
+        wd_gaz.lookup("Foo\\bar")
+
+
+def test_lookup_no_match_raises_not_found(wd_gaz):
+    from siege_utilities.geo.gazetteers.base import GazetteerNotFoundError
+
+    with patch.object(wd_gaz._session, "get", return_value=_sparql_response([])):
+        with pytest.raises(GazetteerNotFoundError, match="no match"):
+            wd_gaz.lookup("Nonexistentplace")
+
+
+def test_lookup_multiple_matches_raises_ambiguous(wd_gaz):
+    from siege_utilities.geo.gazetteers.base import GazetteerAmbiguousError
+
+    bindings = [
+        _binding("Springfield", country="United States"),
+        _binding("Springfield", country="United Kingdom"),
+    ]
+    with patch.object(wd_gaz._session, "get", return_value=_sparql_response(bindings)):
+        with pytest.raises(GazetteerAmbiguousError) as ei:
+            wd_gaz.lookup("Springfield")
+        assert len(ei.value.candidates) == 2
+
+
+def test_lookup_single_match_with_osm_rel_fetches_polygon(wd_gaz):
+    pytest.importorskip("shapely")
+    from siege_utilities.geo.gazetteers.base import GazetteerResult
+
+    bindings = [_binding("Appalachia", osm_rel=12345, country="United States")]
+    sparql_resp = _sparql_response(bindings)
+    overpass_resp = _overpass_response_with_polygon()
+
+    def get_or_post(*args, **kwargs):
+        if args and args[0] == wd_gaz._sparql_url:
+            return sparql_resp
+        raise AssertionError("unexpected GET")
+
+    with patch.object(wd_gaz._session, "get", side_effect=get_or_post), \
+         patch.object(wd_gaz._session, "post", return_value=overpass_resp):
+        result = wd_gaz.lookup("Appalachia")
+
+    assert isinstance(result, GazetteerResult)
+    assert result.source == "wikidata"
+    assert result.geometry.geom_type == "Polygon"
+
+
+def test_lookup_falls_back_to_point_when_no_osm_rel(wd_gaz):
+    pytest.importorskip("shapely")
+    from siege_utilities.geo.gazetteers.base import GazetteerResult
+
+    bindings = [_binding("Coordy", coord=(-122.5, 37.7), country="United States")]
+    with patch.object(wd_gaz._session, "get", return_value=_sparql_response(bindings)):
+        result = wd_gaz.lookup("Coordy")
+
+    assert isinstance(result, GazetteerResult)
+    assert result.geometry.geom_type == "Point"
+
+
+def test_lookup_rejects_negative_osm_relation(wd_gaz):
+    from siege_utilities.geo.gazetteers.base import GazetteerBackendError
+
+    bindings = [_binding("X", osm_rel=-1, country="US")]
+    with patch.object(wd_gaz._session, "get", return_value=_sparql_response(bindings)):
+        with pytest.raises(GazetteerBackendError, match="positive"):
+            wd_gaz.lookup("X")
+
+
+def test_country_hint_filters_results(wd_gaz):
+    """The country_hint substring-matches against the countryLabel
+    field so callers can disambiguate."""
+    bindings = [
+        _binding("Springfield", country="United States"),
+        _binding("Springfield", country="United Kingdom"),
+    ]
+    with patch.object(wd_gaz._session, "get", return_value=_sparql_response(bindings)):
+        cands = wd_gaz.search("Springfield", country_hint="United States")
+    assert len(cands) == 1
+    assert cands[0].country == "United States"
+
+
+def test_resolve_gazetteer_returns_wikidata_when_preferred():
+    from siege_utilities.geo.gazetteers import resolve_gazetteer
+    from siege_utilities.geo.gazetteers.wikidata_gazetteer import WikidataGazetteer
+
+    gaz = resolve_gazetteer(prefer="wikidata")
+    assert isinstance(gaz, WikidataGazetteer)

--- a/tests/test_wikidata_gazetteer.py
+++ b/tests/test_wikidata_gazetteer.py
@@ -274,3 +274,99 @@ def test_fetch_osm_relation_geometry_stitches_split_outer(wd_gaz):
     assert isinstance(geom, Polygon)
     # The stitched ring is a unit square; area = 1.0.
     assert geom.area == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Shapely-gating regression (CR follow-up)
+# ---------------------------------------------------------------------------
+
+def test_constructor_raises_when_shapely_missing():
+    """The constructor raises ImportError when SHAPELY_AVAILABLE is False.
+    Without this guard, a missing shapely produces an opaque ImportError
+    deep inside the geometry-assembly path. Future refactors that drop
+    the constructor-time gate would pass CI silently."""
+    import siege_utilities.geo.gazetteers.wikidata_gazetteer as mod
+
+    original = mod.SHAPELY_AVAILABLE
+    mod.SHAPELY_AVAILABLE = False
+    try:
+        with pytest.raises(ImportError, match="shapely"):
+            mod.WikidataGazetteer()
+    finally:
+        mod.SHAPELY_AVAILABLE = original
+
+
+def test_is_available_returns_false_when_shapely_missing():
+    """is_available() ANDs the requests and shapely flags. Flipping
+    SHAPELY_AVAILABLE on an already-constructed instance must surface
+    via is_available() -> False."""
+    import siege_utilities.geo.gazetteers.wikidata_gazetteer as mod
+
+    gaz = mod.WikidataGazetteer()
+    original = mod.SHAPELY_AVAILABLE
+    mod.SHAPELY_AVAILABLE = False
+    try:
+        assert gaz.is_available() is False
+    finally:
+        mod.SHAPELY_AVAILABLE = original
+
+
+# ---------------------------------------------------------------------------
+# Backend-error translation (CR follow-up)
+# ---------------------------------------------------------------------------
+
+def test_sparql_500_raises_backend_error(wd_gaz):
+    from siege_utilities.geo.gazetteers.base import GazetteerBackendError
+
+    bad = MagicMock(status_code=500, text="sparql down")
+    with patch.object(wd_gaz._session, "get", return_value=bad):
+        with pytest.raises(GazetteerBackendError, match="Wikidata SPARQL"):
+            wd_gaz.lookup("Anywhere")
+
+
+def test_sparql_request_exception_raises_backend_error(wd_gaz):
+    import requests
+    from siege_utilities.geo.gazetteers.base import GazetteerBackendError
+
+    with patch.object(
+        wd_gaz._session, "get",
+        side_effect=requests.exceptions.RequestException("network down"),
+    ):
+        with pytest.raises(GazetteerBackendError, match="Wikidata SPARQL"):
+            wd_gaz.lookup("Anywhere")
+
+
+def test_sparql_non_json_raises_backend_error(wd_gaz):
+    from siege_utilities.geo.gazetteers.base import GazetteerBackendError
+
+    resp = MagicMock(status_code=200)
+    resp.json.side_effect = ValueError("not JSON")
+    with patch.object(wd_gaz._session, "get", return_value=resp):
+        with pytest.raises(GazetteerBackendError, match="non-JSON"):
+            wd_gaz.lookup("Anywhere")
+
+
+def test_overpass_504_raises_backend_error(wd_gaz):
+    from siege_utilities.geo.gazetteers.base import GazetteerBackendError
+
+    sparql_resp = _sparql_response([_binding("X", osm_rel=123, country="US")])
+    overpass_bad = MagicMock(status_code=504, text="gateway timeout")
+    with patch.object(wd_gaz._session, "get", return_value=sparql_resp), \
+         patch.object(wd_gaz._session, "post", return_value=overpass_bad):
+        with pytest.raises(GazetteerBackendError, match="Overpass"):
+            wd_gaz.lookup("X")
+
+
+def test_overpass_empty_elements_raises_backend_error(wd_gaz):
+    """Overpass returning {'elements': []} means the relation doesn't
+    exist in OSM; translate to GazetteerBackendError rather than
+    crashing on `relation = elements[0]`."""
+    from siege_utilities.geo.gazetteers.base import GazetteerBackendError
+
+    sparql_resp = _sparql_response([_binding("X", osm_rel=123, country="US")])
+    overpass_empty = MagicMock(status_code=200)
+    overpass_empty.json.return_value = {"elements": []}
+    with patch.object(wd_gaz._session, "get", return_value=sparql_resp), \
+         patch.object(wd_gaz._session, "post", return_value=overpass_empty):
+        with pytest.raises(GazetteerBackendError, match="no elements"):
+            wd_gaz.lookup("X")

--- a/tests/test_wikidata_gazetteer.py
+++ b/tests/test_wikidata_gazetteer.py
@@ -141,17 +141,28 @@ def test_lookup_rejects_negative_osm_relation(wd_gaz):
             wd_gaz.lookup("X")
 
 
-def test_country_hint_filters_results(wd_gaz):
-    """The country_hint substring-matches against the countryLabel
-    field so callers can disambiguate."""
-    bindings = [
-        _binding("Springfield", country="United States"),
-        _binding("Springfield", country="United Kingdom"),
-    ]
-    with patch.object(wd_gaz._session, "get", return_value=_sparql_response(bindings)):
-        cands = wd_gaz.search("Springfield", country_hint="United States")
-    assert len(cands) == 1
-    assert cands[0].country == "United States"
+def test_country_hint_lands_in_sparql_query(wd_gaz):
+    """The country_hint is pushed into the SPARQL WHERE clause as an
+    ISO-code filter on the country entity, rather than being applied
+    client-side after LIMIT. This prevents valid country-specific
+    matches from being dropped outside the first page."""
+    with patch.object(
+        wd_gaz._session, "get", return_value=_sparql_response([]),
+    ) as mock_get:
+        wd_gaz.search("Springfield", country_hint="US")
+    call_kwargs = mock_get.call_args.kwargs
+    sent_query = call_kwargs["params"]["query"]
+    assert "wdt:P297|wdt:P298" in sent_query, (
+        f"country filter not in SPARQL query:\n{sent_query}"
+    )
+    assert '"US"' in sent_query
+
+
+def test_country_hint_rejects_quote_injection(wd_gaz):
+    """country_hint lands in a SPARQL literal so it gets the same
+    injection guard as name."""
+    with pytest.raises(ValueError, match="illegal character"):
+        wd_gaz.search("Springfield", country_hint='US" OR 1=1')
 
 
 def test_resolve_gazetteer_returns_wikidata_when_preferred():

--- a/tests/test_wikidata_gazetteer.py
+++ b/tests/test_wikidata_gazetteer.py
@@ -171,3 +171,106 @@ def test_resolve_gazetteer_returns_wikidata_when_preferred():
 
     gaz = resolve_gazetteer(prefer="wikidata")
     assert isinstance(gaz, WikidataGazetteer)
+
+
+# ---------------------------------------------------------------------------
+# Segment stitching: OSM relations split exterior across multiple ways
+# ---------------------------------------------------------------------------
+
+def test_stitch_segments_already_closed_passthrough():
+    from siege_utilities.geo.gazetteers.wikidata_gazetteer import _stitch_segments_into_rings
+
+    closed = [[(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0), (0.0, 0.0)]]
+    rings = _stitch_segments_into_rings(closed)
+    assert len(rings) == 1
+    assert rings[0][0] == rings[0][-1]
+
+
+def test_stitch_segments_two_open_segments_form_one_ring():
+    """OSM relation with two outer ways that share endpoints and close
+    when stitched in order."""
+    from siege_utilities.geo.gazetteers.wikidata_gazetteer import _stitch_segments_into_rings
+
+    seg1 = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0)]
+    seg2 = [(1.0, 1.0), (0.0, 1.0), (0.0, 0.0)]
+    rings = _stitch_segments_into_rings([seg1, seg2])
+    assert len(rings) == 1
+    ring = rings[0]
+    assert ring[0] == ring[-1] == (0.0, 0.0)
+    assert (1.0, 1.0) in ring
+
+
+def test_stitch_segments_reversed_segment():
+    """Stitcher reverses a candidate segment whose endpoint matches the
+    current ring's tail at the WRONG end."""
+    from siege_utilities.geo.gazetteers.wikidata_gazetteer import _stitch_segments_into_rings
+
+    seg1 = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0)]
+    # seg2 reversed -- starts at (0,0) but ought to be appended to (1,1).
+    seg2_reversed = [(0.0, 0.0), (0.0, 1.0), (1.0, 1.0)]
+    rings = _stitch_segments_into_rings([seg1, seg2_reversed])
+    assert len(rings) == 1
+    assert rings[0][0] == rings[0][-1]
+
+
+def test_stitch_segments_two_independent_rings():
+    """Two disjoint rings (e.g., multipolygon: mainland + island)."""
+    from siege_utilities.geo.gazetteers.wikidata_gazetteer import _stitch_segments_into_rings
+
+    mainland = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0), (0.0, 0.0)]
+    island = [(10.0, 10.0), (11.0, 10.0), (11.0, 11.0), (10.0, 11.0), (10.0, 10.0)]
+    rings = _stitch_segments_into_rings([mainland, island])
+    assert len(rings) == 2
+
+
+def test_stitch_segments_drops_unclosable_segment():
+    """A segment that cannot be closed is dropped, not raised. The
+    higher-level call site decides how to react to 'no rings'."""
+    from siege_utilities.geo.gazetteers.wikidata_gazetteer import _stitch_segments_into_rings
+
+    lonely = [(0.0, 0.0), (1.0, 0.0)]  # no partner to close the ring
+    rings = _stitch_segments_into_rings([lonely])
+    assert rings == []
+
+
+def _overpass_response_with_split_outer():
+    """An OSM relation whose exterior is split across two outer ways."""
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {
+        "elements": [{
+            "type": "relation",
+            "members": [
+                {
+                    "type": "way", "role": "outer",
+                    "geometry": [
+                        {"lon": 0.0, "lat": 0.0},
+                        {"lon": 1.0, "lat": 0.0},
+                        {"lon": 1.0, "lat": 1.0},
+                    ],
+                },
+                {
+                    "type": "way", "role": "outer",
+                    "geometry": [
+                        {"lon": 1.0, "lat": 1.0},
+                        {"lon": 0.0, "lat": 1.0},
+                        {"lon": 0.0, "lat": 0.0},
+                    ],
+                },
+            ],
+        }]
+    }
+    return resp
+
+
+def test_fetch_osm_relation_geometry_stitches_split_outer(wd_gaz):
+    """End-to-end: a split-outer OSM relation now produces a valid
+    polygon instead of raising 'multipolygon assembly not implemented'."""
+    from shapely.geometry import Polygon
+
+    with patch.object(
+        wd_gaz._session, "post", return_value=_overpass_response_with_split_outer(),
+    ):
+        geom = wd_gaz._fetch_osm_relation_geometry(123)
+    assert isinstance(geom, Polygon)
+    # The stitched ring is a unit square; area = 1.0.
+    assert geom.area == pytest.approx(1.0)


### PR DESCRIPTION
## Summary

Lands both gazetteer backends from #454. The ticket was reactive-only; building anyway so \`resolve_gazetteer(prefer='census' | 'wikidata')\` no longer raises NotImplementedError and the Gazetteer surface is complete.

## What's in

### CensusGazetteer

Two upstreams chained: Census Geocoder for place name -> coordinates + FIPS, TIGERWeb for FIPS -> admin polygon. County-level resolution when the geocoder returns one, otherwise state-level. Non-US country_hint raises NotFound up front. Standard GazetteerBackendError translation on non-2xx.

### WikidataGazetteer

SPARQL against the Wikidata Query Service for entities matching the English label or alias. When the entity has \`wdt:P402\` (OSM relation), deref through Overpass to assemble the polygon from outer-role ways. Falls back to \`wdt:P625\` (point location) when there's no relation. SPARQL injection guard rejects embedded quotes/backslashes in the name; the OSM relation ID is parsed as positive integer before reaching Overpass QL.

Multipolygon inner / hole rings are not yet honored -- file a follow-up if a consumer hits that limit.

### Factory wiring

\`resolve_gazetteer(prefer='census')\` and \`resolve_gazetteer(prefer='wikidata')\` now return the right backend. Auto-select chain unchanged: still WKLS first, Nominatim fallback, since the new backends require a network round-trip per uncached lookup.

## Tests

Mock both upstream services so the suites run without network. Coverage includes: empty name, country-hint mismatch, no-match -> NotFound, multi-match -> Ambiguous, single match exercising the polygon fetch, SPARQL injection guard, OSM relation positivity guard, country-hint substring filter, factory wiring.

## Test plan

- [ ] CI green
- [ ] Manually verify the live HTTP path works against the public Census Geocoder + TIGERWeb + Wikidata SPARQL endpoints (no API key needed for any of them)

Closes: #454

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Census gazetteer backend for US place lookup with polygon geometry.
  * Added Wikidata gazetteer backend for global place lookup with polygon geometry.
  * Gazetteer resolution now allows selecting preferred provider (census or wikidata).

* **Tests**
  * Added comprehensive tests for Census and Wikidata backends, including geometry assembly, lookup/search behavior, and error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siege-analytics/siege_utilities/pull/470)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->