### PR TITLE
bugfix: assign_boundaries docstring claims predicate='contains' but code uses 'within'

### DIFF
--- a/siege_utilities/engines/dataframe_engine.py
+++ b/siege_utilities/engines/dataframe_engine.py
@@ -403,12 +403,14 @@ class DataFrameEngine(ABC):
     ) -> Any:
         """Assign each point to its containing polygon(s).
 
-        Core DSTK replacement: given addresses (points) and boundaries
-        (polygons), determine which boundary contains each address.
+        Given addresses (points) and boundaries (polygons), determine which
+        boundary contains each address.
 
-        Default delegates to :meth:`spatial_join` with predicate='contains'
-        (reversed: polygon contains point). Engines may override for
-        broadcast optimization or native spatial indexing.
+        Default delegates to :meth:`spatial_join` with predicate='within'
+        (point within polygon, the standard point-in-polygon test). Output
+        is point-left: each input point row is augmented with the matching
+        polygon's attributes. Engines may override for broadcast
+        optimization or native spatial indexing.
         """
         return self.spatial_join(
             points, polygons,


### PR DESCRIPTION
## Summary

`DataFrameEngine.assign_boundaries` had a docstring claiming `predicate='contains'` while the code passed `predicate='within'`. The code is correct; the docstring was an API lie. Fix the docstring to match.

## Tickets

- Fixes #471

## Changes

### Docstring corrections in `siege_utilities/engines/dataframe_engine.py`

- Update the predicate claim from `'contains'` to `'within'` to match the actual call.
- Add a sentence describing output orientation (point-left: each input point row augmented with the matching polygon's attributes) so consumers reading the contract know which side of the join carries through.
- Drop the `Core DSTK replacement:` opening sentence -- references the prior implementation rather than describing current behaviour.

## Commits

| SHA | Description |
|-----|-------------|
| 83ad772 | bugfix: assign_boundaries docstring claims predicate='contains' but code uses predicate='within' |

## Testing

No tests changed. The method had no direct test coverage at the abstract-base-class layer -- the concrete engine `spatial_join` methods are tested, but the default `assign_boundaries` delegate is not.

Manual verification: `gpd.sjoin(left=points, right=polygons, predicate='within')` keeps rows where `left.geometry` is within `right.geometry`. For points and polygons, this means rows where the point is within the polygon (standard point-in-polygon). Output is point-left (left=points carries through). The new docstring matches.

`predicate='contains'` would mean `left.geometry.contains(right.geometry)` -- point contains polygon. That is never true for a single point and a non-degenerate polygon. The old docstring described a non-functional configuration.

## Risks

None. Docstring-only change. No behaviour change in any engine. The Sphinx-rendered docs change accordingly; downstream code that read the docstring's promise was already getting the actual point-left output.

## How this surfaced

Hostile-review pass of `dataframe_engine.py` (full 1424-line read). One of several findings in that pass; this one is fixable without waiting for the rule-set updates the rest are blocked on, so cutting it as a standalone fix.