### PR TITLE
bugfix: multi_assign docstring honestly describes current chain-without-rename behaviour (refs #473)

### DIFF
--- a/siege_utilities/engines/dataframe_engine.py
+++ b/siege_utilities/engines/dataframe_engine.py
@@ -527,9 +527,19 @@ class DataFrameEngine(ABC):
         *,
         point_geom: str = "geometry",
     ) -> Any:
-        """Assign points to multiple boundary layers simultaneously.
+        """Assign points to multiple boundary layers, chaining the joins.
 
-        Calls :meth:`assign_boundaries` for each layer and joins results.
+        Current behaviour: calls :meth:`assign_boundaries` once per layer,
+        with each iteration's result feeding the next iteration's input.
+        Joined columns from each layer are NOT renamed -- they retain
+        their original column names from the polygon DataFrame. If two
+        boundary layers share a column name (e.g. both have a ``geoid``
+        column, which is the common case for Census layers), the later
+        layer's value overwrites the earlier one.
+
+        Layer-prefixed output columns (``{layer_name}_geoid``,
+        ``{layer_name}_name``) are not yet implemented; see issue #473
+        for the planned column-renaming fix.
 
         Parameters
         ----------
@@ -542,17 +552,17 @@ class DataFrameEngine(ABC):
         Returns
         -------
         DataFrame
-            Points enriched with ``{layer_name}_geoid`` and
-            ``{layer_name}_name`` from each boundary layer.
+            Points after chained spatial joins. Column names are NOT
+            disambiguated by layer; for non-overlapping column sets this
+            works fine, otherwise see issue #473.
         """
         result = points
-        for layer_name, polygons in boundary_layers.items():
-            assigned = self.assign_boundaries(
+        for _layer_name, polygons in boundary_layers.items():
+            result = self.assign_boundaries(
                 result, polygons,
                 point_geom=point_geom, polygon_geom="geometry",
                 how="left",
             )
-            result = assigned
         return result
 
 


### PR DESCRIPTION
## Summary

`DataFrameEngine.multi_assign` promised layer-prefixed output columns (`{layer_name}_geoid` / `{layer_name}_name`) that the implementation never produces. The current code chains `assign_boundaries` calls without renaming any columns; for boundary layers with shared column names (the common Census case), later joins silently overwrite earlier ones.

This PR makes the docstring honest about CURRENT behaviour. The actual implementation fix (layer-prefixed columns) is tracked separately as #473.

## Tickets

- Refs #473 (impl fix tracked separately)

## Changes

### `siege_utilities/engines/dataframe_engine.py`

- Rewrite the `multi_assign` docstring to describe the current chain-without-rename behaviour and explicitly note the column-overwrite hazard for shared names.
- Add a forward pointer to issue #473 for the eventual prefixed-column implementation.
- Cosmetic: replace the intermediate `assigned` variable with direct reassignment to `result`.

## Commits

| SHA | Description |
|-----|-------------|
| 26a2a23 | bugfix: multi_assign docstring honestly describes current chain-without-rename behaviour |

## Testing

No tests changed. `multi_assign` has no pre-existing test coverage (no caller in production code, no test in `tests/`). The docstring-only change has no behaviour impact; the cosmetic variable rename has no behaviour impact.

## Risks

None. Docstring + cosmetic-only.

## Why fix the docs first

`multi_assign` has no callers, so the impl can be safely changed -- but the impl change is non-trivial (column renaming across engines, with tests for the Census-multi-layer case). Splitting:

1. **This PR**: docstring tells the truth about current behaviour. No one is misled by reading the docstring today.
2. **Issue #473**: tracks the proper layer-prefixed-columns implementation as a real feature change with tests.

## How this surfaced

Hostile-review pass of `dataframe_engine.py`. Sibling finding to PR #472 (`assign_boundaries` docstring mismatch); both are aspirational-documentation cases. The two PRs are independent and can be merged in either order.