### PR TITLE
cleanup: writing-code:2 history-reference sweep in dataframe_engine.py and spatial_data.py

### DIFF
--- a/siege_utilities/engines/dataframe_engine.py
+++ b/siege_utilities/engines/dataframe_engine.py
@@ -57,8 +57,8 @@ POSTGIS = Engine.POSTGIS.value
 
 
 # Shared across all engines; see docs/engines/INVARIANTS.md groupby_agg.
-# "avg" is a Spark synonym for "mean" the original SparkEngine impl
-# accepted; keeping both so existing callers continue to work.
+# "avg" is the Spark spelling; "mean" is the pandas spelling. Both are
+# accepted at the validator and normalised inside each engine.
 _SUPPORTED_AGG_NAMES = frozenset({
     "sum", "mean", "avg", "count", "min", "max",
     "first", "last", "stddev", "variance", "approx_count_distinct",
@@ -464,9 +464,10 @@ class DataFrameEngine(ABC):
         tgt = self.to_geodataframe(target_polys, target_geom)
 
         # Detect zero-area sources BEFORE gpd.overlay. A degenerate source
-        # polygon that produces no intersection rows would otherwise
-        # disappear entirely — the post-overlay check missed exactly the
-        # data-loss case it was trying to surface.
+        # polygon produces no intersection rows; without a pre-check it
+        # would disappear entirely from the output, with no signal that
+        # data was dropped. Log the drop count so the data loss is
+        # observable to the caller.
         import logging as _logging
         _log = _logging.getLogger(__name__)
         src = src.assign(_src_area=src.geometry.area)

--- a/siege_utilities/geo/spatial_data.py
+++ b/siege_utilities/geo/spatial_data.py
@@ -20,11 +20,11 @@ import os
 import warnings
 
 # Opt-in TLS-verification bypass for environments behind broken
-# corporate MITM proxies. Defaults to False — the previous
-# implementation silently disabled verification on the first SSL
-# failure, which is exactly the case where a MITM is in play and we
-# should refuse rather than oblige. To restore the legacy behaviour
-# set SIEGE_INSECURE_SSL=1 in the environment (and own the risk).
+# corporate MITM proxies. Defaults to False because silent fallback to
+# verify=False is exactly the path a MITM exploits; the safer default
+# is to fail loudly on SSL errors. Set SIEGE_INSECURE_SSL=1 in the
+# environment to allow verify=False as a documented fallback (and own
+# the risk).
 _ALLOW_INSECURE_SSL = os.environ.get("SIEGE_INSECURE_SSL", "").lower() in ("1", "true", "yes")
 if _ALLOW_INSECURE_SSL:
     warnings.filterwarnings('ignore', message='Unverified HTTPS request')
@@ -529,8 +529,9 @@ class CensusDirectoryDiscovery:
         force_refresh : bool
             Bypass the in-memory cache.
         on_error : ``"raise"`` | ``"warn"`` | ``"skip"``
-            What to do when the network request fails.  ``"skip"`` (default)
-            returns an empty list silently — preserving the legacy behaviour.
+            What to do when the network request fails. ``"skip"`` (default)
+            returns an empty list silently; ``"warn"`` logs and returns
+            empty; ``"raise"`` propagates the SiegeGeoError.
         """
         from siege_utilities.exceptions import SiegeGeoError, handle_error
 


### PR DESCRIPTION
## Summary

Four code comments across two files referenced history (previous versions of the code, "legacy behaviour", "the original implementation") instead of describing current behaviour. The `writing-code:2` rule from claude-configs-public v2.0.0 governs this. Rewrite each to describe what the code currently does.

## Tickets

- Fixes #475

## Changes

### `siege_utilities/engines/dataframe_engine.py`

- Line 60: `_SUPPORTED_AGG_NAMES` comment rewritten. Was "avg is a Spark synonym for mean the original SparkEngine impl accepted; keeping both so existing callers continue to work." Now describes the current accepted-and-normalised behaviour.
- Line 467: zero-area pre-check comment rewritten. Was narrating the previous post-overlay bug. Now describes what the pre-check does and why.

### `siege_utilities/geo/spatial_data.py`

- Line 23: `SIEGE_INSECURE_SSL` comment rewritten. Was narrating what the previous SSL handler did. Now describes the MITM-safety rationale for the current default.
- Line 533: `on_error` docstring rewritten. Was naming "the legacy behaviour" for the skip default. Now names what each value does (skip / warn / raise).

## Commits

| SHA | Description |
|-----|-------------|
| a1e9ef8 | cleanup: rewrite code comments to describe current behaviour, not history |

## Testing

No tests changed; comment rewrites only. No behaviour change in any path.

## Risks

None. Code paths untouched.

## Out of scope

These two files have additional findings tracked separately:

- 26 em-dashes (writing-prose:1 extended at claude-configs-public v2.2.0; mechanical scanner enhancement pending)
- Several writing-code:7 (silent error swallowing) cases in pre-existing code
- Silently-dropped parameters (writing-code:9, pending at v2.2.0)
- Deprecation messages without removal target (writing-releases:3, pending at v2.2.0)

Those land in the v2.2.0 fix exercise once the rule package ships. This PR is the writing-code:2 slice that doesn't need any new rule -- the v2.0.0 rule was already in force.

## How this surfaced

Two hostile-review passes documented in `plans/hostile-review-findings.md` (session 260502-vital-channel). The rule (writing-code:2) is from claude-configs-public v2.0.0 and was already in force; these comments are pre-existing slop the original v3.16.0 review missed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified support for both Spark and pandas naming conventions in aggregation operations.
  * Expanded documentation on error handling behavior for directory discovery operations, detailing outcomes for skip, warn, and raise options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siege-analytics/siege_utilities/pull/476)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->