### PR TITLE
bugfix: core/logging.py no longer silently falls back to NullHandler on file-handler-creation failure

### DIFF
--- a/siege_utilities/core/logging.py
+++ b/siege_utilities/core/logging.py
@@ -6,7 +6,7 @@ Provides structured logging with proper configuration management.
 import logging
 import logging.handlers
 from pathlib import Path
-from typing import Optional, Dict, Any, Union, Generator
+from typing import Optional, Dict, Union, Generator
 from dataclasses import dataclass, field
 from contextlib import contextmanager
 import sys

--- a/siege_utilities/core/logging.py
+++ b/siege_utilities/core/logging.py
@@ -160,34 +160,37 @@ class LoggerManager:
             
             logger.addHandler(file_handler)
     
-    def _create_rotating_file_handler(self, 
+    def _create_rotating_file_handler(self,
                                     log_file: Path,
                                     max_bytes: int,
                                     backup_count: int,
                                     level: int) -> logging.Handler:
-        """Create a rotating file handler."""
+        """Create a rotating file handler.
+
+        Raises OSError (or subclass: PermissionError, FileNotFoundError,
+        etc.) when the log file cannot be created at *log_file*. An
+        earlier version silently substituted a NullHandler on any
+        Exception, which made the LOGGING module fail silently for the
+        operator who most needs observability -- the misconfiguration
+        case. The factory raises; the caller decides how to recover.
+        """
         try:
-            # Ensure the directory exists
             log_file.parent.mkdir(parents=True, exist_ok=True)
-            
             handler = logging.handlers.RotatingFileHandler(
                 log_file,
                 maxBytes=max_bytes,
-                backupCount=backup_count
+                backupCount=backup_count,
             )
-            handler.setLevel(level)
-            
-            formatter = logging.Formatter(
-                '[%(name)s] %(asctime)s %(levelname)s: %(message)s'
-            )
-            handler.setFormatter(formatter)
-            
-            return handler
-            
-        except Exception as e:
-            logging.warning(f"Failed to create file handler for {log_file}: {e}")
-            # Return a null handler as fallback
-            return logging.NullHandler()
+        except OSError as exc:
+            raise OSError(
+                f"Failed to create rotating file handler for {log_file}. "
+                f"Check that {log_file.parent} exists and is writable."
+            ) from exc
+        handler.setLevel(level)
+        handler.setFormatter(logging.Formatter(
+            '[%(name)s] %(asctime)s %(levelname)s: %(message)s'
+        ))
+        return handler
     
     @staticmethod
     def _parse_log_level(level: LogLevel) -> int:


### PR DESCRIPTION
## Summary

`LoggerManager._create_rotating_file_handler` caught any `Exception` during `RotatingFileHandler` creation, logged a warning, and returned `NullHandler`. The LOGGING module silently failed to log when the operator most needed observability — file-system misconfiguration on production hardening.

`writing-code:7` (silent error swallowing) explicitly bans this shape: catch-all-then-return-sentinel where the docstring doesn't document the sentinel as failure. Fix: narrow to `OSError` and re-raise with a clear wrap naming the path and the likely cause.

## Tickets

- Fixes #479

## Changes

### `siege_utilities/core/logging.py`

- `_create_rotating_file_handler`: replace `except Exception: logging.warning(...); return NullHandler()` with `except OSError: raise OSError(...)` wrapping the original cause.
- Docstring updated to name the raise behaviour and the design intent (factory raises; caller decides recovery).

## Commits

| SHA | Description |
|-----|-------------|
| cdfb2b5 | bugfix: core/logging.py no longer silently falls back to NullHandler on file-handler-creation failure |

## Testing

Smoke test:
- Writable path: creates handler, writes log line, file exists ✓
- Read-only filesystem: OSError raises with clear message naming the path ✓

No regression tests added/changed because no test asserted the old silent-NullHandler behaviour. Would-be-affected tests covering the `_create_rotating_file_handler` exception path don't exist in the test suite (writing-tests:1 territory: the failure path was untested).

## Risks

**Behaviour change**: a caller passing a log path the process can't write to now gets `OSError` at handler-creation time instead of silently logging to NullHandler. This is the intended improvement — silent NullHandler in production hardening is exactly the case where the operator most needs the failure to be loud.

If any consumer code relies on the silent NullHandler fallback (e.g., "configure logging to a path that may or may not exist; if it doesn't, accept silent discard"), that consumer will now raise. The right fix on the consumer side is to:

1. Pre-check the path is writable before calling `configure_shared_logging`, OR
2. Catch `OSError` from `configure_shared_logging` and explicitly fall back to console-only logging.

Either is a real recovery path; the silent NullHandler was not.

## How this surfaced

Hostile-review pass 5 of `siege_utilities/core/logging.py` documented in session 260502-vital-channel's `plans/hostile-review-findings.md`. The LOGGING module silently failing was the highest-irony finding of the pass.

Eval observation: this fix shape is the canonical `writing-code:7` fix recipe (narrow except + re-raise with wrap), and the rule wording made the fix obvious. No new rule needed; pre-existing writing-code:7 at v2.0.0 covers this.