### PR TITLE
security: validate inputs in databricks lakebase/unity helpers

### DIFF
--- a/siege_utilities/databricks/lakebase.py
+++ b/siege_utilities/databricks/lakebase.py
@@ -1,9 +1,33 @@
 """LakeBase/Postgres connection helpers for Databricks workflows."""
 
+import re
 import shlex
 from typing import Dict
 
 from siege_utilities.conf import settings
+
+
+# Postgres connection-string field allow-lists. These match the typical
+# Postgres identifier rules; values matching anything outside are rejected
+# rather than escaped, because the conninfo / pgpass / shell contexts each
+# have different metacharacter rules and "validate at the boundary" is
+# cleaner than "escape at every callsite."
+_HOSTNAME_RE = re.compile(r"^[A-Za-z0-9._-]+(?::[0-9]+)?$")
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]*$")
+_SSLMODE_RE = re.compile(r"^(disable|allow|prefer|require|verify-ca|verify-full)$")
+
+
+def _validate_conninfo_value(value: str, regex: re.Pattern, label: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{label} must be a string, got {type(value).__name__}")
+    if not value:
+        raise ValueError(f"{label} must not be empty")
+    if not regex.match(value):
+        raise ValueError(
+            f"{label} {value!r} contains characters not permitted in a "
+            f"Postgres conninfo field; expected pattern {regex.pattern}."
+        )
+    return value
 
 
 def parse_conninfo(conninfo: str) -> Dict[str, str]:
@@ -30,13 +54,37 @@ def build_lakebase_psql_command(
     port: int | None = None,
     sslmode: str | None = None,
 ) -> str:
-    """Build a psql command line for LakeBase/Postgres."""
+    """Build a psql command line for LakeBase/Postgres.
+
+    All caller-provided values are validated against strict allow-lists
+    (hostname characters for host, identifier characters for user/dbname,
+    Postgres sslmode enum for sslmode). The returned command is then
+    safe to execute via subprocess.run(..., shell=True) or shell=False.
+
+    Raises ValueError if any field contains characters that could break
+    out of the conninfo or the surrounding shell quoting.
+    """
     port = port if port is not None else settings.LAKEBASE_PORT
     sslmode = sslmode if sslmode is not None else settings.LAKEBASE_SSLMODE
+    _validate_conninfo_value(host, _HOSTNAME_RE, "host")
+    _validate_conninfo_value(user, _IDENTIFIER_RE, "user")
+    _validate_conninfo_value(dbname, _IDENTIFIER_RE, "dbname")
+    _validate_conninfo_value(str(sslmode), _SSLMODE_RE, "sslmode")
     conninfo = (
         f"host={host} user={user} dbname={dbname} port={int(port)} sslmode={sslmode}"
     )
-    return f'psql "{conninfo}"'
+    # Quote the conninfo with shlex.quote so the surrounding command is
+    # safe even if a future contributor relaxes the allow-list above.
+    return f"psql {shlex.quote(conninfo)}"
+
+
+def _escape_pgpass_field(value: str) -> str:
+    """Backslash-escape ``:`` and ``\\`` per the Postgres .pgpass format."""
+    if not isinstance(value, str):
+        raise TypeError(
+            f".pgpass field must be a string, got {type(value).__name__}"
+        )
+    return value.replace("\\", "\\\\").replace(":", "\\:")
 
 
 def build_pgpass_entry(
@@ -46,11 +94,29 @@ def build_pgpass_entry(
     user: str,
     password: str,
 ) -> str:
-    """Build a single .pgpass line."""
-    return f"{host}:{int(port)}:{dbname}:{user}:{password}"
+    """Build a single .pgpass line.
+
+    Each field is backslash-escaped per the Postgres .pgpass format
+    (``\\`` -> ``\\\\``; ``:`` -> ``\\:``). A password containing ``:``
+    or ``\\`` previously produced a malformed entry that either failed
+    to match or matched the wrong host/db.
+    """
+    return (
+        f"{_escape_pgpass_field(host)}:"
+        f"{int(port)}:"
+        f"{_escape_pgpass_field(dbname)}:"
+        f"{_escape_pgpass_field(user)}:"
+        f"{_escape_pgpass_field(password)}"
+    )
 
 
 def build_jdbc_url(host: str, dbname: str, port: int | None = None) -> str:
-    """Build a PostgreSQL JDBC URL."""
+    """Build a PostgreSQL JDBC URL.
+
+    Validates ``host`` and ``dbname`` against allow-lists to prevent
+    URL-injection into the JDBC connection string.
+    """
     port = port if port is not None else settings.LAKEBASE_PORT
+    _validate_conninfo_value(host, _HOSTNAME_RE, "host")
+    _validate_conninfo_value(dbname, _IDENTIFIER_RE, "dbname")
     return f"jdbc:postgresql://{host}:{int(port)}/{dbname}"

--- a/siege_utilities/databricks/unity_catalog.py
+++ b/siege_utilities/databricks/unity_catalog.py
@@ -2,6 +2,11 @@
 
 from typing import Iterable, List
 
+from siege_utilities.core.sql_safety import (
+    escape_sql_string_literal,
+    validate_sql_identifier,
+)
+
 
 def quote_ident(value: str) -> str:
     """Quote an identifier with backticks for Databricks SQL."""
@@ -19,12 +24,29 @@ def build_foreign_table_sql(
     """
     Build SQL for creating a Unity Catalog foreign table from a LakeBase source table.
 
-    Note: syntax can vary by workspace/feature flag. Keep this as a composable
-    helper and validate generated SQL in the target Databricks environment.
+    All identifier fields (catalog, schema, table, connection_name,
+    source_schema, source_table) are validated against the Postgres
+    identifier allow-list before interpolation. An earlier version
+    interpolated source_schema and source_table directly into the SQL
+    string without validation, producing an injection risk if either
+    contained a single quote.
+
+    Note: syntax can vary by workspace/feature flag. Keep this as a
+    composable helper and validate generated SQL in the target
+    Databricks environment.
     """
     resolved_source = source_table or table
+    validate_sql_identifier(catalog, "catalog")
+    validate_sql_identifier(schema, "schema")
+    validate_sql_identifier(table, "table")
+    validate_sql_identifier(connection_name, "connection_name")
+    validate_sql_identifier(source_schema, "source_schema")
+    validate_sql_identifier(resolved_source, "source_table")
     fq_table = ".".join([quote_ident(catalog), quote_ident(schema), quote_ident(table)])
-    source_ref = f"{source_schema}.{resolved_source}"
+    # source_ref goes inside a single-quoted SQL string literal. Even
+    # though the identifier validator already rejects single quotes,
+    # escape defensively in case a future relaxation allows them.
+    source_ref = escape_sql_string_literal(f"{source_schema}.{resolved_source}")
     return (
         f"CREATE FOREIGN TABLE IF NOT EXISTS {fq_table}\n"
         f"USING CONNECTION {quote_ident(connection_name)}\n"

--- a/tests/test_databricks_lakebase_unity.py
+++ b/tests/test_databricks_lakebase_unity.py
@@ -70,6 +70,88 @@ def test_unity_sql_helpers():
     assert statements[0].startswith("CREATE SCHEMA IF NOT EXISTS")
 
 
+def test_lakebase_psql_command_rejects_shell_metacharacters():
+    """The conninfo fields go through a shell command line; metacharacters
+    in host/user/dbname must be rejected at the boundary (issue #481)."""
+    with pytest.raises(ValueError, match="host"):
+        build_lakebase_psql_command(
+            host="example.com; rm -rf /",
+            user="alice",
+            dbname="analytics",
+        )
+    with pytest.raises(ValueError, match="user"):
+        build_lakebase_psql_command(
+            host="db.example.net",
+            user="alice && cat /etc/passwd",
+            dbname="analytics",
+        )
+    with pytest.raises(ValueError, match="dbname"):
+        build_lakebase_psql_command(
+            host="db.example.net",
+            user="alice",
+            dbname='analytics" $(rm -rf /)',
+        )
+
+
+def test_lakebase_psql_command_legitimate_values_accepted():
+    """Hostnames with dots, hyphens, numeric ports, and identifier-shaped
+    user/dbname values must continue to work after the security fix."""
+    cmd = build_lakebase_psql_command(
+        host="db-1.example-prod.net",
+        user="svc_account_1",
+        dbname="my_db",
+    )
+    assert "db-1.example-prod.net" in cmd
+    assert "svc_account_1" in cmd
+    assert "my_db" in cmd
+
+
+def test_pgpass_entry_escapes_colons_and_backslashes():
+    """The .pgpass file format uses ':' as field separator and '\\' as
+    escape; both must be backslash-escaped in every field (issue #481)."""
+    pgpass = build_pgpass_entry(
+        host="db:1.example.com",
+        port=5432,
+        dbname="my:db",
+        user="my:user",
+        password=r"pa\ss:word",
+    )
+    # Each field's special characters escaped.
+    assert pgpass == r"db\:1.example.com:5432:my\:db:my\:user:pa\\ss\:word"
+
+
+def test_jdbc_url_rejects_url_injection():
+    """JDBC URL builder validates host and dbname to prevent injection
+    into the connection string (issue #481)."""
+    with pytest.raises(ValueError, match="host"):
+        build_jdbc_url('localhost"/etc/passwd', "mydb")
+    with pytest.raises(ValueError, match="dbname"):
+        build_jdbc_url("db.example.net", "mydb?foo=bar")
+
+
+def test_foreign_table_sql_rejects_source_identifier_injection():
+    """source_schema and source_table go through the same identifier
+    validator as the other fields, closing the asymmetric-quoting gap
+    that issue #481 surfaced."""
+    with pytest.raises(ValueError, match="source_schema"):
+        build_foreign_table_sql(
+            catalog="main",
+            schema="ext",
+            table="zip",
+            connection_name="lakebase_conn",
+            source_schema="census';DROP TABLE x;--",
+        )
+    with pytest.raises(ValueError, match="source_table"):
+        build_foreign_table_sql(
+            catalog="main",
+            schema="ext",
+            table="zip",
+            connection_name="lakebase_conn",
+            source_schema="census_reference",
+            source_table="zip'; --",
+        )
+
+
 def test_build_databricks_run_url():
     """Run URL helper should generate stable links."""
     url = build_databricks_run_url(

--- a/tests/test_databricks_lakebase_unity.py
+++ b/tests/test_databricks_lakebase_unity.py
@@ -108,16 +108,26 @@ def test_lakebase_psql_command_legitimate_values_accepted():
 
 def test_pgpass_entry_escapes_colons_and_backslashes():
     """The .pgpass file format uses ':' as field separator and '\\' as
-    escape; both must be backslash-escaped in every field (issue #481)."""
+    escape; both must be backslash-escaped in every field (issue #481).
+
+    The test value is constructed from clearly-non-credential parts to
+    avoid GitGuardian false-positives; the input contains every
+    special character the escaper handles.
+    """
+    sentinel_with_colons_and_backslash = "FAKE-PASSWORD-VALUE" + r":has:colons\and-backslash"
     pgpass = build_pgpass_entry(
         host="db:1.example.com",
         port=5432,
         dbname="my:db",
         user="my:user",
-        password=r"pa\ss:word",
+        password=sentinel_with_colons_and_backslash,
     )
     # Each field's special characters escaped.
-    assert pgpass == r"db\:1.example.com:5432:my\:db:my\:user:pa\\ss\:word"
+    assert pgpass == (
+        r"db\:1.example.com:5432:my\:db:my\:user:"
+        "FAKE-PASSWORD-VALUE"
+        r"\:has\:colons\\and-backslash"
+    )
 
 
 def test_jdbc_url_rejects_url_injection():


### PR DESCRIPTION
## Summary

Three input-validation gaps in publicly-exported `siege_utilities.databricks` helpers that interpolate caller-provided strings into shell commands and SQL without validation. Closes a potential RCE vector and two correctness gaps.

## Tickets

- Fixes #481

## Findings drained

| Finding | Function | Risk | Fix |
|---------|----------|------|-----|
| DB-Sec-1 | `build_lakebase_psql_command` | RCE via shell=True execution if caller passes user-controlled `host`/`user`/`dbname` | Validate against allow-lists; wrap conninfo in `shlex.quote` |
| DB-Sec-2 | `build_pgpass_entry` | Malformed .pgpass when `:`/`\` present in any field (silent wrong-host match) | Backslash-escape per Postgres format |
| DB-Sec-3 | `build_foreign_table_sql` | SQL injection via `source_schema`/`source_table` (mixed-quoting pattern) | Pass through `validate_sql_identifier`; escape OPTIONS literal |
| DB-Sec-1b | `build_jdbc_url` | URL-injection into JDBC connection string | Same allow-list as psql command |

## Changes

### `siege_utilities/databricks/lakebase.py`
- Added `_HOSTNAME_RE`, `_IDENTIFIER_RE`, `_SSLMODE_RE` regexes matching Postgres allow-lists.
- Added `_validate_conninfo_value` helper that raises `ValueError` on mismatch.
- Added `_escape_pgpass_field` helper that backslash-escapes `\` and `:` per the .pgpass format.
- `build_lakebase_psql_command`: validates all four fields and wraps the conninfo in `shlex.quote`.
- `build_pgpass_entry`: each field passes through `_escape_pgpass_field`.
- `build_jdbc_url`: validates `host` and `dbname`.

### `siege_utilities/databricks/unity_catalog.py`
- Imports `validate_sql_identifier` and `escape_sql_string_literal` from `core.sql_safety`.
- `build_foreign_table_sql`: validates `source_schema` and `source_table` (the two previously-unvalidated fields), and escapes the composed `source_ref` for defense-in-depth even though identifier validation already rejects quotes.

### `tests/test_databricks_lakebase_unity.py`
- Five new tests covering rejection paths: shell metacharacters in psql command, .pgpass escape verification, JDBC URL injection, foreign-table SQL injection via source_schema and source_table.
- All 3 existing tests continue to pass; legitimate inputs unchanged.

## Commits

| SHA | Description |
|-----|-------------|
| cfa0fb8 | security: validate inputs in databricks lakebase/unity helpers |

## Testing

Local smoke + tests:

```
8 passed in 3.85s
```

Smoke test of legitimate + malicious inputs:

- Legitimate hostnames (db-1.example-prod.net), identifier-shaped users/dbnames: accepted, unchanged output
- Injection attempt `host=\"example.com; rm -rf /\"`: rejected with ValueError naming the field and the regex
- Injection attempt `source_schema=\"census';DROP TABLE x;--\"`: rejected with ValueError from `validate_sql_identifier`
- .pgpass with `host=\"db:1.example.com\"`, password=`\"pa\\\\ss:word\"`: correctly escaped to `db\\\\:1.example.com:5432:...:pa\\\\\\\\ss\\\\:word`

## Risks

**Behaviour change**: callers passing values containing characters previously interpolated raw (`;`, `'`, `\"`, `:` in pgpass fields, etc.) now get `ValueError` instead of a malformed-but-runnable output. This is the intended improvement -- the previous outputs were either security risks (shell injection) or correctness bugs (malformed pgpass).

If any consumer relied on passing exotic identifiers (e.g., a Postgres database name with a dot or hyphen), they will now need to either rename or document the limitation. The allow-lists chosen match standard Postgres identifier rules; deviations from those rules were ALWAYS suspect.

## How this surfaced

Hostile-review pass 6 of `siege_utilities/databricks/` (infrastructure shape, sixth distinct module type) per session 260502-vital-channel's audit loop. The pre-existing `_data-trust-rules.md` (validate at boundaries) and `core/sql_safety.py` discipline (validate_sql_identifier) were the right precedents to extend.

Eval observation: writing the rejection tests was the natural application of `writing-tests:5` (every except block exercised by a test that forces it) -- in this case, every `raise ValueError on invalid input` branch exercised by an explicit test passing the invalid input. The discipline maps cleanly to input-validation code, not just exception-handling code.