### PR TITLE
fix(security): credential_manager silent-swallow drain (1Password silent fall-through fix)

### DIFF
--- a/siege_utilities/config/credential_manager.py
+++ b/siege_utilities/config/credential_manager.py
@@ -129,15 +129,22 @@ class CredentialManager:
             for path in additional_paths:
                 paths.append(Path(path))
         
-        # Try to get paths from user config
+        # Try to get paths from user config. Narrow except to the two
+        # legitimate "config not available" failure modes (the module
+        # isn't importable, or the function exists but the attribute
+        # we're reading is missing). A bare `except Exception` here
+        # would have swallowed a TypeError in user_config.credential_paths
+        # iteration (e.g., if a user wrote a string instead of a list),
+        # masking a real config bug as "no credential paths configured."
         try:
             from .user_config import get_user_config
+        except ImportError:
+            pass  # user_config module not available; no extra paths.
+        else:
             user_config = get_user_config()
-            if user_config and hasattr(user_config, 'credential_paths'):
+            if user_config is not None and hasattr(user_config, 'credential_paths'):
                 for path in user_config.credential_paths:
                     paths.append(Path(path))
-        except Exception:
-            pass  # User config not available or no credential paths configured
         
         return paths
     
@@ -219,28 +226,35 @@ class CredentialManager:
             if not self.available_backends.get(backend, False):
                 continue
 
-            try:
-                if backend == 'files':
-                    value = self._get_from_files(service, username, field, search_paths)
-                elif backend == 'env':
-                    value = self._get_from_env(service, username, field)
-                elif backend == '1password':
-                    value = self._get_from_1password(service, field, vault=vault, account=account)
-                elif backend == 'keychain':
-                    value = self._get_from_keychain(service, username)
-                elif backend == 'prompt':
-                    value = self._get_from_prompt(service, username, field)
-                else:
-                    continue
-                    
-                if value:
-                    log_info(f"Retrieved {field} for {service} from {backend}")
-                    return value
-                    
-            except Exception as e:
-                log_warning(f"Error retrieving from {backend}: {e}")
+            # Backend helpers now return None for "this backend does not
+            # have the credential" and raise for transport / auth /
+            # permission failures. An earlier version caught all
+            # exceptions here and continued to the next backend, which
+            # silently fell through from 1Password to keychain to prompt
+            # on transient errors -- causing the operator to be prompted
+            # for credentials 1Password actually has. Per writing-code:7
+            # (silent error swallowing) the rule is: backend says "not
+            # found" -> fall through; backend errors -> propagate so the
+            # caller can decide.
+            if backend == 'files':
+                value = self._get_from_files(service, username, field, search_paths)
+            elif backend == 'env':
+                value = self._get_from_env(service, username, field)
+            elif backend == '1password':
+                value = self._get_from_1password(service, field, vault=vault, account=account)
+            elif backend == 'keychain':
+                value = self._get_from_keychain(service, username)
+            elif backend == 'prompt':
+                value = self._get_from_prompt(service, username, field)
+            else:
                 continue
-        
+
+            if value:
+                log_info(f"Retrieved {field} for {service} from {backend}")
+                return value
+            # value is None: this backend legitimately does not have the
+            # credential; continue to the next backend.
+
         log_warning(f"Could not retrieve {field} for {service} from any backend")
         return None
     
@@ -347,41 +361,54 @@ class CredentialManager:
                             account: Optional[str] = None) -> Optional[str]:
         """Get credential from 1Password.
 
+        Returns the credential string if found, ``None`` if the item
+        legitimately does not exist in 1Password (under the requested
+        name OR any of the documented service-name variations). Raises
+        on transport / auth / vault-permission errors so the caller
+        does not silently fall through to a less-trusted backend when
+        1Password actually had the credential but had a transient
+        access problem.
+
         Args:
             service: Item title or identifier in 1Password
             field: Field name to retrieve
             vault: Vault override (falls back to default_vault)
             account: Account override (falls back to default_account)
         """
-        try:
-            op_flags = self._build_op_flags(vault=vault, account=account)
-
-            # Try to find item by service name
-            cmd = ['op', 'item', 'get', service, f'--field={field}', '--reveal'] + op_flags
+        op_flags = self._build_op_flags(vault=vault, account=account)
+        names_to_try = [
+            service,
+            f"{service} API",
+            f"{service} Credentials",
+            f"{service.replace('-', ' ').title()} API",
+            f"{service.replace('-', ' ').title()} Credentials",
+        ]
+        # op exit codes (per `op` CLI docs):
+        # 0 = success
+        # 1 = item not found / no match
+        # other = auth required, transport, vault-permission, etc.
+        # Treat exit code 1 (and only 1) as "not in this backend"; everything
+        # else is a real failure that should bubble up.
+        for name in names_to_try:
+            cmd = ['op', 'item', 'get', name, f'--field={field}', '--reveal'] + op_flags
             result = subprocess.run(cmd, capture_output=True, text=True)
-
             if result.returncode == 0:
                 return result.stdout.strip()
-
-            # Try with common service name variations
-            service_variations = [
-                f"{service} API",
-                f"{service} Credentials",
-                f"{service.replace('-', ' ').title()} API",
-                f"{service.replace('-', ' ').title()} Credentials"
-            ]
-
-            for variation in service_variations:
-                cmd = ['op', 'item', 'get', variation, f'--field={field}', '--reveal'] + op_flags
-                result = subprocess.run(cmd, capture_output=True, text=True)
-
-                if result.returncode == 0:
-                    return result.stdout.strip()
-
-            return None
-
-        except Exception:
-            return None
+            if result.returncode == 1:
+                # Item not found under this name; try the next variation.
+                continue
+            # Non-1 nonzero exit: 1Password CLI is signalling something
+            # other than "item not found." Raise so the caller does not
+            # silently fall through to keychain/prompt for credentials
+            # 1Password actually has.
+            raise RuntimeError(
+                f"1Password CLI (`op item get {name} --field={field}`) "
+                f"exited with code {result.returncode}: "
+                f"{(result.stderr or result.stdout)[:200]!r}. "
+                f"Resolve the 1Password CLI state before falling back "
+                f"to other backends."
+            )
+        return None
     
     def _get_from_keychain(self, service: str, username: str) -> Optional[str]:
         """Get credential from Apple Keychain."""

--- a/tests/test_credential_manager.py
+++ b/tests/test_credential_manager.py
@@ -466,12 +466,41 @@ class TestGetFrom1Password:
         result = manager._get_from_1password('nonexistent', 'field')
         assert result is None
 
-    def test_returns_none_on_exception(self, manager_with_defaults):
+    def test_propagates_transport_errors_instead_of_swallowing(self, manager_with_defaults):
+        """Transport / auth / vault-permission errors PROPAGATE; they no
+        longer fall through to a less-trusted backend.
+
+        Per writing-tests:1 retroactive-fix corollary (RG-9 / v2.3.1):
+        this test was previously named test_returns_none_on_exception
+        and asserted the silent-swallow as feature. writing-code:7
+        treats catch-all-except-and-return-None as banned; the fix in
+        issue #483 narrowed the helper to "exit code 1 (item not
+        found) -> return None; other failures -> raise." Tests follow
+        the rule.
+
+        The author's writing-tests:1 check passed at original-author
+        time because the test was designed for the now-banned silent
+        fallback; correctness against the implementation did not equal
+        correctness against the rule. Rules win on conflict.
+        """
         manager, mock_run = manager_with_defaults
         mock_run.side_effect = Exception("connection failed")
 
-        result = manager._get_from_1password('svc', 'field')
-        assert result is None
+        with pytest.raises(Exception, match="connection failed"):
+            manager._get_from_1password('svc', 'field')
+
+    def test_propagates_nonzero_nonone_exit_codes(self, manager_with_defaults):
+        """Non-1 nonzero exit (auth required, vault permission, etc.)
+        raises RuntimeError naming the exit code and stderr so the
+        caller can decide what to do; it must NOT silently return None
+        and let the backend loop fall through to keychain/prompt for a
+        credential 1Password may actually have."""
+        manager, mock_run = manager_with_defaults
+        # exit code 2 = some op CLI error other than "not found."
+        mock_run.return_value = Mock(returncode=2, stdout='', stderr='auth required')
+
+        with pytest.raises(RuntimeError, match="exited with code 2"):
+            manager._get_from_1password('svc', 'field')
 
 
 # =============================================================================
@@ -586,13 +615,30 @@ class TestGetCredentialInstance:
             result = manager.get_credential('svc', 'user', 'password')
             assert result == 'found'
 
-    def test_exception_in_backend_continues(self, mock_op_available):
-        """If a backend raises an exception, continue to the next."""
+    def test_exception_in_backend_propagates(self, mock_op_available):
+        """A backend that raises an exception PROPAGATES; the loop does
+        not silently continue to a less-trusted backend.
+
+        Per writing-tests:1 retroactive-fix corollary (RG-9 / v2.3.1):
+        this test was previously named test_exception_in_backend_continues
+        and asserted the silent-swallow fall-through as feature. The
+        rationale from issue #483: silent fallback from a backend that
+        errored (vs a backend that legitimately did not have the
+        credential) caused the operator to be prompted for credentials
+        that 1Password actually had -- UX-degrading at best,
+        security-degrading at worst. writing-code:7 bans the
+        catch-all-and-continue shape. Rules win on conflict.
+
+        Backend helpers are now responsible for distinguishing
+        'not in this backend' (return None, fall through) from
+        'errored' (raise, do not fall through). The loop itself no
+        longer has a catch-all.
+        """
         manager = CredentialManager(backend_priority=['files', 'env'])
         with patch.object(manager, '_get_from_files', side_effect=Exception("read error")), \
              patch.dict(os.environ, {'SVC_API_KEY': 'fallback_key'}, clear=False):
-            result = manager.get_credential('svc', 'user', 'api_key')
-            assert result == 'fallback_key'
+            with pytest.raises(Exception, match="read error"):
+                manager.get_credential('svc', 'user', 'api_key')
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Three writing-code:7 violations in `credential_manager.py` masked real auth/storage failures and silently fell through the backend hierarchy. Security-relevant: 1Password having the credential plus a transient error caused the operator to be prompted for credentials they thought were stored. Closes the silent-fall-through that was "graceful degradation as the violation, not the design."

## Tickets

- Fixes #483

## Findings drained

| # | Function | Pattern | Fix |
|---|----------|---------|-----|
| CM1 | `_setup_credential_paths` (line 139) | `except Exception: pass` swallowing both ImportError and config-iteration TypeError | Narrow to `except ImportError`; iteration runs in else-clause so TypeError propagates |
| CM5 | `_get_from_1password` (line 352) | Catch-all returning None on any subprocess error | Distinguish op exit code 1 ("not found", return None) from other nonzero (auth/permission/transport, raise RuntimeError) |
| CM3 | `get_credential` backend loop (line 225) | `except Exception: log_warning; continue` causing silent fall-through 1Password -> keychain -> prompt | Remove the try/except; backend helpers signal not-found via None and errored via raise |

## Architecture change

**The op CLI becomes the trust boundary** for the 1Password backend: exit code 1 = "fall through to next backend"; anything else = "raise, do not silently degrade." This means:

- 1Password has the credential, returns it -> OK, used.
- 1Password legitimately doesn't have the credential (op exit 1) -> fall through to keychain, then prompt.
- 1Password has an auth/permission/transport error (op exit != 0 and != 1) -> RuntimeError propagates to caller. Caller can re-authenticate, retry, or surface to the operator -- decisions the credential manager should not make silently.

## Test updates per writing-tests:1 retroactive-fix corollary (RG-9 / v2.3.1)

Two tests codified the silent-swallow as feature; both updated per the discipline:

- `test_returns_none_on_exception` (TestGetFrom1Password) -> `test_propagates_transport_errors_instead_of_swallowing` + companion `test_propagates_nonzero_nonone_exit_codes`.
- `test_exception_in_backend_continues` (TestGetCredentialInstance) -> `test_exception_in_backend_propagates`.

Both tests retain their original intent ("the function handles exceptions correctly") with the updated assertion ("propagates" instead of "swallows"). The author's writing-tests:1 check passed at original-author time; the rule wins when implementation-correctness conflicts with rule-correctness.

This PR is the SECOND instance (after PR #478) of the test-codifies-the-banned-behaviour pattern. Real-world evidence the writing-tests:1 corollary fold queued for v2.3.1 is the right discipline.

## Testing

136 credential_manager tests pass after the update:

```
======================== 136 passed, 1 warning in 7.73s ========================
```

## Risks

**Behaviour change**: callers that relied on the silent fall-through behaviour will now see exceptions propagate. This is the intended improvement: silent fall-through caused the security-relevant case (1Password has credential, transient error, operator prompted to type it manually under stress).

Callers wanting graceful degradation should:
1. Catch RuntimeError from `get_credential` and explicitly decide whether to fall back, OR
2. Configure the backend_priority to exclude 1Password if they want pure-fall-through semantics.

Either is a deliberate operator choice; the silent default is not.

## Commits

| SHA | Description |
|-----|-------------|
| 046c258 | fix(security): credential_manager silent-swallow drain per writing-code:7 |

## How this surfaced

Hostile-review pass 8 of `config/credential_manager.py` per session 260502-vital-channel's audit loop. The security-relevant failure-mode framing in issue #483 ("graceful degradation as the violation, not the design") clarified the fix shape.

Eval observation worth recording for v2.3.1's writing-tests:1 corollary: this is the second instance of test-codifies-the-banned-behaviour from a retroactive rule application (PR #478 was the first). The fix recipe (rename test + cite rule in docstring + do not delete) worked again. Two instances = the corollary's discipline is reproducibly applicable.