### PR TITLE
fix-exercise: apply claude-configs-public v2.3.1-rc1 cohort against three pre-identified targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### BREAKING
 
+**From the v2.3.0 fix exercise (PR #487):**
+
 - **`siege_utilities.databricks.ensure_secret_scope`** now returns the scope name (`str`) instead of `True`. Callers asserting on the bool return need to update; callers ignoring the return value are unaffected.
 - **`siege_utilities.databricks.put_secret`** now returns the scope-qualified key (`str`, e.g. `"my-scope/my-key"`) instead of `True`. Callers asserting on the bool return need to update; callers ignoring the return value are unaffected.
 - **`siege_utilities.databricks.runtime_secret_exists`** no longer catches `Exception` and silently returns `False` on lookup errors. The function now propagates the underlying exception (scope-missing, auth-denied, etc.) so the caller can distinguish "key not present in scope" from "lookup failed entirely." Callers relying on the silent-False on lookup errors need to wrap in their own exception handler or pre-check scope existence.
 
 All three are public-API changes per `__all__` in `siege_utilities.databricks` and the top-level `siege_utilities` namespace. The new contracts are stricter (more informative returns; no silent error swallowing) but break callers depending on the previous shapes. Drift is intentional: the previous contracts violated [`writing-code:7`](https://github.com/siege-analytics/claude-configs-public/blob/main/skills/_writing-code-rules.md) (silent error swallowing) and [`writing-code:11`](https://github.com/siege-analytics/claude-configs-public/blob/main/skills/_writing-code-rules.md) (no silent processes) from claude-configs-public v2.3.0.
 
-See PR #487 for the fix-exercise that drove these changes and the per-rule eval observations.
+**From the v2.3.1 fix exercise (PR #489):**
+
+- **`siege_utilities.reporting.PowerPointGenerator.generate_powerpoint_presentation`** now returns `Path` (the saved file location) instead of `bool`. Raises on any python-pptx or filesystem error. Consistent with sibling `create_*_presentation` methods per [claude-configs-public v2.3.1 writing-code:13](https://github.com/siege-analytics/claude-configs-public) (sibling methods within a class follow the same failure-mode contract). Callers using the bool return need to switch to try/except + Path; callers ignoring the return value are unaffected. The bundled example in `siege_utilities/reporting/examples/comprehensive_mapping_example.py` was updated as part of the change.
+- **`siege_utilities.geo.spatial_data.GovernmentDataSource._get_dataset_metadata`** now raises `SpatialDataError` on HTTP non-2xx instead of returning `None`. Per writing-code:13 (consistent failure-mode contract), the mixed contract (return None for HTTP non-2xx, raise for transport/parse errors) collapsed to a single raise-everything-non-success contract. The private method's contract change is invisible to external consumers; the public `download_dataset` caller's contract is unchanged.
+
+Drift is intentional and traceable: each BREAKING entry cites the rule that drove it (writing-code:13) so consumers can trace the contract change back to the rule's originating-arc evidence. Per claude-configs-public v2.3.1 writing-releases:1 composition discipline, the BREAKING-changelog entry lands as a separate commit on the fix-exercise PR, composing writing-code:13 with writing-releases:1 without losing per-rule attribution.
 
 ## [3.16.0] - 2026-05-13
 

--- a/siege_utilities/geo/spatial_data.py
+++ b/siege_utilities/geo/spatial_data.py
@@ -1908,9 +1908,10 @@ def get_census_boundaries(year: int = DEFAULT_CENSUS_YEAR, geographic_level: str
     """
     Convenience function to get Census boundaries.
 
-    .. deprecated::
+    .. deprecated:: 3.16.0
         Use :func:`fetch_geographic_boundaries` (via CensusDataSource) for
         structured diagnostics via :class:`BoundaryFetchResult`.
+        ``get_census_boundaries`` will be removed in v3.17.0.
 
     Args:
         year: Census year
@@ -2064,12 +2065,20 @@ def get_geographic_boundaries(
 ) -> Optional[GeoDataFrame]:
     """Get geographic boundaries (legacy, returns None on failure).
 
-    .. deprecated::
+    .. deprecated:: 3.16.0
         Use :func:`fetch_geographic_boundaries` for structured diagnostics.
+        ``get_geographic_boundaries`` will be removed in v3.17.0.
 
     Args:
         crs: Output CRS. Defaults to :func:`~siege_utilities.geo.crs.get_default_crs`.
     """
+    warnings.warn(
+        "get_geographic_boundaries() is deprecated; will be removed in v3.17.0. "
+        "Use fetch_geographic_boundaries() for structured diagnostics via "
+        "BoundaryFetchResult.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     gdf = census_source.get_geographic_boundaries(year, geographic_level, state_fips, state_identifier)
     return reproject_if_needed(gdf, crs)
 

--- a/siege_utilities/geo/spatial_data.py
+++ b/siege_utilities/geo/spatial_data.py
@@ -4,20 +4,20 @@ Provides clean, type-safe access to Census, Government, and OpenStreetMap data.
 """
 
 import logging
-import geopandas as gpd
-from pathlib import Path
-
-from siege_utilities.geo.crs import reproject_if_needed
-from typing import Dict, Any, Optional, List, Union
 import os
+import re
 import time
+import warnings
 import warnings as _warnings_mod
 from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+import geopandas as gpd
 import requests
 from bs4 import BeautifulSoup
-import re
-import os
-import warnings
+
+from siege_utilities.geo.crs import reproject_if_needed
 
 # Opt-in TLS-verification bypass for environments behind broken
 # corporate MITM proxies. Defaults to False because silent fallback to

--- a/siege_utilities/geo/spatial_data.py
+++ b/siege_utilities/geo/spatial_data.py
@@ -1734,19 +1734,32 @@ class GovernmentDataSource(SpatialDataSource):
                 f"Failed to download dataset {dataset_id}: {e}"
             ) from e
     
-    def _get_dataset_metadata(self, url: str) -> Optional[Dict[str, Any]]:
-        """Get dataset metadata from the portal."""
+    def _get_dataset_metadata(self, url: str) -> Dict[str, Any]:
+        """Get dataset metadata from the portal.
+
+        Single failure-indication mechanism per writing-code:13: raises
+        SpatialDataError for any failure path (transport, HTTP non-2xx,
+        JSON decode). The previous mixed contract (return None for
+        HTTP non-2xx, raise for everything else) forced callers to
+        handle two failure paths for one call; that has been collapsed
+        to one raise-everything-non-success contract.
+
+        Returns the parsed `result` dict from a 2xx JSON response.
+        Raises SpatialDataError for HTTP non-2xx, network failures,
+        non-JSON bodies, or any other path. Caller pattern-matches on
+        the exception type, not on a returned sentinel.
+        """
         try:
-            import requests
-            
             response = requests.get(url, timeout=get_service_timeout('census_download'))
-            if response.ok:
-                data = response.json()
-                return data.get('result', {})
-            else:
-                log.error(f"Failed to get metadata: HTTP {response.status_code}")
-                return None
-                
+            if not response.ok:
+                raise SpatialDataError(
+                    f"Dataset metadata fetch from {url} returned HTTP "
+                    f"{response.status_code}: {response.text[:200]!r}"
+                )
+            data = response.json()
+            return data.get('result', {})
+        except SpatialDataError:
+            raise
         except Exception as e:
             raise SpatialDataError(
                 f"Error getting dataset metadata from {url}: {e}"

--- a/siege_utilities/reporting/examples/comprehensive_mapping_example.py
+++ b/siege_utilities/reporting/examples/comprehensive_mapping_example.py
@@ -463,14 +463,16 @@ def create_comprehensive_powerpoint(maps_dict):
         level=1
     )
     
-    # Generate PowerPoint
+    # Generate PowerPoint. Returns Path on success; raises on failure
+    # (consistent with sibling create_*_presentation methods per
+    # writing-code:13 at claude-configs-public v2.3.1).
     output_path = "comprehensive_geographic_presentation.pptx"
-    success = ppt_gen.generate_powerpoint_presentation(presentation_content, output_path)
-    
-    if success:
-        print(f"✅ PowerPoint presentation generated successfully: {output_path}")
-    else:
-        print("❌ Error generating PowerPoint presentation")
+    try:
+        saved_to = ppt_gen.generate_powerpoint_presentation(presentation_content, output_path)
+        print(f"PowerPoint presentation generated successfully: {saved_to}")
+    except Exception as exc:
+        print(f"Error generating PowerPoint presentation: {exc}")
+        raise
     
     return success
 

--- a/siege_utilities/reporting/powerpoint_generator.py
+++ b/siege_utilities/reporting/powerpoint_generator.py
@@ -489,44 +489,53 @@ class PowerPointGenerator:
         return self.add_slide_section(presentation_content, 'summary_slide', title, content, level)
 
     def generate_powerpoint_presentation(self, presentation_content: Dict[str, Any],
-                                       output_path: str) -> bool:
+                                       output_path: str) -> Path:
         """
-        Generate a comprehensive PowerPoint presentation.
-        
+        Generate a comprehensive PowerPoint presentation from a structure dict.
+
+        Consistent with sibling ``create_*_presentation`` methods (per
+        writing-code:13): returns ``Path`` on success and raises on
+        failure. The previous bool-return contract conflicted with the
+        sibling family's raise-on-failure contract and forced callers
+        of the PowerPointGenerator class to handle two failure-indication
+        mechanisms across methods that looked similar.
+
         Args:
-            presentation_content: Presentation content structure
-            output_path: Output PowerPoint file path
-            
+            presentation_content: Presentation content structure (a Dict
+                produced by ``create_comprehensive_presentation`` + the
+                ``add_*_slide`` builders).
+            output_path: Output PowerPoint file path.
+
         Returns:
-            True if successful, False otherwise
+            Path to the saved .pptx file.
+
+        Raises:
+            Exception: any python-pptx or filesystem error during slide
+                construction or save. Caller pattern-matches on the
+                exception type, not on a boolean.
         """
         try:
-            # Create presentation
             prs = Presentation()
-            
+
             # Apply template if specified
             template_path = presentation_content.get('template_path')
             if template_path and Path(template_path).exists():
                 prs = Presentation(template_path)
-            
+
             # Process each section
             for section in presentation_content.get('sections', []):
                 slide = self._create_slide_from_section(section, prs)
-                if slide:
-                    # Add speaker notes if provided
-                    if section.get('notes'):
-                        notes_slide = slide.notes_slide
-                        notes_slide.notes_text_frame.text = section['notes']
-            
-            # Save presentation
+                if slide and section.get('notes'):
+                    notes_slide = slide.notes_slide
+                    notes_slide.notes_text_frame.text = section['notes']
+
             prs.save(output_path)
-            
             log.info(f"PowerPoint presentation generated successfully: {output_path}")
-            return True
-            
+            return Path(output_path)
+
         except Exception as e:
             log.error(f"Error generating PowerPoint presentation: {e}")
-            return False
+            raise
 
     def _add_title_slide(self, prs: Presentation, title: str) -> Any:
         """Add a title slide. Returns the added Slide for caller inspection."""

--- a/tests/test_spatial_data_errors.py
+++ b/tests/test_spatial_data_errors.py
@@ -38,20 +38,36 @@ class TestGovernmentDataSource:
                 src._get_dataset_metadata("https://example.com/api/x")
         assert isinstance(exc_info.value.__cause__, ConnectionError)
 
-    def test_metadata_http_error_status_returns_none(self):
-        """HTTP 4xx/5xx without exception goes through the response.ok
-        branch and returns None — that's a legitimate 'no metadata' path,
-        not a silent-swallow of a transport-level failure."""
+    def test_metadata_http_error_status_raises(self):
+        """HTTP 4xx/5xx raises SpatialDataError per writing-code:13
+        (single failure-indication mechanism per function).
+
+        Per writing-tests:1 retroactive-fix corollary (v2.3.1): this
+        test was previously named test_metadata_http_error_status_returns_none
+        and asserted None-on-HTTP-failure as feature. writing-code:13
+        ratified at v2.3.1-rc1 collapsed the mixed contract (return None
+        for non-2xx, raise for everything else) to a single raise-
+        everything-non-success contract. The author's writing-tests:1
+        check passed at original-author time because the test was
+        designed for the now-banned mixed-contract impl; correctness
+        against the implementation did not equal correctness against
+        the rule. Rules win on conflict.
+
+        Third instance of the test-codifies-banned-behaviour pattern
+        (after PR #478 + PR #484) -- evidence that writing-tests:1's
+        corollary discipline transfers across module shapes.
+        """
         src = GovernmentDataSource(portal_url="https://example.com")
         fake_response = MagicMock()
         fake_response.ok = False
         fake_response.status_code = 404
+        fake_response.text = "Not Found"
         with patch(
             "siege_utilities.geo.spatial_data.requests.get",
             return_value=fake_response,
         ):
-            result = src._get_dataset_metadata("https://example.com/api/x")
-        assert result is None
+            with pytest.raises(SpatialDataError, match="HTTP 404"):
+                src._get_dataset_metadata("https://example.com/api/x")
 
     def test_format_finder_propagates_programming_errors(self):
         """_find_best_format does NOT wrap programming errors as


### PR DESCRIPTION
## Summary

Application of the v2.3.1-rc1 cohort (writing-code:12, writing-code:13, writing-releases:3+:4 composition, writing-code:11 carve-outs, writing-releases:1 composition, writing-tests:1 retroactive-fix corollary) against three pre-identified targets from hostile-review passes 2 and 4. Five thematic commits, per-rule attribution preserved.

## Tickets

- Fixes #488

## Findings drained

| # | Module | Function/Site | Rule(s) | Eval observation |
|---|--------|--------------|---------|------------------|
| 1 | `geo/spatial_data.py` | duplicate `import os` at lines 12, 19 | writing-code:12 | Carve-out for dual-aliased `warnings`/`_warnings_mod` correctly stayed silent (both aliases used) |
| 2 | `geo/spatial_data.py` | `_get_dataset_metadata` (SP14) | writing-code:13 | Mixed contract collapsed to raise-everything-non-success; test renamed per writing-tests:1 corollary |
| 3 | `reporting/powerpoint_generator.py` | `generate_powerpoint_presentation` (PG7) | writing-code:13 | Sibling-consistency fix: bool→Path to match `create_*_presentation` family; BREAKING |
| 4 | `geo/spatial_data.py` | two RST `.. deprecated::` markers + one message-format gap | writing-releases:4 + writing-releases:3 | Composition resolved in ONE commit per site, not two as predicted |
| 5 | CHANGELOG.md | BREAKING entries | writing-releases:1 | Separate commit; second application of the v2.3.1 composition discipline |

## Eval observations against Skills Remote's pre-registered hypotheses

**writing-code:12 — hypothesis confirmed.** Strict violation (duplicate `import os`) fixed in one-line removal. The dual-alias `warnings`/`_warnings_mod` case stayed silent per the rule's explicit carve-out (both aliases used). The carve-out was specifically designed for this kind of case; the rule wording correctly distinguished slop from intentional dual-aliasing. **Zero wording mis-fire.**

**writing-code:13 — hypothesis partially confirmed.** Skills Remote predicted "2 of 3 converge to single contract; 1 of 3 renames `generate_powerpoint_presentation` to surface the bool-vs-Path divergence."

Result: **2 of 2 converged** (the third instance — credential_manager 1Password backend — was already handled by PR #484 and didn't need to be re-touched in this exercise). The genuine-divergence-with-naming-differentiation option in writing-code:13's body was NOT exercised. Both fixed instances chose contract-convergence over rename. Worth banking: the rename-instead-of-converge case may be rarer than the wording suggests; the option is in the rule for completeness but most real-world inconsistent-contract cases ARE pure slop that converges cleanly.

**writing-releases:4 — hypothesis adjusted.** Skills Remote predicted "each RST marker fix lands two commits — one for the warn, one for the message-format compliance." Result: **one commit per site**, not two. Both fixes (add warn + comply with message format) happened at the same line; splitting was more artificial than per-rule attribution warranted.

Worth banking for v2.3.x or v2.4.0 wording: **"the per-rule-commit pattern composes naturally when one fix satisfies two composing rules at one site; do not split artificially."** This is the inverse of the per-rule-commit-composition-with-BREAKING case where the fix touches different files (impl + CHANGELOG) and naturally splits.

**writing-code:11 carve-outs — exercised one of three.** The per-rule-commit composition with writing-releases:1 was exercised (BREAKING return-type changes from `generate_powerpoint_presentation` and `_get_dataset_metadata`). Contract-preservation override and family-of-methods scaling did not exercise — no rule conflict, no method family.

**writing-tests:1 retroactive-fix corollary — THIRD instance.** `test_metadata_http_error_status_returns_none` codified the old mixed-contract behavior as feature; renamed to `test_metadata_http_error_status_raises` with rule citation in the docstring. Three instances now (PR #478 + PR #484 + this PR), at three different module shapes (engine abstraction, credential security, government data fetcher). The corollary's three-step recipe (rename / cite rule / preserve test) worked unchanged for the third application.

**The self-validating observation in writing-tests:1's body** held: I applied the recipe naturally without needing to consult the rule text, confirming "experienced operators apply it without the rule needing to exist." Strong empirical evidence for the body extension rather than standalone rule.

## Commits

| SHA | Description |
|-----|-------------|
| 7a42798 | drop duplicate `import os` per writing-code:12 |
| d60e811 | `_get_dataset_metadata` single failure-mode contract per writing-code:13 (+ test rename per writing-tests:1 corollary) |
| fadc482 | `generate_powerpoint_presentation` aligns with sibling raise-on-failure contract per writing-code:13 |
| aca76a3 | RST markers gain runtime warnings per writing-releases:4 + version anchors per writing-releases:3 |
| b64d993 | BREAKING changelog entries per writing-releases:1 composition |

## Testing

`tests/test_spatial_data_errors.py::TestGovernmentDataSource` — 4 passed, including the renamed `test_metadata_http_error_status_raises` and the unchanged `test_metadata_http_failure_raises`.

## Risks

Two BREAKING changes documented in CHANGELOG [Unreleased]:
- `generate_powerpoint_presentation` bool → Path
- `_get_dataset_metadata` None → raise on HTTP non-2xx (private method; external consumers unaffected)

## Cross-pass eval observation

**Eight rules across two cohorts (v2.3.0 + v2.3.1) have now bitten cleanly in fix-exercise application.** No rule ratified through this arc has produced a wording mis-fire at fix-time. The framework's three-samples-before-ship discipline (RD-1) is paying off — every shipped rule had originating + cross-pass + fix-exercise evidence before promotion to final.

Companion to claude-configs-public#66.