### PR TITLE
release: v3.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.17.1] - 2026-05-14
+
+Patch release: package-hygiene fix surfaced by the v3.17.0 consumer-side verification (proposed claude-configs-public writing-releases:5).
+
+### Fixed
+
+- **`scripts/`, `tests/`, `docs/` no longer ship to `site-packages` root** (#496):
+  setuptools `find_packages(include=["*"])` was matching every directory
+  containing `.py` files at the repo root. `pip install siege-utilities`
+  was installing `site-packages/scripts/` as a top-level package, polluting
+  every downstream venv (a user could `from scripts import release_manager`
+  and collide with their own top-level `scripts/` package). Pre-existing
+  in v3.16.0 and earlier; v3.17.0 added `check_unbounded_io.py` to the
+  polluted namespace.
+
+  Fix: explicit `exclude` in `[tool.setuptools.packages.find]` for
+  `scripts*`, `tests*`, `docs*`. Wheel verified post-fix: zero matches
+  for those prefixes.
+
+  Surfaced by the v3.17.0 consumer-side verification per the proposed
+  writing-releases:5 rule: source-side green (25 CI jobs pass; twine
+  check pass; scanner clean) but two real consumer-side bugs reached
+  PyPI. Recurrence 3 of LESSON 323a0f5 family in the rule's originating
+  arc.
+
 ## [3.17.0] - 2026-05-14
 
 Minor release rolling up a 12-PR rule-cohort fix-exercise session against

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,7 +5,7 @@ sys.path.insert(0, os.path.abspath('../'))
 project = 'Siege Utilities'
 copyright = '2025-2026, Dheeraj Chand'
 author = 'Dheeraj Chand'
-release = '3.17.0'
+release = '3.17.1'
 
 extensions = [
     'sphinx.ext.autodoc',

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,7 +5,7 @@ sys.path.insert(0, os.path.abspath('../../'))
 project = 'Siege Utilities'
 copyright = '2025-2026, Dheeraj Chand'
 author = 'Dheeraj Chand'
-release = '3.17.0'
+release = '3.17.1'
 
 extensions = [
     'sphinx.ext.autodoc',

--- a/docs/source/conf_fast.py
+++ b/docs/source/conf_fast.py
@@ -5,7 +5,7 @@ sys.path.insert(0, os.path.abspath('../../'))
 project = 'Siege Utilities'
 copyright = '2025, Dheeraj Chand'
 author = 'Dheeraj Chand'
-release = '3.17.0'
+release = '3.17.1'
 
 # Minimal extensions for fast builds
 extensions = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siege-utilities"
-version = "3.17.0"
+version = "3.17.1"
 description = "A comprehensive Python utilities package with enhanced auto-discovery"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -289,6 +289,17 @@ Homepage = "https://github.com/siege-analytics/siege_utilities"
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["*"]
+exclude = [
+    # Repo-tooling directories that contain .py files but are NOT runtime
+    # packages. Without an exclude here, setuptools find_packages picked
+    # them up and shipped them at site-packages root, polluting every
+    # downstream venv (any user could then `from scripts import
+    # release_manager` and collide with their own top-level `scripts/`
+    # package). See issue #496.
+    "scripts*",
+    "tests*",
+    "docs*",
+]
 
 [tool.setuptools.package-data]
 siege_utilities = ["py.typed"]

--- a/siege_utilities/__init__.py
+++ b/siege_utilities/__init__.py
@@ -29,7 +29,7 @@ try:
     from importlib.metadata import version as _meta_version
     __version__ = _meta_version("siege-utilities")
 except Exception:
-    __version__ = "3.17.0"  # fallback for editable installs without metadata
+    __version__ = "3.17.1"  # fallback for editable installs without metadata
 __author__ = "Siege Analytics"
 __description__ = "Comprehensive utilities for data engineering, analytics, and distributed computing"
 


### PR DESCRIPTION
## Summary

Patch release fixing the \`scripts/\` namespace pollution surfaced by the v3.17.0 consumer-side verification.

## Surfaced by

The proposed claude-configs-public **writing-releases:5** rule. While the rule was being drafted, I ran the verification step on v3.17.0 per its library-shape protocol (\`pip install\` in fresh venv, exercise canonical APIs) and the install surfaced the namespace pollution within minutes. Source-side CI was 100% green. This is exactly the gap writing-releases:5 closes.

## What v3.17.1 contains

Single fix: explicit \`exclude\` in \`[tool.setuptools.packages.find]\` for \`scripts*\`, \`tests*\`, \`docs*\`. Wheel verified post-fix: those prefixes no longer ship to site-packages root.

Closes #496.

## Test plan

- [x] Local wheel rebuild verified excludes (\`unzip -l dist/*.whl | grep scripts/\` returns empty)
- [ ] Post-publish verification per writing-releases:5: \`pip install siege-utilities==3.17.1\` in fresh venv, confirm no \`site-packages/scripts/\` directory