### PR TITLE
release: v3.17.2 (hydra optional-extra fix, closes #498)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.17.2] - 2026-05-14
+
+Patch release: hydra is an optional extra; importing siege_utilities without it must not emit a misleading "Pydantic config system" warning. Closes #498.
+
+### Fixed
+
+- **Hydra absence no longer surfaces as "Could not import Pydantic config system"** (#498).
+  `siege_utilities/config/__init__.py` had `from .hydra_manager import HydraConfigManager` inside the pydantic try block. When hydra was absent, the whole block failed and emitted a WARNING blaming pydantic. The eager hydra-manager import is now in its own narrow try/except; hydra absence drops to DEBUG (it's an optional `[config-extras]` extra), and the dependency wrapper cites `hydra-core` / `omegaconf` rather than `pydantic` when the consumer tries to use `HydraConfigManager`.
+
+  writing-code:8 (conditional-import callsite hygiene) territory. Three regression tests in `tests/test_config_hydra_optional.py` pin the new behavior.
+
 ## [3.17.1] - 2026-05-14
 
 Patch release: package-hygiene fix surfaced by the v3.17.0 consumer-side verification (proposed claude-configs-public writing-releases:5).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,7 +5,7 @@ sys.path.insert(0, os.path.abspath('../'))
 project = 'Siege Utilities'
 copyright = '2025-2026, Dheeraj Chand'
 author = 'Dheeraj Chand'
-release = '3.17.1'
+release = '3.17.2'
 
 extensions = [
     'sphinx.ext.autodoc',

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,7 +5,7 @@ sys.path.insert(0, os.path.abspath('../../'))
 project = 'Siege Utilities'
 copyright = '2025-2026, Dheeraj Chand'
 author = 'Dheeraj Chand'
-release = '3.17.1'
+release = '3.17.2'
 
 extensions = [
     'sphinx.ext.autodoc',

--- a/docs/source/conf_fast.py
+++ b/docs/source/conf_fast.py
@@ -5,7 +5,7 @@ sys.path.insert(0, os.path.abspath('../../'))
 project = 'Siege Utilities'
 copyright = '2025, Dheeraj Chand'
 author = 'Dheeraj Chand'
-release = '3.17.1'
+release = '3.17.2'
 
 # Minimal extensions for fast builds
 extensions = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siege-utilities"
-version = "3.17.1"
+version = "3.17.2"
 description = "A comprehensive Python utilities package with enhanced auto-discovery"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/siege_utilities/__init__.py
+++ b/siege_utilities/__init__.py
@@ -29,7 +29,7 @@ try:
     from importlib.metadata import version as _meta_version
     __version__ = _meta_version("siege-utilities")
 except Exception:
-    __version__ = "3.17.1"  # fallback for editable installs without metadata
+    __version__ = "3.17.2"  # fallback for editable installs without metadata
 __author__ = "Siege Analytics"
 __description__ = "Comprehensive utilities for data engineering, analytics, and distributed computing"
 

--- a/siege_utilities/config/__init__.py
+++ b/siege_utilities/config/__init__.py
@@ -279,7 +279,6 @@ try:
         export_config_yaml,
         import_config_yaml,
     )
-    from .hydra_manager import HydraConfigManager
     from .models import (
         UserProfile as PydanticUserProfile,
         ClientProfile as PydanticClientProfile,
@@ -322,7 +321,6 @@ except ImportError as e:
     list_client_profiles = _config_dependency_wrapper('list_client_profiles', _pd)
     export_config_yaml = _config_dependency_wrapper('export_config_yaml', _pd)
     import_config_yaml = _config_dependency_wrapper('import_config_yaml', _pd)
-    HydraConfigManager = _config_dependency_wrapper('HydraConfigManager', _pd)
     PydanticUserProfile = _config_dependency_wrapper('PydanticUserProfile', _pd)
     PydanticClientProfile = _config_dependency_wrapper('PydanticClientProfile', _pd)
     ContactInfo = _config_dependency_wrapper('ContactInfo', _pd)
@@ -351,6 +349,26 @@ except ImportError as e:
     ConfigurationMigrator = _config_dependency_wrapper('ConfigurationMigrator', _pd)
     migrate_configurations = _config_dependency_wrapper('migrate_configurations', _pd)
     backup_and_migrate = _config_dependency_wrapper('backup_and_migrate', _pd)
+
+# Hydra is an optional dependency (in the `[config-extras]` extra). Import
+# it separately from the pydantic-config try block: when hydra is missing,
+# the consumer's stderr previously emitted a misleading "Could not import
+# Pydantic config system" warning because the eager `from .hydra_manager
+# import HydraConfigManager` lived inside the pydantic try block and took
+# the whole block down. Hydra absence drops to DEBUG (the consumer didn't
+# install the extra; they don't need a warning about it).
+try:
+    from .hydra_manager import HydraConfigManager
+except ImportError as e:
+    _config_logger.debug(
+        "Hydra config manager not available (install with the "
+        "'config-extras' extra: pip install siege-utilities[config-extras]): %s",
+        e,
+    )
+    HydraConfigManager = _config_dependency_wrapper(
+        'HydraConfigManager',
+        ['hydra-core>=1.3.0', 'omegaconf>=2.3.0'],
+    )
 
 from .databases import (
     create_database_config,

--- a/tests/test_config_hydra_optional.py
+++ b/tests/test_config_hydra_optional.py
@@ -1,0 +1,98 @@
+"""Regression tests for #498: hydra is optional, not core.
+
+When the consumer hasn't installed the `[config-extras]` extra, importing
+`siege_utilities` must NOT emit a warning that misattributes the failure
+to pydantic. The hydra-config-manager import lives in its own narrow
+try/except block; its absence drops to DEBUG, not WARNING.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+
+import pytest
+
+
+def _reload_siege_config_with_hydra_blocked(monkeypatch, caplog_or_handler):
+    """Force a fresh import of siege_utilities.config with hydra unimportable.
+
+    Uses a meta_path finder that raises ImportError on any hydra import,
+    then reloads siege_utilities.config so the try/except runs cleanly.
+    """
+
+    class _BlockHydra:
+        def find_spec(self, name, path, target=None):
+            if name == "hydra" or name.startswith("hydra.") or name == "omegaconf":
+                raise ImportError(f"blocked for test: {name}")
+            return None
+
+    blocker = _BlockHydra()
+    monkeypatch.setattr(sys, "meta_path", [blocker, *sys.meta_path])
+
+    # Purge any cached siege_utilities.config / hydra_manager modules so
+    # the re-import re-runs the try/except.
+    for mod_name in list(sys.modules):
+        if mod_name.startswith("siege_utilities.config") or mod_name in {
+            "hydra",
+            "omegaconf",
+            "siege_utilities.config.hydra_manager",
+        }:
+            sys.modules.pop(mod_name, None)
+
+    # Capture warnings emitted during the (re-)import.
+    return importlib.import_module("siege_utilities.config")
+
+
+def test_hydra_missing_emits_no_misleading_pydantic_warning(monkeypatch, caplog):
+    """Issue #498: hydra absence must not surface as 'Could not import Pydantic config system'."""
+    caplog.set_level(logging.DEBUG, logger="siege_utilities.config")
+
+    _reload_siege_config_with_hydra_blocked(monkeypatch, caplog)
+
+    # The pydantic-config WARNING must NOT mention hydra.
+    misleading = [
+        rec for rec in caplog.records
+        if rec.levelno >= logging.WARNING
+        and "Pydantic config system" in rec.getMessage()
+        and "hydra" in rec.getMessage().lower()
+    ]
+    assert not misleading, (
+        "Importing siege_utilities.config without hydra installed emitted "
+        "a misleading WARNING blaming pydantic for a missing hydra: "
+        f"{[r.getMessage() for r in misleading]}"
+    )
+
+
+def test_hydra_missing_logs_at_debug_not_warning(monkeypatch, caplog):
+    """Issue #498: optional-extra absence is DEBUG-level, not WARNING."""
+    caplog.set_level(logging.DEBUG, logger="siege_utilities.config")
+
+    _reload_siege_config_with_hydra_blocked(monkeypatch, caplog)
+
+    debug_records = [
+        rec for rec in caplog.records
+        if "Hydra config manager not available" in rec.getMessage()
+    ]
+    assert debug_records, (
+        "Expected a DEBUG record explaining hydra is unavailable; got nothing. "
+        f"All records: {[(r.levelname, r.getMessage()) for r in caplog.records]}"
+    )
+    assert all(rec.levelno == logging.DEBUG for rec in debug_records), (
+        "Hydra-absent message must log at DEBUG, not WARNING/INFO."
+    )
+
+
+def test_hydra_missing_HydraConfigManager_is_dependency_wrapper(monkeypatch):
+    """Issue #498: with hydra missing, HydraConfigManager raises ImportError
+    citing the correct package (hydra-core), not pydantic."""
+    config_mod = _reload_siege_config_with_hydra_blocked(monkeypatch, None)
+
+    # HydraConfigManager should be the dependency-wrapper sentinel, not a
+    # real class. Calling it should raise an ImportError that names hydra.
+    with pytest.raises(ImportError) as exc_info:
+        config_mod.HydraConfigManager()
+    msg = str(exc_info.value).lower()
+    assert "hydra-core" in msg or "hydra" in msg, (
+        f"Dependency error must name the missing package (hydra), got: {exc_info.value!r}"
+    )


### PR DESCRIPTION
Closes #498. Fixes the misleading 'Could not import Pydantic config system: No module named hydra' warning emitted on every consumer venv that hasn't installed the optional `[config-extras]` extra.

## Fix

`from .hydra_manager import HydraConfigManager` moved out of the pydantic try/except in `config/__init__.py` into its own narrow try/except. Hydra absence drops to DEBUG (it's optional); dependency wrapper cites `hydra-core`/`omegaconf` rather than `pydantic`.

Three regression tests in `tests/test_config_hydra_optional.py` pin the new behavior.

## Test plan

- [x] 93 targeted config tests pass locally (including 3 new hydra-optional tests)
- [x] writing-code:15 scanner clean
- [ ] CI green on release branch
- [ ] Per writing-releases:5: post-publish fresh-venv verification (run BEFORE PyPI upload this time)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved misleading warning message about missing Pydantic configuration system when optional Hydra support is unavailable during initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siege-analytics/siege_utilities/pull/499)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->