### PR TITLE
fix(geo): PostGISConnector.upload_spatial_data writes all columns (P0 / #516)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ geo = [
     "pysal>=24.1",
     "censusgeocode>=0.5.2",
     "topojson>=1.8",
+    # Required by PostGISConnector.upload_spatial_data for full-column
+    # writes via gpd.GeoDataFrame.to_postgis (closes #516).
+    "geoalchemy2>=0.14.0",
 ]
 # H3 hexagonal spatial index (lightweight spatial joins)
 h3 = [

--- a/siege_utilities/geo/spatial_transformations.py
+++ b/siege_utilities/geo/spatial_transformations.py
@@ -321,80 +321,73 @@ class PostGISConnector:
     
     def upload_spatial_data(self, gdf: GeoDataFrame, table_name: str, **kwargs) -> bool:
         """
-        Upload spatial data to PostGIS.
+        Upload spatial data to PostGIS with all columns preserved.
+
+        Uses geopandas.GeoDataFrame.to_postgis under the hood, which
+        handles full-column writes (geometry + every attribute column) via
+        SQLAlchemy + GeoAlchemy2. This is the canonical geopandas idiom
+        for PostGIS upload.
+
+        Pre-#516 behavior (replaced): the old implementation manually
+        built `INSERT INTO {table} (geom) VALUES (...)` statements,
+        dropping all tabular columns from the GeoDataFrame. Any caller
+        passing attribute data got an empty-attribute table silently.
 
         Args:
-            gdf: GeoDataFrame to upload
-            table_name: Target table name
+            gdf: GeoDataFrame to upload (all columns including geometry).
+            table_name: Target table name.
             **kwargs: Additional parameters:
-                if_exists: How to handle existing table -- ``'replace'`` (default,
-                    drops and recreates), ``'append'`` (inserts into existing table),
-                    or ``'fail'`` (raises if table exists).
+                if_exists: How to handle existing table -- ``'fail'``,
+                    ``'replace'`` (default), or ``'append'``.
                 schema: PostgreSQL schema name (default ``'public'``).
 
         Returns:
-            True if successful, False otherwise
+            True if successful, False otherwise.
+
+        Note:
+            Requires ``geoalchemy2`` (declared in the ``geo`` optional
+            extra). If missing, the import error is logged and the
+            upload returns False with a clear remediation hint.
         """
-        if not self.connection:
-            log.error("No PostGIS connection available")
+        if not self.connection_string:
+            log.error("No PostGIS connection_string available")
             return False
 
         if_exists = kwargs.get('if_exists', 'replace')
         schema = kwargs.get('schema', 'public')
 
-        # Validate identifiers before they reach SQL, then use
-        # psycopg2.sql.Identifier for safe quoting in interpolation.
+        # Validate identifiers before they reach SQL. to_postgis itself
+        # uses parameterized SQL but defense-in-depth keeps the validation
+        # consistent with download_spatial_data + the prior implementation.
         from siege_utilities.core.sql_safety import validate_sql_identifier as validate_identifier
-        from psycopg2 import sql as _pg_sql
         validate_identifier(schema, label="schema name", allow_dotted=False)
         validate_identifier(table_name, label="table name", allow_dotted=False)
-        qualified_table = f"{schema}.{table_name}"
-        qualified_ident = _pg_sql.Identifier(schema, table_name)
 
         try:
-            cursor = self.connection.cursor()
+            import geoalchemy2  # noqa: F401  -- presence-check; to_postgis needs it
+        except ImportError:
+            log.error(
+                "geoalchemy2 not available -- upload_spatial_data requires it "
+                "for full-column writes. Install with: pip install 'siege_utilities[geo]'"
+            )
+            return False
 
-            if if_exists == 'fail':
-                cursor.execute(
-                    "SELECT to_regclass(%s)",
-                    (qualified_table,),
-                )
-                if cursor.fetchone()[0] is not None:
-                    raise ValueError(
-                        f"Table {qualified_table} already exists and if_exists='fail'"
-                    )
-
-            if if_exists == 'replace':
-                cursor.execute(
-                    _pg_sql.SQL("DROP TABLE IF EXISTS {}").format(qualified_ident)
-                )
-                self.connection.commit()
-
-            if if_exists in ('replace', 'fail'):
-                self._create_spatial_table(qualified_table, gdf)
-
-            # Upload data. _create_spatial_table writes the column as
-            # GEOMETRY(<type>, <srid>) and rejects mismatched SRIDs, so
-            # we must pass the same SRID to ST_GeomFromText here. Prefer
-            # gdf.crs's EPSG code; fall back to STORAGE_CRS.
-            cursor = self.connection.cursor()
-            srid = None
+        try:
+            from sqlalchemy import create_engine
+            engine = create_engine(self.connection_string)
             try:
-                crs = getattr(gdf, "crs", None)
-                if crs is not None:
-                    srid = crs.to_epsg()
-            except Exception:
-                srid = None
-            srid = srid or settings.STORAGE_CRS
-
-            insert_stmt = _pg_sql.SQL(
-                "INSERT INTO {} (geom) VALUES (ST_GeomFromText(%s, %s))"
-            ).format(qualified_ident)
-            params = [(geom.wkt, srid) for geom in gdf.geometry]
-            cursor.executemany(insert_stmt, params)
-
-            self.connection.commit()
-            log.info(f"Successfully uploaded to PostGIS table: {qualified_table}")
+                gdf.to_postgis(
+                    name=table_name,
+                    con=engine,
+                    schema=schema,
+                    if_exists=if_exists,
+                )
+            finally:
+                engine.dispose()
+            log.info(
+                f"Successfully uploaded to PostGIS table: {schema}.{table_name} "
+                f"({len(gdf)} rows, {len(gdf.columns)} columns)"
+            )
             return True
 
         except Exception as e:
@@ -511,7 +504,17 @@ class PostGISConnector:
                 cursor.close()
     
     def _create_spatial_table(self, table_name: str, gdf: GeoDataFrame):
-        """Create a spatial table in PostGIS."""
+        """DEPRECATED. Kept only for backward compatibility with callers
+        that referenced this private helper directly (pre-#516).
+
+        The new upload_spatial_data uses gdf.to_postgis which creates the
+        table with the full column set automatically. This helper, if
+        called directly, still creates only (id, geom) -- which is the
+        same broken behavior #516 fixed. Do not call this directly; use
+        upload_spatial_data.
+
+        Will be removed in a future major version.
+        """
         cursor = self.connection.cursor()
 
         # Detect geometry type from the GeoDataFrame

--- a/tests/test_spatial_transformations.py
+++ b/tests/test_spatial_transformations.py
@@ -306,19 +306,63 @@ class TestPostGISConnector:
                 connector.connection = mock_conn
                 return connector
 
-    def test_upload_no_connection_returns_false(self, sample_gdf):
+    def test_upload_no_connection_string_returns_false(self, sample_gdf):
+        # Post-#516: upload_spatial_data requires self.connection_string
+        # (used to build the SQLAlchemy engine for to_postgis), not the
+        # raw psycopg2 connection.
         connector = self._make_connector()
-        connector.connection = None
+        connector.connection_string = None
         assert connector.upload_spatial_data(sample_gdf, "test_table") is False
 
-    def test_upload_spatial_data_calls_cursor(self, sample_gdf):
-        mock_conn = MagicMock()
-        connector = self._make_connector(mock_conn)
-        with patch.object(connector, "_create_spatial_table"):
+    def _mock_geoalchemy2_available(self):
+        """Patch sys.modules so the upload's `import geoalchemy2` succeeds
+        even when the dependency is not installed in the test environment."""
+        return patch.dict("sys.modules", {"geoalchemy2": MagicMock()})
+
+    def test_upload_calls_to_postgis_with_all_columns(self, sample_gdf):
+        """Post-#516 regression: upload_spatial_data must delegate to
+        gpd.GeoDataFrame.to_postgis, which writes ALL columns from the
+        input GeoDataFrame -- not just geom. Pre-#516 the implementation
+        manually built an INSERT for just geom and silently dropped every
+        attribute column."""
+        connector = self._make_connector()
+        with self._mock_geoalchemy2_available(), \
+             patch("sqlalchemy.create_engine") as mock_engine_factory, \
+             patch.object(type(sample_gdf), "to_postgis", create=True) as mock_to_postgis:
+            mock_engine = MagicMock()
+            mock_engine_factory.return_value = mock_engine
+
             result = connector.upload_spatial_data(sample_gdf, "test_table")
-        assert result is True
-        mock_conn.cursor.assert_called()
-        mock_conn.commit.assert_called()
+
+            assert result is True
+            # to_postgis must be called exactly once with the engine + schema + if_exists.
+            mock_to_postgis.assert_called_once()
+            kwargs = mock_to_postgis.call_args.kwargs
+            assert kwargs["name"] == "test_table"
+            assert kwargs["con"] is mock_engine
+            assert kwargs["schema"] == "public"
+            assert kwargs["if_exists"] == "replace"
+            # Engine must be disposed even on success.
+            mock_engine.dispose.assert_called_once()
+
+    def test_upload_geoalchemy2_missing_returns_false(self, sample_gdf):
+        """If geoalchemy2 is not installed, upload returns False with a
+        clear log error rather than failing inside to_postgis."""
+        connector = self._make_connector()
+        with patch.dict("sys.modules", {"geoalchemy2": None}):
+            # Force the import attempt to fail by removing it from sys.modules
+            # and patching the import. Simpler: use builtins.__import__.
+            import builtins
+            real_import = builtins.__import__
+
+            def fake_import(name, *args, **kw):
+                if name == "geoalchemy2":
+                    raise ImportError("simulated missing geoalchemy2")
+                return real_import(name, *args, **kw)
+
+            with patch("builtins.__import__", side_effect=fake_import):
+                result = connector.upload_spatial_data(sample_gdf, "test_table")
+        assert result is False
 
     def test_download_no_connection_returns_none(self):
         connector = self._make_connector()
@@ -378,80 +422,71 @@ class TestPostGISConnector:
 
     # -- if_exists and schema parameter tests (#326) --
 
-    def test_upload_default_schema_is_public(self, sample_gdf):
-        mock_conn = MagicMock()
-        mock_conn.cursor.return_value.fetchone.return_value = (None,)
-        connector = self._make_connector(mock_conn)
-        with patch.object(connector, "_create_spatial_table"):
-            connector.upload_spatial_data(sample_gdf, "test_table")
-        # SQL is now built with psycopg2.sql.Identifier(schema, table),
-        # which str()s as `Identifier('public', 'test_table')`. Match
-        # both the dotted form (legacy) and the Identifier repr (new).
-        calls = [str(c) for c in mock_conn.cursor.return_value.execute.call_args_list]
-        # Match exactly the legacy dotted form OR the exact psycopg2
-        # Identifier repr — separate-token tests would pass even if the
-        # qualified identifier was built incorrectly.
-        assert any(
-            ("public.test_table" in c)
-            or ("Identifier('public', 'test_table')" in c)
-            for c in calls
+    # Post-#516: upload_spatial_data delegates to gdf.to_postgis; the
+    # if_exists/schema/table_name parameters are pass-through. Tests
+    # below assert that the pass-through happens correctly. The actual
+    # behavior of if_exists (drop on replace, raise on fail-when-exists,
+    # etc) is owned by to_postgis itself; we don't re-test pandas/geopandas.
+
+    def _patch_to_postgis(self, sample_gdf):
+        """Context-manager helper that patches create_engine + to_postgis."""
+        return patch("sqlalchemy.create_engine"), patch.object(
+            type(sample_gdf), "to_postgis", create=True
         )
+
+    def test_upload_default_schema_is_public(self, sample_gdf):
+        connector = self._make_connector()
+        with self._mock_geoalchemy2_available(), \
+             patch("sqlalchemy.create_engine"), \
+             patch.object(type(sample_gdf), "to_postgis", create=True) as mock_tp:
+            connector.upload_spatial_data(sample_gdf, "test_table")
+        assert mock_tp.call_args.kwargs["schema"] == "public"
+        assert mock_tp.call_args.kwargs["name"] == "test_table"
 
     def test_upload_custom_schema(self, sample_gdf):
-        mock_conn = MagicMock()
-        mock_conn.cursor.return_value.fetchone.return_value = (None,)
-        connector = self._make_connector(mock_conn)
-        with patch.object(connector, "_create_spatial_table"):
-            connector.upload_spatial_data(
-                sample_gdf, "test_table", schema="staging"
-            )
-        calls = [str(c) for c in mock_conn.cursor.return_value.execute.call_args_list]
-        assert any(
-            ("staging.test_table" in c)
-            or ("Identifier('staging', 'test_table')" in c)
-            for c in calls
-        )
+        connector = self._make_connector()
+        with self._mock_geoalchemy2_available(), \
+             patch("sqlalchemy.create_engine"), \
+             patch.object(type(sample_gdf), "to_postgis", create=True) as mock_tp:
+            connector.upload_spatial_data(sample_gdf, "test_table", schema="staging")
+        assert mock_tp.call_args.kwargs["schema"] == "staging"
 
-    def test_upload_if_exists_replace_drops_table(self, sample_gdf):
-        mock_conn = MagicMock()
-        connector = self._make_connector(mock_conn)
-        with patch.object(connector, "_create_spatial_table"):
-            connector.upload_spatial_data(
-                sample_gdf, "test_table", if_exists="replace"
-            )
-        calls = [str(c) for c in mock_conn.cursor.return_value.execute.call_args_list]
-        assert any("DROP TABLE IF EXISTS" in c for c in calls)
+    def test_upload_if_exists_replace_passed_through(self, sample_gdf):
+        connector = self._make_connector()
+        with self._mock_geoalchemy2_available(), \
+             patch("sqlalchemy.create_engine"), \
+             patch.object(type(sample_gdf), "to_postgis", create=True) as mock_tp:
+            connector.upload_spatial_data(sample_gdf, "test_table", if_exists="replace")
+        assert mock_tp.call_args.kwargs["if_exists"] == "replace"
 
-    def test_upload_if_exists_append_no_drop_no_create(self, sample_gdf):
-        mock_conn = MagicMock()
-        connector = self._make_connector(mock_conn)
-        with patch.object(connector, "_create_spatial_table") as mock_create:
-            connector.upload_spatial_data(
-                sample_gdf, "test_table", if_exists="append"
-            )
-        calls = [str(c) for c in mock_conn.cursor.return_value.execute.call_args_list]
-        assert not any("DROP TABLE" in c for c in calls)
-        mock_create.assert_not_called()
+    def test_upload_if_exists_append_passed_through(self, sample_gdf):
+        connector = self._make_connector()
+        with self._mock_geoalchemy2_available(), \
+             patch("sqlalchemy.create_engine"), \
+             patch.object(type(sample_gdf), "to_postgis", create=True) as mock_tp:
+            connector.upload_spatial_data(sample_gdf, "test_table", if_exists="append")
+        assert mock_tp.call_args.kwargs["if_exists"] == "append"
 
-    def test_upload_if_exists_fail_raises_when_table_exists(self, sample_gdf):
-        mock_conn = MagicMock()
-        # to_regclass returns a non-None value meaning the table exists
-        mock_conn.cursor.return_value.fetchone.return_value = ("public.test_table",)
-        connector = self._make_connector(mock_conn)
-        result = connector.upload_spatial_data(
-            sample_gdf, "test_table", if_exists="fail"
-        )
+    def test_upload_if_exists_fail_passed_through(self, sample_gdf):
+        connector = self._make_connector()
+        with self._mock_geoalchemy2_available(), \
+             patch("sqlalchemy.create_engine"), \
+             patch.object(type(sample_gdf), "to_postgis", create=True) as mock_tp:
+            connector.upload_spatial_data(sample_gdf, "test_table", if_exists="fail")
+        assert mock_tp.call_args.kwargs["if_exists"] == "fail"
+
+    def test_upload_engine_disposed_on_to_postgis_failure(self, sample_gdf):
+        """Even when to_postgis raises, the SQLAlchemy engine must be disposed."""
+        connector = self._make_connector()
+        with self._mock_geoalchemy2_available(), \
+             patch("sqlalchemy.create_engine") as mock_engine_factory, \
+             patch.object(type(sample_gdf), "to_postgis", create=True,
+                          side_effect=RuntimeError("simulated db error")):
+            mock_engine = MagicMock()
+            mock_engine_factory.return_value = mock_engine
+            result = connector.upload_spatial_data(sample_gdf, "test_table")
         assert result is False
-
-    def test_upload_if_exists_fail_succeeds_when_table_absent(self, sample_gdf):
-        mock_conn = MagicMock()
-        mock_conn.cursor.return_value.fetchone.return_value = (None,)
-        connector = self._make_connector(mock_conn)
-        with patch.object(connector, "_create_spatial_table"):
-            result = connector.upload_spatial_data(
-                sample_gdf, "test_table", if_exists="fail"
-            )
-        assert result is True
+        mock_engine.dispose.assert_called_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

P0 / catastrophe fix for #516. Pre-fix `PostGISConnector.upload_spatial_data` inserted ONLY the `geom` column from the input GeoDataFrame; all tabular columns were silently dropped. The function returned `True`, logged success, and produced unusable empty-attribute tables.

## Reproducer

```python
gdf = gpd.GeoDataFrame({"name": ["A"], "value": [1],
                        "geometry": [Point(0, 0)]}, crs="EPSG:4326")
connector.upload_spatial_data(gdf, "test_table")
# Result: test_table has columns (id, geom) only.
# `name` and `value` silently lost. Function returns True.
```

## Downstream impact

Filed at siege-analytics/socialwarehouse#162 as the SW-side tracking issue.

- `swh/voters.py:load_voter_file` loaded TargetSmart voter CSVs but the 100+ tabular columns (precinct, county, FIPS, district, demographics, contact info) never reached PostGIS.
- `swh/census.py:load_census_to_postgis` loaded TIGER boundaries but attribute fields (GEOID, NAME, vintage_year, etc.) silently dropped.

Any downstream consumer depending on these PostGIS tables having attribute columns has been silently broken since this code shipped. Data may need reloading after this fix lands.

## Fix shape

Delegate to `gpd.GeoDataFrame.to_postgis` — the canonical geopandas idiom for PostGIS upload. Uses SQLAlchemy + GeoAlchemy2, handles all columns including geometry, supports `if_exists` in `("fail", "replace", "append")`, creates the table with the full column set automatically.

```python
def upload_spatial_data(self, gdf, table_name, **kwargs):
    if not self.connection_string: return False
    if_exists = kwargs.get('if_exists', 'replace')
    schema = kwargs.get('schema', 'public')
    validate_identifier(schema, ...); validate_identifier(table_name, ...)
    try: import geoalchemy2
    except ImportError: log.error(...); return False
    try:
        from sqlalchemy import create_engine
        engine = create_engine(self.connection_string)
        try:
            gdf.to_postgis(name=table_name, con=engine, schema=schema, if_exists=if_exists)
        finally:
            engine.dispose()
        return True
    except Exception as e:
        log.error(f"Failed to upload to PostGIS: {e}")
        return False
```

## Dependency

`geoalchemy2>=0.14.0` added to `pyproject.toml` `[geo]` optional-extra. Only users of the `[geo]` extra (which already pulls geopandas + 12 other deps) pay the install cost.

## Test plan

`tests/test_spatial_transformations.py`:

- [x] `test_upload_no_connection_string_returns_false` — checks connection_string (engine build prerequisite) instead of raw connection.
- [x] `test_upload_calls_to_postgis_with_all_columns` — THE load-bearing assertion. Verifies `to_postgis` called with correct args; engine disposed.
- [x] `test_upload_geoalchemy2_missing_returns_false` — import-failure path returns False cleanly with log error.
- [x] `test_upload_default_schema_is_public` / `_custom_schema` — schema pass-through.
- [x] `test_upload_if_exists_replace_passed_through` / `_append_` / `_fail_` — if_exists pass-through.
- [x] `test_upload_engine_disposed_on_to_postgis_failure` — engine.dispose() in finally.
- [x] 4 existing `_create_spatial_table_*` tests unchanged (deprecated body unchanged).
- [x] **All 56 tests pass.**

## What this PR does NOT fix

- `_create_spatial_table` retains broken behavior (kept for backward compatibility with direct callers; deprecation docstring added). Removal in a major-version bump.
- DuckDBConnector unchanged (uses `CREATE TABLE AS SELECT *` which DOES write all columns but doesn't support `if_exists="append"`; separate concern).
- No live PostGIS integration test added — requires fixture DB; out of scope. Mocked tests verify `to_postgis` is called correctly; the actual semantic guarantee is owned by geopandas/geoalchemy2.

## Discovery

Discovered via `writing-claims:7` (verify finding-text against live source) while scoping a downstream fix for what was framed as a chunk-append column-misalignment bug in SW. The chunk-misalignment framing was wrong because columns weren't reaching PostGIS in the first place. The rule fired correctly: reading the upstream implementation rather than trusting the downstream ticket text surfaced the actual bug.

Closes #516


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Spatial data uploads now preserve all attribute columns during writes instead of only retaining geometry, improving data integrity.

* **Deprecations**
  * Internal spatial table creation method marked as deprecated; use the standard data upload method instead.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siege-analytics/siege_utilities/pull/517?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->