### PR TITLE
Rename databricks.unity_catalog -> lakehouse_federation (#519)

### DIFF
--- a/siege_utilities/databricks/__init__.py
+++ b/siege_utilities/databricks/__init__.py
@@ -41,7 +41,11 @@ from .secrets import (
     runtime_secret_exists,
 )
 from .session import get_active_spark_session, get_dbutils
-from .unity_catalog import build_foreign_table_sql, build_schema_and_table_sync_sql
+# Canonical import path post-SU#519 rename. The old
+# .unity_catalog module remains as a deprecation shim re-exporting
+# these same symbols; importing this package does NOT trigger the
+# shim's DeprecationWarning.
+from .lakehouse_federation import build_foreign_table_sql, build_schema_and_table_sync_sql
 
 __all__ = [
     "build_databricks_run_url",

--- a/siege_utilities/databricks/lakehouse_federation.py
+++ b/siege_utilities/databricks/lakehouse_federation.py
@@ -1,0 +1,108 @@
+"""SQL helpers for Databricks Lakehouse Federation foreign tables.
+
+This module generates SQL of the form
+``CREATE FOREIGN TABLE ... USING CONNECTION ...``, which is a
+**Databricks-managed Unity Catalog only** feature (Lakehouse Federation).
+It does NOT work against the open-source Unity Catalog implementation
+(unitycatalog.io / ``unitycatalog/unitycatalog``). OSS UC has no
+``CREATE CONNECTION`` / ``CREATE FOREIGN TABLE`` mechanism — federation
+is handled at the compute layer (Trino, Spark) instead.
+
+Previously named ``siege_utilities.databricks.unity_catalog``. Renamed
+in SU#519 because the old name implied the helpers worked against any
+Unity Catalog and burned consumers planning OSS UC bridges. The old
+module path remains importable as a deprecation shim.
+
+See ``unity_catalog.py`` (sibling) for the back-compat re-export and
+SU#519 for the rename rationale.
+"""
+
+from typing import Iterable, List
+
+from siege_utilities.core.sql_safety import (
+    escape_sql_string_literal,
+    validate_sql_identifier,
+)
+
+
+def quote_ident(value: str) -> str:
+    """Quote an identifier with backticks for Databricks SQL."""
+    return "`" + value.replace("`", "``") + "`"
+
+
+def build_foreign_table_sql(
+    catalog: str,
+    schema: str,
+    table: str,
+    connection_name: str,
+    source_schema: str,
+    source_table: str | None = None,
+) -> str:
+    """
+    Build SQL for creating a Databricks Lakehouse Federation foreign
+    table from a LakeBase (or other UC-Federation-registered) source.
+
+    Databricks Lakehouse Federation only. The generated
+    ``CREATE FOREIGN TABLE ... USING CONNECTION`` syntax is not
+    parseable by OSS unitycatalog.io. (SU#519)
+
+    All identifier fields (catalog, schema, table, connection_name,
+    source_schema, source_table) are validated against the Postgres
+    identifier allow-list before interpolation. An earlier version
+    interpolated source_schema and source_table directly into the SQL
+    string without validation, producing an injection risk if either
+    contained a single quote.
+
+    Note: syntax can vary by Databricks workspace / feature flag. Keep
+    this as a composable helper and validate generated SQL in the
+    target Databricks environment.
+    """
+    resolved_source = source_table or table
+    validate_sql_identifier(catalog, "catalog")
+    validate_sql_identifier(schema, "schema")
+    validate_sql_identifier(table, "table")
+    validate_sql_identifier(connection_name, "connection_name")
+    validate_sql_identifier(source_schema, "source_schema")
+    validate_sql_identifier(resolved_source, "source_table")
+    fq_table = ".".join([quote_ident(catalog), quote_ident(schema), quote_ident(table)])
+    # source_ref goes inside a single-quoted SQL string literal. Even
+    # though the identifier validator already rejects single quotes,
+    # escape defensively in case a future relaxation allows them.
+    source_ref = escape_sql_string_literal(f"{source_schema}.{resolved_source}")
+    return (
+        f"CREATE FOREIGN TABLE IF NOT EXISTS {fq_table}\n"
+        f"USING CONNECTION {quote_ident(connection_name)}\n"
+        f"OPTIONS (table '{source_ref}');"
+    )
+
+
+def build_schema_and_table_sync_sql(
+    catalog: str,
+    schema: str,
+    connection_name: str,
+    source_schema: str,
+    tables: Iterable[str],
+) -> List[str]:
+    """Build CREATE SCHEMA + CREATE FOREIGN TABLE statements for multiple tables.
+
+    Databricks Lakehouse Federation only — see module docstring.
+    """
+    statements: List[str] = [
+        (
+            "CREATE SCHEMA IF NOT EXISTS "
+            + ".".join([quote_ident(catalog), quote_ident(schema)])
+            + ";"
+        )
+    ]
+    for table in tables:
+        statements.append(
+            build_foreign_table_sql(
+                catalog=catalog,
+                schema=schema,
+                table=table,
+                connection_name=connection_name,
+                source_schema=source_schema,
+                source_table=table,
+            )
+        )
+    return statements

--- a/siege_utilities/databricks/unity_catalog.py
+++ b/siege_utilities/databricks/unity_catalog.py
@@ -1,83 +1,35 @@
-"""Unity Catalog SQL helpers for foreign table registration."""
+"""Deprecated alias for :mod:`siege_utilities.databricks.lakehouse_federation`.
 
-from typing import Iterable, List
+The helpers in this module generate ``CREATE FOREIGN TABLE ... USING
+CONNECTION`` SQL, which is a Databricks Lakehouse Federation feature.
+It does NOT work against the open-source Unity Catalog implementation
+(unitycatalog.io). The old module name implied otherwise and burned
+consumers planning OSS UC bridges. Renamed in SU#519.
 
-from siege_utilities.core.sql_safety import (
-    escape_sql_string_literal,
-    validate_sql_identifier,
+Import from :mod:`siege_utilities.databricks.lakehouse_federation`
+instead. This shim re-exports the public surface unchanged; importing
+this module emits a single :class:`DeprecationWarning`.
+"""
+
+import warnings
+
+from siege_utilities.databricks.lakehouse_federation import (  # noqa: F401
+    build_foreign_table_sql,
+    build_schema_and_table_sync_sql,
+    quote_ident,
 )
 
+warnings.warn(
+    "siege_utilities.databricks.unity_catalog is deprecated; "
+    "import from siege_utilities.databricks.lakehouse_federation instead. "
+    "The generated SQL is Databricks Lakehouse Federation only and does "
+    "not work against OSS unitycatalog.io. (SU#519)",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
-def quote_ident(value: str) -> str:
-    """Quote an identifier with backticks for Databricks SQL."""
-    return "`" + value.replace("`", "``") + "`"
-
-
-def build_foreign_table_sql(
-    catalog: str,
-    schema: str,
-    table: str,
-    connection_name: str,
-    source_schema: str,
-    source_table: str | None = None,
-) -> str:
-    """
-    Build SQL for creating a Unity Catalog foreign table from a LakeBase source table.
-
-    All identifier fields (catalog, schema, table, connection_name,
-    source_schema, source_table) are validated against the Postgres
-    identifier allow-list before interpolation. An earlier version
-    interpolated source_schema and source_table directly into the SQL
-    string without validation, producing an injection risk if either
-    contained a single quote.
-
-    Note: syntax can vary by workspace/feature flag. Keep this as a
-    composable helper and validate generated SQL in the target
-    Databricks environment.
-    """
-    resolved_source = source_table or table
-    validate_sql_identifier(catalog, "catalog")
-    validate_sql_identifier(schema, "schema")
-    validate_sql_identifier(table, "table")
-    validate_sql_identifier(connection_name, "connection_name")
-    validate_sql_identifier(source_schema, "source_schema")
-    validate_sql_identifier(resolved_source, "source_table")
-    fq_table = ".".join([quote_ident(catalog), quote_ident(schema), quote_ident(table)])
-    # source_ref goes inside a single-quoted SQL string literal. Even
-    # though the identifier validator already rejects single quotes,
-    # escape defensively in case a future relaxation allows them.
-    source_ref = escape_sql_string_literal(f"{source_schema}.{resolved_source}")
-    return (
-        f"CREATE FOREIGN TABLE IF NOT EXISTS {fq_table}\n"
-        f"USING CONNECTION {quote_ident(connection_name)}\n"
-        f"OPTIONS (table '{source_ref}');"
-    )
-
-
-def build_schema_and_table_sync_sql(
-    catalog: str,
-    schema: str,
-    connection_name: str,
-    source_schema: str,
-    tables: Iterable[str],
-) -> List[str]:
-    """Build CREATE SCHEMA + CREATE FOREIGN TABLE statements for multiple tables."""
-    statements: List[str] = [
-        (
-            "CREATE SCHEMA IF NOT EXISTS "
-            + ".".join([quote_ident(catalog), quote_ident(schema)])
-            + ";"
-        )
-    ]
-    for table in tables:
-        statements.append(
-            build_foreign_table_sql(
-                catalog=catalog,
-                schema=schema,
-                table=table,
-                connection_name=connection_name,
-                source_schema=source_schema,
-                source_table=table,
-            )
-        )
-    return statements
+__all__ = [
+    "build_foreign_table_sql",
+    "build_schema_and_table_sync_sql",
+    "quote_ident",
+]

--- a/tests/test_databricks_lakebase_unity.py
+++ b/tests/test_databricks_lakebase_unity.py
@@ -11,7 +11,7 @@ from siege_utilities.databricks.lakebase import (
     build_pgpass_entry,
     parse_conninfo,
 )
-from siege_utilities.databricks.unity_catalog import (
+from siege_utilities.databricks.lakehouse_federation import (
     build_foreign_table_sql,
     build_schema_and_table_sync_sql,
 )

--- a/tests/test_databricks_unity_catalog_shim.py
+++ b/tests/test_databricks_unity_catalog_shim.py
@@ -1,0 +1,77 @@
+"""Regression test for SU#519: unity_catalog module is a deprecation
+shim that re-exports the lakehouse_federation symbols and emits a
+DeprecationWarning naming the new module path.
+
+Behavior tests — no pytest.mark.databricks because the shim is pure
+Python with no Databricks SDK calls.
+"""
+
+import importlib
+import sys
+import warnings
+
+import pytest
+
+
+def _fresh_import(name):
+    """Drop the module from sys.modules and re-import so the
+    module-level DeprecationWarning fires under our catch_warnings."""
+    sys.modules.pop(name, None)
+    return importlib.import_module(name)
+
+
+def test_shim_emits_deprecation_warning_naming_su519():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _fresh_import("siege_utilities.databricks.unity_catalog")
+    deps = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert deps, f"expected DeprecationWarning, got {[w.message for w in caught]}"
+    msg = str(deps[0].message)
+    assert "lakehouse_federation" in msg
+    assert "SU#519" in msg
+
+
+def test_shim_reexports_are_identity_equal_to_canonical():
+    # Re-import freshly so the shim runs against a clean lakehouse_federation.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        sys.modules.pop("siege_utilities.databricks.unity_catalog", None)
+        from siege_utilities.databricks import lakehouse_federation as canon
+        from siege_utilities.databricks import unity_catalog as shim
+    assert shim.build_foreign_table_sql is canon.build_foreign_table_sql
+    assert shim.build_schema_and_table_sync_sql is canon.build_schema_and_table_sync_sql
+    assert shim.quote_ident is canon.quote_ident
+
+
+def test_package_import_does_not_emit_deprecation_warning():
+    # `import siege_utilities.databricks` should resolve through
+    # __init__.py without touching the shim.
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        sys.modules.pop("siege_utilities.databricks", None)
+        importlib.import_module("siege_utilities.databricks")
+    deps = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    su519_deps = [w for w in deps if "SU#519" in str(w.message)]
+    assert not su519_deps, (
+        f"package-level import unexpectedly triggered SU#519 shim warning: "
+        f"{[str(w.message) for w in su519_deps]}"
+    )
+
+
+def test_lakehouse_federation_sql_unchanged():
+    # Sanity: the SQL output post-rename is identical to the
+    # documented pre-rename output.
+    from siege_utilities.databricks.lakehouse_federation import (
+        build_foreign_table_sql,
+    )
+    sql = build_foreign_table_sql(
+        catalog="enterprise_dw_psql",
+        schema="enterprise_dw",
+        table="persons",
+        connection_name="db_postgis_enterprise",
+        source_schema="enterprise_dw",
+    )
+    assert "CREATE FOREIGN TABLE IF NOT EXISTS" in sql
+    assert "`enterprise_dw_psql`.`enterprise_dw`.`persons`" in sql
+    assert "USING CONNECTION `db_postgis_enterprise`" in sql
+    assert "OPTIONS (table 'enterprise_dw.persons');" in sql

--- a/tests/test_databricks_unity_catalog_shim.py
+++ b/tests/test_databricks_unity_catalog_shim.py
@@ -10,8 +10,6 @@ import importlib
 import sys
 import warnings
 
-import pytest
-
 
 def _fresh_import(name):
     """Drop the module from sys.modules and re-import so the


### PR DESCRIPTION
## Summary

Closes #519. The helpers in \`siege_utilities/databricks/unity_catalog.py\` generate \`CREATE FOREIGN TABLE ... USING CONNECTION\` SQL — a Databricks Lakehouse Federation feature. The SQL is not parseable by OSS unitycatalog.io. The old module name implied universal Unity Catalog support and burned a consumer planning an OSS UC bridge.

**Option A** from the ticket: rename + honest docstring.

## Changes

- New canonical module **\`siege_utilities/databricks/lakehouse_federation.py\`** with a docstring that explicitly names the Databricks-LF-only scope and the OSS UC gap.
- **\`siege_utilities/databricks/unity_catalog.py\`** becomes a back-compat deprecation shim — re-exports \`build_foreign_table_sql\`, \`build_schema_and_table_sync_sql\`, \`quote_ident\` and emits a single module-load \`DeprecationWarning\` pointing at the new path and SU#519.
- **\`siege_utilities/databricks/__init__.py\`** now imports from \`.lakehouse_federation\`. Callers using \`from siege_utilities.databricks import build_foreign_table_sql\` get **zero** warnings.
- Existing \`tests/test_databricks_lakebase_unity.py\` updated to import from the canonical module.

## Back-compat

| Call pattern | Effect |
|---|---|
| \`from siege_utilities.databricks import build_foreign_table_sql\` | Works. No warning. |
| \`from siege_utilities.databricks.lakehouse_federation import ...\` | Works. No warning. (Recommended new path.) |
| \`from siege_utilities.databricks.unity_catalog import ...\` | Works. Emits one DeprecationWarning naming the new path and SU#519. |

## Test plan

New \`tests/test_databricks_unity_catalog_shim.py\` covers the rename contract:

- [x] Shim emits DeprecationWarning naming \`lakehouse_federation\` and \`SU#519\`
- [x] Shim symbols are **identity-equal** to canonical symbols (\`is\` comparison)
- [x] Package import is silent (no shim warning when using the canonical path)
- [x] Generated SQL is byte-identical pre/post-rename
- [x] All 8 existing tests in \`tests/test_databricks_lakebase_unity.py\` still pass

## Not in scope

- Option B (add OSS UC helpers) — correct longer-term, separate ticket.
- Option C (split the databricks subdirectory into a separate package) — disruptive, no clear additional benefit today.

## Self-review

See trailer in commit message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * SQL helper functions for Databricks Lakehouse Federation foreign tables have been reorganized to a new canonical module location for improved organization.

* **Documentation**
  * Importing from the legacy module path now emits a deprecation warning directing users to the new import location.

* **Tests**
  * Added regression tests to verify deprecation warnings and compatibility shim behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siege-analytics/siege_utilities/pull/520?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->