### PR TITLE
Add siege_utilities.trino.federation for OSS UC PostgreSQL bridge (#521 Shape B)

### DIFF
--- a/siege_utilities/trino/__init__.py
+++ b/siege_utilities/trino/__init__.py
@@ -1,0 +1,25 @@
+"""Trino-dialect SQL helpers.
+
+Trino is the OSS query engine commonly paired with the open-source
+unitycatalog.io implementation when callers need live federation to a
+foreign RDBMS — OSS UC itself has no native federation primitive (see
+SU#519 / SU#521).
+
+The first surface here is :mod:`siege_utilities.trino.federation`,
+which generates ``CREATE VIEW`` statements that select through Trino's
+``postgresql`` connector. This is the OSS analog of
+:mod:`siege_utilities.databricks.lakehouse_federation` for the Databricks
+Lakehouse Federation use case.
+"""
+
+from .federation import (
+    build_trino_federation_view_sql,
+    build_trino_schema_and_view_sync_sql,
+    quote_ident,
+)
+
+__all__ = [
+    "build_trino_federation_view_sql",
+    "build_trino_schema_and_view_sync_sql",
+    "quote_ident",
+]

--- a/siege_utilities/trino/federation.py
+++ b/siege_utilities/trino/federation.py
@@ -1,0 +1,145 @@
+"""Trino SQL helpers for federating to a foreign RDBMS via Trino connectors.
+
+This is the OSS analog of
+:mod:`siege_utilities.databricks.lakehouse_federation` for the open-source
+unitycatalog.io (and any other catalog Trino can write a VIEW into).
+
+OSS Unity Catalog does NOT support live query federation natively
+(no ``CREATE FOREIGN TABLE``/``USING CONNECTION`` syntax — that is
+Databricks-specific). The OSS path is to configure Trino with the
+``postgresql`` connector (catalog config file), then expose the
+foreign table under a stable name in a different Trino catalog via
+``CREATE OR REPLACE VIEW``. Readers query the view; Trino does the
+federation transparently.
+
+This module generates the view-creation SQL. Catalog configuration
+(the ``etc/catalog/*.properties`` files Trino reads at startup) is
+out of scope — that is operator territory.
+
+See SU#521 (umbrella) and SU#519 (root context).
+"""
+
+from typing import Iterable, List
+
+from siege_utilities.core.sql_safety import validate_sql_identifier
+
+
+def quote_ident(value: str) -> str:
+    """Quote an identifier in Trino dialect.
+
+    Trino uses ANSI double quotes for identifiers (not backticks like
+    Databricks). Internal double-quote characters are escaped by
+    doubling. The identifier itself is also run through the SU
+    identifier allow-list before quoting, so the double-quote
+    doubling is defense-in-depth.
+    """
+    return '"' + value.replace('"', '""') + '"'
+
+
+def _join_fq(parts: Iterable[str]) -> str:
+    return ".".join(quote_ident(p) for p in parts)
+
+
+def build_trino_federation_view_sql(
+    target_catalog: str,
+    target_schema: str,
+    target_view: str,
+    postgres_catalog: str,
+    source_schema: str,
+    source_table: str | None = None,
+) -> str:
+    """Build SQL for a Trino federation view over a PostgreSQL source.
+
+    Generates a ``CREATE OR REPLACE VIEW`` statement in
+    ``target_catalog.target_schema.target_view`` that selects every
+    column from the PostgreSQL table ``postgres_catalog.source_schema.source_table``
+    via Trino's ``postgresql`` connector.
+
+    All identifier fields are validated against the SU identifier
+    allow-list before interpolation. The output is double-quoted in
+    Trino's ANSI dialect (not backticks).
+
+    Args:
+        target_catalog: Trino catalog the view lives in (e.g. ``"iceberg"``
+            for an OSS UC-backed Iceberg catalog).
+        target_schema: Schema within the target catalog (e.g. ``"analytics"``).
+        target_view: View name (e.g. ``"persons"``).
+        postgres_catalog: Trino catalog alias for the PostgreSQL connector
+            (whatever the operator named the ``etc/catalog/postgresql.properties``
+            file, sans extension).
+        source_schema: PostgreSQL schema (e.g. ``"public"``).
+        source_table: PostgreSQL table name. Defaults to ``target_view``
+            when omitted, which is the common case (same name on both
+            sides).
+
+    Returns:
+        A single SQL statement ending in ``;``.
+
+    Example:
+        >>> build_trino_federation_view_sql(
+        ...     target_catalog="iceberg",
+        ...     target_schema="analytics",
+        ...     target_view="persons",
+        ...     postgres_catalog="postgresql",
+        ...     source_schema="public",
+        ... )
+        'CREATE OR REPLACE VIEW "iceberg"."analytics"."persons" AS\\nSELECT * FROM "postgresql"."public"."persons";'
+    """
+    resolved_source = source_table or target_view
+    validate_sql_identifier(target_catalog, "target_catalog")
+    validate_sql_identifier(target_schema, "target_schema")
+    validate_sql_identifier(target_view, "target_view")
+    validate_sql_identifier(postgres_catalog, "postgres_catalog")
+    validate_sql_identifier(source_schema, "source_schema")
+    validate_sql_identifier(resolved_source, "source_table")
+    target_fq = _join_fq([target_catalog, target_schema, target_view])
+    source_fq = _join_fq([postgres_catalog, source_schema, resolved_source])
+    return (
+        f"CREATE OR REPLACE VIEW {target_fq} AS\n"
+        f"SELECT * FROM {source_fq};"
+    )
+
+
+def build_trino_schema_and_view_sync_sql(
+    target_catalog: str,
+    target_schema: str,
+    postgres_catalog: str,
+    source_schema: str,
+    tables: Iterable[str],
+) -> List[str]:
+    """Build ``CREATE SCHEMA`` + per-table ``CREATE VIEW`` statements.
+
+    Convenience for syncing many PostgreSQL tables into a Trino catalog
+    in one pass. The schema statement uses ``IF NOT EXISTS`` so the
+    list is safe to re-run. Each view statement is ``CREATE OR REPLACE``
+    so re-runs after upstream column additions stay correct.
+
+    Args:
+        target_catalog: Trino catalog the schema + views live in.
+        target_schema: Schema within ``target_catalog``.
+        postgres_catalog: Trino PostgreSQL connector alias.
+        source_schema: PostgreSQL schema containing ``tables``.
+        tables: Iterable of PostgreSQL table names. Same names are
+            used for the Trino views.
+
+    Returns:
+        List of SQL statements: one ``CREATE SCHEMA`` followed by one
+        ``CREATE OR REPLACE VIEW`` per table, in the order given.
+    """
+    statements: List[str] = [
+        "CREATE SCHEMA IF NOT EXISTS "
+        + _join_fq([target_catalog, target_schema])
+        + ";"
+    ]
+    for table in tables:
+        statements.append(
+            build_trino_federation_view_sql(
+                target_catalog=target_catalog,
+                target_schema=target_schema,
+                target_view=table,
+                postgres_catalog=postgres_catalog,
+                source_schema=source_schema,
+                source_table=table,
+            )
+        )
+    return statements

--- a/tests/test_trino_federation.py
+++ b/tests/test_trino_federation.py
@@ -1,0 +1,129 @@
+"""Tests for siege_utilities.trino.federation (SU#521 Shape B).
+
+The OSS analog of the Databricks Lakehouse Federation helpers:
+generates Trino ``CREATE VIEW`` statements that federate to a foreign
+PostgreSQL source via Trino's ``postgresql`` connector.
+"""
+
+import pytest
+
+from siege_utilities.trino import (
+    build_trino_federation_view_sql,
+    build_trino_schema_and_view_sync_sql,
+    quote_ident,
+)
+
+
+def test_quote_ident_uses_double_quotes_not_backticks():
+    # Trino dialect is ANSI; backticks are Databricks-only.
+    assert quote_ident("persons") == '"persons"'
+    assert "`" not in quote_ident("persons")
+
+
+def test_quote_ident_doubles_internal_double_quotes():
+    # Defense-in-depth — the validator rejects '"' in identifiers,
+    # but the quoter still doubles them in case the validator is ever
+    # relaxed.
+    assert quote_ident('a"b') == '"a""b"'
+
+
+def test_federation_view_default_source_table_uses_view_name():
+    sql = build_trino_federation_view_sql(
+        target_catalog="iceberg",
+        target_schema="analytics",
+        target_view="persons",
+        postgres_catalog="postgresql",
+        source_schema="public",
+    )
+    assert sql == (
+        'CREATE OR REPLACE VIEW "iceberg"."analytics"."persons" AS\n'
+        'SELECT * FROM "postgresql"."public"."persons";'
+    )
+
+
+def test_federation_view_explicit_source_table_name_used():
+    sql = build_trino_federation_view_sql(
+        target_catalog="iceberg",
+        target_schema="analytics",
+        target_view="people_view",
+        postgres_catalog="postgresql",
+        source_schema="public",
+        source_table="persons",
+    )
+    assert '"iceberg"."analytics"."people_view"' in sql
+    assert '"postgresql"."public"."persons"' in sql
+
+
+def test_federation_view_rejects_target_catalog_injection():
+    with pytest.raises(ValueError, match="target_catalog"):
+        build_trino_federation_view_sql(
+            target_catalog='evil";DROP TABLE x;--',
+            target_schema="analytics",
+            target_view="persons",
+            postgres_catalog="postgresql",
+            source_schema="public",
+        )
+
+
+def test_federation_view_rejects_source_table_injection():
+    with pytest.raises(ValueError, match="source_table"):
+        build_trino_federation_view_sql(
+            target_catalog="iceberg",
+            target_schema="analytics",
+            target_view="persons",
+            postgres_catalog="postgresql",
+            source_schema="public",
+            source_table='persons"; DROP TABLE persons; --',
+        )
+
+
+def test_federation_view_rejects_postgres_catalog_injection():
+    with pytest.raises(ValueError, match="postgres_catalog"):
+        build_trino_federation_view_sql(
+            target_catalog="iceberg",
+            target_schema="analytics",
+            target_view="persons",
+            postgres_catalog="postgresql\"--",
+            source_schema="public",
+        )
+
+
+def test_schema_and_view_sync_emits_schema_then_views_in_order():
+    statements = build_trino_schema_and_view_sync_sql(
+        target_catalog="iceberg",
+        target_schema="analytics",
+        postgres_catalog="postgresql",
+        source_schema="public",
+        tables=["persons", "households", "addresses"],
+    )
+    assert len(statements) == 4
+    assert statements[0] == (
+        'CREATE SCHEMA IF NOT EXISTS "iceberg"."analytics";'
+    )
+    # Order preserved — each statement targets exactly its assigned table.
+    assert '"persons"' in statements[1] and '"households"' not in statements[1]
+    assert '"households"' in statements[2] and '"addresses"' not in statements[2]
+    assert '"addresses"' in statements[3] and '"persons"' not in statements[3]
+
+
+def test_schema_and_view_sync_empty_tables_yields_schema_only():
+    statements = build_trino_schema_and_view_sync_sql(
+        target_catalog="iceberg",
+        target_schema="analytics",
+        postgres_catalog="postgresql",
+        source_schema="public",
+        tables=[],
+    )
+    assert len(statements) == 1
+    assert statements[0].startswith("CREATE SCHEMA IF NOT EXISTS")
+
+
+def test_schema_and_view_sync_rejects_bad_table_name():
+    with pytest.raises(ValueError):
+        build_trino_schema_and_view_sync_sql(
+            target_catalog="iceberg",
+            target_schema="analytics",
+            postgres_catalog="postgresql",
+            source_schema="public",
+            tables=["persons", 'evil"; DROP TABLE x; --'],
+        )


### PR DESCRIPTION
## Summary

Part of #521 (umbrella). **Shape B**: Trino federation SQL generator — the OSS analog of \`siege_utilities.databricks.lakehouse_federation\` for the PostgreSQL → OSS UC bridge use case that motivated #519.

OSS unitycatalog.io has no native query federation primitive. The standard OSS path is Trino's \`postgresql\` connector exposed as a \`CREATE OR REPLACE VIEW\` in an OSS-UC-backed catalog (Iceberg, Hive, etc.). This PR ships the SQL generator for that view.

## New module surface

\`\`\`python
from siege_utilities.trino import (
    build_trino_federation_view_sql,
    build_trino_schema_and_view_sync_sql,
    quote_ident,
)

sql = build_trino_federation_view_sql(
    target_catalog=\"iceberg\",
    target_schema=\"analytics\",
    target_view=\"persons\",
    postgres_catalog=\"postgresql\",
    source_schema=\"public\",
)
# 'CREATE OR REPLACE VIEW \"iceberg\".\"analytics\".\"persons\" AS\n'
# 'SELECT * FROM \"postgresql\".\"public\".\"persons\";'
\`\`\`

## Why \`siege_utilities/trino/\` instead of \`siege_utilities/oss_unity_catalog/\`

Trino is the compute engine. The federation works against any Trino catalog (Iceberg, Hive, OSS UC) — UC is just the target catalog name. Nesting these helpers under an OSS-UC namespace would conflate the compute layer with the catalog layer. Future Trino helpers (connector \`.properties\` generators, Iceberg catalog config) have a natural home here.

## Dialect notes

- Trino uses ANSI double-quote identifiers (\`\"x\"\`), not backticks. The Databricks LF helper's backtick \`quote_ident\` does not apply.
- \`quote_ident\` doubles internal \`\"\` characters as defense-in-depth on top of the shared \`siege_utilities.core.sql_safety.validate_sql_identifier\` allow-list.

## Test plan

\`tests/test_trino_federation.py\` — 10 behavior tests, all passing locally:

- [x] ANSI double-quote dialect (not backticks)
- [x] Internal-quote doubling
- [x] Default vs explicit \`source_table\` name
- [x] Identifier-injection rejection on \`target_catalog\`, \`postgres_catalog\`, \`source_table\` (regression for the issue #519 surfaced)
- [x] Multi-table \`build_trino_schema_and_view_sync_sql\` emits schema then views in order
- [x] Empty-tables case yields schema only
- [x] Bad table name inside the iterable raises
- [x] Each statement targets exactly its assigned table (no cross-contamination)

## Out of scope (this PR)

- Spark JDBC federation generator — add when there is a consumer.
- Trino connector \`.properties\` generators — operator territory today.
- Shape A (OSS UC REST external-table registration) — follows in a separate PR per #521.

## Closes

Partially closes #521 (Shape B sub-task).

## Self-review

See trailer in commit message.