### PR TITLE
Add siege_utilities.oss_unity_catalog.external_tables (#521 Shape A)

### DIFF
--- a/siege_utilities/oss_unity_catalog/__init__.py
+++ b/siege_utilities/oss_unity_catalog/__init__.py
@@ -1,0 +1,30 @@
+"""Helpers for the open-source Unity Catalog implementation (unitycatalog.io).
+
+OSS Unity Catalog is the open-source reference catalog server published
+at https://github.com/unitycatalog/unitycatalog (Docker image
+``unitycatalog/unitycatalog``). It exposes a REST API for catalog /
+schema / table metadata management. Unlike Databricks-managed Unity
+Catalog it has no native query federation primitive — for live
+federation to a foreign RDBMS see :mod:`siege_utilities.trino.federation`.
+
+This package's first surface is
+:mod:`siege_utilities.oss_unity_catalog.external_tables`, which
+generates payloads for (and optionally POSTs) external table
+registrations against the OSS UC REST endpoint
+``POST /api/2.1/unity-catalog/tables``.
+
+Filed under SU#521 (umbrella) following the SU#519 rename of the
+Databricks-only helper.
+"""
+
+from .external_tables import (
+    SUPPORTED_DATA_SOURCE_FORMATS,
+    build_external_table_payload,
+    register_external_table,
+)
+
+__all__ = [
+    "SUPPORTED_DATA_SOURCE_FORMATS",
+    "build_external_table_payload",
+    "register_external_table",
+]

--- a/siege_utilities/oss_unity_catalog/external_tables.py
+++ b/siege_utilities/oss_unity_catalog/external_tables.py
@@ -1,0 +1,189 @@
+"""External-table registration helpers for OSS Unity Catalog.
+
+Generates payloads for (and optionally POSTs) external-table creation
+against the OSS UC REST API endpoint
+``POST /api/2.1/unity-catalog/tables``. Pure metadata: tells OSS UC
+"a table named X exists at storage_location Y in format Z with these
+columns." Readers (Spark, Trino, DuckDB) connect to UC, look up the
+location, and read the files directly. No query federation is
+involved — for live federation to a foreign RDBMS see
+:mod:`siege_utilities.trino.federation`.
+
+The payload builder is the load-bearing part — it is mock-friendly and
+can be used standalone with any HTTP client. The thin
+:func:`register_external_table` helper exists for the common case where
+the caller wants a one-line ``requests.post`` against an OSS UC server.
+
+See SU#521 (umbrella) and SU#519 (root context).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import requests
+
+from siege_utilities.core.sql_safety import validate_sql_identifier
+
+# OSS UC v0.4.0 supported data source formats (from the proto schema).
+# Update this set when OSS UC adds formats. Keys are upper-case because
+# OSS UC's REST API requires upper-case format names.
+SUPPORTED_DATA_SOURCE_FORMATS: frozenset[str] = frozenset({
+    "DELTA",
+    "PARQUET",
+    "CSV",
+    "JSON",
+    "AVRO",
+    "ORC",
+    "TEXT",
+})
+
+
+def _validate_column(column: Mapping[str, Any], index: int) -> dict[str, Any]:
+    """Validate one element of the columns list and return a clean dict.
+
+    Required keys: ``name``, ``type_name``. Optional: ``type_text``,
+    ``type_json``, ``nullable``, ``comment``, ``position``,
+    ``partition_index``.
+    """
+    if not isinstance(column, Mapping):
+        raise TypeError(
+            f"columns[{index}] must be a Mapping; got {type(column).__name__}"
+        )
+    name = column.get("name")
+    type_name = column.get("type_name")
+    if not isinstance(name, str) or not name:
+        raise ValueError(f"columns[{index}].name must be a non-empty string")
+    if not isinstance(type_name, str) or not type_name:
+        raise ValueError(f"columns[{index}].type_name must be a non-empty string")
+    validate_sql_identifier(name, f"columns[{index}].name")
+
+    cleaned: dict[str, Any] = {
+        "name": name,
+        "type_name": type_name,
+        "nullable": bool(column.get("nullable", True)),
+        "position": int(column.get("position", index)),
+    }
+    for optional_key in ("type_text", "type_json", "comment", "partition_index"):
+        if optional_key in column and column[optional_key] is not None:
+            cleaned[optional_key] = column[optional_key]
+    return cleaned
+
+
+def build_external_table_payload(
+    catalog: str,
+    schema: str,
+    name: str,
+    storage_location: str,
+    data_source_format: str,
+    columns: list[Mapping[str, Any]],
+    *,
+    properties: Mapping[str, str] | None = None,
+    comment: str | None = None,
+) -> dict[str, Any]:
+    """Build the JSON payload for ``POST /api/2.1/unity-catalog/tables``.
+
+    Args:
+        catalog: Existing OSS UC catalog name.
+        schema: Existing OSS UC schema within ``catalog``.
+        name: Table name to create.
+        storage_location: Absolute URI to the data location (e.g.
+            ``"s3://bucket/path/persons"`` or ``"file:///srv/uc/data/persons"``).
+        data_source_format: One of :data:`SUPPORTED_DATA_SOURCE_FORMATS`.
+            Case-insensitive on input; normalized to upper case in the
+            payload.
+        columns: Ordered list of column specs. Each entry must be a
+            Mapping with ``name`` (str) and ``type_name`` (str — one of
+            OSS UC's typed column names like ``LONG``, ``STRING``,
+            ``DOUBLE``). Optional per-column: ``type_text``, ``type_json``,
+            ``nullable`` (default True), ``comment``, ``partition_index``.
+            ``position`` defaults to the column's index in the list.
+        properties: Optional table properties (key/value strings).
+        comment: Optional human-readable table description.
+
+    Returns:
+        Plain dict ready to be passed to ``requests.post(..., json=payload)``.
+
+    Raises:
+        ValueError: identifier failed allow-list, format unsupported,
+            or a column spec is malformed.
+        TypeError: a column entry is not a Mapping.
+    """
+    validate_sql_identifier(catalog, "catalog")
+    validate_sql_identifier(schema, "schema")
+    validate_sql_identifier(name, "name")
+
+    fmt = data_source_format.upper()
+    if fmt not in SUPPORTED_DATA_SOURCE_FORMATS:
+        raise ValueError(
+            f"data_source_format={data_source_format!r} not in "
+            f"{sorted(SUPPORTED_DATA_SOURCE_FORMATS)}"
+        )
+
+    if not isinstance(storage_location, str) or not storage_location:
+        raise ValueError("storage_location must be a non-empty string")
+
+    if not isinstance(columns, list) or not columns:
+        raise ValueError("columns must be a non-empty list")
+
+    cleaned_columns = [_validate_column(c, i) for i, c in enumerate(columns)]
+
+    payload: dict[str, Any] = {
+        "name": name,
+        "catalog_name": catalog,
+        "schema_name": schema,
+        "table_type": "EXTERNAL",
+        "data_source_format": fmt,
+        "storage_location": storage_location,
+        "columns": cleaned_columns,
+    }
+    if properties:
+        payload["properties"] = dict(properties)
+    if comment is not None:
+        payload["comment"] = comment
+    return payload
+
+
+def register_external_table(
+    uc_base_url: str,
+    payload: Mapping[str, Any],
+    *,
+    auth_token: str | None = None,
+    timeout: float = 30.0,
+    session: requests.Session | None = None,
+) -> dict[str, Any]:
+    """POST ``payload`` to ``{uc_base_url}/api/2.1/unity-catalog/tables``.
+
+    Thin convenience wrapper around :func:`requests.post`. Use this
+    when you have the payload from :func:`build_external_table_payload`
+    and want the one-call shape. Callers who prefer to manage their own
+    HTTP client (retry policies, mTLS, proxies, etc.) should build the
+    payload with :func:`build_external_table_payload` and POST it
+    themselves.
+
+    Args:
+        uc_base_url: Base URL of the OSS UC server (e.g.
+            ``"http://uc.internal:8080"``). Trailing slashes are
+            tolerated.
+        payload: A dict in the shape produced by
+            :func:`build_external_table_payload`.
+        auth_token: Optional bearer token. When set, sent as
+            ``Authorization: Bearer <token>``.
+        timeout: Per-request timeout in seconds.
+        session: Optional :class:`requests.Session`. Useful for
+            connection pooling across many registrations.
+
+    Returns:
+        Parsed JSON response from the server.
+
+    Raises:
+        requests.HTTPError: non-2xx response (via ``raise_for_status``).
+    """
+    url = uc_base_url.rstrip("/") + "/api/2.1/unity-catalog/tables"
+    headers = {"Content-Type": "application/json"}
+    if auth_token:
+        headers["Authorization"] = f"Bearer {auth_token}"
+    poster = session.post if session is not None else requests.post
+    response = poster(url, json=dict(payload), headers=headers, timeout=timeout)
+    response.raise_for_status()
+    return response.json()

--- a/tests/test_oss_unity_catalog_external_tables.py
+++ b/tests/test_oss_unity_catalog_external_tables.py
@@ -1,0 +1,258 @@
+"""Tests for siege_utilities.oss_unity_catalog.external_tables (SU#521 Shape A).
+
+OSS UC external-table registration payload builder + REST helper.
+Pure-payload tests run with no network; the REST helper test uses a
+MagicMock session so no socket is opened.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from siege_utilities.oss_unity_catalog import (
+    SUPPORTED_DATA_SOURCE_FORMATS,
+    build_external_table_payload,
+    register_external_table,
+)
+
+
+# ---- Payload builder --------------------------------------------------------
+
+
+def _minimal_columns():
+    return [
+        {"name": "id", "type_name": "LONG"},
+        {"name": "name", "type_name": "STRING", "nullable": False, "comment": "label"},
+    ]
+
+
+def test_payload_shape_minimal():
+    payload = build_external_table_payload(
+        catalog="main",
+        schema="default",
+        name="persons",
+        storage_location="s3://bucket/path/persons",
+        data_source_format="DELTA",
+        columns=_minimal_columns(),
+    )
+    assert payload["name"] == "persons"
+    assert payload["catalog_name"] == "main"
+    assert payload["schema_name"] == "default"
+    assert payload["table_type"] == "EXTERNAL"
+    assert payload["data_source_format"] == "DELTA"
+    assert payload["storage_location"] == "s3://bucket/path/persons"
+    assert len(payload["columns"]) == 2
+    assert payload["columns"][0]["name"] == "id"
+    assert payload["columns"][0]["position"] == 0
+    assert payload["columns"][0]["nullable"] is True
+    assert payload["columns"][1]["nullable"] is False
+    assert payload["columns"][1]["comment"] == "label"
+    assert "properties" not in payload
+    assert "comment" not in payload
+
+
+def test_payload_includes_optional_properties_and_comment():
+    payload = build_external_table_payload(
+        catalog="main",
+        schema="default",
+        name="persons",
+        storage_location="file:///srv/uc/data/persons",
+        data_source_format="parquet",  # lower-case allowed, normalized
+        columns=_minimal_columns(),
+        properties={"owner": "alice", "freshness_sla": "P1D"},
+        comment="Person registry",
+    )
+    assert payload["data_source_format"] == "PARQUET"
+    assert payload["properties"] == {"owner": "alice", "freshness_sla": "P1D"}
+    assert payload["comment"] == "Person registry"
+
+
+@pytest.mark.parametrize("fmt", sorted(SUPPORTED_DATA_SOURCE_FORMATS))
+def test_payload_accepts_every_supported_format(fmt):
+    payload = build_external_table_payload(
+        catalog="main",
+        schema="default",
+        name="t",
+        storage_location="s3://b/p",
+        data_source_format=fmt,
+        columns=_minimal_columns(),
+    )
+    assert payload["data_source_format"] == fmt
+
+
+def test_payload_rejects_unsupported_format():
+    with pytest.raises(ValueError, match="data_source_format"):
+        build_external_table_payload(
+            catalog="main",
+            schema="default",
+            name="t",
+            storage_location="s3://b/p",
+            data_source_format="HUDI",  # not yet supported by OSS UC
+            columns=_minimal_columns(),
+        )
+
+
+def test_payload_rejects_identifier_injection():
+    with pytest.raises(ValueError, match="catalog"):
+        build_external_table_payload(
+            catalog="main; DROP TABLE x; --",
+            schema="default",
+            name="t",
+            storage_location="s3://b/p",
+            data_source_format="DELTA",
+            columns=_minimal_columns(),
+        )
+    with pytest.raises(ValueError, match="schema"):
+        build_external_table_payload(
+            catalog="main",
+            schema='evil"--',
+            name="t",
+            storage_location="s3://b/p",
+            data_source_format="DELTA",
+            columns=_minimal_columns(),
+        )
+    with pytest.raises(ValueError, match="name"):
+        build_external_table_payload(
+            catalog="main",
+            schema="default",
+            name="t; DROP",
+            storage_location="s3://b/p",
+            data_source_format="DELTA",
+            columns=_minimal_columns(),
+        )
+
+
+def test_payload_rejects_empty_columns():
+    with pytest.raises(ValueError, match="columns"):
+        build_external_table_payload(
+            catalog="main",
+            schema="default",
+            name="t",
+            storage_location="s3://b/p",
+            data_source_format="DELTA",
+            columns=[],
+        )
+
+
+def test_payload_rejects_column_without_name():
+    with pytest.raises(ValueError, match=r"columns\[0\]\.name"):
+        build_external_table_payload(
+            catalog="main",
+            schema="default",
+            name="t",
+            storage_location="s3://b/p",
+            data_source_format="DELTA",
+            columns=[{"type_name": "LONG"}],
+        )
+
+
+def test_payload_rejects_column_with_bad_identifier_name():
+    with pytest.raises(ValueError, match=r"columns\[0\]\.name"):
+        build_external_table_payload(
+            catalog="main",
+            schema="default",
+            name="t",
+            storage_location="s3://b/p",
+            data_source_format="DELTA",
+            columns=[{"name": "id-1", "type_name": "LONG"}],  # hyphen rejected
+        )
+
+
+def test_payload_rejects_non_mapping_column_entry():
+    with pytest.raises(TypeError, match=r"columns\[0\]"):
+        build_external_table_payload(
+            catalog="main",
+            schema="default",
+            name="t",
+            storage_location="s3://b/p",
+            data_source_format="DELTA",
+            columns=["not a dict"],  # type: ignore[list-item]
+        )
+
+
+def test_payload_rejects_empty_storage_location():
+    with pytest.raises(ValueError, match="storage_location"):
+        build_external_table_payload(
+            catalog="main",
+            schema="default",
+            name="t",
+            storage_location="",
+            data_source_format="DELTA",
+            columns=_minimal_columns(),
+        )
+
+
+def test_payload_column_position_overrides_index_when_provided():
+    payload = build_external_table_payload(
+        catalog="main",
+        schema="default",
+        name="t",
+        storage_location="s3://b/p",
+        data_source_format="DELTA",
+        columns=[
+            {"name": "id", "type_name": "LONG", "position": 5},
+            {"name": "name", "type_name": "STRING"},
+        ],
+    )
+    assert payload["columns"][0]["position"] == 5  # explicit override
+    assert payload["columns"][1]["position"] == 1  # index fallback
+
+
+# ---- REST helper (mocked) ---------------------------------------------------
+
+
+def test_register_external_table_posts_to_canonical_url_and_strips_trailing_slash():
+    session = MagicMock(spec=requests.Session)
+    response = MagicMock()
+    response.json.return_value = {"name": "persons", "table_id": "abc-123"}
+    response.raise_for_status.return_value = None
+    session.post.return_value = response
+
+    payload = {"name": "persons", "catalog_name": "main"}
+    result = register_external_table(
+        uc_base_url="http://uc.internal:8080/",  # trailing slash should be stripped
+        payload=payload,
+        session=session,
+    )
+
+    assert result == {"name": "persons", "table_id": "abc-123"}
+    session.post.assert_called_once()
+    args, kwargs = session.post.call_args
+    assert args[0] == "http://uc.internal:8080/api/2.1/unity-catalog/tables"
+    assert kwargs["json"] == payload
+    assert kwargs["headers"]["Content-Type"] == "application/json"
+    assert "Authorization" not in kwargs["headers"]  # no token, no header
+    assert kwargs["timeout"] == 30.0
+
+
+def test_register_external_table_sets_bearer_auth_when_token_given():
+    session = MagicMock(spec=requests.Session)
+    response = MagicMock()
+    response.json.return_value = {}
+    response.raise_for_status.return_value = None
+    session.post.return_value = response
+
+    register_external_table(
+        uc_base_url="http://uc.internal:8080",
+        payload={},
+        auth_token="placeholder-token-not-a-real-secret",
+        session=session,
+    )
+
+    _, kwargs = session.post.call_args
+    assert kwargs["headers"]["Authorization"] == "Bearer placeholder-token-not-a-real-secret"
+
+
+def test_register_external_table_raises_on_http_error():
+    session = MagicMock(spec=requests.Session)
+    response = MagicMock()
+    response.raise_for_status.side_effect = requests.HTTPError("409 Conflict")
+    session.post.return_value = response
+
+    with pytest.raises(requests.HTTPError, match="Conflict"):
+        register_external_table(
+            uc_base_url="http://uc.internal:8080",
+            payload={},
+            session=session,
+        )


### PR DESCRIPTION
## Summary

Part of #521 (umbrella). **Shape A**: REST payload generator + thin POST helper for OSS Unity Catalog's external-table registration endpoint \`POST /api/2.1/unity-catalog/tables\`.

This is the catalog-side of the OSS UC story — pure metadata that tells UC \"a table named X lives at storage_location Y in format Z with these columns.\" Readers (Spark, Trino, DuckDB) connect to UC, look up the location, and read the files directly. No query federation involved; that's #522 (Shape B Trino).

Together with #522, this closes the #521 umbrella.

## New module surface

\`\`\`python
from siege_utilities.oss_unity_catalog import (
    SUPPORTED_DATA_SOURCE_FORMATS,
    build_external_table_payload,
    register_external_table,
)

payload = build_external_table_payload(
    catalog=\"main\",
    schema=\"default\",
    name=\"persons\",
    storage_location=\"s3://bucket/path/persons\",
    data_source_format=\"DELTA\",
    columns=[
        {\"name\": \"id\", \"type_name\": \"LONG\"},
        {\"name\": \"name\", \"type_name\": \"STRING\", \"nullable\": False},
    ],
    properties={\"owner\": \"alice\"},
    comment=\"Person registry\",
)

# Either POST it yourself with your preferred HTTP setup, or use
# the thin helper:
result = register_external_table(
    uc_base_url=\"http://uc.internal:8080\",
    payload=payload,
    auth_token=os.environ[\"UC_TOKEN\"],
)
\`\`\`

## Design notes

- **Payload builder is the load-bearing part.** Pure function, no side effects, mock-friendly. Callers who manage their own HTTP client (retry policies, mTLS, proxies, custom session pools) build the payload and POST it themselves.
- **REST helper is intentionally thin.** Wraps \`requests.post\` with bearer-auth support, configurable timeout, and an optional \`requests.Session\` for connection pooling across many registrations.
- **Validation at function entry.** Identifier allow-list (shared \`siege_utilities.core.sql_safety\`), format check (case-normalized), column-by-column inspection. Failures raise before any side effect.
- **Format support** matches OSS UC v0.4.0: DELTA, PARQUET, CSV, JSON, AVRO, ORC, TEXT. Update \`SUPPORTED_DATA_SOURCE_FORMATS\` when OSS UC adds formats.

## Module placement

\`siege_utilities/oss_unity_catalog/\` — top-level, sibling to \`databricks/\` and (from #522) \`trino/\`. Each catalog/engine gets its own namespace; the symmetry with #522 is intentional.

## Test plan

\`tests/test_oss_unity_catalog_external_tables.py\` — 20 tests, all passing locally:

- [x] Minimal payload shape
- [x] Optional \`properties\` + \`comment\` included when given
- [x] Parametrized: every entry in \`SUPPORTED_DATA_SOURCE_FORMATS\` accepted
- [x] Unsupported format rejected with informative error
- [x] Identifier-injection rejection on catalog, schema, name, column name
- [x] Empty-columns / non-mapping-column-entry / column-without-name / empty-storage rejected
- [x] Column \`position\` overrides list index when explicitly provided
- [x] REST helper POSTs to \`{base}/api/2.1/unity-catalog/tables\` (trailing slash stripped)
- [x] REST helper sends \`Authorization: Bearer <token>\` only when token given
- [x] REST helper raises on non-2xx via \`raise_for_status\`

REST tests use \`MagicMock(spec=requests.Session)\` — no socket opened.

## Out of scope

- Spark JDBC federation — add when there is a consumer.
- Catalog/schema CRUD endpoints — same shape if a consumer needs them; separate ticket.
- Async / aiohttp variant — keep the surface minimal until asked.

## Self-review

See trailer in commit message.