### PR TITLE
fix(geo/migrations): add missing RedistrictingPlan fields (#527)

### DIFF
--- a/siege_utilities/geo/django/migrations/0006_redistrictingplan_missing_fields.py
+++ b/siege_utilities/geo/django/migrations/0006_redistrictingplan_missing_fields.py
@@ -1,0 +1,79 @@
+"""Add the RedistrictingPlan fields declared on the model but absent from
+migration 0005: `state` FK, `effective_from`, `effective_to`,
+`superseded_by` self-FK, and `court_case`.
+
+Fixes SU#527 — model declared the fields, schema didn't have the
+columns, so `for_date()` and any `select_related("redistricting_plan")`
+from downstream code crashed with UndefinedColumn.
+
+All new columns are nullable / have safe defaults so existing rows
+backfill cleanly. No data migration needed: existing rows simply have
+NULL `state`, NULL `effective_from` / `effective_to`, NULL
+`superseded_by`, and empty `court_case`.
+"""
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("siege_geo", "0005_add_temporal_models_and_plan_assignment"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="redistrictingplan",
+            name="state",
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="redistricting_plans",
+                to="siege_geo.state",
+                help_text="Parent state",
+            ),
+        ),
+        migrations.AddField(
+            model_name="redistrictingplan",
+            name="effective_from",
+            field=models.DateField(
+                null=True,
+                blank=True,
+                db_index=True,
+                help_text="Date this plan took legal effect (may differ from enacted_date)",
+            ),
+        ),
+        migrations.AddField(
+            model_name="redistrictingplan",
+            name="effective_to",
+            field=models.DateField(
+                null=True,
+                blank=True,
+                db_index=True,
+                help_text="Date this plan was superseded (NULL = still in effect)",
+            ),
+        ),
+        migrations.AddField(
+            model_name="redistrictingplan",
+            name="superseded_by",
+            field=models.ForeignKey(
+                null=True,
+                blank=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="supersedes",
+                to="siege_geo.redistrictingplan",
+                help_text="The plan that replaced this one (court order, new cycle, etc.)",
+            ),
+        ),
+        migrations.AddField(
+            model_name="redistrictingplan",
+            name="court_case",
+            field=models.CharField(
+                max_length=255,
+                blank=True,
+                default="",
+                help_text="Court case name if court-ordered (e.g., 'Allen v. Milligan')",
+            ),
+        ),
+    ]


### PR DESCRIPTION
Fixes #527.

## Problem

`RedistrictingPlanManager.for_date()` (and `active()`, `for_state()`) raise `psycopg2.errors.UndefinedColumn: column siege_geo_redistrictingplan.effective_from does not exist` at runtime. Migration 0005 created the table without `state` FK, `effective_from`, `effective_to`, `superseded_by` self-FK, or `court_case` columns — all declared on the model.

## Fix

New migration `0006_redistrictingplan_missing_fields.py` with `AddField` operations for the five missing columns. All five are nullable / have safe defaults; existing rows backfill cleanly without a data migration.

## Field-by-field reconciliation

| Field | In model | In 0005 | Added by 0006 |
|---|---|---|---|
| `state` (FK to siege_geo.State) | Y | N | Y |
| `state_fips` | Y | Y | — |
| `chamber` | Y | Y | — |
| `cycle_year` | Y | Y | — |
| `plan_name` | Y | Y | — |
| `plan_type` | Y | Y | — |
| `source` | Y | Y | — |
| `source_url` | Y | Y | — |
| `num_districts` | Y | Y | — |
| `enacted_date` | Y | Y | — |
| `effective_from` | Y | N | Y |
| `effective_to` | Y | N | Y |
| `superseded_by` (self-FK) | Y | N | Y |
| `court_case` | Y | N | Y |
| `data_source` | Y | Y | — |

After this migration, the schema matches the model declaration.

## App-label note

This app uses `app_label="siege_geo"` (set on `CensusTIGERBoundary` metaclass). The migration's `dependencies` and FK `to=` strings use `siege_geo.*` accordingly, matching the 0005 convention.

## Downstream coordination

socialwarehouse [#187](https://github.com/siege-analytics/socialwarehouse/pull/187) (F11 step-2 helpers) added a `context_date`-based workaround for this bug. Once this lands and SU releases, a small SW follow-up can restore plan-bound date preference where available.

## Test plan
- [ ] CI green.
- [ ] After merge: bump SW's SU pin; verify SW#187's tests still pass against the migrated schema.
- [ ] Optional follow-up SU ticket: add ORM-level tests for `RedistrictingPlanManager.for_date / active / for_state` (currently only Pydantic schema tests exist; the ORM layer is untested, which is why the bug was hidden).
