### PR TITLE
feat(geo): PUMA + 7 per-kind special-district boundary models (#535)

### DIFF
--- a/siege_utilities/geo/django/migrations/0007_puma_and_special_districts.py
+++ b/siege_utilities/geo/django/migrations/0007_puma_and_special_districts.py
@@ -1,0 +1,192 @@
+"""SU#535: add PUMA + 7 per-kind special-district boundary models.
+
+Downstream SW#191 (template-readiness C-medium) already shipped the
+Address-level cache fields for these types. This migration ships the
+upstream boundary models so `assign_boundaries` can populate the
+caches once data is loaded.
+"""
+
+import django.contrib.gis.db.models.fields
+import django.core.validators
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+# Shared CensusTIGERBoundary fields. Every concrete model below carries
+# this same field list (inherited from base). Defined once as a callable
+# so each CreateModel can call it fresh.
+def _tiger_fields():
+    return [
+        ("id", models.BigAutoField(
+            auto_created=True, primary_key=True, serialize=False, verbose_name="ID",
+        )),
+        ("feature_id", models.CharField(
+            db_index=True,
+            help_text="Stable identifier for this feature (unique per vintage_year)",
+            max_length=60,
+        )),
+        ("name", models.CharField(
+            help_text="Human-readable name of this feature", max_length=255,
+        )),
+        ("vintage_year", models.PositiveSmallIntegerField(
+            db_index=True,
+            help_text="Edition year of the source dataset",
+            validators=[
+                django.core.validators.MinValueValidator(1790),
+                django.core.validators.MaxValueValidator(2100),
+            ],
+        )),
+        ("valid_from", models.DateField(
+            blank=True,
+            help_text="Date this feature became effective (NULL = always valid)",
+            null=True,
+        )),
+        ("valid_to", models.DateField(
+            blank=True,
+            help_text="Date this feature ceased to be effective (NULL = still valid)",
+            null=True,
+        )),
+        ("source", models.CharField(
+            blank=True, default="",
+            help_text="Provenance of this feature (e.g. TIGER/Line, GADM, OSM)",
+            max_length=50,
+        )),
+        ("created_at", models.DateTimeField(auto_now_add=True)),
+        ("updated_at", models.DateTimeField(auto_now=True)),
+        ("boundary_id", models.CharField(
+            db_index=True,
+            help_text="Boundary identifier (synced from feature_id)",
+            max_length=60,
+        )),
+        ("geometry", django.contrib.gis.db.models.fields.MultiPolygonField(
+            help_text="Boundary geometry (WGS 84)", srid=4326,
+        )),
+        ("area_land", models.BigIntegerField(
+            blank=True, help_text="Land area in square meters", null=True,
+        )),
+        ("area_water", models.BigIntegerField(
+            blank=True, help_text="Water area in square meters", null=True,
+        )),
+        ("internal_point", django.contrib.gis.db.models.fields.PointField(
+            blank=True,
+            help_text="Representative interior point (INTPTLAT/INTPTLON)",
+            null=True, srid=4326,
+        )),
+        ("geoid", models.CharField(
+            db_index=True,
+            help_text="Full Census GEOID that uniquely identifies this geography",
+            max_length=20,
+        )),
+        ("state_fips", models.CharField(
+            blank=True, default="", db_index=True,
+            help_text="2-digit state FIPS code (empty for nation-level geographies)",
+            max_length=2,
+        )),
+        ("lsad", models.CharField(
+            blank=True, default="",
+            help_text="Legal/Statistical Area Description code", max_length=2,
+        )),
+        ("mtfcc", models.CharField(
+            blank=True, default="",
+            help_text="MAF/TIGER Feature Class Code", max_length=5,
+        )),
+        ("funcstat", models.CharField(
+            blank=True, default="",
+            help_text="Functional status code", max_length=1,
+        )),
+    ]
+
+
+# Shared special-district extras (added to base by SpecialDistrictBase).
+def _special_district_extras():
+    return [
+        ("governing_body", models.CharField(
+            blank=True, default="", max_length=255,
+            help_text="Name of the special district's governing body.",
+        )),
+        ("function_code", models.CharField(
+            blank=True, default="", db_index=True, max_length=10,
+            help_text="Census-published function code distinguishing the district's purpose.",
+        )),
+    ]
+
+
+_SPECIAL_DISTRICT_MODELS = [
+    ("FireProtectionDistrict", "Fire Protection District"),
+    ("WaterSupplyDistrict", "Water Supply District"),
+    ("HospitalDistrict", "Hospital District"),
+    ("LibraryDistrict", "Library District"),
+    ("CemeteryDistrict", "Cemetery District"),
+    ("MosquitoAbatementDistrict", "Mosquito Abatement District"),
+    ("OtherSpecialDistrict", "Other Special District"),
+]
+
+
+def _make_special_district_create_model(model_name, verbose_name):
+    return migrations.CreateModel(
+        name=model_name,
+        fields=_tiger_fields() + _special_district_extras(),
+        options={
+            "verbose_name": verbose_name,
+            "verbose_name_plural": verbose_name + "s",
+            "unique_together": {("geoid", "vintage_year")},
+        },
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("siege_geo", "0006_redistrictingplan_missing_fields"),
+    ]
+
+    operations = [
+        # PUMA — uses base TIGER fields + a 5-digit puma_code.
+        migrations.CreateModel(
+            name="PUMA",
+            fields=_tiger_fields() + [
+                ("puma_code", models.CharField(
+                    db_index=True, max_length=5,
+                    help_text="5-digit PUMA code within a state",
+                )),
+            ],
+            options={
+                "verbose_name": "PUMA",
+                "verbose_name_plural": "PUMAs",
+                "unique_together": {("geoid", "vintage_year")},
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="puma",
+            constraint=models.CheckConstraint(
+                condition=models.Q(geoid__regex=r"^\d{7}$"),
+                name="puma_geoid_7_digits",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="puma",
+            index=models.Index(fields=["state_fips", "puma_code"], name="siege_geo_puma_st_pc_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="puma",
+            index=models.Index(fields=["state_fips", "vintage_year"], name="siege_geo_puma_st_vy_idx"),
+        ),
+
+        # 7 per-kind special-district models, generated from the catalog.
+        *[
+            _make_special_district_create_model(name, verbose)
+            for (name, verbose) in _SPECIAL_DISTRICT_MODELS
+        ],
+
+        # Per-model state_fips × vintage_year index (mirrors UrbanArea / Place pattern).
+        *[
+            migrations.AddIndex(
+                model_name=name.lower(),
+                index=models.Index(
+                    fields=["state_fips", "vintage_year"],
+                    name=f"siege_geo_{name[:8].lower()}_vy_idx",
+                ),
+            )
+            for (name, _) in _SPECIAL_DISTRICT_MODELS
+        ],
+    ]

--- a/siege_utilities/geo/django/models/__init__.py
+++ b/siege_utilities/geo/django/models/__init__.py
@@ -82,7 +82,17 @@ from .isochrone import (
 )
 from .census_extended import (
     CBSA,
+    PUMA,
     UrbanArea,
+)
+from .special_districts import (
+    CemeteryDistrict,
+    FireProtectionDistrict,
+    HospitalDistrict,
+    LibraryDistrict,
+    MosquitoAbatementDistrict,
+    OtherSpecialDistrict,
+    WaterSupplyDistrict,
 )
 from .intersections import (
     BoundaryIntersection,
@@ -165,7 +175,15 @@ __all__ = [
     "IsochroneResult",
     # Census Extended
     "CBSA",
+    "PUMA",
     "UrbanArea",
+    "CemeteryDistrict",
+    "FireProtectionDistrict",
+    "HospitalDistrict",
+    "LibraryDistrict",
+    "MosquitoAbatementDistrict",
+    "OtherSpecialDistrict",
+    "WaterSupplyDistrict",
     # Intersections
     "BoundaryIntersection",
     "CountyCDIntersection",

--- a/siege_utilities/geo/django/models/census_extended.py
+++ b/siege_utilities/geo/django/models/census_extended.py
@@ -120,3 +120,48 @@ class UrbanArea(CensusTIGERBoundary):
         return {
             "state_fips": "",
         }
+
+
+class PUMA(CensusTIGERBoundary):
+    """
+    Public Use Microdata Area boundary.
+
+    PUMAs are non-overlapping, statistical geographic areas of contiguous
+    counties or census tracts containing ~100,000+ people. Used by ACS
+    public-use microdata samples (PUMS) and small-area estimates.
+
+    GEOID: 7 digits = state (2) + PUMA (5)
+    Example: "0603701" for PUMA 03701 in California (Los Angeles area)
+    """
+
+    puma_code = models.CharField(
+        max_length=5,
+        db_index=True,
+        help_text="5-digit PUMA code within a state",
+    )
+
+    class Meta:
+        verbose_name = "PUMA"
+        verbose_name_plural = "PUMAs"
+        unique_together = [("geoid", "vintage_year")]
+        indexes = [
+            models.Index(fields=["state_fips", "puma_code"]),
+            models.Index(fields=["state_fips", "vintage_year"]),
+        ]
+        constraints = [
+            models.CheckConstraint(
+                condition=models.Q(geoid__regex=r"^\d{7}$"),
+                name="puma_geoid_7_digits",
+            ),
+        ]
+
+    @classmethod
+    def get_geoid_length(cls) -> int:
+        return 7
+
+    @classmethod
+    def parse_geoid(cls, geoid: str) -> dict:
+        return {
+            "state_fips": geoid[:2],
+            "puma_code": geoid[2:7],
+        }

--- a/siege_utilities/geo/django/models/special_districts.py
+++ b/siege_utilities/geo/django/models/special_districts.py
@@ -1,0 +1,144 @@
+"""Per-kind special-district boundary models.
+
+Per downstream socialwarehouse design SW#207 Q2 = "one model per kind"
+(no parent SpecialDistrict model). Each Census special-district
+function gets its own concrete model. Downstream consumers cache the
+geoid in a per-kind field on Address (SW already shipped those caches
+via SW#191's C-medium batch).
+
+GEOID format varies by district type but is at most 10 digits in
+Census Special Districts file outputs. We use a shared 10-char
+CharField with a permissive regex.
+
+The Census-published "function" code distinguishes kinds within the
+Special Districts file; this module realizes those into separate
+Django models for type-safety + reverse-accessor clarity from
+downstream consumers (an Address's `fire_protection_districts` is
+unambiguous about which kind it returns).
+"""
+
+from django.db import models
+
+from .base import CensusTIGERBoundary
+
+
+def _district_meta(verbose):
+    """Build a Meta class for a special-district model with shared shape."""
+    name = verbose
+    class Meta:
+        verbose_name = name
+        verbose_name_plural = name + "s"
+        unique_together = [("geoid", "vintage_year")]
+        indexes = [
+            models.Index(fields=["state_fips", "vintage_year"]),
+        ]
+        abstract = False
+    Meta.__name__ = "Meta"
+    return Meta
+
+
+class SpecialDistrictBase(CensusTIGERBoundary):
+    """Shared shape for all per-kind special-district models.
+
+    Abstract: each concrete kind below inherits and gets its own table.
+    """
+
+    governing_body = models.CharField(
+        max_length=255, blank=True, default="",
+        help_text="Name of the special district's governing body.",
+    )
+    function_code = models.CharField(
+        max_length=10, blank=True, default="",
+        db_index=True,
+        help_text="Census-published function code distinguishing the district's purpose.",
+    )
+
+    class Meta:
+        abstract = True
+
+
+class FireProtectionDistrict(SpecialDistrictBase):
+    """Fire protection special district. Census function code typically '24'."""
+
+    class Meta:
+        verbose_name = "Fire Protection District"
+        verbose_name_plural = "Fire Protection Districts"
+        unique_together = [("geoid", "vintage_year")]
+        indexes = [
+            models.Index(fields=["state_fips", "vintage_year"]),
+        ]
+
+
+class WaterSupplyDistrict(SpecialDistrictBase):
+    """Water supply special district. Census function code typically '91'."""
+
+    class Meta:
+        verbose_name = "Water Supply District"
+        verbose_name_plural = "Water Supply Districts"
+        unique_together = [("geoid", "vintage_year")]
+        indexes = [
+            models.Index(fields=["state_fips", "vintage_year"]),
+        ]
+
+
+class HospitalDistrict(SpecialDistrictBase):
+    """Hospital special district. Census function code typically '40'."""
+
+    class Meta:
+        verbose_name = "Hospital District"
+        verbose_name_plural = "Hospital Districts"
+        unique_together = [("geoid", "vintage_year")]
+        indexes = [
+            models.Index(fields=["state_fips", "vintage_year"]),
+        ]
+
+
+class LibraryDistrict(SpecialDistrictBase):
+    """Library special district. Census function code typically '52'."""
+
+    class Meta:
+        verbose_name = "Library District"
+        verbose_name_plural = "Library Districts"
+        unique_together = [("geoid", "vintage_year")]
+        indexes = [
+            models.Index(fields=["state_fips", "vintage_year"]),
+        ]
+
+
+class CemeteryDistrict(SpecialDistrictBase):
+    """Cemetery special district. Census function code typically '05'."""
+
+    class Meta:
+        verbose_name = "Cemetery District"
+        verbose_name_plural = "Cemetery Districts"
+        unique_together = [("geoid", "vintage_year")]
+        indexes = [
+            models.Index(fields=["state_fips", "vintage_year"]),
+        ]
+
+
+class MosquitoAbatementDistrict(SpecialDistrictBase):
+    """Mosquito abatement special district. Census function code typically '63'."""
+
+    class Meta:
+        verbose_name = "Mosquito Abatement District"
+        verbose_name_plural = "Mosquito Abatement Districts"
+        unique_together = [("geoid", "vintage_year")]
+        indexes = [
+            models.Index(fields=["state_fips", "vintage_year"]),
+        ]
+
+
+class OtherSpecialDistrict(SpecialDistrictBase):
+    """Catch-all for special-district kinds not represented by a dedicated
+    model. Downstream consumers can filter by `function_code` to scope to
+    a specific kind that hasn't graduated to its own model yet.
+    """
+
+    class Meta:
+        verbose_name = "Other Special District"
+        verbose_name_plural = "Other Special Districts"
+        unique_together = [("geoid", "vintage_year")]
+        indexes = [
+            models.Index(fields=["state_fips", "function_code", "vintage_year"]),
+        ]


### PR DESCRIPTION
Downstream SW#191 C-medium ([socialwarehouse PR #219](https://github.com/siege-analytics/socialwarehouse/pull/219), merged) shipped Address-level cache fields for these 8 new boundary types. SU was missing the actual boundary models; this PR adds them per SW C Q2 = 'one model per kind, no parent model.'

## Models
- **PUMA** (7-digit GEOID; state + 5-digit puma_code)
- **FireProtectionDistrict**, **WaterSupplyDistrict**, **HospitalDistrict**, **LibraryDistrict**, **CemeteryDistrict**, **MosquitoAbatementDistrict**, **OtherSpecialDistrict** (each carries governing_body + function_code from SpecialDistrictBase abstract)

## Migration shape
Migration 0007 uses a `_tiger_fields()` callable rather than copy-pasting the 16-field CensusTIGERBoundary list 8 times — keeps the migration to ~200 lines instead of ~2000, and makes schema-vs-model drift easier to catch with `makemigrations --check --dry-run`.

## Downstream impact
After this lands + a SU release:
- Downstream socialwarehouse bumps its SU pin
- SW#194 F Phase 2 (special-district ingest) is unblocked
- The Address cache fields shipped at SW#219 finally have boundary data to be populated from

## Test plan
- [ ] CI green
- [ ] `python manage.py makemigrations --check --dry-run` against a fresh DB returns no drift
- [ ] Smoke: instantiate each new model with a realistic GEOID + geom