### PR TITLE
feat(economic): lift QCEWFiles from socialwarehouse (#533)

### DIFF
--- a/siege_utilities/economic/__init__.py
+++ b/siege_utilities/economic/__init__.py
@@ -1,0 +1,10 @@
+"""Economic data utilities.
+
+Currently:
+- `bls.qcew`: BLS Quarterly Census of Employment and Wages downloader/parser.
+
+Future:
+- `bls.api`: keyed-API client for incremental loads.
+- `bea`: BEA Regional Economic Accounts.
+- `irs.soi`: IRS Statistics of Income by ZIP/ZCTA.
+"""

--- a/siege_utilities/economic/bls/__init__.py
+++ b/siege_utilities/economic/bls/__init__.py
@@ -1,0 +1,5 @@
+"""BLS (Bureau of Labor Statistics) data utilities."""
+
+from .qcew import QCEWFiles
+
+__all__ = ["QCEWFiles"]

--- a/siege_utilities/economic/bls/qcew.py
+++ b/siege_utilities/economic/bls/qcew.py
@@ -1,0 +1,125 @@
+"""BLS Quarterly Census of Employment and Wages — open data downloader + parser.
+
+BLS publishes QCEW open data files (no API key needed) at data.bls.gov.
+Each quarter ships as a CSV inside a zip. This module downloads,
+unzips, caches, and parses into a DataFrame normalized to the shape
+downstream warehouses (e.g., socialwarehouse) consume.
+
+Lift origin: this module was first written in socialwarehouse and
+graduated to siege_utilities per the SU-first rule (SU#533).
+Downstream consumers should `from siege_utilities.economic.bls import QCEWFiles`.
+
+Phase 1 scope: files-only path (no BLS API key required). Phase 2
+will add an `APIClient` that uses the keyed BLS API for incremental
+loads.
+"""
+
+from __future__ import annotations
+
+import logging
+import zipfile
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+import requests
+
+
+logger = logging.getLogger(__name__)
+
+
+# QCEW open-data URL pattern.
+# Example: https://data.bls.gov/cew/data/files/2024/csv/2024_qtrly_singlefile.zip
+QCEW_FILE_URL = "https://data.bls.gov/cew/data/files/{year}/csv/{year}_qtrly_singlefile.zip"
+
+# Default cache location.
+DEFAULT_CACHE_DIR = Path.home() / ".siege_utilities" / "cache" / "qcew"
+
+
+class QCEWFiles:
+    """Thin wrapper around BLS QCEW open-data files.
+
+    Network-only on the first download for a `(year)` tuple; cached on
+    disk thereafter. `parse()` filters by `(state_fips, quarter,
+    naics_depth)` without re-hitting the network.
+
+    Example:
+        files = QCEWFiles()
+        df = files.load(year=2024, quarter=3, state_fips="06", naics_depth=2)
+    """
+
+    def __init__(self, cache_dir: Optional[Path] = None, timeout: int = 120):
+        self.cache_dir = Path(cache_dir) if cache_dir else DEFAULT_CACHE_DIR
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.timeout = timeout
+
+    def download(self, year: int) -> Path:
+        """Download (or return cached) the year's QCEW zip; return CSV path."""
+        zip_path = self.cache_dir / f"{year}_qtrly_singlefile.zip"
+        csv_path = self.cache_dir / f"{year}.qcew.csv"
+
+        if csv_path.exists():
+            logger.debug("QCEW year %s already cached at %s", year, csv_path)
+            return csv_path
+
+        url = QCEW_FILE_URL.format(year=year)
+        logger.info("Downloading QCEW %s from %s", year, url)
+        resp = requests.get(url, timeout=self.timeout)
+        resp.raise_for_status()
+        zip_path.write_bytes(resp.content)
+
+        with zipfile.ZipFile(zip_path) as zf:
+            csv_name = next(
+                (n for n in zf.namelist() if n.endswith(".csv")),
+                None,
+            )
+            if not csv_name:
+                raise ValueError(f"No CSV found inside {zip_path}")
+            with zf.open(csv_name) as src, open(csv_path, "wb") as dst:
+                dst.write(src.read())
+        zip_path.unlink(missing_ok=True)
+        return csv_path
+
+    def parse(
+        self,
+        csv_path: Path,
+        *,
+        year: int,
+        quarter: int,
+        state_fips: Optional[str] = None,
+        naics_depth: int = 2,
+    ) -> pd.DataFrame:
+        """Parse a downloaded QCEW CSV into a normalized DataFrame.
+
+        Filters:
+          - `quarter`: the BLS `qtr` column matches; 1-4.
+          - `state_fips`: if given, `area_fips` startswith `state_fips`.
+          - `naics_depth`: keep only rows where `industry_code` length matches
+            (NAICS 2-digit = sector level by default).
+
+        Returns columns: area_fips, own_code, industry_code, agglvl_code,
+        qtrly_estabs, month1/2/3_emplvl, total_qtrly_wages, avg_wkly_wage,
+        year, qtr.
+        """
+        df = pd.read_csv(csv_path, dtype={"area_fips": str, "industry_code": str})
+        df = df[df["qtr"] == quarter]
+        if state_fips:
+            df = df[df["area_fips"].str.startswith(state_fips)]
+        df = df[df["industry_code"].str.len() == naics_depth]
+        return df.reset_index(drop=True)
+
+    def load(
+        self,
+        *,
+        year: int,
+        quarter: int,
+        state_fips: Optional[str] = None,
+        naics_depth: int = 2,
+    ) -> pd.DataFrame:
+        """Download + parse in one call."""
+        csv_path = self.download(year)
+        return self.parse(
+            csv_path,
+            year=year, quarter=quarter,
+            state_fips=state_fips, naics_depth=naics_depth,
+        )

--- a/tests/test_economic_bls_qcew.py
+++ b/tests/test_economic_bls_qcew.py
@@ -1,12 +1,7 @@
 """Tests for siege_utilities.economic.bls.qcew (SU#533)."""
 
-import tempfile
 import zipfile
-from pathlib import Path
 from unittest.mock import patch, MagicMock
-
-import pandas as pd
-import pytest
 
 from siege_utilities.economic.bls.qcew import QCEWFiles, QCEW_FILE_URL
 

--- a/tests/test_economic_bls_qcew.py
+++ b/tests/test_economic_bls_qcew.py
@@ -1,0 +1,103 @@
+"""Tests for siege_utilities.economic.bls.qcew (SU#533)."""
+
+import tempfile
+import zipfile
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pandas as pd
+import pytest
+
+from siege_utilities.economic.bls.qcew import QCEWFiles, QCEW_FILE_URL
+
+
+def _make_zip(tmp_path, year, csv_content):
+    """Build a fake QCEW zip in tmp_path; return zip-bytes."""
+    csv_path = tmp_path / f"{year}.qcew.csv"
+    csv_path.write_text(csv_content)
+    zip_path = tmp_path / "fake.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.write(csv_path, arcname=f"{year}.qcew.csv")
+    return zip_path.read_bytes()
+
+
+class TestParse:
+
+    def test_parse_filters_by_quarter(self, tmp_path):
+        csv = tmp_path / "data.csv"
+        csv.write_text(
+            "area_fips,own_code,industry_code,qtr,year,qtrly_estabs,month3_emplvl,total_qtrly_wages,avg_wkly_wage\n"
+            "06037,5,10,1,2024,1,1000,100000,1500\n"
+            "06037,5,10,3,2024,1,1100,110000,1550\n"
+            "06037,5,10,4,2024,1,1200,120000,1600\n"
+        )
+        files = QCEWFiles(cache_dir=tmp_path)
+        df = files.parse(csv, year=2024, quarter=3)
+        assert len(df) == 1
+        assert df.iloc[0]["qtr"] == 3
+
+    def test_parse_filters_by_state(self, tmp_path):
+        csv = tmp_path / "data.csv"
+        csv.write_text(
+            "area_fips,own_code,industry_code,qtr,year,qtrly_estabs,month3_emplvl,total_qtrly_wages,avg_wkly_wage\n"
+            "06037,5,10,3,2024,1,1000,100000,1500\n"
+            "48201,5,10,3,2024,1,2000,200000,1600\n"
+        )
+        files = QCEWFiles(cache_dir=tmp_path)
+        df = files.parse(csv, year=2024, quarter=3, state_fips="06")
+        assert len(df) == 1
+        assert df.iloc[0]["area_fips"] == "06037"
+
+    def test_parse_filters_by_naics_depth(self, tmp_path):
+        csv = tmp_path / "data.csv"
+        csv.write_text(
+            "area_fips,own_code,industry_code,qtr,year,qtrly_estabs,month3_emplvl,total_qtrly_wages,avg_wkly_wage\n"
+            "06037,5,10,3,2024,1,1000,100000,1500\n"
+            "06037,5,238,3,2024,1,500,50000,1400\n"
+        )
+        files = QCEWFiles(cache_dir=tmp_path)
+        df = files.parse(csv, year=2024, quarter=3, naics_depth=2)
+        assert len(df) == 1
+        assert df.iloc[0]["industry_code"] == "10"
+
+
+class TestDownloadCache:
+
+    def test_returns_cached_csv_when_present(self, tmp_path):
+        # Pre-populate cache with the target CSV.
+        (tmp_path / "2024.qcew.csv").write_text("placeholder")
+        files = QCEWFiles(cache_dir=tmp_path)
+        result = files.download(2024)
+        assert result == tmp_path / "2024.qcew.csv"
+
+    def test_download_writes_then_returns_csv(self, tmp_path):
+        files = QCEWFiles(cache_dir=tmp_path)
+        # Mock requests.get to return our fake zip.
+        fake_zip_bytes = _make_zip(
+            tmp_path, 2024,
+            "area_fips,own_code,industry_code,qtr,year,qtrly_estabs,month3_emplvl,total_qtrly_wages,avg_wkly_wage\n",
+        )
+        # The fake CSV is one of multiple test setup steps; download() looks for
+        # .csv in the zip but our _make_zip side-effect already wrote the csv to
+        # tmp_path. Clean slate:
+        (tmp_path / "2024.qcew.csv").unlink(missing_ok=True)
+
+        with patch.object(__import__("siege_utilities.economic.bls.qcew", fromlist=["requests"]).requests, "get") as mock_get:
+            mock_get.return_value = MagicMock(content=fake_zip_bytes, raise_for_status=lambda: None)
+            result = files.download(2024)
+        assert result.exists()
+        assert result.name == "2024.qcew.csv"
+
+
+def test_url_template_format():
+    assert QCEW_FILE_URL.format(year=2024) == (
+        "https://data.bls.gov/cew/data/files/2024/csv/2024_qtrly_singlefile.zip"
+    )
+
+
+def test_import_path():
+    """The downstream-documented import path works."""
+    from siege_utilities.economic.bls import QCEWFiles as q1
+    from siege_utilities.economic.bls.qcew import QCEWFiles as q2
+
+    assert q1 is q2


### PR DESCRIPTION
Downstream [socialwarehouse PR #215](https://github.com/siege-analytics/socialwarehouse/pull/215) shipped a SW-local QCEWFiles helper with an explicit TODO + SU#533 reference for the lift. This PR ships the SU side.

New namespace: `siege_utilities.economic.bls`. QCEWFiles preserves the SW-local API surface so the downstream import swap is mechanical.

After release, SW: bumps pin → switches `from socialwarehouse.economic.services.bls_qcew_files` to `from siege_utilities.economic.bls` → deletes the SW-local helper.

## Test plan
- [ ] CI green (mocked-network tests)
- [ ] Smoke: `from siege_utilities.economic.bls import QCEWFiles`