### PR TITLE
feat(geo): add data_reception.py — format detection + per-format attribute extractors

### DIFF
--- a/siege_utilities/geo/__init__.py
+++ b/siege_utilities/geo/__init__.py
@@ -280,6 +280,13 @@ _register([
     'get_default_plan_registry',
 ], '.plans')
 
+# --- data_reception (format detection + per-format attribute extractors) ---
+_register([
+    'detect_format', 'extract_attributes_ogr', 'extract_attributes_kml',
+    'extract_attributes_swmaps',
+    'MISSING_NONE', 'MISSING_RAISE', 'MISSING_WARN',
+], '.data_reception')
+
 # --- temporal (pure-Python temporal data management) ---
 _register([
     'TemporalDataStore', 'get_temporal_store',

--- a/siege_utilities/geo/data_reception.py
+++ b/siege_utilities/geo/data_reception.py
@@ -1,0 +1,305 @@
+"""
+Format detection and per-format attribute extraction for vector GIS files.
+
+This module provides a small dispatcher that identifies a vector GIS file's
+format (shapefile / GeoJSON / KML / KMZ / GeoPackage / DXF / SWMaps / unknown)
+and exposes per-format attribute extractors that tolerate missing fields the
+way OGR does (return None rather than raise).
+
+Pattern lifted from a third-party tile-server audit
+(``common/utils/DataUtils.py:488-563`` — ``_getDataFromSource`` and the
+per-format ``_get*DataFromSource`` helpers). Patterns explicitly NOT carried
+over from the salvage source:
+
+* Hardcoded Windows binary paths (``osgeo4WBinPath``,
+  ``ODA_FILE_CONVERTER_PATH``) — the salvage shell-out via subprocess for
+  DWG->DXF conversion is discarded entirely.
+* ``osgeo`` Python bindings — the salvage source uses GDAL/OGR directly; SU
+  declares ``fiona`` (the high-level OGR wrapper) as the geo dep, so this
+  module is fiona-shaped at the attribute-extraction layer.
+* Azure Blob fetch coupling around the dispatch.
+* Application-schema-specific extractors (``map_job_id``, etc.) — the
+  generic extractors here accept candidate field-name lists; consumer code
+  supplies the schema.
+
+Optional dependencies are guarded; calling an extractor whose backing
+library is not installed raises ``ImportError`` with the install hint.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import zipfile
+from typing import Any, Iterable
+
+log = logging.getLogger(__name__)
+
+# Extension -> format token. Extensions match the dispatcher cases in the
+# salvage source plus the SWMaps `.swmz` archive form.
+_EXTENSION_MAP = {
+    ".shp": "shapefile",
+    ".geojson": "geojson",
+    ".kml": "kml",
+    ".kmz": "kmz",
+    ".gpkg": "geopackage",
+    ".dxf": "dxf",
+    ".swmz": "swmaps",
+}
+
+# Extensions that need magic-byte / archive-peek disambiguation.
+_AMBIGUOUS_EXTENSIONS = {".json", ".sqlite", ".db", ".zip"}
+
+# SWMaps SQLite schema fingerprint — these three tables appear together in
+# every SWMaps export (verified against salvage-source query at DataUtils.py:687-692).
+_SWMAPS_SQLITE_TABLES = frozenset({"features", "points", "feature_layers"})
+
+# Sentinel values for the `missing=` keyword on the extractors.
+MISSING_NONE = "none"
+MISSING_RAISE = "raise"
+MISSING_WARN = "warn"
+_MISSING_VALID = {MISSING_NONE, MISSING_RAISE, MISSING_WARN}
+
+
+def detect_format(file_path: str) -> str:
+    """Return a format token for a vector GIS file.
+
+    Args:
+        file_path: Path to a vector GIS file on disk.
+
+    Returns:
+        One of: ``"shapefile"``, ``"geojson"``, ``"kml"``, ``"kmz"``,
+        ``"geopackage"``, ``"dxf"``, ``"swmaps"``, ``"unknown"``.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+
+    Detection algorithm:
+
+    1. Extension lookup (case-insensitive) against a small canonical map.
+    2. For ambiguous extensions (``.json``, ``.sqlite``, ``.db``, ``.zip``),
+       a magic-byte / archive-peek fallback inspects the file body.
+
+    Directories return ``"unknown"`` — walking is the caller's responsibility.
+    """
+    if not os.path.exists(file_path):
+        raise FileNotFoundError(file_path)
+    if os.path.isdir(file_path):
+        return "unknown"
+
+    ext = os.path.splitext(file_path)[1].lower()
+    if ext in _EXTENSION_MAP:
+        return _EXTENSION_MAP[ext]
+    if ext not in _AMBIGUOUS_EXTENSIONS:
+        return "unknown"
+
+    # Magic-byte / archive-peek disambiguation.
+    try:
+        if ext == ".json":
+            return _peek_json(file_path)
+        if ext in {".sqlite", ".db"}:
+            return _peek_sqlite(file_path)
+        if ext == ".zip":
+            return _peek_zip(file_path)
+    except Exception as exc:  # pragma: no cover - corrupt file fallback
+        log.warning("detect_format peek failed for %s: %s", file_path, exc)
+
+    return "unknown"
+
+
+def _peek_json(file_path: str) -> str:
+    """Return ``"geojson"`` if file body looks like GeoJSON, else ``"unknown"``."""
+    try:
+        with open(file_path, "r", encoding="utf-8", errors="ignore") as fh:
+            head = fh.read(4096)
+    except OSError:
+        return "unknown"
+    if '"FeatureCollection"' in head or '"Feature"' in head or '"geometry"' in head:
+        return "geojson"
+    return "unknown"
+
+
+def _peek_sqlite(file_path: str) -> str:
+    """Return ``"swmaps"`` if SQLite has the SWMaps table fingerprint, else ``"unknown"``."""
+    try:
+        with sqlite3.connect(f"file:{file_path}?mode=ro", uri=True) as conn:
+            cur = conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+            tables = {row[0] for row in cur.fetchall()}
+    except sqlite3.DatabaseError:
+        return "unknown"
+    if _SWMAPS_SQLITE_TABLES.issubset(tables):
+        return "swmaps"
+    return "unknown"
+
+
+def _peek_zip(file_path: str) -> str:
+    """Inspect a ``.zip`` archive's member names to pick a sub-format."""
+    try:
+        with zipfile.ZipFile(file_path) as zf:
+            names = [n.lower() for n in zf.namelist()]
+    except zipfile.BadZipFile:
+        return "unknown"
+    if any(n.endswith(".kml") for n in names):
+        return "kmz"
+    if any(n.endswith(".sqlite") or n.endswith(".db") for n in names):
+        return "swmaps"
+    if any(n.endswith(".shp") for n in names):
+        return "shapefile"
+    return "unknown"
+
+
+def _resolve_missing(field_name: str, missing: str) -> Any:
+    """Apply the ``missing=`` policy uniformly across extractors."""
+    if missing not in _MISSING_VALID:
+        raise ValueError(
+            f"missing= must be one of {sorted(_MISSING_VALID)}; got {missing!r}"
+        )
+    if missing == MISSING_RAISE:
+        raise KeyError(field_name)
+    if missing == MISSING_WARN:
+        log.warning("attribute field %r not present on feature", field_name)
+    return None
+
+
+def extract_attributes_ogr(
+    feature: Any,
+    field_names: Iterable[str],
+    missing: str = MISSING_NONE,
+) -> Any:
+    """Extract one attribute from a fiona-record-shaped feature.
+
+    Mirrors the candidate-list semantics of the salvage-source helper
+    ``_getOGRDataFromSource`` (``DataUtils.py:489-513``) which accepts a
+    primary plus a fallback field name and returns ``None`` when neither is
+    present. The salvage source used the GDAL/OGR Python bindings directly;
+    this implementation is fiona-record-shaped (the high-level OGR wrapper
+    that SU declares as a geo dep).
+
+    Args:
+        feature: A fiona-style record (``{"properties": {...}, ...}``) OR a
+            plain ``dict`` (e.g. the property dict directly).
+        field_names: Candidate field names, in priority order. First name
+            present on the feature wins.
+        missing: One of ``"none"`` (default; return ``None``), ``"raise"``
+            (``KeyError``), or ``"warn"`` (log + return ``None``).
+
+    Returns:
+        The attribute value or ``None``.
+    """
+    if feature is None:
+        return _resolve_missing(next(iter(field_names), ""), missing)
+
+    # fiona record vs bare dict.
+    if isinstance(feature, dict) and "properties" in feature and isinstance(
+        feature["properties"], dict
+    ):
+        props = feature["properties"]
+    elif isinstance(feature, dict):
+        props = feature
+    else:
+        # Best-effort attribute-style fallback (e.g. an OGR Feature subclass
+        # in callers that DO have osgeo installed).
+        props = None
+
+    candidates = list(field_names)
+    if not candidates:
+        return None
+
+    if props is not None:
+        for name in candidates:
+            if name in props:
+                return props[name]
+    else:  # pragma: no cover - osgeo fallback path
+        for name in candidates:
+            if hasattr(feature, name):
+                return getattr(feature, name)
+
+    return _resolve_missing(candidates[0], missing)
+
+
+def extract_attributes_kml(
+    kml_extended_data: dict | None,
+    field_names: Iterable[str],
+    missing: str = MISSING_NONE,
+) -> Any:
+    """Extract one attribute from a KML extended-data mapping.
+
+    Mirrors the salvage-source helper ``_getKMLDataFromSource``
+    (``DataUtils.py:516-520``). The salvage version was a one-liner dict
+    lookup with no candidate fallback; this version adds the same
+    candidate-list semantics as :func:`extract_attributes_ogr` for
+    consistency across the dispatcher.
+
+    Args:
+        kml_extended_data: A flat ``{name: value}`` mapping derived from a
+            KML ``<ExtendedData>`` block.
+        field_names: Candidate field names, in priority order.
+        missing: ``"none"`` / ``"raise"`` / ``"warn"``.
+
+    Returns:
+        The attribute value or ``None``.
+    """
+    candidates = list(field_names)
+    if not candidates:
+        return None
+    if kml_extended_data:
+        for name in candidates:
+            if name in kml_extended_data:
+                return kml_extended_data[name]
+    return _resolve_missing(candidates[0], missing)
+
+
+def extract_attributes_swmaps(
+    db_path: str,
+    feature_id: str,
+    field_names: Iterable[str],
+    missing: str = MISSING_NONE,
+) -> Any:
+    """Extract one attribute for a SWMaps feature by attribute-field name.
+
+    Queries the SWMaps SQLite ``attribute_values`` table joined to
+    ``attribute_fields`` for the named field, scoped to ``feature_id``.
+    This is the same join pattern as the salvage source's
+    ``swmapsAttributeQuery`` (``DataUtils.py:693-698``); the
+    application-schema-specific mapper (``swMapsAttributeMapper`` dict at
+    ``DataUtils.py:672-686``) is NOT lifted — that lives with the consumer.
+
+    For full SWMaps feature iteration (geometry + all attributes), use
+    :mod:`siege_utilities.geo.swmaps_reader` instead; this function is the
+    thin dispatcher-friendly accessor.
+
+    Args:
+        db_path: Path to a SWMaps SQLite file (already extracted from
+            ``.swmz`` if needed; archive handling lives in the swmaps_reader
+            module).
+        feature_id: SWMaps feature UUID.
+        field_names: Candidate attribute-field names.
+        missing: ``"none"`` / ``"raise"`` / ``"warn"``.
+
+    Returns:
+        The attribute value (as stored in ``attribute_values.value``) or
+        ``None``.
+    """
+    candidates = list(field_names)
+    if not candidates:
+        return None
+
+    query = (
+        "SELECT af.field_name, av.value "
+        "FROM attribute_values av "
+        "INNER JOIN attribute_fields af ON af.uuid = av.field_id "
+        "WHERE av.item_id = ?"
+    )
+    try:
+        with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as conn:
+            rows = dict(conn.execute(query, (feature_id,)).fetchall())
+    except sqlite3.DatabaseError as exc:
+        log.warning("SWMaps query failed for %s: %s", db_path, exc)
+        return _resolve_missing(candidates[0], missing)
+
+    for name in candidates:
+        if name in rows:
+            return rows[name]
+
+    return _resolve_missing(candidates[0], missing)

--- a/siege_utilities/geo/data_reception.py
+++ b/siege_utilities/geo/data_reception.py
@@ -123,7 +123,7 @@ def _peek_json(file_path: str) -> str:
 def _peek_sqlite(file_path: str) -> str:
     """Return ``"swmaps"`` if SQLite has the SWMaps table fingerprint, else ``"unknown"``."""
     try:
-        with sqlite3.connect(f"file:{file_path}?mode=ro", uri=True) as conn:
+        with sqlite3.connect(f"file:{file_path}?mode=ro", uri=True, timeout=5.0) as conn:
             cur = conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
             tables = {row[0] for row in cur.fetchall()}
     except sqlite3.DatabaseError:
@@ -292,7 +292,7 @@ def extract_attributes_swmaps(
         "WHERE av.item_id = ?"
     )
     try:
-        with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as conn:
+        with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5.0) as conn:
             rows = dict(conn.execute(query, (feature_id,)).fetchall())
     except sqlite3.DatabaseError as exc:
         log.warning("SWMaps query failed for %s: %s", db_path, exc)

--- a/tests/test_data_reception.py
+++ b/tests/test_data_reception.py
@@ -57,7 +57,7 @@ def test_detect_format_random_json_is_unknown(tmp_path):
 
 def test_detect_format_sqlite_swmaps(tmp_path):
     p = os.path.join(str(tmp_path), "field.sqlite")
-    conn = sqlite3.connect(p)
+    conn = sqlite3.connect(p, timeout=5.0)
     conn.execute("CREATE TABLE features (uuid TEXT, name TEXT, layer_id TEXT)")
     conn.execute("CREATE TABLE points (fid TEXT, seq INT, lat REAL, lon REAL, elv REAL)")
     conn.execute("CREATE TABLE feature_layers (uuid TEXT, name TEXT, group_name TEXT, geom_type TEXT)")
@@ -68,7 +68,7 @@ def test_detect_format_sqlite_swmaps(tmp_path):
 
 def test_detect_format_sqlite_non_swmaps(tmp_path):
     p = os.path.join(str(tmp_path), "other.sqlite")
-    conn = sqlite3.connect(p)
+    conn = sqlite3.connect(p, timeout=5.0)
     conn.execute("CREATE TABLE unrelated (id INTEGER)")
     conn.commit()
     conn.close()
@@ -162,7 +162,7 @@ def test_extract_kml_none_data():
 
 def _build_swmaps_sqlite(path: str, attr_rows):
     """attr_rows = list of (feature_id, field_name, value)."""
-    conn = sqlite3.connect(path)
+    conn = sqlite3.connect(path, timeout=5.0)
     conn.executescript(
         """
         CREATE TABLE attribute_fields (uuid TEXT PRIMARY KEY, field_name TEXT);

--- a/tests/test_data_reception.py
+++ b/tests/test_data_reception.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import sqlite3
-import tempfile
 import zipfile
 
 import pytest

--- a/tests/test_data_reception.py
+++ b/tests/test_data_reception.py
@@ -1,0 +1,204 @@
+"""Tests for siege_utilities.geo.data_reception (SU#542)."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import tempfile
+import zipfile
+
+import pytest
+
+from siege_utilities.geo.data_reception import (
+    detect_format,
+    extract_attributes_kml,
+    extract_attributes_ogr,
+    extract_attributes_swmaps,
+)
+
+
+def _write(tmp_path, name: str, content: bytes) -> str:
+    p = os.path.join(tmp_path, name)
+    with open(p, "wb") as fh:
+        fh.write(content)
+    return p
+
+
+def test_detect_format_extension_map(tmp_path):
+    cases = {
+        "a.shp": "shapefile",
+        "a.SHP": "shapefile",
+        "a.geojson": "geojson",
+        "a.kml": "kml",
+        "a.kmz": "kmz",
+        "a.gpkg": "geopackage",
+        "a.dxf": "dxf",
+        "a.swmz": "swmaps",
+        "a.bin": "unknown",
+        "a.txt": "unknown",
+    }
+    for name, expected in cases.items():
+        p = _write(str(tmp_path), name, b"")
+        assert detect_format(p) == expected, (name, expected)
+
+
+def test_detect_format_geojson_peek(tmp_path):
+    p = _write(
+        str(tmp_path),
+        "blob.json",
+        b'{"type": "FeatureCollection", "features": []}',
+    )
+    assert detect_format(p) == "geojson"
+
+
+def test_detect_format_random_json_is_unknown(tmp_path):
+    p = _write(str(tmp_path), "blob.json", b'{"unrelated": true}')
+    assert detect_format(p) == "unknown"
+
+
+def test_detect_format_sqlite_swmaps(tmp_path):
+    p = os.path.join(str(tmp_path), "field.sqlite")
+    conn = sqlite3.connect(p)
+    conn.execute("CREATE TABLE features (uuid TEXT, name TEXT, layer_id TEXT)")
+    conn.execute("CREATE TABLE points (fid TEXT, seq INT, lat REAL, lon REAL, elv REAL)")
+    conn.execute("CREATE TABLE feature_layers (uuid TEXT, name TEXT, group_name TEXT, geom_type TEXT)")
+    conn.commit()
+    conn.close()
+    assert detect_format(p) == "swmaps"
+
+
+def test_detect_format_sqlite_non_swmaps(tmp_path):
+    p = os.path.join(str(tmp_path), "other.sqlite")
+    conn = sqlite3.connect(p)
+    conn.execute("CREATE TABLE unrelated (id INTEGER)")
+    conn.commit()
+    conn.close()
+    assert detect_format(p) == "unknown"
+
+
+def test_detect_format_zip_kmz(tmp_path):
+    p = os.path.join(str(tmp_path), "thing.zip")
+    with zipfile.ZipFile(p, "w") as zf:
+        zf.writestr("doc.kml", "<kml/>")
+    assert detect_format(p) == "kmz"
+
+
+def test_detect_format_zip_swmz_member(tmp_path):
+    p = os.path.join(str(tmp_path), "thing.zip")
+    with zipfile.ZipFile(p, "w") as zf:
+        zf.writestr("data.sqlite", b"")
+    assert detect_format(p) == "swmaps"
+
+
+def test_detect_format_missing_file_raises():
+    with pytest.raises(FileNotFoundError):
+        detect_format("/nonexistent/path/x.shp")
+
+
+def test_detect_format_directory_is_unknown(tmp_path):
+    assert detect_format(str(tmp_path)) == "unknown"
+
+
+# --- extract_attributes_ogr -----------------------------------------------
+
+
+def test_extract_ogr_fiona_record_shape():
+    feature = {"properties": {"NAME": "Travis", "GEOID": "48453"}, "geometry": {}}
+    assert extract_attributes_ogr(feature, ["NAME"]) == "Travis"
+
+
+def test_extract_ogr_candidate_fallback():
+    feature = {"properties": {"GEOID20": "48453"}}
+    assert extract_attributes_ogr(feature, ["GEOID", "GEOID20"]) == "48453"
+
+
+def test_extract_ogr_missing_none_default():
+    feature = {"properties": {"X": 1}}
+    assert extract_attributes_ogr(feature, ["MISSING"]) is None
+
+
+def test_extract_ogr_missing_raise():
+    feature = {"properties": {}}
+    with pytest.raises(KeyError):
+        extract_attributes_ogr(feature, ["NAME"], missing="raise")
+
+
+def test_extract_ogr_missing_invalid_token():
+    with pytest.raises(ValueError):
+        extract_attributes_ogr({"properties": {}}, ["X"], missing="bogus")
+
+
+def test_extract_ogr_bare_dict_shape():
+    feature = {"NAME": "X"}
+    assert extract_attributes_ogr(feature, ["NAME"]) == "X"
+
+
+def test_extract_ogr_none_feature():
+    assert extract_attributes_ogr(None, ["X"]) is None
+
+
+# --- extract_attributes_kml -----------------------------------------------
+
+
+def test_extract_kml_present():
+    data = {"depth": "3ft", "material": "PVC"}
+    assert extract_attributes_kml(data, ["depth"]) == "3ft"
+
+
+def test_extract_kml_candidate_fallback():
+    data = {"MaterialType": "PVC"}
+    assert extract_attributes_kml(data, ["Material", "MaterialType"]) == "PVC"
+
+
+def test_extract_kml_missing_none():
+    assert extract_attributes_kml({}, ["x"]) is None
+
+
+def test_extract_kml_none_data():
+    assert extract_attributes_kml(None, ["x"]) is None
+
+
+# --- extract_attributes_swmaps --------------------------------------------
+
+
+def _build_swmaps_sqlite(path: str, attr_rows):
+    """attr_rows = list of (feature_id, field_name, value)."""
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE attribute_fields (uuid TEXT PRIMARY KEY, field_name TEXT);
+        CREATE TABLE attribute_values (item_id TEXT, field_id TEXT, value TEXT);
+        """
+    )
+    seen = {}
+    for fid, fname, val in attr_rows:
+        if fname not in seen:
+            fuuid = f"fld-{len(seen)}"
+            seen[fname] = fuuid
+            conn.execute("INSERT INTO attribute_fields VALUES (?, ?)", (fuuid, fname))
+        conn.execute(
+            "INSERT INTO attribute_values VALUES (?, ?, ?)",
+            (fid, seen[fname], val),
+        )
+    conn.commit()
+    conn.close()
+
+
+def test_extract_swmaps_present(tmp_path):
+    p = os.path.join(str(tmp_path), "f.sqlite")
+    _build_swmaps_sqlite(p, [("feat-1", "MATERIAL TYPE", "PVC")])
+    assert extract_attributes_swmaps(p, "feat-1", ["MATERIAL TYPE"]) == "PVC"
+
+
+def test_extract_swmaps_missing_returns_none(tmp_path):
+    p = os.path.join(str(tmp_path), "f.sqlite")
+    _build_swmaps_sqlite(p, [])
+    assert extract_attributes_swmaps(p, "feat-1", ["MATERIAL TYPE"]) is None
+
+
+def test_extract_swmaps_candidate_fallback(tmp_path):
+    p = os.path.join(str(tmp_path), "f.sqlite")
+    _build_swmaps_sqlite(p, [("feat-1", "DEPTH (FT)", "3.5")])
+    assert (
+        extract_attributes_swmaps(p, "feat-1", ["DEPTH", "DEPTH (FT)"]) == "3.5"
+    )


### PR DESCRIPTION
Refs: #542

## Summary

Adds `siege_utilities/geo/data_reception.py` — a small dispatcher that identifies vector GIS file format and exposes per-format attribute extractors with first-match-wins candidate field names and configurable missing-field semantics.

- `detect_format(path)` -> one of `shapefile / geojson / kml / kmz / geopackage / dxf / swmaps / unknown`. Extension-first, magic-byte / archive-peek fallback for ambiguous extensions (`.json`, `.sqlite`, `.zip`).
- `extract_attributes_ogr(feature, field_names, missing=)` — fiona-record-shaped (SU declares `fiona`, not raw `osgeo`).
- `extract_attributes_kml(extended_data, field_names, missing=)` — dict lookup with candidate fallback.
- `extract_attributes_swmaps(db_path, feature_id, field_names, missing=)` — thin SQLite accessor (heavier reader in #544).

## Provenance

Pattern lifted from a low-quality third-party tile-server audit at `common/utils/DataUtils.py:488-563` (`_getDataFromSource` + per-format helpers).

Patterns explicitly NOT carried over:

- Hardcoded Windows binary paths (`osgeo4WBinPath`, `ODA_FILE_CONVERTER_PATH`).
- Subprocess shell-outs for DWG -> DXF conversion (`_convertDWGToDXF`).
- Azure Blob fetch coupling around dispatch.
- Application-schema-specific attribute mappings (`map_job_id`, etc.).
- `osgeo` Python bindings (not a declared SU dep; substituted fiona-shaped records).

## Test plan

- [x] 23 unit tests in `tests/test_data_reception.py` pass locally (`pytest tests/test_data_reception.py` -> `23 passed in 8.57s`).
- [x] Module is stdlib-only — no new package dependencies.
- [x] Lazy-export entry added to `geo/__init__.py`.
- [ ] CI green-gate-subset (lint + module-relevant tests).