### PR TITLE
feat(geo/crs): add detect_crs + axis-order-aware reproject_geom

### DIFF
--- a/siege_utilities/geo/__init__.py
+++ b/siege_utilities/geo/__init__.py
@@ -19,9 +19,11 @@ def _register(names, module):
 # --- capabilities (runtime tier detection) ---
 _register(['geo_capabilities'], '.capabilities')
 
-# --- crs (configurable default CRS) ---
+# --- crs (configurable default CRS + axis-order-aware reprojection) ---
 _register([
     'get_default_crs', 'set_default_crs', 'reproject_if_needed',
+    'detect_crs', 'reproject_geom',
+    'AXIS_ORDER_TRAD_GIS', 'AXIS_ORDER_AUTH_COMPLIANT',
 ], '.crs')
 
 # --- boundary_result (structured diagnostics) ---

--- a/siege_utilities/geo/crs.py
+++ b/siege_utilities/geo/crs.py
@@ -1,21 +1,52 @@
 """
-Configurable default CRS for all spatial-returning functions.
+Configurable default CRS plus geometry-level CRS detection and
+axis-order-aware reprojection.
 
-Every function in ``siege_utilities.geo`` that returns spatial data
-uses :func:`get_default_crs` as its default ``crs`` argument.  Call
-:func:`set_default_crs` once at the top of a notebook or script to
-change the default globally::
+The default-CRS layer (``get_default_crs`` / ``set_default_crs`` /
+``reproject_if_needed``) is the existing thin GeoDataFrame-shaped API
+that every spatial-returning function in :mod:`siege_utilities.geo`
+uses as its default. Call :func:`set_default_crs` once at the top of a
+notebook or script to change the default globally::
 
     import siege_utilities as su
     su.set_default_crs("EPSG:3857")
 
     # All subsequent calls return Web Mercator unless overridden:
     gdf = su.download_data(2020, "county")  # already in EPSG:3857
+
+:func:`detect_crs` and :func:`reproject_geom` extend the module to
+geometry-level work with explicit axis-order control. Pattern lifted
+from a third-party tile-server audit (``common/repos/ImportServerRepo.py:150-336``,
+specifically the SRS handling at lines 255-274). The salvage source
+used the GDAL/OGR Python bindings (``osgeo.osr``) with
+``OAMS_TRADITIONAL_GIS_ORDER`` to force lon-first axis order; SU does
+not declare ``osgeo`` as a dep, so this module is built on ``pyproj``
+(which IS declared). ``pyproj.Transformer.from_crs(..., always_xy=True)``
+is the documented modern equivalent of the OGR axis-mapping strategy.
+
+Why the axis-order toggle exists: GeoJSON / Shapefile / KML files store
+coordinates lon-first (x, y) but the EPSG authority specifies lat-first
+(y, x) for many CRSes including EPSG:4326. The default ``"trad_gis"``
+mode honors the file conventions (what most consumers expect). The
+``"auth_compliant"`` mode honors the EPSG authority (what GIS
+standards-compliant code paths require). Most consumer code expects
+``trad_gis``; choosing ``auth_compliant`` without knowing why is a
+subtle source of transposed lat/lon bugs.
 """
 
 from __future__ import annotations
 
+import logging
+from typing import Any
+
+log = logging.getLogger(__name__)
+
 _DEFAULT_CRS: str = "EPSG:4326"
+
+# Axis-order tokens accepted by reproject_geom.
+AXIS_ORDER_TRAD_GIS = "trad_gis"
+AXIS_ORDER_AUTH_COMPLIANT = "auth_compliant"
+_AXIS_ORDER_VALID = {AXIS_ORDER_TRAD_GIS, AXIS_ORDER_AUTH_COMPLIANT}
 
 
 def get_default_crs() -> str:
@@ -48,3 +79,158 @@ def reproject_if_needed(gdf, crs: str | None = None):
     if gdf.crs and str(gdf.crs).upper() != target.upper():
         return gdf.to_crs(target)
     return gdf
+
+
+def detect_crs(geom_or_ds: Any) -> str | None:
+    """Resolve the source CRS of a spatial object.
+
+    Args:
+        geom_or_ds: One of:
+
+            * A GeoDataFrame — reads ``.crs`` and returns an ``EPSG:<n>``
+              string when authoritative, otherwise the WKT.
+            * A GeoJSON-like ``dict`` — reads
+              ``["crs"]["properties"]["name"]`` if present.
+            * A fiona ``Collection`` — reads ``.crs`` / ``.crs_wkt``.
+            * A bare shapely geometry — bare geometries carry no CRS
+              metadata; this returns ``None`` (callers should treat this
+              as "consult :func:`get_default_crs`").
+            * ``None`` — returns ``None``.
+
+    Returns:
+        An EPSG string (``"EPSG:4326"``), a WKT string, or ``None``.
+
+    Mirrors the SRS-detection branch of the salvage source
+    (``ImportServerRepo.py:250-253``), which read the spatial reference
+    from an OGR DataSource via ``GetGeometryRef().GetSpatialReference()``.
+    This implementation reads ``.crs`` / ``.crs_wkt`` from
+    GeoDataFrames or fiona collections — same intent, declared-deps
+    surface.
+    """
+    if geom_or_ds is None:
+        return None
+
+    # GeoDataFrame
+    crs_attr = getattr(geom_or_ds, "crs", None)
+    if crs_attr is not None:
+        return _normalize_crs(crs_attr)
+
+    # fiona Collection exposes .crs_wkt as well
+    crs_wkt = getattr(geom_or_ds, "crs_wkt", None)
+    if crs_wkt:
+        return _normalize_crs(crs_wkt)
+
+    # GeoJSON-shaped dict
+    if isinstance(geom_or_ds, dict):
+        crs_block = geom_or_ds.get("crs")
+        if isinstance(crs_block, dict):
+            name = crs_block.get("properties", {}).get("name")
+            if name:
+                return _normalize_crs(name)
+        return None
+
+    # Bare shapely geometry has no CRS metadata.
+    if hasattr(geom_or_ds, "geom_type"):
+        return None
+
+    return None
+
+
+def _normalize_crs(value: Any) -> str:
+    """Best-effort normalization of various CRS representations to a string."""
+    try:
+        from pyproj import CRS
+    except ImportError:
+        # pyproj is a declared SU geo dep; if it's not present we just
+        # stringify and return.
+        return str(value)
+
+    try:
+        crs = CRS.from_user_input(value)
+    except Exception:
+        return str(value)
+    epsg = crs.to_epsg()
+    if epsg:
+        return f"EPSG:{epsg}"
+    return crs.to_wkt()
+
+
+def reproject_geom(
+    geom,
+    src_crs: Any,
+    dst_epsg: int = 4326,
+    axis_order: str = AXIS_ORDER_TRAD_GIS,
+):
+    """Reproject a shapely geometry with explicit axis-order control.
+
+    Args:
+        geom: A shapely geometry (``Point``, ``LineString``, ``Polygon``,
+            etc.) or ``None``.
+        src_crs: The geometry's source CRS, in any form
+            :class:`pyproj.CRS.from_user_input` accepts (``"EPSG:4326"``,
+            an integer EPSG code, a WKT string, a ``pyproj.CRS`` object).
+        dst_epsg: Target EPSG code. Defaults to ``4326``.
+        axis_order: One of:
+
+            * ``"trad_gis"`` (default) — ``pyproj`` ``always_xy=True``.
+              Coordinates are interpreted and emitted as (lon, lat),
+              matching GeoJSON, Shapefile, KML, and most consumer
+              expectations. This is the modern-pyproj equivalent of
+              ``osgeo.osr.OAMS_TRADITIONAL_GIS_ORDER`` used in the
+              salvage source (``ImportServerRepo.py:267-268``).
+            * ``"auth_compliant"`` — ``always_xy=False``. Coordinates
+              follow the CRS authority's declared axis order (lat-first
+              for EPSG:4326). Use only if you know your input data is
+              lat-first and your consumer expects lat-first.
+
+    Returns:
+        A new shapely geometry in the target CRS, or ``None`` if ``geom``
+        is ``None``.
+
+    Raises:
+        ValueError: If ``axis_order`` is not one of the two accepted
+            tokens, or if ``src_crs`` is ``None`` (a CRS-less geometry
+            cannot be reprojected without an explicit source).
+        ImportError: If ``pyproj`` or ``shapely`` are not installed.
+
+    Round-trip note: 4326 -> 3857 -> 4326 on a Point should return the
+    same coordinates within 1e-6 degrees. The test suite verifies this.
+    """
+    if geom is None:
+        return None
+    if axis_order not in _AXIS_ORDER_VALID:
+        raise ValueError(
+            f"axis_order must be one of {sorted(_AXIS_ORDER_VALID)}; "
+            f"got {axis_order!r}"
+        )
+    if src_crs is None:
+        raise ValueError(
+            "src_crs is required; bare shapely geometries carry no CRS metadata"
+        )
+
+    try:
+        from pyproj import CRS, Transformer
+    except ImportError as exc:  # pragma: no cover - dep guard
+        raise ImportError(
+            "pyproj is required for reproject_geom. "
+            "Install with: pip install 'siege-utilities[geo]'"
+        ) from exc
+
+    try:
+        from shapely.ops import transform as shapely_transform
+    except ImportError as exc:  # pragma: no cover - dep guard
+        raise ImportError(
+            "shapely is required for reproject_geom. "
+            "Install with: pip install 'siege-utilities[geo]'"
+        ) from exc
+
+    src = CRS.from_user_input(src_crs)
+    dst = CRS.from_epsg(dst_epsg)
+
+    # No-op if source equals target.
+    if src == dst:
+        return geom
+
+    always_xy = axis_order == AXIS_ORDER_TRAD_GIS
+    transformer = Transformer.from_crs(src, dst, always_xy=always_xy)
+    return shapely_transform(transformer.transform, geom)

--- a/tests/test_crs_axis_order.py
+++ b/tests/test_crs_axis_order.py
@@ -1,0 +1,128 @@
+"""Tests for siege_utilities.geo.crs detect_crs + reproject_geom (SU#543)."""
+
+from __future__ import annotations
+
+import pytest
+
+# Skip the whole module if shapely / pyproj aren't installed; reproject_geom
+# raises ImportError otherwise but a clean skip avoids noisy collection errors
+# in stripped-down environments.
+pyproj = pytest.importorskip("pyproj")
+shapely_geometry = pytest.importorskip("shapely.geometry")
+
+from siege_utilities.geo.crs import (
+    AXIS_ORDER_AUTH_COMPLIANT,
+    AXIS_ORDER_TRAD_GIS,
+    detect_crs,
+    reproject_geom,
+)
+
+
+def test_detect_crs_none_returns_none():
+    assert detect_crs(None) is None
+
+
+def test_detect_crs_bare_geometry_returns_none():
+    from shapely.geometry import Point
+    assert detect_crs(Point(0, 0)) is None
+
+
+def test_detect_crs_dict_with_crs_block():
+    geojson = {
+        "type": "FeatureCollection",
+        "crs": {"type": "name", "properties": {"name": "EPSG:4326"}},
+        "features": [],
+    }
+    assert detect_crs(geojson) == "EPSG:4326"
+
+
+def test_detect_crs_dict_without_crs_block():
+    geojson = {"type": "FeatureCollection", "features": []}
+    assert detect_crs(geojson) is None
+
+
+def test_detect_crs_object_with_crs_attribute():
+    class FakeGDF:
+        crs = "EPSG:3857"
+
+    assert detect_crs(FakeGDF()) == "EPSG:3857"
+
+
+def test_detect_crs_object_with_crs_wkt_attribute():
+    class FakeCollection:
+        crs = None
+        crs_wkt = pyproj.CRS.from_epsg(4326).to_wkt()
+
+    assert detect_crs(FakeCollection()) == "EPSG:4326"
+
+
+# --- reproject_geom -------------------------------------------------------
+
+
+def test_reproject_geom_none_returns_none():
+    assert reproject_geom(None, "EPSG:4326") is None
+
+
+def test_reproject_geom_invalid_axis_order():
+    from shapely.geometry import Point
+    with pytest.raises(ValueError, match="axis_order"):
+        reproject_geom(Point(0, 0), "EPSG:4326", axis_order="bogus")
+
+
+def test_reproject_geom_missing_src_crs():
+    from shapely.geometry import Point
+    with pytest.raises(ValueError, match="src_crs"):
+        reproject_geom(Point(0, 0), None)
+
+
+def test_reproject_geom_same_crs_noop():
+    from shapely.geometry import Point
+    p = Point(1.0, 2.0)
+    result = reproject_geom(p, "EPSG:4326", dst_epsg=4326)
+    # Identity short-circuit returns the same object.
+    assert result is p
+
+
+def test_reproject_geom_4326_to_3857_round_trip():
+    from shapely.geometry import Point
+
+    # Origin Point in Austin, TX
+    src = Point(-97.7431, 30.2672)
+    web_merc = reproject_geom(src, "EPSG:4326", dst_epsg=3857)
+    back = reproject_geom(web_merc, "EPSG:3857", dst_epsg=4326)
+
+    assert abs(back.x - src.x) < 1e-6
+    assert abs(back.y - src.y) < 1e-6
+
+
+def test_reproject_geom_trad_gis_lon_first():
+    from shapely.geometry import Point
+
+    # Input is (lon, lat). With trad_gis (always_xy=True) reprojecting
+    # 4326 -> 3857 should produce easting near the equator origin (-97.7431
+    # is roughly -10878000 in EPSG:3857).
+    src = Point(-97.7431, 30.2672)
+    web_merc = reproject_geom(
+        src, "EPSG:4326", dst_epsg=3857, axis_order=AXIS_ORDER_TRAD_GIS
+    )
+    assert -1.1e7 < web_merc.x < -1.0e7
+
+
+def test_reproject_geom_axis_order_toggle_differs():
+    """trad_gis vs auth_compliant must produce different output for EPSG:4326
+    (which the authority defines as lat-first, while consumer files store
+    lon-first)."""
+    from shapely.geometry import Point
+
+    src = Point(-97.7431, 30.2672)
+    trad = reproject_geom(
+        src, "EPSG:4326", dst_epsg=3857, axis_order=AXIS_ORDER_TRAD_GIS
+    )
+    auth = reproject_geom(
+        src, "EPSG:4326", dst_epsg=3857, axis_order=AXIS_ORDER_AUTH_COMPLIANT
+    )
+    # Under auth_compliant, the (x=-97.7431, y=30.2672) tuple is interpreted
+    # as (lat=-97.7431, lon=30.2672) which is nonsense and produces a different
+    # transformed coordinate. The test asserts the differ-ness, which is the
+    # whole point of the toggle existing.
+    assert (trad.x, trad.y) != (auth.x, auth.y)


### PR DESCRIPTION
Refs: #543

## Summary

Extends `siege_utilities/geo/crs.py` with geometry-level CRS detection and reprojection with explicit axis-order control. The existing `get_default_crs / set_default_crs / reproject_if_needed` GeoDataFrame surface is unchanged; this PR is additive.

- `detect_crs(geom_or_ds)` -> EPSG / WKT / None. Accepts GeoDataFrame, fiona Collection, GeoJSON dict, or bare shapely geometry.
- `reproject_geom(geom, src_crs, dst_epsg=4326, axis_order='trad_gis')` -> reproject a shapely geometry with `trad_gis` (lon-first, default — matches GeoJSON / Shapefile / KML) or `auth_compliant` (lat-first per EPSG authority).

## Provenance

Pattern lifted from `ImportServerRepo.py:150-336` (SRS handling at lines 255-274 specifically). The salvage source used `osgeo.osr.OAMS_TRADITIONAL_GIS_ORDER`; SU declares `pyproj` (not `osgeo`), so this implementation uses `pyproj.Transformer.from_crs(..., always_xy=True)` which is the documented modern equivalent. Substitution recorded in the module docstring.

## Test plan

- [x] 13 new unit tests in `tests/test_crs_axis_order.py` pass locally.
- [x] Full CRS regression: `pytest tests/ -k crs --no-cov` -> `28 passed, 1 skipped (pre-existing), 4849 deselected`.
- [x] Round-trip 4326 -> 3857 -> 4326 within 1e-6 degrees verified.
- [x] Axis-order toggle effect verified (trad_gis vs auth_compliant differ).
- [ ] CI green-gate-subset (lint + crs-touching tests).