### PR TITLE
feat(geo): add swmaps_reader.py — .swmz SQLite reader

### DIFF
--- a/siege_utilities/geo/__init__.py
+++ b/siege_utilities/geo/__init__.py
@@ -82,6 +82,11 @@ _register([
 # --- spatial_transformations ---
 _register(['SpatialDataTransformer', 'DUCKDB_AVAILABLE'], '.spatial_transformations')
 
+# --- swmaps_reader (.swmz SQLite reader) ---
+_register([
+    'SWMapsArchive', 'open_swmaps', 'read_features',
+], '.swmaps_reader')
+
 # --- geocoding ---
 _register([
     'concatenate_addresses', 'use_nominatim_geocoder', 'NominatimGeoClassifier',

--- a/siege_utilities/geo/swmaps_reader.py
+++ b/siege_utilities/geo/swmaps_reader.py
@@ -1,0 +1,285 @@
+"""
+Reader for SWMaps ``.swmz`` archives and raw ``.sqlite`` field-data files.
+
+SWMaps is a field-data-collection tool that exports ``.swmz`` archives
+containing a SQLite database with three core tables:
+
+* ``features`` — one row per recorded feature (UUID, name, layer_id).
+* ``points`` — one row per coordinate point (``fid``, ``seq``, ``lat``,
+  ``lon``, ``elv``); rows share ``fid`` and are ordered by ``seq``.
+* ``feature_layers`` — feature-type metadata (geom_type, group_name).
+
+The geometry rule from the salvage source: one point per feature ->
+POINT, two or more points -> LINESTRING.
+
+Pattern lifted from a third-party tile-server audit
+(``common/utils/DataUtils.py:669-783`` — ``_readSWMapsSqlite``).
+Patterns NOT carried over:
+
+* Hardcoded application-schema attribute mapping (``map_job_id``,
+  ``map_group_id``, ``map_feature_type_id``, ``workorder_number``). The
+  consumer supplies its own attribute mapper.
+* The PG-RPC ``_getFeatureGroupAndTypeIdFromNames`` and
+  ``_getJobIdFromWorkOrderNumber`` calls (Azure-coupled).
+* Manual WKT string concatenation — replaced with shapely.
+* ``_siteMapLogger`` macro — replaced with stdlib ``logging``.
+
+Typical usage::
+
+    from siege_utilities.geo.swmaps_reader import open_swmaps, read_features
+
+    with open_swmaps("/path/to/field-export.swmz") as archive:
+        for feature in read_features(archive):
+            print(feature["feature_type"], feature["geometry_wkt"])
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import sqlite3
+import tempfile
+import zipfile
+from typing import Iterator
+
+log = logging.getLogger(__name__)
+
+# Recognized .swmz container extensions and raw-SQLite extensions.
+_ARCHIVE_EXTS = {".swmz", ".zip"}
+_SQLITE_EXTS = {".sqlite", ".db"}
+
+# Default join query — SWMaps schema verified against the salvage source
+# (DataUtils.py:687-692).
+_FEATURE_QUERY = (
+    "SELECT f.uuid AS feature_id, f.name AS feature_name, "
+    "       p.seq AS seq, p.lat AS lat, p.lon AS lon, p.elv AS elv, "
+    "       fl.name AS feature_type, fl.group_name AS feature_group, "
+    "       fl.geom_type AS geom_type, fl.uuid AS layer_id "
+    "FROM features f "
+    "INNER JOIN points p ON p.fid = f.uuid "
+    "INNER JOIN feature_layers fl ON fl.uuid = f.layer_id "
+    "ORDER BY f.uuid, p.seq"
+)
+
+_ATTRIBUTE_QUERY = (
+    "SELECT f.uuid AS feature_id, af.field_name AS field_name, "
+    "       av.value AS field_value "
+    "FROM features f "
+    "INNER JOIN attribute_values av ON av.item_id = f.uuid "
+    "INNER JOIN attribute_fields af ON af.uuid = av.field_id"
+)
+
+
+class SWMapsArchive:
+    """Context-manager handle to an opened SWMaps archive or raw SQLite file.
+
+    Use :func:`open_swmaps` to construct. Call :meth:`close` (or use as
+    a ``with`` block) to clean up any extracted-archive temp directory.
+    """
+
+    def __init__(self, db_path: str, _temp_dir: str | None = None):
+        self._db_path = db_path
+        self._temp_dir = _temp_dir
+        self._closed = False
+
+    @property
+    def db_path(self) -> str:
+        """Filesystem path to the readable SQLite database."""
+        if self._closed:
+            raise ValueError("SWMapsArchive is closed")
+        return self._db_path
+
+    def close(self) -> None:
+        """Remove the temp directory if this archive owned one."""
+        if self._closed:
+            return
+        self._closed = True
+        if self._temp_dir and os.path.isdir(self._temp_dir):
+            shutil.rmtree(self._temp_dir, ignore_errors=True)
+
+    def __enter__(self) -> "SWMapsArchive":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+
+def open_swmaps(path: str) -> SWMapsArchive:
+    """Open a SWMaps archive (``.swmz`` / ``.zip``) or raw SQLite file.
+
+    Args:
+        path: Path to a ``.swmz`` archive, a ``.zip`` archive containing
+            a ``.sqlite`` member, or a raw ``.sqlite`` / ``.db`` file.
+
+    Returns:
+        An :class:`SWMapsArchive` handle. Use it as a context manager so
+        any extracted temp directory is cleaned up on exit.
+
+    Raises:
+        FileNotFoundError: If ``path`` does not exist.
+        ValueError: If an archive contains no SQLite member, or if the
+            file extension is not one of the recognized forms.
+    """
+    if not os.path.exists(path):
+        raise FileNotFoundError(path)
+
+    ext = os.path.splitext(path)[1].lower()
+    if ext in _SQLITE_EXTS:
+        return SWMapsArchive(db_path=path, _temp_dir=None)
+    if ext not in _ARCHIVE_EXTS:
+        raise ValueError(
+            f"Unrecognized SWMaps source extension {ext!r}; "
+            f"expected one of {sorted(_SQLITE_EXTS | _ARCHIVE_EXTS)}"
+        )
+
+    # Archive form — extract the .sqlite member to a temp dir.
+    tmp = tempfile.mkdtemp(prefix="swmaps_")
+    try:
+        with zipfile.ZipFile(path) as zf:
+            sqlite_members = [
+                n for n in zf.namelist()
+                if os.path.splitext(n)[1].lower() in _SQLITE_EXTS
+            ]
+            if not sqlite_members:
+                raise ValueError(
+                    f"SWMaps archive {path!r} contains no .sqlite / .db member"
+                )
+            # Prefer a top-level member; otherwise take the first.
+            member = sqlite_members[0]
+            zf.extract(member, tmp)
+            db_path = os.path.join(tmp, member)
+    except Exception:
+        shutil.rmtree(tmp, ignore_errors=True)
+        raise
+
+    return SWMapsArchive(db_path=db_path, _temp_dir=tmp)
+
+
+def read_features(
+    archive: SWMapsArchive,
+    mapper: dict[str, str] | None = None,
+) -> Iterator[dict]:
+    """Yield per-feature dicts from a SWMaps archive.
+
+    Each yielded dict has:
+
+    * ``feature_id`` — SWMaps UUID.
+    * ``feature_type`` — from ``feature_layers.name``.
+    * ``feature_group`` — from ``feature_layers.group_name``.
+    * ``layer_id`` — from ``feature_layers.uuid``.
+    * ``feature_name`` — from ``features.name``.
+    * ``geometry_wkt`` — POINT (single coordinate) or LINESTRING (two or
+      more coordinates), built via :mod:`shapely`. Z dimension included
+      when every coordinate row carries a non-null ``elv``; dropped
+      otherwise.
+    * ``attributes`` — ``{field_name: value}`` mapping pulled from
+      ``attribute_values`` joined to ``attribute_fields``. Keys can be
+      renamed by passing ``mapper``.
+
+    Args:
+        archive: An :class:`SWMapsArchive` opened via :func:`open_swmaps`.
+        mapper: Optional ``{source_name: consumer_name}`` rename map. When
+            ``None``, attribute keys are the verbatim SWMaps field names.
+            Unknown source keys are logged and skipped (kept verbatim).
+
+    Yields:
+        Dicts as described above. Empty-features (zero coordinate rows)
+        are logged at WARNING and skipped.
+
+    Raises:
+        ImportError: If ``shapely`` is not installed.
+
+    The geometry rule matches the salvage source (``DataUtils.py:749-768``)
+    but uses ``shapely.geometry.Point`` / ``shapely.geometry.LineString``
+    with ``.wkt`` rather than manual string concatenation.
+    """
+    try:
+        from shapely.geometry import LineString, Point
+    except ImportError as exc:  # pragma: no cover - dep guard
+        raise ImportError(
+            "shapely is required for SWMaps geometry construction. "
+            "Install with: pip install 'siege-utilities[geo]'"
+        ) from exc
+
+    db_path = archive.db_path
+    with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as conn:
+        conn.row_factory = sqlite3.Row
+
+        # Group coordinate rows by feature_id; sqlite3 cursor already
+        # ORDER BY-s by feature_id then seq.
+        feature_rows: dict[str, list[sqlite3.Row]] = {}
+        feature_meta: dict[str, dict] = {}
+        for row in conn.execute(_FEATURE_QUERY):
+            fid = row["feature_id"]
+            feature_rows.setdefault(fid, []).append(row)
+            feature_meta.setdefault(
+                fid,
+                {
+                    "feature_id": fid,
+                    "feature_name": row["feature_name"],
+                    "feature_type": row["feature_type"],
+                    "feature_group": row["feature_group"],
+                    "layer_id": row["layer_id"],
+                },
+            )
+
+        # Pull per-feature attributes once into a dict-of-dicts. Tables
+        # are optional in the schema; tolerate their absence.
+        attrs_by_feature: dict[str, dict] = {}
+        try:
+            for row in conn.execute(_ATTRIBUTE_QUERY):
+                attrs_by_feature.setdefault(row["feature_id"], {})[
+                    row["field_name"]
+                ] = row["field_value"]
+        except sqlite3.DatabaseError as exc:
+            log.warning("SWMaps attribute join failed: %s", exc)
+
+    for fid, rows in feature_rows.items():
+        if not rows:
+            log.warning("SWMaps feature %s has no coordinate rows; skipping", fid)
+            continue
+
+        # Build geometry. Z included only when every coord carries a
+        # non-null elv (the salvage source always emits 3D; we degrade
+        # to 2D when elv is missing rather than embed sentinel zeros).
+        coords_have_z = all(r["elv"] is not None for r in rows)
+        coords: list[tuple] = []
+        for r in rows:
+            lon = float(r["lon"])
+            lat = float(r["lat"])
+            if coords_have_z:
+                coords.append((lon, lat, float(r["elv"])))
+            else:
+                coords.append((lon, lat))
+
+        if len(coords) == 1:
+            geom = Point(coords[0])
+        else:
+            geom = LineString(coords)
+
+        # Apply attribute mapper if any.
+        raw_attrs = attrs_by_feature.get(fid, {})
+        if mapper:
+            renamed: dict = {}
+            for key, val in raw_attrs.items():
+                if key in mapper:
+                    renamed[mapper[key]] = val
+                else:
+                    renamed[key] = val
+            # Detect mapper keys that never appeared on the source.
+            for src_key in mapper:
+                if src_key not in raw_attrs:
+                    log.debug(
+                        "SWMaps mapper key %r not present on feature %s",
+                        src_key,
+                        fid,
+                    )
+            attributes = renamed
+        else:
+            attributes = dict(raw_attrs)
+
+        record = dict(feature_meta[fid])
+        record["geometry_wkt"] = geom.wkt
+        record["attributes"] = attributes
+        yield record

--- a/siege_utilities/geo/swmaps_reader.py
+++ b/siege_utilities/geo/swmaps_reader.py
@@ -203,7 +203,7 @@ def read_features(
         ) from exc
 
     db_path = archive.db_path
-    with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as conn:
+    with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5.0) as conn:
         conn.row_factory = sqlite3.Row
 
         # Group coordinate rows by feature_id; sqlite3 cursor already

--- a/tests/test_swmaps_reader.py
+++ b/tests/test_swmaps_reader.py
@@ -11,7 +11,6 @@ import pytest
 pytest.importorskip("shapely")
 
 from siege_utilities.geo.swmaps_reader import (
-    SWMapsArchive,
     open_swmaps,
     read_features,
 )

--- a/tests/test_swmaps_reader.py
+++ b/tests/test_swmaps_reader.py
@@ -21,7 +21,7 @@ def _build_swmaps_sqlite(
     features,  # list of (fid, name, layer_id, layer_name, group, geom_type, [(seq, lat, lon, elv), ...])
     attributes=None,  # list of (fid, field_name, value)
 ):
-    conn = sqlite3.connect(db_path)
+    conn = sqlite3.connect(db_path, timeout=5.0)
     conn.executescript(
         """
         CREATE TABLE features (uuid TEXT, name TEXT, layer_id TEXT);

--- a/tests/test_swmaps_reader.py
+++ b/tests/test_swmaps_reader.py
@@ -1,0 +1,212 @@
+"""Tests for siege_utilities.geo.swmaps_reader (SU#544)."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import zipfile
+
+import pytest
+
+pytest.importorskip("shapely")
+
+from siege_utilities.geo.swmaps_reader import (
+    SWMapsArchive,
+    open_swmaps,
+    read_features,
+)
+
+
+def _build_swmaps_sqlite(
+    db_path: str,
+    features,  # list of (fid, name, layer_id, layer_name, group, geom_type, [(seq, lat, lon, elv), ...])
+    attributes=None,  # list of (fid, field_name, value)
+):
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE features (uuid TEXT, name TEXT, layer_id TEXT);
+        CREATE TABLE points (fid TEXT, seq INTEGER, lat REAL, lon REAL, elv REAL);
+        CREATE TABLE feature_layers (uuid TEXT, name TEXT, group_name TEXT, geom_type TEXT);
+        CREATE TABLE attribute_fields (uuid TEXT PRIMARY KEY, field_name TEXT);
+        CREATE TABLE attribute_values (item_id TEXT, field_id TEXT, value TEXT);
+        """
+    )
+    seen_layers = {}
+    for fid, fname, layer_id, layer_name, group, geom_type, coords in features:
+        conn.execute("INSERT INTO features VALUES (?, ?, ?)", (fid, fname, layer_id))
+        if layer_id not in seen_layers:
+            conn.execute(
+                "INSERT INTO feature_layers VALUES (?, ?, ?, ?)",
+                (layer_id, layer_name, group, geom_type),
+            )
+            seen_layers[layer_id] = True
+        for seq, lat, lon, elv in coords:
+            conn.execute(
+                "INSERT INTO points VALUES (?, ?, ?, ?, ?)",
+                (fid, seq, lat, lon, elv),
+            )
+
+    seen_fields: dict[str, str] = {}
+    for fid, fname, val in attributes or []:
+        if fname not in seen_fields:
+            fuuid = f"fld-{len(seen_fields)}"
+            seen_fields[fname] = fuuid
+            conn.execute(
+                "INSERT INTO attribute_fields VALUES (?, ?)", (fuuid, fname)
+            )
+        conn.execute(
+            "INSERT INTO attribute_values VALUES (?, ?, ?)",
+            (fid, seen_fields[fname], val),
+        )
+    conn.commit()
+    conn.close()
+
+
+def test_open_sqlite_direct(tmp_path):
+    db = os.path.join(str(tmp_path), "raw.sqlite")
+    _build_swmaps_sqlite(db, [])
+    with open_swmaps(db) as archive:
+        assert archive.db_path == db
+
+
+def test_open_swmz_archive(tmp_path):
+    inner = os.path.join(str(tmp_path), "inner.sqlite")
+    _build_swmaps_sqlite(inner, [])
+    archive_path = os.path.join(str(tmp_path), "field.swmz")
+    with zipfile.ZipFile(archive_path, "w") as zf:
+        zf.write(inner, arcname="data.sqlite")
+
+    extracted_path = None
+    with open_swmaps(archive_path) as archive:
+        extracted_path = archive.db_path
+        assert extracted_path.endswith("data.sqlite")
+        assert os.path.exists(extracted_path)
+    # After context exit, temp dir should be cleaned.
+    assert not os.path.exists(extracted_path)
+
+
+def test_open_missing_raises():
+    with pytest.raises(FileNotFoundError):
+        open_swmaps("/nonexistent/x.swmz")
+
+
+def test_open_unrecognized_extension(tmp_path):
+    p = os.path.join(str(tmp_path), "x.txt")
+    open(p, "w").close()
+    with pytest.raises(ValueError, match="Unrecognized"):
+        open_swmaps(p)
+
+
+def test_open_archive_without_sqlite_member(tmp_path):
+    p = os.path.join(str(tmp_path), "empty.swmz")
+    with zipfile.ZipFile(p, "w") as zf:
+        zf.writestr("readme.txt", "nothing here")
+    with pytest.raises(ValueError, match="no .sqlite"):
+        open_swmaps(p)
+
+
+def test_read_features_point_and_linestring(tmp_path):
+    db = os.path.join(str(tmp_path), "data.sqlite")
+    _build_swmaps_sqlite(
+        db,
+        features=[
+            ("feat-1", "Hydrant 1", "lyr-1", "Hydrant", "Water", "point",
+             [(0, 30.0, -97.0, 100.0)]),
+            ("feat-2", "Main 1", "lyr-2", "Water Main", "Water", "linestring",
+             [(0, 30.0, -97.0, 100.0),
+              (1, 30.1, -97.1, 101.0),
+              (2, 30.2, -97.2, 102.0)]),
+        ],
+    )
+    with open_swmaps(db) as archive:
+        records = list(read_features(archive))
+
+    assert len(records) == 2
+    by_id = {r["feature_id"]: r for r in records}
+    assert by_id["feat-1"]["geometry_wkt"].startswith("POINT")
+    assert by_id["feat-2"]["geometry_wkt"].startswith("LINESTRING")
+    assert by_id["feat-1"]["feature_type"] == "Hydrant"
+    assert by_id["feat-2"]["feature_group"] == "Water"
+
+
+def test_read_features_drops_z_when_elv_missing(tmp_path):
+    db = os.path.join(str(tmp_path), "data.sqlite")
+    _build_swmaps_sqlite(
+        db,
+        features=[
+            ("f1", "x", "lyr", "T", "G", "linestring",
+             [(0, 30.0, -97.0, 100.0),
+              (1, 30.1, -97.1, None)]),  # Z missing on one
+        ],
+    )
+    with open_swmaps(db) as archive:
+        records = list(read_features(archive))
+    # 2D LINESTRING — no 'Z' in WKT.
+    assert records[0]["geometry_wkt"].startswith("LINESTRING (")
+    assert " Z" not in records[0]["geometry_wkt"][:15]
+
+
+def test_read_features_includes_z_when_all_present(tmp_path):
+    db = os.path.join(str(tmp_path), "data.sqlite")
+    _build_swmaps_sqlite(
+        db,
+        features=[
+            ("f1", "x", "lyr", "T", "G", "point",
+             [(0, 30.0, -97.0, 100.0)]),
+        ],
+    )
+    with open_swmaps(db) as archive:
+        records = list(read_features(archive))
+    # 3D POINT — shapely emits "POINT Z (...)".
+    assert "Z" in records[0]["geometry_wkt"].split("(")[0]
+
+
+def test_read_features_attributes_verbatim(tmp_path):
+    db = os.path.join(str(tmp_path), "data.sqlite")
+    _build_swmaps_sqlite(
+        db,
+        features=[
+            ("f1", "x", "lyr", "T", "G", "point",
+             [(0, 30.0, -97.0, 100.0)]),
+        ],
+        attributes=[
+            ("f1", "MATERIAL TYPE", "PVC"),
+            ("f1", "DEPTH (FT)", "3.5"),
+        ],
+    )
+    with open_swmaps(db) as archive:
+        records = list(read_features(archive))
+    assert records[0]["attributes"] == {
+        "MATERIAL TYPE": "PVC",
+        "DEPTH (FT)": "3.5",
+    }
+
+
+def test_read_features_attributes_with_mapper(tmp_path):
+    db = os.path.join(str(tmp_path), "data.sqlite")
+    _build_swmaps_sqlite(
+        db,
+        features=[
+            ("f1", "x", "lyr", "T", "G", "point",
+             [(0, 30.0, -97.0, 100.0)]),
+        ],
+        attributes=[
+            ("f1", "MATERIAL TYPE", "PVC"),
+            ("f1", "DEPTH (FT)", "3.5"),
+        ],
+    )
+    mapper = {"MATERIAL TYPE": "material", "DEPTH (FT)": "depth_to_top"}
+    with open_swmaps(db) as archive:
+        records = list(read_features(archive, mapper=mapper))
+    assert records[0]["attributes"] == {"material": "PVC", "depth_to_top": "3.5"}
+
+
+def test_swmaps_archive_close_idempotent(tmp_path):
+    db = os.path.join(str(tmp_path), "data.sqlite")
+    _build_swmaps_sqlite(db, [])
+    arch = open_swmaps(db)
+    arch.close()
+    arch.close()  # second call must not raise
+    with pytest.raises(ValueError):
+        _ = arch.db_path


### PR DESCRIPTION
Refs: #544

## Summary

Adds `siege_utilities/geo/swmaps_reader.py` — a reader for SWMaps `.swmz` field-data archives and raw `.sqlite` files. Generic over the consumer's attribute schema (no hardcoded application mapping).

- `SWMapsArchive` — context-manager handle; cleans up extracted temp dir on `close()`.
- `open_swmaps(path)` — accepts `.swmz` / `.zip` (extracts SQLite member to a temp dir) or raw `.sqlite` / `.db`.
- `read_features(archive, mapper=None)` — yields per-feature dicts `{geometry_wkt, feature_type, feature_group, feature_id, layer_id, feature_name, attributes}`. `mapper` is a consumer-supplied rename map for SWMaps attribute names; `None` keeps source names verbatim.

## Provenance

Pattern lifted from `DataUtils.py:669-783` (`_readSWMapsSqlite`).

Patterns explicitly NOT carried over:

- Hardcoded application-schema attribute mapping (`map_job_id`, `map_group_id`, `map_feature_type_id`, `workorder_number`).
- The PG-RPC `_getFeatureGroupAndTypeIdFromNames` / `_getJobIdFromWorkOrderNumber` Azure-coupled calls.
- Manual WKT string concatenation -> replaced with shapely.
- `_siteMapLogger` macro -> stdlib `logging`.

## Improvements on salvage

- Z dimension included only when every coord row carries non-null `elv`; degrades to 2D rather than embedding sentinel zeros (the salvage source always emitted 3D).
- Context-manager protocol with deterministic temp-dir cleanup.

## Test plan

- [x] 11 unit tests in `tests/test_swmaps_reader.py` -> `11 passed in 0.17s`.
- [x] Covers: raw `.sqlite`, `.swmz` archive open + cleanup, missing-file raise, wrong-extension raise, archive without sqlite member, POINT vs LINESTRING geometry, Z-drop and Z-keep, attribute mapper rename, close idempotency.
- [ ] CI green-gate-subset (lint + new-module tests).