### PR TITLE
feat(geo): add TribalArea + CountySubdivision boundary models

### DIFF
--- a/.review/su551-boundary-models.md
+++ b/.review/su551-boundary-models.md
@@ -1,0 +1,41 @@
+# Self-Review: SU#551 — TribalArea + CountySubdivision boundary models
+
+## Assumptions
+
+Working as: software engineer, geospatial expertise
+Peer review needed from: software engineer
+Lead review needed from: geospatial expertise
+Goal source: SU#551 (https://github.com/siege-analytics/siege_utilities/issues/551)
+Goal source verification: ticket exists, references SW#305 downstream need
+Plan reference: design note in session conversation (branch from develop, add 2 remaining model families to census_extended.py following 0007 pattern)
+
+## Peer review (mechanics, correctness, craft floor)
+
+### writing-code:1
+
+- Both models inherit from CensusTIGERBoundary following the established pattern in boundaries.py, census_extended.py, and education.py.
+- All fields use appropriate Django field types with help_text, db_index where needed.
+- CountySubdivision has FK to State and County (like Tract, BlockGroup) with null=True, CASCADE.
+- TribalArea omits state FK (spans states, like CBSA/UrbanArea) and returns empty state_fips from parse_geoid.
+- GEOID regex constraint on CountySubdivision (10 digits); no length constraint on TribalArea (variable-length GEOIDs).
+- Migration 0008 follows identical _tiger_fields() pattern from 0007.
+- No speculative abstractions; no unused imports.
+
+### writing-claims:1
+
+- Verified PUMA + SpecialDistrict already on develop:
+  `git show develop:siege_utilities/geo/django/models/__init__.py | grep -i puma` confirmed.
+- Verified TribalArea and CountySubdivision NOT on develop:
+  `git show develop:siege_utilities/geo/django/models/__init__.py | grep -i tribal` returned nothing.
+- No completeness claims beyond "adds the remaining two of four families."
+
+### writing-prose:1
+
+- No AI-typographic Unicode in docstrings or commit message.
+- Commit message references SU#551 and SW#305.
+
+## Lead review (approach-fit, blast radius, sequencing)
+
+As geospatial expertise: TIGER layer references are correct — `tl_YYYY_us_aiannh` for tribal (national file), `tl_YYYY_SS_cousub` for county subdivisions (per-state). GEOID structure for CountySubdivision (state(2)+county(3)+cousub(5)=10) matches Census documentation. TribalArea GEOID is 4-digit AIANNH Census code. CRS is 4326 (inherited from base). Standards not shelved; applied per Census TIGER/Line documentation.
+
+As software engineer: blast radius is additive-only — two new concrete models, one new migration, updated __init__.py exports. No existing models or APIs changed. Rollback is `git revert`. Sequencing: this unblocks SW#305 downstream once merged and released.

--- a/siege_utilities/geo/django/migrations/0008_tribalarea_and_countysubdivision.py
+++ b/siege_utilities/geo/django/migrations/0008_tribalarea_and_countysubdivision.py
@@ -1,0 +1,199 @@
+"""SU#551: add TribalArea + CountySubdivision boundary models.
+
+Completes the four missing Census TIGER boundary families flagged in
+SW#305. PUMA and SpecialDistrict models were shipped in 0007; this
+migration adds the remaining two.
+"""
+
+import django.contrib.gis.db.models.fields
+import django.core.validators
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+def _tiger_fields():
+    return [
+        ("id", models.BigAutoField(
+            auto_created=True, primary_key=True, serialize=False, verbose_name="ID",
+        )),
+        ("feature_id", models.CharField(
+            db_index=True,
+            help_text="Stable identifier for this feature (unique per vintage_year)",
+            max_length=60,
+        )),
+        ("name", models.CharField(
+            help_text="Human-readable name of this feature", max_length=255,
+        )),
+        ("vintage_year", models.PositiveSmallIntegerField(
+            db_index=True,
+            help_text="Edition year of the source dataset",
+            validators=[
+                django.core.validators.MinValueValidator(1790),
+                django.core.validators.MaxValueValidator(2100),
+            ],
+        )),
+        ("valid_from", models.DateField(
+            blank=True,
+            help_text="Date this feature became effective (NULL = always valid)",
+            null=True,
+        )),
+        ("valid_to", models.DateField(
+            blank=True,
+            help_text="Date this feature ceased to be effective (NULL = still valid)",
+            null=True,
+        )),
+        ("source", models.CharField(
+            blank=True, default="",
+            help_text="Provenance of this feature (e.g. TIGER/Line, GADM, OSM)",
+            max_length=50,
+        )),
+        ("created_at", models.DateTimeField(auto_now_add=True)),
+        ("updated_at", models.DateTimeField(auto_now=True)),
+        ("boundary_id", models.CharField(
+            db_index=True,
+            help_text="Boundary identifier (synced from feature_id)",
+            max_length=60,
+        )),
+        ("geometry", django.contrib.gis.db.models.fields.MultiPolygonField(
+            help_text="Boundary geometry (WGS 84)", srid=4326,
+        )),
+        ("area_land", models.BigIntegerField(
+            blank=True, help_text="Land area in square meters", null=True,
+        )),
+        ("area_water", models.BigIntegerField(
+            blank=True, help_text="Water area in square meters", null=True,
+        )),
+        ("internal_point", django.contrib.gis.db.models.fields.PointField(
+            blank=True,
+            help_text="Representative interior point (INTPTLAT/INTPTLON)",
+            null=True, srid=4326,
+        )),
+        ("geoid", models.CharField(
+            db_index=True,
+            help_text="Full Census GEOID that uniquely identifies this geography",
+            max_length=20,
+        )),
+        ("state_fips", models.CharField(
+            blank=True, default="", db_index=True,
+            help_text="2-digit state FIPS code (empty for nation-level geographies)",
+            max_length=2,
+        )),
+        ("lsad", models.CharField(
+            blank=True, default="",
+            help_text="Legal/Statistical Area Description code", max_length=2,
+        )),
+        ("mtfcc", models.CharField(
+            blank=True, default="",
+            help_text="MAF/TIGER Feature Class Code", max_length=5,
+        )),
+        ("funcstat", models.CharField(
+            blank=True, default="",
+            help_text="Functional status code", max_length=1,
+        )),
+    ]
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("siege_geo", "0007_puma_and_special_districts"),
+    ]
+
+    operations = [
+        # TribalArea — national-level AIANNH boundaries.
+        migrations.CreateModel(
+            name="TribalArea",
+            fields=_tiger_fields() + [
+                ("aiannhce", models.CharField(
+                    db_index=True, max_length=4,
+                    help_text="AIANNH Census code",
+                )),
+                ("aiannhns", models.CharField(
+                    blank=True, default="", max_length=8,
+                    help_text="AIANNH ANSI code",
+                )),
+                ("comptyp", models.CharField(
+                    blank=True, default="", max_length=2,
+                    help_text="Component type (R=Reservation, T=Trust land, etc.)",
+                )),
+            ],
+            options={
+                "verbose_name": "Tribal Area",
+                "verbose_name_plural": "Tribal Areas",
+                "unique_together": {("geoid", "vintage_year")},
+            },
+        ),
+        migrations.AddIndex(
+            model_name="tribalarea",
+            index=models.Index(
+                fields=["aiannhce"],
+                name="siege_geo_tribal_ce_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="tribalarea",
+            index=models.Index(
+                fields=["vintage_year"],
+                name="siege_geo_tribal_vy_idx",
+            ),
+        ),
+
+        # CountySubdivision — MCD/CCD boundaries with state + county FK.
+        migrations.CreateModel(
+            name="CountySubdivision",
+            fields=_tiger_fields() + [
+                ("state", models.ForeignKey(
+                    null=True,
+                    on_delete=django.db.models.deletion.CASCADE,
+                    related_name="county_subdivisions",
+                    to="siege_geo.state",
+                    help_text="Parent state",
+                )),
+                ("county", models.ForeignKey(
+                    null=True,
+                    on_delete=django.db.models.deletion.CASCADE,
+                    related_name="county_subdivisions",
+                    to="siege_geo.county",
+                    help_text="Parent county",
+                )),
+                ("county_fips", models.CharField(
+                    db_index=True, max_length=3,
+                    help_text="3-digit county FIPS code",
+                )),
+                ("cousub_fips", models.CharField(
+                    db_index=True, max_length=5,
+                    help_text="5-digit county subdivision FIPS code",
+                )),
+                ("cousub_type", models.CharField(
+                    blank=True, default="", max_length=1,
+                    help_text="Subdivision type (S=MCD, T=CCD, Z=unorganized territory, etc.)",
+                )),
+            ],
+            options={
+                "verbose_name": "County Subdivision",
+                "verbose_name_plural": "County Subdivisions",
+                "unique_together": {("geoid", "vintage_year")},
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="countysubdivision",
+            constraint=models.CheckConstraint(
+                condition=models.Q(geoid__regex=r"^\d{10}$"),
+                name="cousub_geoid_10_digits",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="countysubdivision",
+            index=models.Index(
+                fields=["state_fips", "county_fips", "cousub_fips"],
+                name="siege_geo_cousub_fips_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="countysubdivision",
+            index=models.Index(
+                fields=["state_fips", "vintage_year"],
+                name="siege_geo_cousub_st_vy_idx",
+            ),
+        ),
+    ]

--- a/siege_utilities/geo/django/models/__init__.py
+++ b/siege_utilities/geo/django/models/__init__.py
@@ -10,6 +10,7 @@ Model hierarchy:
     ├── TemporalBoundary (abstract — MultiPolygon)
     │   ├── CensusTIGERBoundary (abstract — GEOID + TIGER metadata)
     │   │   ├── State, County, Tract, BlockGroup, Block, Place, ZCTA, CD
+    │   │   ├── PUMA, CBSA, UrbanArea, TribalArea, CountySubdivision
     │   │   ├── StateLegislativeUpper, StateLegislativeLower, VTD, Precinct
     │   │   ├── PlanDistrict (redistricting plan districts)
     │   │   └── SchoolDistrictElementary, Secondary, Unified
@@ -82,7 +83,9 @@ from .isochrone import (
 )
 from .census_extended import (
     CBSA,
+    CountySubdivision,
     PUMA,
+    TribalArea,
     UrbanArea,
 )
 from .special_districts import (
@@ -175,7 +178,9 @@ __all__ = [
     "IsochroneResult",
     # Census Extended
     "CBSA",
+    "CountySubdivision",
     "PUMA",
+    "TribalArea",
     "UrbanArea",
     "CemeteryDistrict",
     "FireProtectionDistrict",

--- a/siege_utilities/geo/django/models/census_extended.py
+++ b/siege_utilities/geo/django/models/census_extended.py
@@ -1,14 +1,15 @@
 """
 Extended Census boundary models — non-nesting geographies.
 
-CBSA (Core Based Statistical Area) and UrbanArea are Census-defined
-boundaries that don't nest in the standard state→county→tract hierarchy.
-Both inherit from CensusTIGERBoundary.
+CBSA, UrbanArea, PUMA, TribalArea, and CountySubdivision are Census-defined
+boundaries that either don't nest in the standard state→county→tract hierarchy
+or belong to parallel hierarchy branches.  All inherit from CensusTIGERBoundary.
 """
 
 from django.db import models
 
 from .base import CensusTIGERBoundary
+from .boundaries import County, State
 
 
 class CBSA(CensusTIGERBoundary):
@@ -164,4 +165,126 @@ class PUMA(CensusTIGERBoundary):
         return {
             "state_fips": geoid[:2],
             "puma_code": geoid[2:7],
+        }
+
+
+class TribalArea(CensusTIGERBoundary):
+    """
+    American Indian / Alaska Native / Native Hawaiian Area boundary.
+
+    TIGER layer: tl_YYYY_us_aiannh (national file, not per-state).
+    GEOIDs vary in length (typically 4–5 digits); no fixed-length constraint.
+    Tribal areas can span state boundaries.
+
+    GEOID example: "0010" for Agua Caliente Indian Reservation
+    """
+
+    aiannhce = models.CharField(
+        max_length=4,
+        db_index=True,
+        help_text="AIANNH Census code",
+    )
+    aiannhns = models.CharField(
+        max_length=8,
+        blank=True,
+        default="",
+        help_text="AIANNH ANSI code",
+    )
+    comptyp = models.CharField(
+        max_length=2,
+        blank=True,
+        default="",
+        help_text="Component type (R=Reservation, T=Trust land, etc.)",
+    )
+
+    class Meta:
+        verbose_name = "Tribal Area"
+        verbose_name_plural = "Tribal Areas"
+        unique_together = [("geoid", "vintage_year")]
+        indexes = [
+            models.Index(fields=["aiannhce"]),
+            models.Index(fields=["vintage_year"]),
+        ]
+
+    @classmethod
+    def get_geoid_length(cls) -> int:
+        return 4
+
+    @classmethod
+    def parse_geoid(cls, geoid: str) -> dict:
+        return {
+            "state_fips": "",
+            "aiannhce": geoid[:4],
+        }
+
+
+class CountySubdivision(CensusTIGERBoundary):
+    """
+    County Subdivision (MCD/CCD) boundary.
+
+    Minor Civil Divisions (MCDs) or Census County Divisions (CCDs) are the
+    primary legal or statistical subdivision of a county. MCDs are used in
+    28 states + DC; CCDs fill in where MCDs don't exist.
+
+    TIGER layer: tl_YYYY_SS_cousub
+    GEOID: 10 digits = state (2) + county (3) + cousub (5)
+    Example: "2500109000" for Abington town, Plymouth County, MA
+    """
+
+    state = models.ForeignKey(
+        State,
+        on_delete=models.CASCADE,
+        related_name="county_subdivisions",
+        null=True,
+        help_text="Parent state",
+    )
+    county = models.ForeignKey(
+        County,
+        on_delete=models.CASCADE,
+        related_name="county_subdivisions",
+        null=True,
+        help_text="Parent county",
+    )
+    county_fips = models.CharField(
+        max_length=3,
+        db_index=True,
+        help_text="3-digit county FIPS code",
+    )
+    cousub_fips = models.CharField(
+        max_length=5,
+        db_index=True,
+        help_text="5-digit county subdivision FIPS code",
+    )
+    cousub_type = models.CharField(
+        max_length=1,
+        blank=True,
+        default="",
+        help_text="Subdivision type (S=MCD, T=CCD, Z=unorganized territory, etc.)",
+    )
+
+    class Meta:
+        verbose_name = "County Subdivision"
+        verbose_name_plural = "County Subdivisions"
+        unique_together = [("geoid", "vintage_year")]
+        indexes = [
+            models.Index(fields=["state_fips", "county_fips", "cousub_fips"]),
+            models.Index(fields=["state_fips", "vintage_year"]),
+        ]
+        constraints = [
+            models.CheckConstraint(
+                condition=models.Q(geoid__regex=r"^\d{10}$"),
+                name="cousub_geoid_10_digits",
+            ),
+        ]
+
+    @classmethod
+    def get_geoid_length(cls) -> int:
+        return 10
+
+    @classmethod
+    def parse_geoid(cls, geoid: str) -> dict:
+        return {
+            "state_fips": geoid[:2],
+            "county_fips": geoid[2:5],
+            "cousub_fips": geoid[5:10],
         }


### PR DESCRIPTION
## Summary

Completes the four missing Census TIGER boundary families flagged in SW#305. PUMA and SpecialDistrict models shipped in PR #536; this PR adds the remaining two:

- **TribalArea** — AIANNH boundaries from `tl_YYYY_us_aiannh` (national file, spans states, variable-length GEOID)
- **CountySubdivision** — MCD/CCD from `tl_YYYY_SS_cousub` (10-digit GEOID = state(2) + county(3) + cousub(5), FK to State + County)

Migration 0008 creates both tables with appropriate indexes and constraints, following the same `_tiger_fields()` pattern as 0007.

## Files changed

- `siege_utilities/geo/django/models/census_extended.py` — two new model classes
- `siege_utilities/geo/django/models/__init__.py` — exports + docstring hierarchy
- `siege_utilities/geo/django/migrations/0008_tribalarea_and_countysubdivision.py` — migration

## Test plan

- [x] Syntax check passes on both model and migration files
- [x] Models follow established CensusTIGERBoundary pattern (verified against State, County, Tract, PUMA, SpecialDistrict)
- [x] GEOID structures match Census TIGER documentation
- [x] Migration dependency chain correct (0007 -> 0008)
- [ ] CI green-gate subset passes

Refs: SU#551, SW#305