### PR TITLE
fix(security): close credential exposure and shell injection (SU#559)

### DIFF
--- a/.review/su559-credential-shell-exposure.md
+++ b/.review/su559-credential-shell-exposure.md
@@ -1,0 +1,27 @@
+# Self-Review: SU#559 — credential exposure and shell injection fixes
+
+## Assumptions
+
+Working as: software engineer, security focus
+Goal source: https://github.com/siege-analytics/siege_utilities/issues/559
+Goal source verification: ticket exists with 4 specific exposure sites
+
+- `run_subprocess_unrestricted` has no callers in the codebase (grep confirmed)
+- 1Password CLI `op item edit` supports `[password]` field type annotation with stdin for value
+- Snowflake connector config keys are well-known; an allowlist doesn't break legitimate configs
+
+## Peer review
+
+Shelf: writing-code:1, writing-code:3
+
+### Shelf checks
+
+1. **shell.py**: renamed to `_run_subprocess_unrestricted`, removed from `__all__`. No callers found in codebase.
+2. **credential_manager.py**: changed `f'{field}={value}'` to `f'{field}[password]'` with `input=value` to pipe secret via stdin
+3. **snowflake_connector.py**: replaced `hasattr(self, key)` check with explicit `_ALLOWED_CONFIG_KEYS` frozenset
+4. **No unused imports introduced**
+
+## Lead review
+
+- **[Security]** No credentials in process arguments; unrestricted shell removed from public API
+- **[Backwards compatibility]** `_run_subprocess_unrestricted` has zero callers; Snowflake allowlist covers all documented connection params

--- a/siege_utilities/analytics/snowflake_connector.py
+++ b/siege_utilities/analytics/snowflake_connector.py
@@ -83,9 +83,12 @@ class SnowflakeConnector:
             with open(config_path, 'r') as f:
                 config = json.load(f)
             
-            # Update instance variables with config values
+            _ALLOWED_CONFIG_KEYS = frozenset({
+                "account", "user", "password", "warehouse",
+                "database", "schema", "role",
+            })
             for key, value in config.items():
-                if hasattr(self, key) and value is not None:
+                if key in _ALLOWED_CONFIG_KEYS and value is not None:
                     setattr(self, key, value)
                     
         except Exception as e:

--- a/siege_utilities/config/credential_manager.py
+++ b/siege_utilities/config/credential_manager.py
@@ -491,20 +491,22 @@ class CredentialManager:
             existing = self._get_from_1password(service, field, vault=vault, account=account)
 
             if existing:
-                # Update existing item
-                cmd = ['op', 'item', 'edit', service, f'{field}={value}'] + op_flags
-                result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+                cmd = ['op', 'item', 'edit', service, f'{field}[password]'] + op_flags
+                result = subprocess.run(
+                    cmd, input=value, capture_output=True, text=True, timeout=60,
+                )
             else:
-                # Create new item
                 cmd = [
                     'op', 'item', 'create',
                     '--category=login',
                     f'--title={service}',
                     f'username={username}',
-                    f'{field}={value}',
+                    f'{field}[password]',
                     f'--tags=siege-utilities,{service}'
                 ] + op_flags
-                result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+                result = subprocess.run(
+                    cmd, input=value, capture_output=True, text=True, timeout=60,
+                )
             
             if result.returncode == 0:
                 log_info(f"Stored {field} for {service} in 1Password")

--- a/siege_utilities/files/shell.py
+++ b/siege_utilities/files/shell.py
@@ -199,8 +199,8 @@ def run_subprocess(command_list: Union[str, List[str]],
         raise
 
 
-def run_subprocess_unrestricted(command_list: Union[str, List[str]],
-                                timeout: int = 30) -> str:
+def _run_subprocess_unrestricted(command_list: Union[str, List[str]],
+                                 timeout: int = 30) -> str:
     """
     Run a shell command WITHOUT security restrictions.
 
@@ -270,7 +270,6 @@ def run_subprocess_unrestricted(command_list: Union[str, List[str]],
 
 __all__ = [
     'run_subprocess',
-    'run_subprocess_unrestricted',
     'validate_command_safety',
     'SecurityError',
     'ALLOWED_COMMANDS'


### PR DESCRIPTION
> Closes #559

## Summary

- **`run_subprocess_unrestricted`**: renamed to private `_run_subprocess_unrestricted`, removed from `__all__`. Zero callers in codebase.
- **1Password `_store_in_1password`**: pipe secret via `stdin` instead of CLI argument (no longer visible in `ps aux`)
- **Snowflake `_load_config`**: restrict `setattr` to allowlisted connection keys only (prevents method overwrites from malicious config)