### PR TITLE
fix: resolve runtime NameErrors and broken methods (SU#560)

### DIFF
--- a/.review/su560-runtime-errors-broken-methods.md
+++ b/.review/su560-runtime-errors-broken-methods.md
@@ -1,0 +1,32 @@
+# Self-Review: SU#560 — runtime NameErrors and broken methods
+
+## Assumptions
+
+Working as: software engineer, correctness focus
+Goal source: https://github.com/siege-analytics/siege_utilities/issues/560
+Goal source verification: ticket exists with 6 specific runtime failure sites
+
+- `place_rank_dict` keys are `int`, but `get_place_ranks_by_label` received a `str` label and did a `.get()` against int keys — always returned `[]`
+- JSON serialisation stringifies dict keys; `from_json` must coerce them back
+- `RESULTS_OUTPUT_FORMAT`, `RESULTS_OUTPUT_DELIMITER`, `DEBUG_SUBDIRECTORY` were never defined in spark_utils.py — masked by F405 baseline from star imports
+- `batch_retrieve_ga_data` created a connector with dummy credentials, making it always fail at authentication time
+
+## Peer review
+
+Shelf: writing-code:1, writing-code:3
+
+### Shelf checks
+
+1. **spatial_transformations.py:27**: `GeoDataFrame` alias guarded with `if _GEOPANDAS_AVAILABLE else None` to prevent `NameError` when geopandas is not installed
+2. **geocoding.py:518**: changed `.get(label, [])` to list comprehension that iterates dict values, matching the reverse-lookup intent
+3. **geocoding.py:559-561**: added `int(k)` and `float(k)` coercion in `from_json` so round-tripped dicts recover their original key types
+4. **spark_utils.py**: added `import shutil`, lazy `tabulate` import, and defined `RESULTS_OUTPUT_FORMAT = 'csv'`, `RESULTS_OUTPUT_DELIMITER = ','`, `DEBUG_SUBDIRECTORY = Path('debug_output')` with sensible defaults
+5. **spark_utils.py:print_debug_table**: added guard raising `ImportError` when tabulate is not installed
+6. **google_analytics.py:609**: replaced dummy credentials with actual service-account loading from the account profile's `credentials_file`
+7. **No unused imports introduced**
+
+## Lead review
+
+- **[Correctness]** All six identified runtime failures are now fixed; each had a clear reproduction path
+- **[Backwards compatibility]** `get_place_ranks_by_label` now returns correct results instead of always `[]`; callers expecting `[]` for valid labels will see actual data — this is a bugfix, not a break
+- **[Defaults]** Spark output constants use CSV format matching the only call-site pattern; downstream consumers that relied on the undefined names were already broken

--- a/siege_utilities/analytics/google_analytics.py
+++ b/siege_utilities/analytics/google_analytics.py
@@ -604,9 +604,16 @@ def batch_retrieve_ga_data(client_id: str, start_date: str, end_date: str,
                     results['errors'].append(f"No credentials for account: {account['ga_account_id']}")
                     continue
 
-                # Create connector and retrieve data
-                # Note: In production, you'd load actual credentials from the file
-                connector = GoogleAnalyticsConnector("dummy_id", "dummy_secret")
+                creds_path = pathlib.Path(account['credentials_file'])
+                if not creds_path.exists():
+                    results['errors'].append(f"Credentials file not found: {creds_path}")
+                    continue
+                with open(creds_path, 'r') as creds_f:
+                    service_account_data = json.load(creds_f)
+                connector = GoogleAnalyticsConnector(
+                    auth_method="service_account",
+                    service_account_data=service_account_data,
+                )
 
                 if account['account_type'] in ['ga4', 'both']:
                     df = connector.get_ga4_data(

--- a/siege_utilities/distributed/spark_utils.py
+++ b/siege_utilities/distributed/spark_utils.py
@@ -3,6 +3,7 @@ import os
 import pathlib
 from pathlib import Path
 import json
+import shutil
 import time
 import logging
 import uuid
@@ -31,7 +32,16 @@ except ImportError:
     SparkSession = None
     Column = None
 
+try:
+    from tabulate import tabulate
+except ImportError:
+    tabulate = None
+
 logger = logging.getLogger(__name__)
+
+RESULTS_OUTPUT_FORMAT = 'csv'
+RESULTS_OUTPUT_DELIMITER = ','
+DEBUG_SUBDIRECTORY = Path('debug_output')
 
 def sanitise_dataframe_column_names(df: "DataFrame") ->Optional["DataFrame"]:
     """
@@ -801,6 +811,8 @@ def print_debug_table(spark_df, title):
     Helper function to convert a Spark DataFrame into a Pandas DataFrame,
     format it using tabulate, and print the result with a title.
     """
+    if tabulate is None:
+        raise ImportError("tabulate is required for print_debug_table: pip install tabulate")
     pdf = spark_df.toPandas()
     table_str = tabulate(pdf, headers='keys', tablefmt='psql', showindex=False)
     log_info(title)

--- a/siege_utilities/geo/geocoding.py
+++ b/siege_utilities/geo/geocoding.py
@@ -515,7 +515,7 @@ class NominatimGeoClassifier:
         Returns ``[]`` (not ``None``) when the label is unknown so the
         caller can ``in`` / iterate without a None-check.
         """
-        return self.place_rank_dict.get(label, [])
+        return [k for k, v in self.place_rank_dict.items() if v == label]
 
     def get_importance_threshold_by_label(self, label):
         """Reverse lookup on ``importance_dict``: label → importance threshold.
@@ -557,8 +557,8 @@ class NominatimGeoClassifier:
         classifier.
         """
         data = json.loads(json_string)
-        self.place_rank_dict = data.get('place_ranks', {})
-        self.importance_dict = data.get('importance_thresholds', {})
+        self.place_rank_dict = {int(k): v for k, v in data.get('place_ranks', {}).items()}
+        self.importance_dict = {float(k): v for k, v in data.get('importance_thresholds', {}).items()}
         return self
 
 

--- a/siege_utilities/geo/spatial_transformations.py
+++ b/siege_utilities/geo/spatial_transformations.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 
 # Type aliases
 FilePath = Union[str, Path]
-GeoDataFrame = gpd.GeoDataFrame
+GeoDataFrame = gpd.GeoDataFrame if _GEOPANDAS_AVAILABLE else None
 
 # Try to import DuckDB (optional)
 try:


### PR DESCRIPTION
## Summary

Fixes 6 runtime failures identified in the code review audit (#557):

- **`geo/spatial_transformations.py`**: guard `GeoDataFrame` alias behind `_GEOPANDAS_AVAILABLE` check
- **`geo/geocoding.py`**: fix `get_place_ranks_by_label` reverse-lookup (was `.get()` on int-keyed dict with a string label — always returned `[]`)
- **`geo/geocoding.py`**: coerce JSON-stringified keys back to `int`/`float` in `from_json` so round-tripped classifiers work correctly
- **`distributed/spark_utils.py`**: add missing `shutil` import, lazy `tabulate` import, and define `RESULTS_OUTPUT_FORMAT`, `RESULTS_OUTPUT_DELIMITER`, `DEBUG_SUBDIRECTORY` constants that were referenced but never defined
- **`analytics/google_analytics.py`**: replace dummy credentials in `batch_retrieve_ga_data` with actual service-account loading from the account profile's `credentials_file`

Closes #560