### PR TITLE
chore: clean up test suite structure (SU#562)

### DIFF
--- a/.review/su562-test-suite-cleanup.md
+++ b/.review/su562-test-suite-cleanup.md
@@ -1,0 +1,30 @@
+# Self-Review: SU#562 — test suite cleanup
+
+## Assumptions
+
+Working as: software engineer, test infrastructure focus
+Goal source: https://github.com/siege-analytics/siege_utilities/issues/562
+Goal source verification: ticket exists with 4 acceptance criteria
+
+- 63 macOS Finder duplicate files ("copy 2" / "copy 3") are untracked junk — verified none are tracked or referenced
+- In-package test dirs (identifiers/tests, political/tests, schema/tests) exist but were excluded from pytest discovery
+- `--disable-warnings` in addopts overrides `filterwarnings` config entirely, making the filter stanza dead code
+- Coverage floor of 40% is low; 45% is a conservative ratchet that won't block CI
+
+## Peer review
+
+Shelf: writing-code:1, writing-code:3
+
+### Shelf checks
+
+1. **63 duplicate files deleted**: all "` 2.`" and "` 3.`" files removed from working tree (untracked, not committed)
+2. **pytest.ini testpaths**: added `siege_utilities/identifiers/tests`, `siege_utilities/political/tests`, `siege_utilities/schema/tests`
+3. **--disable-warnings removed**: was masking all warnings including our own DeprecationWarnings
+4. **filterwarnings scoped**: `default::DeprecationWarning:siege_utilities` surfaces our own deprecations; third-party libs (pyspark, shapely, pyproj, fiona, google) still suppressed
+5. **Coverage floor**: 40% → 45%
+
+## Lead review
+
+- **[CI impact]** Removing `--disable-warnings` may surface new warnings in CI output — these are real and should be visible
+- **[Coverage]** 45% is intentionally conservative; can ratchet further once in-package tests are wired up
+- **[Duplicate files]** Deletion is on-disk only (untracked); no git history impact

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,7 +4,11 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = tests.django_project.settings
 # Test discovery and execution
-testpaths = tests
+testpaths =
+    tests
+    siege_utilities/identifiers/tests
+    siege_utilities/political/tests
+    siege_utilities/schema/tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
@@ -12,11 +16,10 @@ addopts =
     -v
     --tb=short
     --strict-markers
-    --disable-warnings
     --cov=siege_utilities
     --cov-report=term-missing
     --cov-report=html:htmlcov
-    --cov-fail-under=40
+    --cov-fail-under=45
     -m "not integration"
 
 # Markers for test organization
@@ -48,9 +51,15 @@ markers =
 
 # Test filtering
 filterwarnings =
-    ignore::DeprecationWarning
+    default::DeprecationWarning:siege_utilities
+    ignore::DeprecationWarning:pyspark
+    ignore::DeprecationWarning:shapely
+    ignore::DeprecationWarning:pyproj
+    ignore::DeprecationWarning:fiona
+    ignore::DeprecationWarning:google
     ignore::PendingDeprecationWarning
-    ignore::UserWarning
+    ignore::UserWarning:pyspark
+    ignore::UserWarning:shapely
 
 # Coverage configuration
 [coverage:run]


### PR DESCRIPTION
## Summary

Fixes test infrastructure issues identified in the code review audit (#557):

- **Delete 63 macOS Finder duplicates**: untracked "copy 2"/"copy 3" files cluttering the working tree
- **Expand test discovery**: add `identifiers/tests`, `political/tests`, `schema/tests` to `pytest.ini testpaths`
- **Fix warning visibility**: remove `--disable-warnings` and scope `filterwarnings` to suppress only third-party libs (pyspark, shapely, pyproj, fiona, google) — our own `DeprecationWarning`s are now visible
- **Ratchet coverage floor**: 40% → 45%

Closes #562