### PR TITLE
fix: medium-severity correctness fixes across 7 modules (SU#563)

### DIFF
--- a/.review/su563-quick-correctness-fixes.md
+++ b/.review/su563-quick-correctness-fixes.md
@@ -1,0 +1,33 @@
+# Self-Review: SU#563 (Group 1) — quick correctness fixes
+
+## Assumptions
+
+Working as: software engineer, correctness focus
+Goal source: https://github.com/siege-analytics/siege_utilities/issues/563
+Goal source verification: ticket exists as sub-issue of epic #557
+
+- `clean_working_directory` is used in CI pipelines where `input()` blocks forever
+- `matplotlib.use("Agg")` called per-chart can conflict with user-set backends; once at import is standard practice
+- PowerPoint `create_performance_presentation` had the same collision bug that was already fixed in `create_analytics_presentation`
+- CredentialManager is stateless between calls; caching by vault/account key is safe
+- `SIEGE_AUTO_INIT_DIRS` defaulting to "true" means importing `config.paths` creates 18 directories as a side effect — surprising for library users
+
+## Peer review
+
+Shelf: writing-code:1, writing-code:3
+
+### Shelf checks
+
+1. **git_operations.py**: added `interactive=True` param to `clean_working_directory`; when `interactive=False` and `force=False`, returns cancelled status instead of hanging
+2. **crosstab.py**: extracted hardcoded `1.96` to `DEFAULT_Z_VALUE` module constant; dispatch interface unchanged
+3. **render.py**: moved `matplotlib.use("Agg")` to module level behind import guard; function now checks `_MATPLOTLIB_AVAILABLE` flag
+4. **powerpoint_generator.py**: added uuid4 suffix to `create_performance_presentation` filename, matching existing pattern in `create_analytics_presentation`
+5. **vista_social.py**: added `close()`, `__enter__`, `__exit__` to `VistaSocialConnector` for session lifecycle
+6. **credential_manager.py**: added `_get_default_manager()` with `_default_managers` cache dict; 4 convenience functions now reuse managers
+7. **paths.py**: changed `SIEGE_AUTO_INIT_DIRS` default from `"true"` to `"false"` — opt-in
+8. **choropleth.py**: verified already guarded (no change needed)
+
+## Lead review
+
+- **[Backwards compatibility]** `clean_working_directory` adds an optional param (default preserves old behavior); `SIEGE_AUTO_INIT_DIRS` default change may affect users who relied on auto-creation — documented in commit message
+- **[No new imports]** All changes use existing stdlib/package imports

--- a/siege_utilities/analytics/vista_social.py
+++ b/siege_utilities/analytics/vista_social.py
@@ -170,6 +170,16 @@ class VistaSocialConnector:
         })
         log.info("VistaSocialConnector initialised against %s", self._base_url)
 
+    def close(self) -> None:
+        """Close the underlying HTTP session."""
+        self._session.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
     # ------------------------------------------------------------------
     # Low-level: HTTP plumbing (well-tested; endpoints sit on top)
     # ------------------------------------------------------------------

--- a/siege_utilities/config/credential_manager.py
+++ b/siege_utilities/config/credential_manager.py
@@ -788,6 +788,20 @@ class CredentialManager:
         return status
 
 
+_default_managers: Dict[tuple, "CredentialManager"] = {}
+
+
+def _get_default_manager(vault: Optional[str] = None,
+                         account: Optional[str] = None) -> "CredentialManager":
+    """Return a cached CredentialManager for the given vault/account pair."""
+    key = (vault or "Private", account)
+    if key not in _default_managers:
+        _default_managers[key] = CredentialManager(
+            default_vault=key[0], default_account=key[1],
+        )
+    return _default_managers[key]
+
+
 # Convenience functions for common operations
 def get_credential(service: str, username: str, field: str = "password",
                   search_paths: Optional[List[Union[str, Path]]] = None,
@@ -807,10 +821,7 @@ def get_credential(service: str, username: str, field: str = "password",
     Returns:
         Credential value or None
     """
-    manager = CredentialManager(
-        default_vault=vault or "Private",
-        default_account=account,
-    )
+    manager = _get_default_manager(vault=vault, account=account)
     path_objects = [Path(p) for p in search_paths] if search_paths else None
     return manager.get_credential(service, username, field, path_objects,
                                   vault=vault, account=account)
@@ -835,10 +846,7 @@ def store_credential(service: str, username: str, value: str,
     Returns:
         True if successful
     """
-    manager = CredentialManager(
-        default_vault=vault or "Private",
-        default_account=account,
-    )
+    manager = _get_default_manager(vault=vault, account=account)
     return manager.store_credential(service, username, value, field, backend,
                                     vault=vault, account=account)
 
@@ -892,13 +900,13 @@ def get_ga_credentials() -> Optional[Tuple[str, str]]:
     Returns:
         Tuple of (client_id, client_secret) or None
     """
-    manager = CredentialManager()
+    manager = _get_default_manager()
     return manager.get_google_analytics_credentials()
 
 
 def credential_status() -> Dict[str, Dict[str, Any]]:
     """Get status of all credential backends."""
-    manager = CredentialManager()
+    manager = _get_default_manager()
     return manager.backend_status()
 
 

--- a/siege_utilities/config/paths.py
+++ b/siege_utilities/config/paths.py
@@ -346,6 +346,6 @@ def initialize_siege_directories() -> List[Path]:
 
     return created
 
-# Auto-initialize on import (can be disabled by setting environment variable)
-if os.getenv('SIEGE_AUTO_INIT_DIRS', 'true').lower() == 'true':
+# Auto-initialize on import (opt-in via environment variable)
+if os.getenv('SIEGE_AUTO_INIT_DIRS', 'false').lower() == 'true':
     initialize_siege_directories()

--- a/siege_utilities/git/git_operations.py
+++ b/siege_utilities/git/git_operations.py
@@ -366,9 +366,15 @@ def apply_stash(
 def clean_working_directory(
     repo_path: str = ".",
     force: bool = False,
-    directories: bool = False
+    directories: bool = False,
+    interactive: bool = True,
 ) -> Dict[str, str]:
-    """Clean untracked files from working directory."""
+    """Clean untracked files from working directory.
+
+    Args:
+        interactive: When False, skip the confirmation prompt (safe for CI).
+                     When True (default), prompt the user before cleaning.
+    """
 
     clean_args = ["clean"]
     if force:
@@ -389,13 +395,18 @@ def clean_working_directory(
     log_info("Files to be cleaned:")
     log_info(dry_run_output)
 
-    if not force:
+    if not force and interactive:
         response = input("Proceed with cleaning? (y/N): ")
         if response.lower() != 'y':
             return {
                 "status": "cancelled",
                 "message": "Clean operation cancelled by user"
             }
+    elif not force and not interactive:
+        return {
+            "status": "cancelled",
+            "message": "Non-interactive mode: pass force=True to clean without confirmation"
+        }
 
     # Execute clean
     try:

--- a/siege_utilities/reporting/powerpoint_generator.py
+++ b/siege_utilities/reporting/powerpoint_generator.py
@@ -146,7 +146,8 @@ class PowerPointGenerator:
         try:
             # Generate filename
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-            filename = f"{self.client_name.lower().replace(' ', '_')}_performance_presentation_{timestamp}.pptx"
+            suffix = uuid.uuid4().hex[:8]
+            filename = f"{self.client_name.lower().replace(' ', '_')}_performance_presentation_{timestamp}_{suffix}.pptx"
             output_path = self.output_dir / filename
             
             # Create presentation

--- a/siege_utilities/survey/crosstab.py
+++ b/siege_utilities/survey/crosstab.py
@@ -13,6 +13,8 @@ import pandas as pd
 from ..reporting.pages.page_models import TableType
 from .models import Chain, View
 
+DEFAULT_Z_VALUE = 1.96
+
 
 class CrosstabInputError(ValueError):
     """Raised when build_chain receives an empty or schema-incompatible DataFrame.
@@ -326,7 +328,7 @@ def _build_mean_scale(
                 if len(cat_vals) == 0:
                     continue
                 mean = float(cat_vals.mean())
-                ci = 1.96 * float(cat_vals.std(ddof=1)) / (len(cat_vals) ** 0.5) if len(cat_vals) > 1 else 0.0
+                ci = DEFAULT_Z_VALUE * float(cat_vals.std(ddof=1)) / (len(cat_vals) ** 0.5) if len(cat_vals) > 1 else 0.0
                 v = View(metric=str(cat), base=base, count=mean, pct=None, ci=ci)
                 cell_views.append(v)
             if top_n:

--- a/siege_utilities/survey/render.py
+++ b/siege_utilities/survey/render.py
@@ -26,6 +26,13 @@ from ..reporting.pages.page_models import Argument, TableType
 if TYPE_CHECKING:
     from .models import Chain, Stack
 
+try:
+    import matplotlib
+    matplotlib.use("Agg")
+    _MATPLOTLIB_AVAILABLE = True
+except ImportError:
+    _MATPLOTLIB_AVAILABLE = False
+
 
 class RenderError(RuntimeError):
     """Raised when Chain-to-Argument rendering hits a configuration or data issue."""
@@ -82,12 +89,9 @@ def _build_chart(
     if chart_generator is not None:
         return chart_generator(df, chart_type, headline)
 
-    try:
-        import matplotlib
-        matplotlib.use("Agg")
-        import matplotlib.pyplot as plt
-    except ImportError:
+    if not _MATPLOTLIB_AVAILABLE:
         return None
+    import matplotlib.pyplot as plt
 
     if df.empty:
         return None


### PR DESCRIPTION
## Summary

Group 1 of SU#563 — quick correctness fixes from the code review audit (#557):

- **`git_operations.py`**: `clean_working_directory()` now accepts `interactive=False` to skip `input()` prompt (prevents CI hangs)
- **`survey/crosstab.py`**: hardcoded `1.96` z-value extracted to `DEFAULT_Z_VALUE` module constant
- **`survey/render.py`**: `matplotlib.use("Agg")` moved to module-level import guard (was called per-chart)
- **`powerpoint_generator.py`**: UUID suffix added to `create_performance_presentation` filename (matches existing `create_analytics_presentation` pattern)
- **`analytics/vista_social.py`**: `VistaSocialConnector` now supports `close()` and context manager protocol to prevent session leaks
- **`config/credential_manager.py`**: convenience functions now cache `CredentialManager` instances by vault/account key
- **`config/paths.py`**: `SIEGE_AUTO_INIT_DIRS` default changed from `"true"` to `"false"` — importing the module no longer creates 18 directories as a side effect

Partial fix for #563