### PR TITLE
refactor: deduplicate run_git_command and admin-level area dicts (SU#563)

### DIFF
--- a/.review/su563-refactors.md
+++ b/.review/su563-refactors.md
@@ -1,0 +1,29 @@
+# Self-Review: SU#563 (Group 2) — code deduplication refactors
+
+## Assumptions
+
+Working as: software engineer, architecture focus
+Goal source: https://github.com/siege-analytics/siege_utilities/issues/563
+Goal source verification: ticket exists as sub-issue of epic #557
+
+- `run_git_command` was byte-identical in all 4 git modules; safe to extract
+- `ADMIN_LEVEL_AVG_AREA_KM2` and `_ADMIN_LEVEL_ALIASES` were identical in h3_utils and s2_utils
+- `UserProfile` collision in config/__init__.py is already handled via aliasing (`EnhancedUserProfile`, `PydanticUserProfile`); no change needed
+
+## Peer review
+
+Shelf: writing-code:1, writing-code:3
+
+### Shelf checks
+
+1. **git/_utils.py**: new file with canonical `run_git_command`; uses same `subprocess` + `GitError` pattern as originals
+2. **git/git_status.py, git_operations.py, branch_analyzer.py, git_workflow.py**: replaced inline definitions with `from ._utils import run_git_command`; removed now-unused `import subprocess`
+3. **geo/_admin_areas.py**: new file with canonical `ADMIN_LEVEL_AVG_AREA_KM2` and `ADMIN_LEVEL_ALIASES`
+4. **geo/h3_utils.py, geo/s2_utils.py**: replaced inline dicts with `from ._admin_areas import ...`
+5. **config/__init__.py UserProfile**: no change — aliasing already resolves the collision
+6. **Import smoke test passed** for both new modules
+
+## Lead review
+
+- **[Backwards compatibility]** `ADMIN_LEVEL_AVG_AREA_KM2` is re-exported at the same module path via the import; existing `from siege_utilities.geo.h3_utils import ADMIN_LEVEL_AVG_AREA_KM2` still works
+- **[run_git_command]** not in any `__all__`; internal-only. Callers within the git package now share one definition

--- a/siege_utilities/geo/_admin_areas.py
+++ b/siege_utilities/geo/_admin_areas.py
@@ -1,0 +1,34 @@
+"""Shared admin-level area constants for H3 and S2 resolution selection.
+
+The average areas below are rough midpoints across the entire US. The
+variance within a level (e.g. NY tract vs WY tract) is huge. The resolution
+returned by callers is a starting point; tune up or down by +/-1 if the
+polygons you actually have are systematically larger or smaller.
+"""
+
+ADMIN_LEVEL_AVG_AREA_KM2 = {
+    "state": 196_600.0,
+    "county": 3_000.0,
+    "zcta": 110.0,
+    "tract": 5.0,
+    "block_group": 1.0,
+    "block": 0.04,
+}
+
+ADMIN_LEVEL_ALIASES = {
+    "states": "state",
+    "us_state": "state",
+    "counties": "county",
+    "us_county": "county",
+    "zip": "zcta",
+    "zip_code": "zcta",
+    "zipcode": "zcta",
+    "zctas": "zcta",
+    "tracts": "tract",
+    "census_tract": "tract",
+    "bg": "block_group",
+    "block_groups": "block_group",
+    "blockgroup": "block_group",
+    "blocks": "block",
+    "census_block": "block",
+}

--- a/siege_utilities/geo/h3_utils.py
+++ b/siege_utilities/geo/h3_utils.py
@@ -326,33 +326,7 @@ def h3_hex_to_boundary(hex_id: str) -> list:
 # returned here is a starting point; tune up or down by ±1 if the polygons
 # you actually have are systematically larger or smaller than the average.
 # ---------------------------------------------------------------------------
-ADMIN_LEVEL_AVG_AREA_KM2 = {
-    "state": 196_600.0,
-    "county": 3_000.0,
-    "zcta": 110.0,
-    "tract": 5.0,
-    "block_group": 1.0,
-    "block": 0.04,
-}
-
-# Aliases that map common variants to the canonical key above.
-_ADMIN_LEVEL_ALIASES = {
-    "states": "state",
-    "us_state": "state",
-    "counties": "county",
-    "us_county": "county",
-    "zip": "zcta",
-    "zip_code": "zcta",
-    "zipcode": "zcta",
-    "zctas": "zcta",
-    "tracts": "tract",
-    "census_tract": "tract",
-    "bg": "block_group",
-    "block_groups": "block_group",
-    "blockgroup": "block_group",
-    "blocks": "block",
-    "census_block": "block",
-}
+from ._admin_areas import ADMIN_LEVEL_AVG_AREA_KM2, ADMIN_LEVEL_ALIASES as _ADMIN_LEVEL_ALIASES
 
 
 def h3_resolution_for_admin_level(level: str) -> int:

--- a/siege_utilities/geo/s2_utils.py
+++ b/siege_utilities/geo/s2_utils.py
@@ -135,25 +135,7 @@ S2_LEVEL_AREA_KM2 = {
     30: 0.00000000007,
 }
 
-# Same admin-level table the H3 module uses; S2 just picks a different
-# level from the same target areas.
-ADMIN_LEVEL_AVG_AREA_KM2 = {
-    "state": 196_600.0,
-    "county": 3_000.0,
-    "zcta": 110.0,
-    "tract": 5.0,
-    "block_group": 1.0,
-    "block": 0.04,
-}
-
-_ADMIN_LEVEL_ALIASES = {
-    "states": "state", "us_state": "state",
-    "counties": "county", "us_county": "county",
-    "zip": "zcta", "zip_code": "zcta", "zipcode": "zcta", "zctas": "zcta",
-    "tracts": "tract", "census_tract": "tract",
-    "bg": "block_group", "block_groups": "block_group", "blockgroup": "block_group",
-    "blocks": "block", "census_block": "block",
-}
+from ._admin_areas import ADMIN_LEVEL_AVG_AREA_KM2, ADMIN_LEVEL_ALIASES as _ADMIN_LEVEL_ALIASES
 
 
 def s2_level_for_area(target_area_km2: float) -> int:

--- a/siege_utilities/git/_utils.py
+++ b/siege_utilities/git/_utils.py
@@ -1,0 +1,23 @@
+"""Shared internal helpers for the git sub-package."""
+
+import subprocess
+
+from siege_utilities.exceptions import GitError
+
+
+def run_git_command(*args, repo_path: str = ".", check: bool = True) -> str:
+    """Run a git command and return the output."""
+    try:
+        result = subprocess.run(
+            ["git"] + list(args),
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+            check=check,
+            timeout=30,  # writing-code:15: bounded git wait
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        if check:
+            raise GitError(f"Git command failed: {' '.join(args)} - {e.stderr}")
+        return ""

--- a/siege_utilities/git/branch_analyzer.py
+++ b/siege_utilities/git/branch_analyzer.py
@@ -3,7 +3,6 @@ Branch analysis utilities for git repositories.
 Based on the Change-Agent-AI branch status generator.
 """
 
-import subprocess
 import re
 from datetime import datetime
 from pathlib import Path
@@ -11,24 +10,7 @@ from typing import List, Dict, Optional
 
 from siege_utilities.core.logging import log_info
 from siege_utilities.exceptions import GitError
-
-
-def run_git_command(*args, repo_path: str = ".", check: bool = True) -> str:
-    """Run a git command and return the output."""
-    try:
-        result = subprocess.run(
-            ["git"] + list(args),
-            cwd=repo_path,
-            capture_output=True,
-            text=True,
-            check=check,
-            timeout=30,  # writing-code:15: bounded git wait
-        )
-        return result.stdout.strip()
-    except subprocess.CalledProcessError as e:
-        if check:
-            raise GitError(f"Git command failed: {' '.join(args)} - {e.stderr}")
-        return ""
+from ._utils import run_git_command
 
 def analyze_branch_status(repo_path: str = ".") -> Dict[str, str]:
     """Analyze the current branch status."""

--- a/siege_utilities/git/git_operations.py
+++ b/siege_utilities/git/git_operations.py
@@ -3,29 +3,12 @@ Git operations utilities for repository management.
 Comprehensive git commands and workflow automation.
 """
 
-import subprocess
 from typing import Dict, Optional
 import re
 
 from siege_utilities.core.logging import log_info, log_warning, log_error
 from siege_utilities.exceptions import GitError
-
-def run_git_command(*args, repo_path: str = ".", check: bool = True) -> str:
-    """Run a git command and return the output."""
-    try:
-        result = subprocess.run(
-            ["git"] + list(args),
-            cwd=repo_path,
-            capture_output=True,
-            text=True,
-            check=check,
-            timeout=30,  # writing-code:15: bounded git wait
-        )
-        return result.stdout.strip()
-    except subprocess.CalledProcessError as e:
-        if check:
-            raise GitError(f"Git command failed: {' '.join(args)} - {e.stderr}")
-        return ""
+from ._utils import run_git_command
 
 def create_feature_branch(
     branch_name: str,

--- a/siege_utilities/git/git_status.py
+++ b/siege_utilities/git/git_status.py
@@ -3,30 +3,12 @@ Git status utilities for repository information and reporting.
 Comprehensive repository state analysis and monitoring.
 """
 
-import subprocess
 from pathlib import Path
 from typing import List, Dict, Optional, Union
 from datetime import datetime
 
 from siege_utilities.exceptions import GitError
-
-
-def run_git_command(*args, repo_path: str = ".", check: bool = True) -> str:
-    """Run a git command and return the output."""
-    try:
-        result = subprocess.run(
-            ["git"] + list(args),
-            cwd=repo_path,
-            capture_output=True,
-            text=True,
-            check=check,
-            timeout=30,  # writing-code:15: bounded git wait
-        )
-        return result.stdout.strip()
-    except subprocess.CalledProcessError as e:
-        if check:
-            raise GitError(f"Git command failed: {' '.join(args)} - {e.stderr}")
-        return ""
+from ._utils import run_git_command
 
 def get_repository_status(repo_path: str = ".") -> Dict[str, Union[str, int, bool]]:
     """Get comprehensive repository status information."""

--- a/siege_utilities/git/git_workflow.py
+++ b/siege_utilities/git/git_workflow.py
@@ -3,31 +3,13 @@ Git workflow utilities for automated git operations and best practices.
 Standardized workflows for feature development, releases, and hotfixes.
 """
 
-import subprocess
 from pathlib import Path
 from typing import List, Dict, Optional, Union
 import re
 
 from siege_utilities.core.logging import log_info, log_warning
 from siege_utilities.exceptions import GitError
-
-
-def run_git_command(*args, repo_path: str = ".", check: bool = True) -> str:
-    """Run a git command and return the output."""
-    try:
-        result = subprocess.run(
-            ["git"] + list(args),
-            cwd=repo_path,
-            capture_output=True,
-            text=True,
-            check=check,
-            timeout=30,  # writing-code:15: bounded git wait
-        )
-        return result.stdout.strip()
-    except subprocess.CalledProcessError as e:
-        if check:
-            raise GitError(f"Git command failed: {' '.join(args)} - {e.stderr}")
-        return ""
+from ._utils import run_git_command
 
 def validate_branch_naming(branch_name: str) -> Dict[str, Union[bool, str, List[str]]]:
     """Validate branch naming conventions."""


### PR DESCRIPTION
## Summary

Group 2 of SU#563 — code deduplication refactors:

- **`git/_utils.py`** (new): canonical `run_git_command` extracted from 4 identical copies across `git_status.py`, `git_operations.py`, `branch_analyzer.py`, `git_workflow.py`
- **`geo/_admin_areas.py`** (new): canonical `ADMIN_LEVEL_AVG_AREA_KM2` and `ADMIN_LEVEL_ALIASES` extracted from identical copies in `h3_utils.py` and `s2_utils.py`
- **`config/__init__.py` UserProfile collision**: verified already resolved via aliasing — no change needed

Net: -29 lines, 2 new shared modules, 6 modules simplified.

Partial fix for #563