### PR TITLE
fix: address 5 unfixed siblings from SU#563 audit

### DIFF
--- a/scripts/release_manager.py
+++ b/scripts/release_manager.py
@@ -360,14 +360,17 @@ def upload_to_pypi(repository: str = 'pypi', token: Optional[str] = None,
         logger.info(f"[DRY RUN] Would upload {len(dist_files)} file(s) to {repository}")
         return True
 
-    cmd = [sys.executable, '-m', 'twine', 'upload',
-           '--username', '__token__', '--password', resolved_token]
+    env = os.environ.copy()
+    env['TWINE_USERNAME'] = '__token__'
+    env['TWINE_PASSWORD'] = resolved_token
+
+    cmd = [sys.executable, '-m', 'twine', 'upload']
     if repository == 'testpypi':
         cmd.extend(['--repository', 'testpypi'])
     cmd.extend([str(f) for f in dist_files])
 
     logger.info(f"Uploading to {repository}...")
-    result = subprocess.run(cmd, cwd=PROJECT_ROOT, timeout=60)
+    result = subprocess.run(cmd, cwd=PROJECT_ROOT, timeout=60, env=env)
     if result.returncode == 0:
         logger.info(f"Upload to {repository} succeeded")
         return True

--- a/siege_utilities/geo/django/__init__.py
+++ b/siege_utilities/geo/django/__init__.py
@@ -125,8 +125,12 @@ def get_service(service_name: str):
     return getattr(services_module, service_name)
 
 
-# Version info — matches package version
-__version__ = "3.0.0"
+# Version derived from the parent package
+try:
+    from importlib.metadata import version as _meta_version
+    __version__ = _meta_version("siege-utilities")
+except Exception:
+    __version__ = "3.18.1-dev"
 
 __all__ = [
     # Models (lazy)

--- a/siege_utilities/geo/django/management/commands/stage_boundaries_s3.py
+++ b/siege_utilities/geo/django/management/commands/stage_boundaries_s3.py
@@ -15,6 +15,7 @@ Usage:
     python manage.py stage_boundaries_s3 --year 2020 --type county --format parquet
 """
 
+import os
 import tempfile
 
 from django.core.management.base import BaseCommand, CommandError
@@ -94,14 +95,14 @@ class Command(BaseCommand):
         parser.add_argument(
             "--access-key",
             type=str,
-            default="electinfo",
-            help="S3 access key",
+            default=os.environ.get("S3_ACCESS_KEY"),
+            help="S3 access key (default: $S3_ACCESS_KEY)",
         )
         parser.add_argument(
             "--secret-key",
             type=str,
-            default="electinfo123",
-            help="S3 secret key",
+            default=os.environ.get("S3_SECRET_KEY"),
+            help="S3 secret key (default: $S3_SECRET_KEY)",
         )
         parser.add_argument(
             "--format",
@@ -131,6 +132,12 @@ class Command(BaseCommand):
         bucket = options["bucket"]
         output_format = options["format"]
         dry_run = options["dry_run"]
+
+        if not options["access_key"] or not options["secret_key"]:
+            raise CommandError(
+                "S3 credentials required. Set --access-key/--secret-key "
+                "or S3_ACCESS_KEY/S3_SECRET_KEY environment variables."
+            )
 
         s3 = boto3.client(
             "s3",

--- a/siege_utilities/geo/spatial_data.py
+++ b/siege_utilities/geo/spatial_data.py
@@ -1919,7 +1919,7 @@ def get_census_boundaries(year: int = DEFAULT_CENSUS_YEAR, geographic_level: str
     .. deprecated:: 3.16.0
         Use :func:`fetch_geographic_boundaries` (via CensusDataSource) for
         structured diagnostics via :class:`BoundaryFetchResult`.
-        ``get_census_boundaries`` will be removed in v3.17.0.
+        ``get_census_boundaries`` will be removed in v4.0.0.
 
     Args:
         year: Census year
@@ -1936,7 +1936,7 @@ def get_census_boundaries(year: int = DEFAULT_CENSUS_YEAR, geographic_level: str
         GeoDataFrame with Census boundaries (filtered by state if specified)
     """
     warnings.warn(
-        "get_census_boundaries() is deprecated; will be removed in v3.17.0. "
+        "get_census_boundaries() is deprecated; will be removed in v4.0.0. "
         "Use CensusDataSource().fetch_geographic_boundaries() for structured "
         "error reporting via BoundaryFetchResult.",
         DeprecationWarning,
@@ -2080,13 +2080,13 @@ def get_geographic_boundaries(
 
     .. deprecated:: 3.16.0
         Use :func:`fetch_geographic_boundaries` for structured diagnostics.
-        ``get_geographic_boundaries`` will be removed in v3.17.0.
+        ``get_geographic_boundaries`` will be removed in v4.0.0.
 
     Args:
         crs: Output CRS. Defaults to :func:`~siege_utilities.geo.crs.get_default_crs`.
     """
     warnings.warn(
-        "get_geographic_boundaries() is deprecated; will be removed in v3.17.0. "
+        "get_geographic_boundaries() is deprecated; will be removed in v4.0.0. "
         "Use fetch_geographic_boundaries() for structured diagnostics via "
         "BoundaryFetchResult.",
         DeprecationWarning,

--- a/siege_utilities/reporting/analytics/polling_analyzer.py
+++ b/siege_utilities/reporting/analytics/polling_analyzer.py
@@ -428,6 +428,10 @@ class PollingAnalyzer:
         PollingAnalysisError
             If matplotlib or seaborn cannot render the input.
         """
+        if not _MATPLOTLIB_AVAILABLE or not _SEABORN_AVAILABLE:
+            raise PollingAnalysisError(
+                "matplotlib and seaborn are required for heatmap visualization"
+            )
         try:
             fig, ax = plt.subplots(figsize=figsize)
             fmt = _choose_heatmap_fmt(crosstab_data)
@@ -479,6 +483,10 @@ class PollingAnalyzer:
         PollingAnalysisError
             If plotting fails.
         """
+        if not _MATPLOTLIB_AVAILABLE:
+            raise PollingAnalysisError(
+                "matplotlib is required for trend analysis charts"
+            )
         try:
             fig, ax = plt.subplots(figsize=figsize)
             for period, data in longitudinal_data.items():

--- a/tests/test_release_manager.py
+++ b/tests/test_release_manager.py
@@ -1,0 +1,67 @@
+"""Tests for scripts/release_manager.py — focused on security properties."""
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from release_manager import upload_to_pypi
+
+
+class TestUploadToPypiTokenSafety:
+    """PyPI token must never appear in subprocess argv (visible in ps aux)."""
+
+    @patch("release_manager.subprocess.run")
+    def test_token_not_in_command_args(self, mock_run, tmp_path):
+        dist = tmp_path / "dist"
+        dist.mkdir()
+        (dist / "pkg-1.0.tar.gz").touch()
+
+        mock_run.return_value = MagicMock(returncode=0)
+
+        with patch("release_manager.PROJECT_ROOT", tmp_path):
+            upload_to_pypi(repository="pypi", token="pypi-SECRET-TOKEN-12345")
+
+        args, kwargs = mock_run.call_args
+        cmd = args[0]
+        cmd_str = " ".join(cmd)
+        assert "pypi-SECRET-TOKEN-12345" not in cmd_str, (
+            "Token must not appear in subprocess command (visible in ps aux)"
+        )
+
+    @patch("release_manager.subprocess.run")
+    def test_token_passed_via_env(self, mock_run, tmp_path):
+        dist = tmp_path / "dist"
+        dist.mkdir()
+        (dist / "pkg-1.0.tar.gz").touch()
+
+        mock_run.return_value = MagicMock(returncode=0)
+
+        with patch("release_manager.PROJECT_ROOT", tmp_path):
+            upload_to_pypi(repository="pypi", token="pypi-SECRET-TOKEN-12345")
+
+        _, kwargs = mock_run.call_args
+        env = kwargs.get("env", {})
+        assert env.get("TWINE_PASSWORD") == "pypi-SECRET-TOKEN-12345"
+        assert env.get("TWINE_USERNAME") == "__token__"
+
+    @patch("release_manager.subprocess.run")
+    def test_testpypi_repository_flag(self, mock_run, tmp_path):
+        dist = tmp_path / "dist"
+        dist.mkdir()
+        (dist / "pkg-1.0.tar.gz").touch()
+
+        mock_run.return_value = MagicMock(returncode=0)
+
+        with patch("release_manager.PROJECT_ROOT", tmp_path):
+            upload_to_pypi(repository="testpypi", token="pypi-TEST-TOKEN")
+
+        cmd = mock_run.call_args[0][0]
+        assert "--repository" in cmd
+        assert "testpypi" in cmd

--- a/tests/test_release_manager.py
+++ b/tests/test_release_manager.py
@@ -1,6 +1,5 @@
 """Tests for scripts/release_manager.py — focused on security properties."""
 
-import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import patch, MagicMock


### PR DESCRIPTION
## Summary

Fixes 5 issues surfaced by the sibling-grep audits during the SU#563 code review:

- **P0 security**: `release_manager.py` passed the PyPI token as `--password` CLI arg (visible in `ps aux`). Now uses `TWINE_PASSWORD` env var.
- **P1 stale deprecation**: `spatial_data.py` promised removal of `get_census_boundaries` and `get_geographic_boundaries` in v3.17.0 but they have 8+ internal callers. Updated deadline to v4.0.0.
- **P2 hardcoded version**: `geo/django/__init__.py` had `__version__ = "3.0.0"` hardcoded. Now uses `importlib.metadata` like the parent package.
- **P2 missing guard**: `polling_analyzer.py` called `plt.subplots()` without checking `_MATPLOTLIB_AVAILABLE`, producing `AttributeError` when matplotlib isn't installed. Now raises `PollingAnalysisError`.
- **P3 hardcoded creds**: `stage_boundaries_s3.py` had MinIO demo credentials as CLI defaults. Now reads from `S3_ACCESS_KEY`/`S3_SECRET_KEY` env vars with no defaults.

## Test plan

- [x] `test_release_manager.py` — 3 tests verifying token not in argv, token in env, testpypi flag
- [x] `test_boundary_diagnostics.py` — existing deprecation warning tests still pass (message checks function names, not version)
- [x] `geo.django.__version__` returns installed package version via `importlib.metadata`
- [x] All existing test suite passes