### PR TITLE
docs: add missing docstrings to geocoding.py; gitignore Finder artifacts (SU#575)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,6 +188,10 @@ notebook_conversion_results.json
 .DS_Store
 ._*
 
+# macOS Finder copy artifacts ("file 2.py", "file 3.py", etc.)
+*\ [0-9].py
+*\ [0-9].ipynb
+
 # Session progress files (temporary)
 SESSION_*_PROGRESS.md
 

--- a/siege_utilities/geo/geocoding.py
+++ b/siege_utilities/geo/geocoding.py
@@ -20,18 +20,22 @@ logger = logging.getLogger(__name__)
 
 
 def log_warning(message: str) -> None:
+    """Emit a WARNING-level log message."""
     logger.warning(message)
 
 
 def log_info(message: str) -> None:
+    """Emit an INFO-level log message."""
     logger.info(message)
 
 
 def log_debug(message: str) -> None:
+    """Emit a DEBUG-level log message."""
     logger.debug(message)
 
 
 def log_error(message: str) -> None:
+    """Emit an ERROR-level log message."""
     logger.error(message)
 
 # Country code mapping for Nominatim geocoding
@@ -1023,7 +1027,9 @@ class SpatiaLiteCache:
             self._conn = None
 
     def __enter__(self):
+        """Enter the runtime context (context-manager protocol)."""
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        """Exit the runtime context, closing the database connection."""
         self.close()


### PR DESCRIPTION
## Summary
- Added docstrings to the 5 remaining undocumented public symbols in `geocoding.py` (4 log wrappers + context manager methods). All three modules cited in #575 are now at 100% docstring coverage.
- Added `.gitignore` rules for macOS Finder copy artifacts (`* [0-9].py` / `* [0-9].ipynb`) that were cluttering local test runs (related to #573).

Closes #575