### PR TITLE
docs: document verb-prefix naming convention for public API (SU#576)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,6 +146,21 @@ pip install papermill
 papermill notebooks/01_Getting_Started.ipynb /tmp/nb01_output.ipynb --execution-timeout 300
 ```
 
+## Function Naming: Verb Conventions
+
+Public functions and methods use verb prefixes that signal I/O behavior:
+
+| Prefix | Meaning | I/O | Example |
+|--------|---------|-----|---------|
+| `get_` | Lookup / compute from in-memory data | None | `get_state_name(fips)` |
+| `load_` | Read from local disk / cache | File | `load_census_inventory(path)` |
+| `fetch_` | Retrieve via network, return structured result | Network | `fetch_geographic_boundaries(year)` |
+| `download_` | Download file(s) to disk | Network + File | `download_data(year, level)` |
+
+Other common prefixes (`validate_`, `normalize_`, `discover_`, `construct_`, `create_`, `refresh_`, `update_`) describe the operation rather than the I/O shape — use whichever reads most naturally.
+
+When adding or renaming a public function, pick the verb prefix that matches its I/O behavior. If an existing function uses the wrong prefix, deprecate the old name and add a correctly-named replacement rather than renaming in place.
+
 ## CI Pipeline
 
 Every push and PR triggers the full CI pipeline (`.github/workflows/ci.yml`):

--- a/siege_utilities/geo/spatial_data.py
+++ b/siege_utilities/geo/spatial_data.py
@@ -1,6 +1,16 @@
 """
 Modern spatial data sources for siege_utilities.
 Provides clean, type-safe access to Census, Government, and OpenStreetMap data.
+
+Verb convention (see CONTRIBUTING.md § "Function Naming: Verb Conventions"):
+  get_*       — in-memory lookup, no I/O
+  load_*      — read from local disk/cache
+  fetch_*     — network I/O, returns structured result
+  download_*  — file download to disk
+
+Legacy ``get_census_boundaries`` and ``get_geographic_boundaries`` violate
+this convention (they do network I/O). Both are deprecated in favour of
+``fetch_geographic_boundaries``; removal scheduled for v4.0.0.
 """
 
 import logging


### PR DESCRIPTION
## Summary
- Added "Function Naming: Verb Conventions" section to CONTRIBUTING.md defining `get_`/`load_`/`fetch_`/`download_` prefixes by I/O behavior
- Added matching docstring note to `spatial_data.py` acknowledging the two legacy violations (`get_census_boundaries`, `get_geographic_boundaries`) already deprecated in favour of `fetch_geographic_boundaries` for v4.0.0
- Audit confirmed the convention is already followed consistently across the library; this formalizes it

Closes #576