### PR TITLE
test: add core tests for files/operations.py and geocoding.py; raise threshold to 52% (SU#578)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -19,7 +19,7 @@ addopts =
     --cov=siege_utilities
     --cov-report=term-missing
     --cov-report=html:htmlcov
-    --cov-fail-under=45
+    --cov-fail-under=52
     -m "not integration"
 
 # Markers for test organization

--- a/tests/test_file_operations_core.py
+++ b/tests/test_file_operations_core.py
@@ -1,0 +1,222 @@
+"""Tests for siege_utilities.files.operations — core file I/O functions."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from siege_utilities.files.operations import (
+    copy_file,
+    count_lines,
+    delete_existing_file_and_replace_it_with_an_empty_file,
+    ensure_directory_exists,
+    file_exists,
+    get_file_size,
+    get_file_size_mb,
+    list_directory,
+    list_files_recursive,
+    move_file,
+    remove_tree,
+    safe_file_read,
+    safe_file_write,
+    safe_json_read,
+    safe_json_write,
+    touch_file,
+)
+
+
+class TestFileExists:
+    def test_existing_file(self, tmp_path):
+        f = tmp_path / "hello.txt"
+        f.write_text("hi")
+        assert file_exists(f) is True
+
+    def test_missing_file(self, tmp_path):
+        assert file_exists(tmp_path / "nope.txt") is False
+
+    def test_directory_returns_true(self, tmp_path):
+        assert file_exists(tmp_path) is True
+
+
+class TestTouchFile:
+    def test_creates_file(self, tmp_path):
+        target = tmp_path / "new.txt"
+        assert touch_file(target) is True
+        assert target.exists()
+
+    def test_creates_parents(self, tmp_path):
+        target = tmp_path / "a" / "b" / "c.txt"
+        assert touch_file(target, create_parents=True) is True
+        assert target.exists()
+
+    def test_existing_file_updated(self, tmp_path):
+        target = tmp_path / "old.txt"
+        target.write_text("content")
+        assert touch_file(target) is True
+
+
+class TestCountLines:
+    def test_counts_lines(self, tmp_path):
+        f = tmp_path / "lines.txt"
+        f.write_text("one\ntwo\nthree\n")
+        assert count_lines(f) == 3
+
+    def test_empty_file(self, tmp_path):
+        f = tmp_path / "empty.txt"
+        f.write_text("")
+        assert count_lines(f) == 0
+
+    def test_missing_file_returns_none(self, tmp_path):
+        assert count_lines(tmp_path / "missing.txt") is None
+
+
+class TestCopyFile:
+    def test_copies_content(self, tmp_path):
+        src = tmp_path / "src.txt"
+        src.write_text("data")
+        dst = tmp_path / "dst.txt"
+        assert copy_file(src, dst) is True
+        assert dst.read_text() == "data"
+
+    def test_no_overwrite_by_default(self, tmp_path):
+        src = tmp_path / "src.txt"
+        src.write_text("new")
+        dst = tmp_path / "dst.txt"
+        dst.write_text("old")
+        assert copy_file(src, dst, overwrite=False) is False
+        assert dst.read_text() == "old"
+
+    def test_overwrite_when_requested(self, tmp_path):
+        src = tmp_path / "src.txt"
+        src.write_text("new")
+        dst = tmp_path / "dst.txt"
+        dst.write_text("old")
+        assert copy_file(src, dst, overwrite=True) is True
+        assert dst.read_text() == "new"
+
+
+class TestMoveFile:
+    def test_moves_file(self, tmp_path):
+        src = tmp_path / "src.txt"
+        src.write_text("data")
+        dst = tmp_path / "dst.txt"
+        assert move_file(src, dst) is True
+        assert not src.exists()
+        assert dst.read_text() == "data"
+
+    def test_no_overwrite_by_default(self, tmp_path):
+        src = tmp_path / "src.txt"
+        src.write_text("new")
+        dst = tmp_path / "dst.txt"
+        dst.write_text("old")
+        assert move_file(src, dst, overwrite=False) is False
+        assert src.exists()
+
+
+class TestGetFileSize:
+    def test_returns_size(self, tmp_path):
+        f = tmp_path / "data.txt"
+        f.write_text("hello")
+        size = get_file_size(f)
+        assert size is not None
+        assert size == 5
+
+    def test_missing_file_returns_none(self, tmp_path):
+        assert get_file_size(tmp_path / "missing.txt") is None
+
+
+class TestGetFileSizeMb:
+    def test_returns_megabytes(self, tmp_path):
+        f = tmp_path / "data.bin"
+        f.write_bytes(b"\x00" * 1048576)
+        mb = get_file_size_mb(f)
+        assert abs(mb - 1.0) < 0.01
+
+
+class TestListDirectory:
+    def test_lists_files_and_dirs(self, tmp_path):
+        (tmp_path / "file.txt").touch()
+        (tmp_path / "subdir").mkdir()
+        result = list_directory(tmp_path)
+        assert result is not None
+        names = {p.name for p in result}
+        assert "file.txt" in names
+        assert "subdir" in names
+
+    def test_pattern_filter(self, tmp_path):
+        (tmp_path / "a.py").touch()
+        (tmp_path / "b.txt").touch()
+        result = list_directory(tmp_path, pattern="*.py")
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].name == "a.py"
+
+
+class TestListFilesRecursive:
+    def test_finds_nested_files(self, tmp_path):
+        (tmp_path / "a.py").touch()
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "b.py").touch()
+        result = list_files_recursive(tmp_path, pattern="*.py")
+        assert len(result) == 2
+
+
+class TestRemoveTree:
+    def test_removes_directory(self, tmp_path):
+        target = tmp_path / "to_delete"
+        target.mkdir()
+        (target / "file.txt").write_text("data")
+        assert remove_tree(target) is True
+        assert not target.exists()
+
+    def test_missing_path_returns_false(self, tmp_path):
+        assert remove_tree(tmp_path / "nope") is False
+
+
+class TestDeleteAndReplace:
+    def test_replaces_with_empty(self, tmp_path):
+        f = tmp_path / "data.txt"
+        f.write_text("content")
+        assert delete_existing_file_and_replace_it_with_an_empty_file(f) is True
+        assert f.exists()
+        assert f.read_text() == ""
+
+
+class TestEnsureDirectoryExists:
+    def test_creates_directory(self, tmp_path):
+        target = tmp_path / "new_dir"
+        result = ensure_directory_exists(target)
+        assert result == target
+        assert target.is_dir()
+
+    def test_existing_directory_ok(self, tmp_path):
+        result = ensure_directory_exists(tmp_path)
+        assert result == tmp_path
+
+
+class TestSafeFileReadWrite:
+    def test_roundtrip(self, tmp_path):
+        f = tmp_path / "safe.txt"
+        assert safe_file_write(f, "hello world") is True
+        assert safe_file_read(f) == "hello world"
+
+    def test_read_missing_returns_default(self, tmp_path):
+        assert safe_file_read(tmp_path / "nope.txt", default="fallback") == "fallback"
+
+    def test_write_creates_parents(self, tmp_path):
+        f = tmp_path / "a" / "b" / "file.txt"
+        assert safe_file_write(f, "nested") is True
+        assert f.read_text() == "nested"
+
+
+class TestSafeJsonReadWrite:
+    def test_roundtrip(self, tmp_path):
+        f = tmp_path / "data.json"
+        data = {"key": "value", "list": [1, 2, 3]}
+        assert safe_json_write(f, data) is True
+        result = safe_json_read(f)
+        assert result == data
+
+    def test_read_missing_returns_default(self, tmp_path):
+        assert safe_json_read(tmp_path / "nope.json", default={}) == {}

--- a/tests/test_geocoding_core.py
+++ b/tests/test_geocoding_core.py
@@ -1,0 +1,182 @@
+"""Tests for siege_utilities.geo.geocoding — pure computation and cache logic."""
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+geocoding = pytest.importorskip("siege_utilities.geo.geocoding")
+
+COUNTRY_CODES = geocoding.COUNTRY_CODES
+DEFAULT_COUNTRY_CODE = geocoding.DEFAULT_COUNTRY_CODE
+NominatimGeoClassifier = geocoding.NominatimGeoClassifier
+SpatiaLiteCache = geocoding.SpatiaLiteCache
+concatenate_addresses = geocoding.concatenate_addresses
+get_country_code = geocoding.get_country_code
+get_country_name = geocoding.get_country_name
+list_countries = geocoding.list_countries
+mark_valid_geocode_data_pandas = geocoding.mark_valid_geocode_data_pandas
+validate_geocode_data_pandas = geocoding.validate_geocode_data_pandas
+
+
+class TestCountryCodeLookup:
+    def test_get_country_name_valid(self):
+        assert get_country_name("us") == "United States"
+        assert get_country_name("gb") == "United Kingdom"
+
+    def test_get_country_name_case_insensitive(self):
+        assert get_country_name("US") == "United States"
+
+    def test_get_country_name_unknown(self):
+        result = get_country_name("zz")
+        assert result is None or result == "Unknown"
+
+    def test_get_country_code_valid(self):
+        assert get_country_code("United States") == "us"
+        assert get_country_code("United Kingdom") == "gb"
+
+    def test_get_country_code_unknown(self):
+        result = get_country_code("Narnia")
+        assert result is None
+
+    def test_list_countries(self):
+        result = list_countries()
+        assert isinstance(result, dict)
+        assert len(result) > 100
+        assert "us" in result
+
+    def test_default_country_code(self):
+        assert DEFAULT_COUNTRY_CODE == "us"
+
+    def test_country_codes_completeness(self):
+        assert "us" in COUNTRY_CODES
+        assert "gb" in COUNTRY_CODES
+        assert "au" in COUNTRY_CODES
+        assert "jp" in COUNTRY_CODES
+
+
+class TestConcatenateAddresses:
+    def test_full_address(self):
+        result = concatenate_addresses(
+            street="123 Main St",
+            city="Austin",
+            state_province_area="TX",
+            postal_code="78701",
+            country="US",
+        )
+        assert "123 Main St" in result
+        assert "Austin" in result
+        assert "TX" in result
+        assert "78701" in result
+
+    def test_partial_address(self):
+        result = concatenate_addresses(city="Austin", state_province_area="TX")
+        assert "Austin" in result
+        assert "TX" in result
+
+    def test_empty_address(self):
+        result = concatenate_addresses()
+        assert result is not None
+
+
+class TestNominatimGeoClassifier:
+    def test_default_instance(self):
+        clf = NominatimGeoClassifier()
+        assert clf is not None
+
+    def test_serialization_roundtrip(self):
+        clf = NominatimGeoClassifier()
+        json_str = clf.to_json()
+        assert json_str is not None
+        parsed = json.loads(json_str)
+        assert isinstance(parsed, dict)
+
+    def test_deserialization(self):
+        clf = NominatimGeoClassifier()
+        json_str = clf.to_json()
+        clf2 = NominatimGeoClassifier()
+        clf2.from_json(json_str)
+
+
+class TestSpatiaLiteCache:
+    def test_init_creates_db(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+        cache = SpatiaLiteCache(db_path=str(db_path))
+        assert db_path.exists()
+        cache.close()
+
+    def test_put_get_geocode(self, tmp_path):
+        cache = SpatiaLiteCache(db_path=str(tmp_path / "cache.db"))
+        cache.put_geocode("123 Main St", 30.2672, -97.7431)
+        result = cache.get_geocode("123 Main St")
+        assert result is not None
+        assert abs(result["latitude"] - 30.2672) < 0.001
+        assert abs(result["longitude"] - (-97.7431)) < 0.001
+        cache.close()
+
+    def test_get_missing_geocode(self, tmp_path):
+        cache = SpatiaLiteCache(db_path=str(tmp_path / "cache.db"))
+        result = cache.get_geocode("nonexistent address")
+        assert result is None
+        cache.close()
+
+    def test_stats(self, tmp_path):
+        cache = SpatiaLiteCache(db_path=str(tmp_path / "cache.db"))
+        cache.put_geocode("addr1", 30.0, -97.0)
+        cache.put_geocode("addr2", 31.0, -98.0)
+        stats = cache.stats()
+        assert isinstance(stats, dict)
+        assert stats.get("geocodes", 0) == 2
+        cache.close()
+
+    def test_clear(self, tmp_path):
+        cache = SpatiaLiteCache(db_path=str(tmp_path / "cache.db"))
+        cache.put_geocode("addr", 30.0, -97.0)
+        cache.clear()
+        assert cache.get_geocode("addr") is None
+        cache.close()
+
+    def test_context_manager(self, tmp_path):
+        with SpatiaLiteCache(db_path=str(tmp_path / "cache.db")) as cache:
+            cache.put_geocode("test", 30.0, -97.0)
+            assert cache.get_geocode("test") is not None
+
+    def test_boundary_cache(self, tmp_path):
+        cache = SpatiaLiteCache(db_path=str(tmp_path / "cache.db"))
+        cache.put_boundary("48453", 2020, point_wkt="POINT(-97.7 30.3)")
+        result = cache.get_boundary("48453", 2020)
+        assert result is not None
+        cache.close()
+
+    def test_crosswalk_cache(self, tmp_path):
+        cache = SpatiaLiteCache(db_path=str(tmp_path / "cache.db"))
+        cache.put_crosswalk("48453001100", "48453", weight=0.85)
+        result = cache.get_crosswalk("48453001100")
+        assert result is not None
+        assert len(result) > 0
+        cache.close()
+
+
+class TestValidateGeocodeData:
+    def test_filters_invalid_coords(self):
+        pd = pytest.importorskip("pandas")
+        df = pd.DataFrame({
+            "lat": [30.0, None, 200.0, 31.0],
+            "lon": [-97.0, -98.0, -97.0, None],
+        })
+        result = validate_geocode_data_pandas(df, "lat", "lon")
+        assert len(result) == 1
+        assert result.iloc[0]["lat"] == 30.0
+
+    def test_marks_validity(self):
+        pd = pytest.importorskip("pandas")
+        df = pd.DataFrame({
+            "lat": [30.0, None, 31.0],
+            "lon": [-97.0, -98.0, None],
+        })
+        result = mark_valid_geocode_data_pandas(df, "lat", "lon")
+        assert "is_valid" in result.columns
+        assert result.iloc[0]["is_valid"] is True
+        assert result.iloc[1]["is_valid"] is False


### PR DESCRIPTION
## Summary
- Added 30 tests for `files/operations.py` covering all public functions (file CRUD, copy/move, safe JSON read/write, directory listing)
- Added 20+ tests for `geocoding.py` covering country code lookups, address concatenation, SpatiaLiteCache CRUD, coordinate validation
- Raised `--cov-fail-under` from 45% to 52% as first increment toward 60%
- Per ticket falsification criterion, further increments (52→56→60) should follow in subsequent PRs

Partial progress on #578 — threshold raised to 52%, targeting 60% across follow-up PRs