### PR TITLE
docs: deprecation notice for top-level imports, prefer domain-scoped (SU#579)

### DIFF
--- a/siege_utilities/__init__.py
+++ b/siege_utilities/__init__.py
@@ -3,6 +3,20 @@ siege_utilities — lazy-loaded package for data engineering, analytics, and dis
 
 Only core logging, settings, and string utilities are loaded eagerly.
 All other modules are loaded on first access via PEP 562 __getattr__.
+
+.. deprecated:: 3.18
+   **Prefer domain-scoped imports** over the top-level namespace::
+
+       # Preferred (domain-scoped):
+       from siege_utilities.geo import fetch_geographic_boundaries
+       from siege_utilities.config import CredentialManager
+       from siege_utilities.reporting import create_bar_chart
+
+       # Deprecated (still works, but clutters autocomplete with 312 symbols):
+       from siege_utilities import fetch_geographic_boundaries
+
+   The top-level lazy imports will remain for backward compatibility
+   until at least v5.0.0, but new code should use subpackage imports.
 """
 
 import importlib


### PR DESCRIPTION
## Summary
- Added deprecation guidance to `siege_utilities/__init__.py` docstring steering users toward domain-scoped imports (`from siege_utilities.geo import ...`) over the 312-symbol top-level namespace
- Verified all 21 subpackages already define `__all__`
- Verified README already uses domain-scoped imports
- Audit: only 16 internal imports use `from siege_utilities import X` vs 1408 using subpackage paths — migration is effectively complete

Closes #579