### PR TITLE
fix: add logging to 3 silent error-swallowing sites (SU#588)

### DIFF
--- a/siege_utilities/config/clients.py
+++ b/siege_utilities/config/clients.py
@@ -342,6 +342,7 @@ def search_client_profiles(
                 profile = json.load(f)
             all_profiles.append(profile)
         except Exception:
+            logger.warning("Skipping unreadable client config: %s", config_file, exc_info=True)
             continue
     
     matching_profiles = []

--- a/siege_utilities/config/connections.py
+++ b/siege_utilities/config/connections.py
@@ -217,8 +217,9 @@ def find_connection_by_name(
                 return profile
                 
         except Exception:
+            logger.warning("Skipping unreadable connection config: %s", config_file, exc_info=True)
             continue
-    
+
     return None
 
 

--- a/siege_utilities/files/hashing.py
+++ b/siege_utilities/files/hashing.py
@@ -244,6 +244,7 @@ def verify_file_integrity(file_path, expected_hash, algorithm='sha256') ->bool:
         return current_hash is not None and current_hash.lower(
             ) == expected_hash.lower()
     except Exception:
+        log_error(f"Failed to verify hash for {file_path}: will return False")
         return False
 
 

--- a/siege_utilities/git/git_operations.py
+++ b/siege_utilities/git/git_operations.py
@@ -36,7 +36,7 @@ def create_feature_branch(
             run_git_command("pull", "origin", base_branch, repo_path=repo_path, check=False)
             log_info(f"Pulled latest changes from {base_branch}")
         except Exception:
-            pass  # Pull failed, continue anyway
+            log_warning(f"Could not pull latest from {base_branch} (continuing anyway)")
 
     # Create and switch to new branch
     run_git_command("checkout", "-b", branch_name, repo_path=repo_path)


### PR DESCRIPTION
Refs: #588, part of Epic #587

## Summary
- config/clients.py:344 — log warning with traceback when client config JSON is unreadable
- git/git_operations.py:38 — log warning when git pull fails during branch creation
- files/hashing.py:246 — log error when hash verification fails due to exception

All three sites previously ate exceptions silently (writing-code:7 violation).