### PR TITLE
fix: preserve tracebacks in analytics error logging (SU#589)

### DIFF
--- a/siege_utilities/analytics/facebook_business.py
+++ b/siege_utilities/analytics/facebook_business.py
@@ -10,10 +10,13 @@ This module provides comprehensive Facebook Business integration capabilities:
 """
 
 import json
+import logging
 import pathlib
 from datetime import datetime, timedelta
 from typing import Dict, Any, Optional, List, Union
 import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 try:
     import facebook_business
@@ -101,7 +104,7 @@ class FacebookBusinessConnector:
             return accounts
 
         except Exception as e:
-            log_error(f"Failed to retrieve ad accounts: {e}")
+            logger.error("Failed to retrieve ad accounts: %s", e, exc_info=True)
             return []
 
     def get_ad_insights(self, ad_account_id: str, start_date: str, end_date: str,
@@ -158,7 +161,7 @@ class FacebookBusinessConnector:
             return df
 
         except Exception as e:
-            log_error(f"Failed to retrieve ad insights: {e}")
+            logger.error("Failed to retrieve ad insights: %s", e, exc_info=True)
             return pd.DataFrame()
 
     def get_page_insights(self, page_id: str, start_date: str, end_date: str,
@@ -212,7 +215,7 @@ class FacebookBusinessConnector:
             return df
 
         except Exception as e:
-            log_error(f"Failed to retrieve page insights: {e}")
+            logger.error("Failed to retrieve page insights: %s", e, exc_info=True)
             return pd.DataFrame()
 
     def get_business_insights(self, business_id: str, start_date: str, end_date: str,
@@ -261,7 +264,7 @@ class FacebookBusinessConnector:
             return df
 
         except Exception as e:
-            log_error(f"Failed to retrieve business insights: {e}")
+            logger.error("Failed to retrieve business insights: %s", e, exc_info=True)
             return pd.DataFrame()
 
     def save_as_pandas(self, df: pd.DataFrame, output_path: str,
@@ -294,7 +297,7 @@ class FacebookBusinessConnector:
             return True
 
         except Exception as e:
-            log_error(f"Failed to save DataFrame: {e}")
+            logger.error("Failed to save DataFrame: %s", e, exc_info=True)
             return False
 
     def save_as_spark(self, df: pd.DataFrame, output_path: str,
@@ -330,7 +333,7 @@ class FacebookBusinessConnector:
             return True
 
         except Exception as e:
-            log_error(f"Failed to save as Spark DataFrame: {e}")
+            logger.error("Failed to save as Spark DataFrame: %s", e, exc_info=True)
             return False
 
 
@@ -420,7 +423,7 @@ def load_facebook_account_profile(account_id: str,
         return profile
 
     except Exception as e:
-        log_error(f"Failed to load Facebook account profile {account_id}: {e}")
+        logger.error("Failed to load Facebook account profile %s: %s", account_id, e, exc_info=True)
         return None
 
 
@@ -451,7 +454,7 @@ def list_facebook_accounts_for_client(client_id: str,
                 accounts.append(profile)
 
         except Exception as e:
-            log_error(f"Error reading Facebook account file {config_file}: {e}")
+            logger.error("Error reading Facebook account file %s: %s", config_file, e, exc_info=True)
 
     log_info(f"Found {len(accounts)} Facebook accounts for client: {client_id}")
     return accounts
@@ -550,13 +553,13 @@ def batch_retrieve_facebook_data(client_id: str, start_date: str, end_date: str,
             except Exception as e:
                 error_msg = f"Error processing account {account['fb_account_id']}: {e}"
                 results['errors'].append(error_msg)
-                log_error(error_msg)
+                logger.error("Error processing account %s", account['fb_account_id'], exc_info=True)
 
         log_info(f"Batch Facebook data retrieval completed: {results['accounts_processed']} accounts, {results['total_rows']} rows")
         return results
 
     except Exception as e:
-        log_error(f"Batch Facebook data retrieval failed: {e}")
+        logger.error("Batch Facebook data retrieval failed: %s", e, exc_info=True)
         return {
             'success': False,
             'error': str(e),

--- a/siege_utilities/analytics/google_analytics.py
+++ b/siege_utilities/analytics/google_analytics.py
@@ -10,11 +10,14 @@ This module provides comprehensive Google Analytics integration capabilities:
 """
 
 import json
+import logging
 import pathlib
 import re
 from datetime import datetime
 from typing import Dict, Any, Optional, List
 import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 # GA4 accepts these relative-date keywords in place of an absolute date.
 # Only the strict documented forms are accepted: ``today``, ``yesterday``,
@@ -157,7 +160,7 @@ class GoogleAnalyticsConnector:
             return True
 
         except Exception as e:
-            log_error(f"Google Analytics authentication failed: {e}")
+            logger.error("Google Analytics authentication failed: %s", e, exc_info=True)
             return False
 
     def _save_credentials(self, token_path: pathlib.Path):
@@ -208,7 +211,7 @@ class GoogleAnalyticsConnector:
                 Path(temp_file).unlink(missing_ok=True)
 
         except Exception as e:
-            log_error(f"Service account authentication failed: {e}")
+            logger.error("Service account authentication failed: %s", e, exc_info=True)
             return False
 
     @staticmethod
@@ -300,7 +303,7 @@ class GoogleAnalyticsConnector:
             return df
 
         except Exception as e:
-            log_error(f"Failed to retrieve GA4 data: {e}")
+            logger.error("Failed to retrieve GA4 data: %s", e, exc_info=True)
             return pd.DataFrame()
 
     def get_ua_data(self, view_id: str, start_date: str, end_date: str,
@@ -354,7 +357,7 @@ class GoogleAnalyticsConnector:
                 return pd.DataFrame()
 
         except Exception as e:
-            log_error(f"Failed to retrieve UA data: {e}")
+            logger.error("Failed to retrieve UA data: %s", e, exc_info=True)
             return pd.DataFrame()
 
     def save_as_pandas(self, df: pd.DataFrame, output_path: str,
@@ -387,7 +390,7 @@ class GoogleAnalyticsConnector:
             return True
 
         except Exception as e:
-            log_error(f"Failed to save DataFrame: {e}")
+            logger.error("Failed to save DataFrame: %s", e, exc_info=True)
             return False
 
     def save_as_spark(self, df: pd.DataFrame, output_path: str,
@@ -423,7 +426,7 @@ class GoogleAnalyticsConnector:
             return True
 
         except Exception as e:
-            log_error(f"Failed to save as Spark DataFrame: {e}")
+            logger.error("Failed to save as Spark DataFrame: %s", e, exc_info=True)
             return False
 
 
@@ -513,7 +516,7 @@ def load_ga_account_profile(account_id: str,
         return profile
 
     except Exception as e:
-        log_error(f"Failed to load GA account profile {account_id}: {e}")
+        logger.error("Failed to load GA account profile %s: %s", account_id, e, exc_info=True)
         return None
 
 
@@ -544,7 +547,7 @@ def list_ga_accounts_for_client(client_id: str,
                 accounts.append(profile)
 
         except Exception as e:
-            log_error(f"Error reading GA account file {config_file}: {e}")
+            logger.error("Error reading GA account file %s: %s", config_file, e, exc_info=True)
 
     log_info(f"Found {len(accounts)} GA accounts for client: {client_id}")
     return accounts
@@ -645,13 +648,13 @@ def batch_retrieve_ga_data(client_id: str, start_date: str, end_date: str,
             except Exception as e:
                 error_msg = f"Error processing account {account['ga_account_id']}: {e}"
                 results['errors'].append(error_msg)
-                log_error(error_msg)
+                logger.error("Error processing account %s", account['ga_account_id'], exc_info=True)
 
         log_info(f"Batch GA data retrieval completed: {results['accounts_processed']} accounts, {results['total_rows']} rows")
         return results
 
     except Exception as e:
-        log_error(f"Batch GA data retrieval failed: {e}")
+        logger.error("Batch GA data retrieval failed: %s", e, exc_info=True)
         return {
             'success': False,
             'error': str(e),
@@ -721,7 +724,7 @@ def create_ga_connector_from_1password(item_title: str = "Google Analytics Servi
             return None
 
     except ImportError as e:
-        log_error(f"Could not import 1Password function: {e}")
+        logger.error("Could not import 1Password function: %s", e, exc_info=True)
         return None
 
 


### PR DESCRIPTION
## Summary
- Replace `log_error(f"...: {e}")` with `logger.error("...", exc_info=True)` at all 21 except-block sites in `google_analytics.py` and `facebook_business.py`
- The `log_error` wrapper only accepts a message string, so stack traces were silently discarded
- Adds `import logging` and module-level `logger` to both files

## Test plan
- [ ] Verify no `log_error(f"` patterns remain in analytics except blocks
- [ ] Confirm both files pass `py_compile`
- [ ] Trigger an error path and verify traceback appears in log output

Closes #589