### PR TITLE
fix: guard pandas import and eliminate exception-as-dispatch (SU#590)

### DIFF
--- a/siege_utilities/reporting/hex_cartogram/algorithms.py
+++ b/siege_utilities/reporting/hex_cartogram/algorithms.py
@@ -34,6 +34,15 @@ from .coords import (
     bounding_grid,
 )
 
+try:
+    from scipy.optimize import linear_sum_assignment as _linear_sum_assignment
+    import numpy as _np
+    _SCIPY_AVAILABLE = True
+except ImportError:
+    _linear_sum_assignment = None  # type: ignore[assignment]
+    _np = None  # type: ignore[assignment]
+    _SCIPY_AVAILABLE = False
+
 if TYPE_CHECKING:  # pragma: no cover
     import geopandas as gpd
 
@@ -128,9 +137,9 @@ def place_polygons(
     if algorithm == Algorithm.HUNGARIAN:
         return _hungarian_place(codes, centroids, cells)
     # Annealing: start from Hungarian if scipy is available, else greedy.
-    try:
+    if _SCIPY_AVAILABLE:
         initial = _hungarian_place(codes, centroids, cells)
-    except ImportError:
+    else:
         initial = _greedy_place(codes, centroids, cells, gdf, code_col)
     return _anneal(
         codes, centroids, cells, gdf, code_col, initial,
@@ -191,26 +200,23 @@ def _hungarian_place(
     Uses ``scipy.optimize.linear_sum_assignment``. Raises ImportError if
     scipy isn't installed; callers should fall back to greedy.
     """
-    try:
-        from scipy.optimize import linear_sum_assignment
-        import numpy as np
-    except ImportError as exc:
+    if not _SCIPY_AVAILABLE:
         raise ImportError(
             "Hungarian assignment requires scipy + numpy. Install "
             "via 'pip install siege-utilities[analytics]' or fall back "
             "to algorithm='greedy'."
-        ) from exc
+        )
 
     n_polys = len(codes)
     n_cells = len(cells)
     # Cost matrix: rows are polygons, cols are cells.
     cell_centroids = [axial_to_cartesian(c) for c in cells]
-    cost = np.zeros((n_polys, n_cells), dtype=float)
+    cost = _np.zeros((n_polys, n_cells), dtype=float)
     for i, code in enumerate(codes):
         cx, cy = centroids[code]
         for j, (xx, yy) in enumerate(cell_centroids):
             cost[i, j] = math.hypot(cx - xx, cy - yy)
-    row_idx, col_idx = linear_sum_assignment(cost)
+    row_idx, col_idx = _linear_sum_assignment(cost)
     return {codes[r]: cells[c] for r, c in zip(row_idx, col_idx)}
 
 

--- a/siege_utilities/survey/significance.py
+++ b/siege_utilities/survey/significance.py
@@ -15,6 +15,13 @@ import numpy as np
 from siege_utilities.core.logging import log_error
 
 try:
+    import pandas as pd
+    _PANDAS_AVAILABLE = True
+except ImportError:
+    pd = None  # type: ignore[assignment]
+    _PANDAS_AVAILABLE = False
+
+try:
     from scipy.stats import norm as _scipy_norm
     _SCIPY_AVAILABLE = True
 except ImportError:
@@ -115,7 +122,11 @@ def chi_square_flag(chain: "Chain", alpha: float = 0.05) -> "Chain":
     Mutates *chain* in place and returns it.
     """
     from ..data.statistics.cross_tabulation import chi_square_test
-    import pandas as pd
+    if not _PANDAS_AVAILABLE:
+        raise ImportError(
+            "chi_square_flag requires pandas. "
+            "Install via: pip install pandas"
+        )
 
     # Build count-based (not pct-based) contingency table for valid chi-square
     records: dict = {}


### PR DESCRIPTION
## Summary
- `significance.py`: move pandas import to module level with availability flag; raise clear ImportError in `chi_square_flag` if missing
- `algorithms.py`: check `_SCIPY_AVAILABLE` flag instead of catching ImportError from `_hungarian_place` to decide greedy fallback

## Test plan
- [ ] Both files pass `py_compile`
- [ ] `chi_square_flag` raises ImportError with helpful message when pandas absent
- [ ] `place_polygons` with `algorithm=ANNEALING` falls back to greedy without exception when scipy absent

Closes #590