### PR TITLE
fix: warn or use silently-dropped parameters (SU#591)

### DIFF
--- a/siege_utilities/analytics/facebook_business.py
+++ b/siege_utilities/analytics/facebook_business.py
@@ -501,9 +501,24 @@ def batch_retrieve_facebook_data(client_id: str, start_date: str, end_date: str,
             'errors': []
         }
 
+        _VALID_DATA_TYPES = {'ad_account', 'page', 'business'}
+        if data_types is not None:
+            unknown = set(data_types) - _VALID_DATA_TYPES
+            if unknown:
+                import warnings
+                warnings.warn(
+                    f"batch_retrieve_facebook_data: unrecognized data_types "
+                    f"{sorted(unknown)}; valid values are {sorted(_VALID_DATA_TYPES)}",
+                    stacklevel=2,
+                )
+
         # Process each account
         for account in accounts:
             try:
+                # Skip accounts whose type doesn't match the requested data_types
+                if data_types is not None and account['account_type'] not in data_types:
+                    continue
+
                 # Load access token
                 if not account.get('access_token'):
                     results['errors'].append(f"No access token for account: {account['fb_account_id']}")

--- a/siege_utilities/engines/dataframe_engine.py
+++ b/siege_utilities/engines/dataframe_engine.py
@@ -365,6 +365,20 @@ class DataFrameEngine(ABC):
         rely on these parameters should test with the engine they intend
         to use.
         """
+        import warnings
+        if format != "auto":
+            warnings.warn(
+                f"load_polygons: format={format!r} is ignored by the default "
+                f"engine; read_spatial infers the format from the path. "
+                f"Use SparkEngine for explicit format control.",
+                stacklevel=2,
+            )
+        if geometry_col != "geometry":
+            warnings.warn(
+                f"load_polygons: geometry_col={geometry_col!r} is ignored by "
+                f"the default engine. Use SparkEngine for column renaming.",
+                stacklevel=2,
+            )
         return self.read_spatial(path, crs=crs)
 
     def load_points(
@@ -407,6 +421,20 @@ class DataFrameEngine(ABC):
         ignores ``format`` and ``geometry_col`` (same shape as the default
         ``load_polygons``); engines that override may honour them.
         """
+        import warnings
+        if format != "auto":
+            warnings.warn(
+                f"load_lines: format={format!r} is ignored by the default "
+                f"engine; read_spatial infers the format from the path. "
+                f"Use SparkEngine for explicit format control.",
+                stacklevel=2,
+            )
+        if geometry_col != "geometry":
+            warnings.warn(
+                f"load_lines: geometry_col={geometry_col!r} is ignored by "
+                f"the default engine. Use SparkEngine for column renaming.",
+                stacklevel=2,
+            )
         return self.read_spatial(path, crs=crs)
 
     # -- Spatial boundary operations (concrete defaults) -------------------

--- a/siege_utilities/geo/locale.py
+++ b/siege_utilities/geo/locale.py
@@ -511,7 +511,17 @@ class NCESLocaleClassifier:
         Raises:
             ImportError: If geopandas is not available.
         """
+        import warnings
         from .spatial_data import CensusDataSource
+
+        if cache_dir is not None:
+            warnings.warn(
+                "from_census_year: cache_dir is accepted for API "
+                "compatibility with from_nces_boundaries but is not yet "
+                "wired through to CensusDataSource. Downloaded data will "
+                "not be cached to the specified directory.",
+                stacklevel=2,
+            )
 
         census = CensusDataSource()
         log.info(f"Loading Census TIGER data for year {year}...")


### PR DESCRIPTION
## Summary
- `load_polygons`/`load_lines`: emit UserWarning when non-default `format` or `geometry_col` is passed to the base engine (which ignores them)
- `from_census_year`: warn when `cache_dir` is passed, since CensusDataSource does not support it yet
- `batch_retrieve_facebook_data`: actually filter accounts by `data_types` parameter instead of ignoring it

## Test plan
- [ ] All 3 files pass `py_compile`
- [ ] `load_polygons(path, format="geojson")` on default engine emits warning
- [ ] `from_census_year(cache_dir="/tmp")` emits warning
- [ ] `batch_retrieve_facebook_data(data_types=["ad_account"])` only processes ad accounts

Closes #591