### PR TITLE
fix: add v4.0.0 removal targets to all deprecation shims (SU#592)

### DIFF
--- a/siege_utilities/analytics/google_analytics.py
+++ b/siege_utilities/analytics/google_analytics.py
@@ -692,7 +692,7 @@ def create_ga_connector_from_1password(item_title: str = "Google Analytics Servi
             data = get_google_service_account_from_1password(item_title)
             connector = create_ga_connector_with_service_account(data)
 
-        This function will be removed in a future minor release. See
+        This function will be removed in v4.0.0. See
         `docs/INTENT.md` (D1) and ELE-2442 for the rationale.
 
     Args:
@@ -703,8 +703,8 @@ def create_ga_connector_from_1password(item_title: str = "Google Analytics Servi
     """
     import warnings
     warnings.warn(
-        "create_ga_connector_from_1password is deprecated; use "
-        "get_google_service_account_from_1password() + "
+        "create_ga_connector_from_1password is deprecated and will be "
+        "removed in v4.0.0; use get_google_service_account_from_1password() + "
         "create_ga_connector_with_service_account() explicitly. "
         "See docs/INTENT.md D1.",
         DeprecationWarning,

--- a/siege_utilities/config/enhanced_config.py
+++ b/siege_utilities/config/enhanced_config.py
@@ -408,7 +408,7 @@ def load_user_profile(username: str, config_dir: Optional[Path] = None) -> Optio
         UserProfile object or None if not found
     """
     warnings.warn(
-        "load_user_profile() is deprecated. Use HydraConfigManager.load_user() for the modern User model.",
+        "load_user_profile() is deprecated and will be removed in v4.0.0. Use HydraConfigManager.load_user() for the modern User model.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -468,7 +468,7 @@ def save_user_profile(profile: UserProfile, username: str, config_dir: Optional[
         True if successful, False otherwise
     """
     warnings.warn(
-        "save_user_profile() is deprecated. Use HydraConfigManager.save_user() for the modern User model.",
+        "save_user_profile() is deprecated and will be removed in v4.0.0. Use HydraConfigManager.save_user() for the modern User model.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -527,7 +527,7 @@ def load_client_profile(client_code: str, config_dir: Optional[Path] = None) -> 
         ClientProfile object or None if not found
     """
     warnings.warn(
-        "load_client_profile() is deprecated. Use HydraConfigManager.load_client() for the modern Client model.",
+        "load_client_profile() is deprecated and will be removed in v4.0.0. Use HydraConfigManager.load_client() for the modern Client model.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -570,7 +570,7 @@ def save_client_profile(profile: ClientProfile, config_dir: Optional[Path] = Non
         True if successful, False otherwise
     """
     warnings.warn(
-        "save_client_profile() is deprecated. Use HydraConfigManager.save_client() for the modern Client model.",
+        "save_client_profile() is deprecated and will be removed in v4.0.0. Use HydraConfigManager.save_client() for the modern Client model.",
         DeprecationWarning,
         stacklevel=2,
     )

--- a/siege_utilities/config/user_config.py
+++ b/siege_utilities/config/user_config.py
@@ -55,7 +55,7 @@ class UserProfile:
 
     def __post_init__(self):
         warnings.warn(
-            "UserProfile (dataclass) is deprecated. Use User from siege_utilities.config.models.actor_types instead.",
+            "UserProfile (dataclass) is deprecated and will be removed in v4.0.0. Use User from siege_utilities.config.models.actor_types instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/siege_utilities/data/cross_tabulation.py
+++ b/siege_utilities/data/cross_tabulation.py
@@ -1,13 +1,14 @@
 """Deprecation shim — re-exports from :mod:`siege_utilities.data.statistics.cross_tabulation`.
 
 Moved during ELE-2437 (statistics primitives grouped under ``data/statistics/``).
-Remove in the next minor release.
+Will be removed in v4.0.0.
 """
 import warnings as _warnings
 
 _warnings.warn(
     "siege_utilities.data.cross_tabulation has moved to "
-    "siege_utilities.data.statistics.cross_tabulation. Update your imports.",
+    "siege_utilities.data.statistics.cross_tabulation. Update your imports; "
+    "this shim will be removed in v4.0.0.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/siege_utilities/data/moe_propagation.py
+++ b/siege_utilities/data/moe_propagation.py
@@ -1,12 +1,13 @@
 """Deprecation shim — re-exports from :mod:`siege_utilities.data.statistics.moe_propagation`.
 
-Moved during ELE-2437. Remove in the next minor release.
+Moved during ELE-2437. Will be removed in v4.0.0.
 """
 import warnings as _warnings
 
 _warnings.warn(
     "siege_utilities.data.moe_propagation has moved to "
-    "siege_utilities.data.statistics.moe_propagation. Update your imports.",
+    "siege_utilities.data.statistics.moe_propagation. Update your imports; "
+    "this shim will be removed in v4.0.0.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/siege_utilities/data/naics_soc_crosswalk.py
+++ b/siege_utilities/data/naics_soc_crosswalk.py
@@ -1,13 +1,14 @@
 """Deprecation shim — re-exports from :mod:`siege_utilities.reference.naics_soc_crosswalk`.
 
 Moved during ELE-2437 (reference data grouped under ``reference/``).
-Remove in the next minor release.
+Will be removed in v4.0.0.
 """
 import warnings as _warnings
 
 _warnings.warn(
     "siege_utilities.data.naics_soc_crosswalk has moved to "
-    "siege_utilities.reference.naics_soc_crosswalk. Update your imports.",
+    "siege_utilities.reference.naics_soc_crosswalk. Update your imports; "
+    "this shim will be removed in v4.0.0.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/siege_utilities/data/redistricting_data_hub.py
+++ b/siege_utilities/data/redistricting_data_hub.py
@@ -1,14 +1,15 @@
 """Deprecation shim — re-exports from :mod:`siege_utilities.geo.providers.redistricting_data_hub`.
 
 RDH is an external spatial data source; moved to ``geo/providers/`` under
-ELE-2438 (D3) so all spatial sources live in one place. Remove in the
-next minor release.
+ELE-2438 (D3) so all spatial sources live in one place. Will be removed
+in v4.0.0.
 """
 import warnings as _warnings
 
 _warnings.warn(
     "siege_utilities.data.redistricting_data_hub has moved to "
-    "siege_utilities.geo.providers.redistricting_data_hub. Update your imports.",
+    "siege_utilities.geo.providers.redistricting_data_hub. Update your imports; "
+    "this shim will be removed in v4.0.0.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/siege_utilities/data/sample_data.py
+++ b/siege_utilities/data/sample_data.py
@@ -1,12 +1,13 @@
 """Deprecation shim — re-exports from :mod:`siege_utilities.reference.sample_data`.
 
-Moved during ELE-2437. Remove in the next minor release.
+Moved during ELE-2437. Will be removed in v4.0.0.
 """
 import warnings as _warnings
 
 _warnings.warn(
     "siege_utilities.data.sample_data has moved to "
-    "siege_utilities.reference.sample_data. Update your imports.",
+    "siege_utilities.reference.sample_data. Update your imports; "
+    "this shim will be removed in v4.0.0.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/siege_utilities/databricks/unity_catalog.py
+++ b/siege_utilities/databricks/unity_catalog.py
@@ -23,7 +23,8 @@ warnings.warn(
     "siege_utilities.databricks.unity_catalog is deprecated; "
     "import from siege_utilities.databricks.lakehouse_federation instead. "
     "The generated SQL is Databricks Lakehouse Federation only and does "
-    "not work against OSS unitycatalog.io. (SU#519)",
+    "not work against OSS unitycatalog.io. (SU#519) "
+    "This shim will be removed in v4.0.0.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/siege_utilities/geo/boundary_providers.py
+++ b/siege_utilities/geo/boundary_providers.py
@@ -1,13 +1,14 @@
 """Deprecation shim — re-exports from :mod:`siege_utilities.geo.providers.boundary_providers`.
 
 Moved during ELE-2438 (spatial providers consolidated under
-``geo/providers/``). Remove in the next minor release.
+``geo/providers/``). Will be removed in v4.0.0.
 """
 import warnings as _warnings
 
 _warnings.warn(
     "siege_utilities.geo.boundary_providers has moved to "
-    "siege_utilities.geo.providers.boundary_providers. Update your imports.",
+    "siege_utilities.geo.providers.boundary_providers. Update your imports; "
+    "this shim will be removed in v4.0.0.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/siege_utilities/geo/census_geocoder.py
+++ b/siege_utilities/geo/census_geocoder.py
@@ -1,12 +1,13 @@
 """Deprecation shim — re-exports from :mod:`siege_utilities.geo.providers.census_geocoder`.
 
-Moved during ELE-2438. Remove in the next minor release.
+Moved during ELE-2438. Will be removed in v4.0.0.
 """
 import warnings as _warnings
 
 _warnings.warn(
     "siege_utilities.geo.census_geocoder has moved to "
-    "siege_utilities.geo.providers.census_geocoder. Update your imports.",
+    "siege_utilities.geo.providers.census_geocoder. Update your imports; "
+    "this shim will be removed in v4.0.0.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/siege_utilities/geo/django/models/base.py
+++ b/siege_utilities/geo/django/models/base.py
@@ -287,7 +287,7 @@ class TemporalPointFeature(TemporalGeographicFeature):
 
 def _census_boundary_warning():
     warnings.warn(
-        "CensusBoundary is deprecated. Use CensusTIGERBoundary instead.",
+        "CensusBoundary is deprecated and will be removed in v4.0.0. Use CensusTIGERBoundary instead.",
         DeprecationWarning,
         stacklevel=2,
     )

--- a/siege_utilities/geo/nces_download.py
+++ b/siege_utilities/geo/nces_download.py
@@ -1,12 +1,13 @@
 """Deprecation shim — re-exports from :mod:`siege_utilities.geo.providers.nces_download`.
 
-Moved during ELE-2438. Remove in the next minor release.
+Moved during ELE-2438. Will be removed in v4.0.0.
 """
 import warnings as _warnings
 
 _warnings.warn(
     "siege_utilities.geo.nces_download has moved to "
-    "siege_utilities.geo.providers.nces_download. Update your imports.",
+    "siege_utilities.geo.providers.nces_download. Update your imports; "
+    "this shim will be removed in v4.0.0.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/siege_utilities/geo/spatial_data.py
+++ b/siege_utilities/geo/spatial_data.py
@@ -1225,7 +1225,8 @@ class CensusDataSource(SpatialDataSource):
             GeoDataFrame with boundaries or None if failed
         """
         _warnings_mod.warn(
-            "get_geographic_boundaries() returns None on failure with no diagnostics. "
+            "get_geographic_boundaries() returns None on failure with no diagnostics "
+            "and will be removed in v4.0.0. "
             "Use fetch_geographic_boundaries() for structured error reporting.",
             DeprecationWarning,
             stacklevel=2,

--- a/siege_utilities/reporting/analytics/analytics_reports.py
+++ b/siege_utilities/reporting/analytics/analytics_reports.py
@@ -1,15 +1,15 @@
 """Deprecation shim — re-exports from :mod:`siege_utilities.reporting.analytics_reports`.
 
 Moved up one level during ELE-2439 so the ``reporting/analytics/`` subdirectory
-can be removed once ``PollingAnalyzer`` is deleted in the next minor release.
+can be removed once ``PollingAnalyzer`` is deleted in v4.0.0.
 See ``docs/adr/0006-polling-analyzer-location.md``.
 """
 import warnings as _warnings
 
 _warnings.warn(
     "siege_utilities.reporting.analytics.analytics_reports has moved to "
-    "siege_utilities.reporting.analytics_reports. Update your imports; the "
-    "old path will be removed in the next minor release.",
+    "siege_utilities.reporting.analytics_reports. Update your imports; "
+    "this shim will be removed in v4.0.0.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/siege_utilities/reporting/analytics/polling_analyzer.py
+++ b/siege_utilities/reporting/analytics/polling_analyzer.py
@@ -74,7 +74,7 @@ class PollingAnalyzer:
           (coming in ELE-2440)
 
         See ``docs/adr/0006-polling-analyzer-location.md`` for the rationale.
-        This class will be removed in the next minor release.
+        This class will be removed in the v4.0.0.
     """
 
     def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- Every deprecation warning and shim docstring now states "will be removed in v4.0.0" instead of vague "next minor release"
- Covers 10 module-level re-export shims, 4 function-level deprecations in `enhanced_config.py`, and individual deprecations in `google_analytics.py`, `user_config.py`, `django/models/base.py`, and `spatial_data.py`
- 15 files changed, all compile clean

## Test plan
- [ ] `grep -r "next minor release" siege_utilities/` returns zero hits in deprecation warnings
- [ ] All 15 files pass `py_compile`

Closes #592