### PR TITLE
feat(geo): Census catalog populator (SU#602)

### DIFF
--- a/.review/su602-census-catalog-population.md
+++ b/.review/su602-census-catalog-population.md
@@ -1,0 +1,33 @@
+# Self-Review: SU#602 — Census Catalog Population
+
+**Domain:** software engineering
+**Geospatial cross-cut:** no (pure HTTP + data marshalling)
+**Trivial-against-state:** no — new I/O layer integrating with Census API discovery endpoints
+
+## Assumptions
+
+1. Census discovery endpoints (`variables.json`, `groups.json`) return stable JSON schemas.
+2. `requests.get` is appropriate here instead of `CensusAPI._make_request_with_retry` because the latter returns DataFrame, not raw JSON.
+3. MOE variables (suffix `M`) should be excluded from table variable lists — users fetch them separately.
+4. Subject grouping uses the `--` delimiter in Census group descriptions (e.g., "Income--HOUSEHOLD INCOME...").
+5. `_DATASET_PATHS` covers the primary datasets; unknown datasets fall through to raw path.
+
+## Peer Review (Junior)
+
+- Implementation is clean: populator fetches, parses, and assembles catalog objects.
+- Test coverage: 12 tests covering `_subject_key`, `_build_tables`, `_build_subjects`, and full integration with mocked HTTP.
+- Separation of concerns preserved: `catalog.py` stays I/O-free, `catalog_populator.py` handles all HTTP.
+- Variable code regex reused from catalog module pattern.
+
+## Lead Review (Adversarial)
+
+- **Q: Why `requests.get` directly instead of a shared session?** A: This is a metadata-fetch utility, not a long-lived client. Session reuse would add complexity for 2 HTTP calls. If we need connection pooling later, `populate()` can accept an optional `requests.Session`.
+- **Q: What about rate limiting?** A: Census discovery endpoints are not rate-limited the same way data endpoints are. If this changes, we add retry logic then — YAGNI now.
+- **Q: `_build_tables` parses `table_id` from the variable code by splitting on `_` — is that robust?** A: Yes, all Census variable codes follow `TABLE_SEQTYPE` format. The regex guard `_VARIABLE_CODE_RE` rejects anything that doesn't match before we reach the split.
+- **Q: Thread safety?** A: `CensusCatalogPopulator` is stateless between calls — safe to share across threads.
+
+## Quantified Claims
+
+- 12 tests, all passing
+- 0 new dependencies (uses `requests` already in the project)
+- ~200 lines of implementation, ~230 lines of tests

--- a/siege_utilities/geo/census/__init__.py
+++ b/siege_utilities/geo/census/__init__.py
@@ -7,11 +7,13 @@ Each module handles one concern:
 - **dataset_selector** — pure-logic dataset/geography validation and URL building
 - **api** — HTTP transport, caching, rate limiting, response processing
 - **catalog** — hierarchical table metadata (Dataset → Subject → Family → Table → Variable)
+- **catalog_populator** — fetches metadata from Census API to populate the catalog
 """
 
 from .variable_registry import VariableRegistry
 from .dataset_selector import DatasetSelector
 from .api import CensusAPI
+from .catalog_populator import CensusCatalogPopulator
 from .catalog import (
     CensusCatalog,
     CensusCatalogDataset,
@@ -26,6 +28,7 @@ from . import tiger_state
 __all__ = [
     "CensusAPI",
     "CensusCatalog",
+    "CensusCatalogPopulator",
     "CensusCatalogDataset",
     "CensusFamily",
     "CensusSubject",

--- a/siege_utilities/geo/census/catalog_populator.py
+++ b/siege_utilities/geo/census/catalog_populator.py
@@ -1,0 +1,197 @@
+"""
+Census catalog populator — fetches metadata from Census API discovery endpoints.
+
+Populates CensusCatalog instances from:
+- ``/data/{year}/{dataset}/variables.json`` — variable definitions
+- ``/data/{year}/{dataset}/groups.json`` — concept groupings
+
+Separated from ``catalog.py`` to keep the data model I/O-free.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Optional
+
+import requests
+
+from siege_utilities.config import CENSUS_API_BASE_URL
+from .catalog import (
+    CensusCatalog,
+    CensusCatalogDataset,
+    CensusSubject,
+    CensusTable,
+    CensusVariable,
+    parse_table_id,
+)
+
+log = logging.getLogger(__name__)
+
+_DATASET_PATHS = {
+    "acs5": "acs/acs5",
+    "acs1": "acs/acs1",
+    "dec/pl": "dec/pl",
+    "dec/dhc": "dec/dhc",
+    "dec/dp": "dec/dp",
+    "dec/sf1": "dec/sf1",
+}
+
+_VARIABLE_CODE_RE = re.compile(
+    r"^[A-Z]{1,3}\d{5}[A-Z]?_\d{3}[EM]?$"
+)
+
+
+class CensusCatalogPopulator:
+    def __init__(
+        self,
+        base_url: str = CENSUS_API_BASE_URL,
+        timeout: int = 30,
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+
+    def populate(
+        self,
+        dataset: str,
+        year: int,
+        survey_type: str = "",
+    ) -> CensusCatalog:
+        dataset_path = _DATASET_PATHS.get(dataset, dataset)
+        raw_variables = self._fetch_variables(dataset_path, year)
+        raw_groups = self._fetch_groups(dataset_path, year)
+
+        tables = self._build_tables(raw_variables)
+        subjects = self._build_subjects(raw_groups, tables)
+
+        catalog = CensusCatalog()
+        catalog.add_tables(tables)
+        catalog.build_families()
+
+        for subject in subjects:
+            catalog.add_subject(subject)
+
+        ds = CensusCatalogDataset(
+            dataset_id=f"{dataset}_{year}",
+            survey_type=survey_type or dataset,
+            year=year,
+            subjects=subjects,
+            tables={t.table_id: t for t in tables},
+        )
+        catalog.add_dataset(ds)
+
+        log.info(
+            "Populated catalog for %s/%d: %d tables, %d families, %d subjects",
+            dataset,
+            year,
+            len(catalog.tables),
+            len(catalog.families),
+            len(catalog.subjects),
+        )
+        return catalog
+
+    def _fetch_variables(self, dataset_path: str, year: int) -> dict:
+        url = f"{self.base_url}/data/{year}/{dataset_path}/variables.json"
+        log.debug("Fetching variables from %s", url)
+        resp = requests.get(url, timeout=self.timeout)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("variables", {})
+
+    def _fetch_groups(self, dataset_path: str, year: int) -> list[dict]:
+        url = f"{self.base_url}/data/{year}/{dataset_path}/groups.json"
+        log.debug("Fetching groups from %s", url)
+        resp = requests.get(url, timeout=self.timeout)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("groups", [])
+
+    def _build_tables(self, raw_variables: dict) -> list[CensusTable]:
+        table_vars: dict[str, list[CensusVariable]] = {}
+        table_meta: dict[str, dict] = {}
+
+        for code, meta in raw_variables.items():
+            if not _VARIABLE_CODE_RE.match(code):
+                continue
+
+            parsed = parse_table_id(code.rsplit("_", 1)[0])
+            if parsed is None:
+                continue
+
+            table_id = code.rsplit("_", 1)[0]
+            label = meta.get("label", "")
+            concept = meta.get("concept", "")
+
+            var = CensusVariable(
+                code=code,
+                label=label,
+                concept=concept,
+                table_id=table_id,
+                stat_type="M" if code.endswith("M") else "E",
+            )
+
+            table_vars.setdefault(table_id, []).append(var)
+            if table_id not in table_meta:
+                table_meta[table_id] = {
+                    "concept": concept,
+                    "group": meta.get("group", ""),
+                }
+
+        tables = []
+        for table_id, variables in sorted(table_vars.items()):
+            meta = table_meta.get(table_id, {})
+            estimate_vars = [v for v in variables if v.stat_type == "E"]
+            tables.append(
+                CensusTable(
+                    table_id=table_id,
+                    label=meta.get("concept", ""),
+                    concept=meta.get("concept", ""),
+                    variables=sorted(estimate_vars, key=lambda v: v.code),
+                )
+            )
+
+        return tables
+
+    def _build_subjects(
+        self,
+        raw_groups: list[dict],
+        tables: list[CensusTable],
+    ) -> list[CensusSubject]:
+        table_lookup = {t.table_id: t for t in tables}
+
+        group_to_tables: dict[str, list[CensusTable]] = {}
+        for group_info in raw_groups:
+            group_name = group_info.get("name", "")
+            if not group_name or group_name == "N/A":
+                continue
+
+            table = table_lookup.get(group_name)
+            if table is None:
+                continue
+
+            description = group_info.get("description", "")
+            concept_key = _subject_key(description)
+            group_to_tables.setdefault(concept_key, []).append(table)
+
+        subjects = []
+        for concept_key, group_tables in sorted(group_to_tables.items()):
+            if not concept_key:
+                continue
+            subjects.append(
+                CensusSubject(
+                    subject_id=concept_key.lower().replace(" ", "_"),
+                    label=concept_key,
+                    tables=sorted(group_tables, key=lambda t: t.table_id),
+                )
+            )
+
+        return subjects
+
+
+def _subject_key(description: str) -> str:
+    if not description:
+        return ""
+    parts = description.upper().split("--")
+    if len(parts) >= 2:
+        return parts[0].strip().title()
+    return description.strip().title()

--- a/tests/test_census_catalog_populator.py
+++ b/tests/test_census_catalog_populator.py
@@ -1,0 +1,230 @@
+"""Tests for siege_utilities.geo.census.catalog_populator."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from siege_utilities.geo.census.catalog_populator import (
+    CensusCatalogPopulator,
+    _subject_key,
+)
+from siege_utilities.geo.census.catalog import FamilyType
+
+
+BASE_URL = "https://api.census.gov"
+
+
+@pytest.fixture()
+def mock_variables():
+    return {
+        "variables": {
+            "NAME": {"label": "Geographic Area Name", "concept": "NAME"},
+            "GEO_ID": {"label": "Geography", "concept": "GEO_ID"},
+            "B19001_001E": {
+                "label": "Estimate!!Total:",
+                "concept": "HOUSEHOLD INCOME IN THE PAST 12 MONTHS",
+                "group": "B19001",
+            },
+            "B19001_002E": {
+                "label": "Estimate!!Total:!!Less than $10,000",
+                "concept": "HOUSEHOLD INCOME IN THE PAST 12 MONTHS",
+                "group": "B19001",
+            },
+            "B19001_001M": {
+                "label": "Margin of Error!!Total:",
+                "concept": "HOUSEHOLD INCOME IN THE PAST 12 MONTHS",
+                "group": "B19001",
+            },
+            "B19001A_001E": {
+                "label": "Estimate!!Total:",
+                "concept": "HOUSEHOLD INCOME IN THE PAST 12 MONTHS (WHITE ALONE HOUSEHOLDER)",
+                "group": "B19001A",
+            },
+            "B19001A_002E": {
+                "label": "Estimate!!Total:!!Less than $10,000",
+                "concept": "HOUSEHOLD INCOME IN THE PAST 12 MONTHS (WHITE ALONE HOUSEHOLDER)",
+                "group": "B19001A",
+            },
+            "B19001B_001E": {
+                "label": "Estimate!!Total:",
+                "concept": "HOUSEHOLD INCOME IN THE PAST 12 MONTHS (BLACK OR AFRICAN AMERICAN ALONE HOUSEHOLDER)",
+                "group": "B19001B",
+            },
+            "B19013_001E": {
+                "label": "Estimate!!Median household income in the past 12 months",
+                "concept": "MEDIAN HOUSEHOLD INCOME IN THE PAST 12 MONTHS",
+                "group": "B19013",
+            },
+            "B01001_001E": {
+                "label": "Estimate!!Total:",
+                "concept": "SEX BY AGE",
+                "group": "B01001",
+            },
+            "B01001_002E": {
+                "label": "Estimate!!Total:!!Male",
+                "concept": "SEX BY AGE",
+                "group": "B01001",
+            },
+        }
+    }
+
+
+@pytest.fixture()
+def mock_groups():
+    return {
+        "groups": [
+            {
+                "name": "B19001",
+                "description": "Income--HOUSEHOLD INCOME IN THE PAST 12 MONTHS (IN 2022 INFLATION-ADJUSTED DOLLARS)",
+            },
+            {
+                "name": "B19001A",
+                "description": "Income--HOUSEHOLD INCOME IN THE PAST 12 MONTHS (WHITE ALONE HOUSEHOLDER)",
+            },
+            {
+                "name": "B19001B",
+                "description": "Income--HOUSEHOLD INCOME IN THE PAST 12 MONTHS (BLACK ALONE HOUSEHOLDER)",
+            },
+            {
+                "name": "B19013",
+                "description": "Income--MEDIAN HOUSEHOLD INCOME IN THE PAST 12 MONTHS",
+            },
+            {
+                "name": "B01001",
+                "description": "Age-Sex--SEX BY AGE",
+            },
+        ]
+    }
+
+
+def _mock_response(json_data, status_code=200):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    resp.raise_for_status.return_value = None
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = Exception(f"HTTP {status_code}")
+    return resp
+
+
+class TestSubjectKey:
+    def test_splits_on_dash_dash(self):
+        assert _subject_key("Income--HOUSEHOLD INCOME") == "Income"
+
+    def test_no_dash_returns_full(self):
+        assert _subject_key("HOUSEHOLD INCOME") == "Household Income"
+
+    def test_empty_string(self):
+        assert _subject_key("") == ""
+
+
+class TestPopulatorBuildTables:
+    def test_builds_correct_tables(self, mock_variables):
+        pop = CensusCatalogPopulator(base_url=BASE_URL)
+        tables = pop._build_tables(mock_variables["variables"])
+        table_ids = {t.table_id for t in tables}
+
+        assert "B19001" in table_ids
+        assert "B19001A" in table_ids
+        assert "B19001B" in table_ids
+        assert "B19013" in table_ids
+        assert "B01001" in table_ids
+        assert "NAME" not in table_ids
+        assert "GEO_ID" not in table_ids
+
+    def test_excludes_moe_from_variables(self, mock_variables):
+        pop = CensusCatalogPopulator(base_url=BASE_URL)
+        tables = pop._build_tables(mock_variables["variables"])
+        b19001 = next(t for t in tables if t.table_id == "B19001")
+        codes = [v.code for v in b19001.variables]
+        assert "B19001_001E" in codes
+        assert "B19001_001M" not in codes
+
+    def test_table_has_concept(self, mock_variables):
+        pop = CensusCatalogPopulator(base_url=BASE_URL)
+        tables = pop._build_tables(mock_variables["variables"])
+        b19001 = next(t for t in tables if t.table_id == "B19001")
+        assert "HOUSEHOLD INCOME" in b19001.concept
+
+
+class TestPopulatorBuildSubjects:
+    def test_builds_subjects_from_groups(self, mock_variables, mock_groups):
+        pop = CensusCatalogPopulator(base_url=BASE_URL)
+        tables = pop._build_tables(mock_variables["variables"])
+        subjects = pop._build_subjects(mock_groups["groups"], tables)
+
+        subject_ids = {s.subject_id for s in subjects}
+        assert "income" in subject_ids
+        assert "age-sex" in subject_ids
+
+    def test_income_subject_has_tables(self, mock_variables, mock_groups):
+        pop = CensusCatalogPopulator(base_url=BASE_URL)
+        tables = pop._build_tables(mock_variables["variables"])
+        subjects = pop._build_subjects(mock_groups["groups"], tables)
+
+        income = next(s for s in subjects if s.subject_id == "income")
+        table_ids = {t.table_id for t in income.tables}
+        assert "B19001" in table_ids
+        assert "B19013" in table_ids
+
+
+class TestPopulatorIntegration:
+    @patch("siege_utilities.geo.census.catalog_populator.requests.get")
+    def test_populate_builds_full_catalog(self, mock_get, mock_variables, mock_groups):
+        mock_get.side_effect = [
+            _mock_response(mock_variables),
+            _mock_response(mock_groups),
+        ]
+
+        pop = CensusCatalogPopulator(base_url=BASE_URL)
+        catalog = pop.populate("acs5", 2022, survey_type="acs_5yr")
+
+        assert len(catalog.tables) >= 5
+        assert len(catalog.families) >= 1
+        assert len(catalog.subjects) >= 2
+        assert catalog.get_dataset("acs5_2022") is not None
+        assert catalog.get_dataset("acs5_2022").year == 2022
+
+    @patch("siege_utilities.geo.census.catalog_populator.requests.get")
+    def test_populate_detects_race_families(self, mock_get, mock_variables, mock_groups):
+        mock_get.side_effect = [
+            _mock_response(mock_variables),
+            _mock_response(mock_groups),
+        ]
+
+        pop = CensusCatalogPopulator(base_url=BASE_URL)
+        catalog = pop.populate("acs5", 2022)
+
+        race_families = [
+            f for f in catalog.families.values()
+            if f.family_type == FamilyType.RACE_ITERATION
+        ]
+        assert len(race_families) >= 1
+        income_race = next(
+            (f for f in race_families if f.root_table_id == "B19001"), None
+        )
+        assert income_race is not None
+        assert "B19001A" in income_race.table_ids
+
+    @patch("siege_utilities.geo.census.catalog_populator.requests.get")
+    def test_populate_handles_api_error(self, mock_get):
+        mock_get.return_value = _mock_response({}, status_code=404)
+
+        pop = CensusCatalogPopulator(base_url=BASE_URL)
+        with pytest.raises(Exception):
+            pop.populate("acs5", 2022)
+
+    @patch("siege_utilities.geo.census.catalog_populator.requests.get")
+    def test_populate_calls_correct_urls(self, mock_get, mock_variables, mock_groups):
+        mock_get.side_effect = [
+            _mock_response(mock_variables),
+            _mock_response(mock_groups),
+        ]
+
+        pop = CensusCatalogPopulator(base_url=BASE_URL)
+        pop.populate("acs5", 2022)
+
+        calls = mock_get.call_args_list
+        assert len(calls) == 2
+        assert "2022/acs/acs5/variables.json" in calls[0].args[0]
+        assert "2022/acs/acs5/groups.json" in calls[1].args[0]


### PR DESCRIPTION
## Summary

- Adds `CensusCatalogPopulator` class that fetches variable and group metadata from Census API discovery endpoints (`variables.json`, `groups.json`) and assembles a full `CensusCatalog`
- Separates I/O concerns from the pure data model in `catalog.py` — the populator handles all HTTP, the catalog stays I/O-free
- Exports `CensusCatalogPopulator` from `siege_utilities.geo.census`

## Test plan

- [x] 12 unit tests covering `_subject_key`, `_build_tables`, `_build_subjects`, and full integration
- [x] HTTP mocked with `unittest.mock.patch` — no external calls
- [x] Verifies MOE variable exclusion, race family detection, API error handling, correct URL construction

Refs: #602