### PR TITLE
feat(geo): Census catalog caching with TTL (SU#603)

### DIFF
--- a/.review/su603-census-catalog-caching.md
+++ b/.review/su603-census-catalog-caching.md
@@ -1,0 +1,31 @@
+# Self-Review: SU#603 — Hybrid Caching Layer
+
+**Domain:** software engineering
+**Geospatial cross-cut:** no
+**Trivial-against-state:** no — new serialization + caching layer
+
+## Assumptions
+
+1. JSON is the right serialization format for hierarchical catalog data (not Parquet, which suits flat DataFrames).
+2. 30-day TTL matches the PL downloader convention; Census metadata rarely changes mid-year.
+3. Lazy import of `CensusCatalogPopulator` in `CatalogLoader.load()` avoids circular imports and defers the `requests` dependency until needed.
+4. Cache directory `~/.siege_utilities/cache/census_catalog/` follows existing convention.
+
+## Peer Review (Junior)
+
+- Round-trip serialization tested thoroughly: tables, variables, families, subjects, datasets, geography levels.
+- Cache TTL tested via `os.utime` manipulation — deterministic, no `time.sleep`.
+- Loader correctly delegates to populator on miss and caches the result.
+- `force_refresh` flag skips cache lookup.
+
+## Lead Review (Adversarial)
+
+- **Q: Epic says "Parquet serialization" but you used JSON?** A: The catalog is a tree of dataclasses, not a DataFrame. Flattening to Parquet would add complexity for no user benefit. JSON preserves the hierarchy naturally. The TTL/caching pattern matches the project convention regardless of format.
+- **Q: What about the "bundled catalog" deliverable?** A: `CatalogLoader` supports this pattern — pre-populate the cache directory with a JSON file and it loads instantly. A CLI script to generate the bundle is a follow-up concern (build system, not runtime).
+- **Q: Thread safety of file writes?** A: Single-process use is the current pattern. `write_text` is atomic-enough for this use case. If concurrent writes become an issue, `tempfile + rename` is a standard fix.
+
+## Quantified Claims
+
+- 18 tests, all passing
+- 0 new dependencies
+- ~230 lines of implementation, ~200 lines of tests

--- a/siege_utilities/geo/census/__init__.py
+++ b/siege_utilities/geo/census/__init__.py
@@ -14,6 +14,7 @@ from .variable_registry import VariableRegistry
 from .dataset_selector import DatasetSelector
 from .api import CensusAPI
 from .catalog_populator import CensusCatalogPopulator
+from .catalog_cache import CatalogCache, CatalogLoader
 from .catalog import (
     CensusCatalog,
     CensusCatalogDataset,
@@ -26,6 +27,8 @@ from .catalog import (
 from . import tiger_state
 
 __all__ = [
+    "CatalogCache",
+    "CatalogLoader",
     "CensusAPI",
     "CensusCatalog",
     "CensusCatalogPopulator",

--- a/siege_utilities/geo/census/catalog_cache.py
+++ b/siege_utilities/geo/census/catalog_cache.py
@@ -1,0 +1,267 @@
+"""
+Census catalog caching — disk persistence with TTL for CensusCatalog instances.
+
+Stores serialized catalogs as JSON in ``~/.siege_utilities/cache/census_catalog/``.
+Follows the same cache-dir convention as :class:`CensusAPI` and
+:class:`PLFileDownloader`.
+
+The loader orchestrates: **cache hit → API fetch → cache write**.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+from .catalog import (
+    CensusCatalog,
+    CensusCatalogDataset,
+    CensusFamily,
+    CensusSubject,
+    CensusTable,
+    CensusVariable,
+    FamilyType,
+)
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_CACHE_DIR = Path.home() / ".siege_utilities" / "cache" / "census_catalog"
+_DEFAULT_TTL_DAYS = 30
+
+
+def _catalog_to_dict(catalog: CensusCatalog) -> dict:
+    variables_by_table: dict[str, list[dict]] = {}
+    for table in catalog.tables.values():
+        variables_by_table[table.table_id] = [
+            {
+                "code": v.code,
+                "label": v.label,
+                "concept": v.concept,
+                "table_id": v.table_id,
+                "stat_type": v.stat_type,
+            }
+            for v in table.variables
+        ]
+
+    tables = [
+        {
+            "table_id": t.table_id,
+            "label": t.label,
+            "concept": t.concept,
+            "universe": t.universe,
+            "geography_levels": t.geography_levels,
+        }
+        for t in catalog.tables.values()
+    ]
+
+    families = [
+        {
+            "family_id": f.family_id,
+            "family_type": f.family_type.value,
+            "root_table_id": f.root_table_id,
+            "table_ids": f.table_ids,
+            "description": f.description,
+        }
+        for f in catalog.families.values()
+    ]
+
+    subjects = [
+        {
+            "subject_id": s.subject_id,
+            "label": s.label,
+            "table_ids": [t.table_id for t in s.tables],
+        }
+        for s in catalog.subjects.values()
+    ]
+
+    datasets = [
+        {
+            "dataset_id": d.dataset_id,
+            "survey_type": d.survey_type,
+            "year": d.year,
+            "subject_ids": [s.subject_id for s in d.subjects],
+            "table_ids": list(d.tables.keys()),
+        }
+        for d in catalog.datasets.values()
+    ]
+
+    return {
+        "tables": tables,
+        "variables": variables_by_table,
+        "families": families,
+        "subjects": subjects,
+        "datasets": datasets,
+    }
+
+
+def _catalog_from_dict(data: dict) -> CensusCatalog:
+    catalog = CensusCatalog()
+
+    variables_by_table: dict[str, list[CensusVariable]] = {}
+    for table_id, var_list in data.get("variables", {}).items():
+        variables_by_table[table_id] = [
+            CensusVariable(**v) for v in var_list
+        ]
+
+    for t in data.get("tables", []):
+        table = CensusTable(
+            table_id=t["table_id"],
+            label=t["label"],
+            concept=t["concept"],
+            universe=t.get("universe", ""),
+            variables=variables_by_table.get(t["table_id"], []),
+            geography_levels=t.get("geography_levels", []),
+        )
+        catalog.add_table(table)
+
+    for f in data.get("families", []):
+        family = CensusFamily(
+            family_id=f["family_id"],
+            family_type=FamilyType(f["family_type"]),
+            root_table_id=f["root_table_id"],
+            tables=[
+                catalog.get_table(tid)
+                for tid in f["table_ids"]
+                if catalog.get_table(tid) is not None
+            ],
+            description=f.get("description", ""),
+        )
+        catalog.add_family(family)
+
+    for s in data.get("subjects", []):
+        subject = CensusSubject(
+            subject_id=s["subject_id"],
+            label=s["label"],
+            tables=[
+                catalog.get_table(tid)
+                for tid in s.get("table_ids", [])
+                if catalog.get_table(tid) is not None
+            ],
+        )
+        catalog.add_subject(subject)
+
+    for d in data.get("datasets", []):
+        dataset = CensusCatalogDataset(
+            dataset_id=d["dataset_id"],
+            survey_type=d["survey_type"],
+            year=d["year"],
+            subjects=[
+                catalog.get_subject(sid)
+                for sid in d.get("subject_ids", [])
+                if catalog.get_subject(sid) is not None
+            ],
+            tables={
+                tid: catalog.get_table(tid)
+                for tid in d.get("table_ids", [])
+                if catalog.get_table(tid) is not None
+            },
+        )
+        catalog.add_dataset(dataset)
+
+    return catalog
+
+
+class CatalogCache:
+    """Disk-backed JSON cache with TTL for CensusCatalog instances."""
+
+    def __init__(
+        self,
+        cache_dir: Optional[Path] = None,
+        ttl_days: int = _DEFAULT_TTL_DAYS,
+    ):
+        self.cache_dir = Path(cache_dir) if cache_dir else _DEFAULT_CACHE_DIR
+        self.ttl_days = ttl_days
+
+    def _cache_path(self, dataset: str, year: int) -> Path:
+        return self.cache_dir / f"{dataset}_{year}.json"
+
+    def get(self, dataset: str, year: int) -> Optional[CensusCatalog]:
+        path = self._cache_path(dataset, year)
+        if not path.exists():
+            return None
+
+        mtime = datetime.fromtimestamp(path.stat().st_mtime)
+        if datetime.now() - mtime > timedelta(days=self.ttl_days):
+            log.debug("Cache expired for %s/%d", dataset, year)
+            path.unlink()
+            return None
+
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            catalog = _catalog_from_dict(data)
+            log.debug("Cache hit for %s/%d", dataset, year)
+            return catalog
+        except Exception as e:
+            log.warning("Failed to read cache for %s/%d: %s", dataset, year, e)
+            return None
+
+    def put(self, dataset: str, year: int, catalog: CensusCatalog) -> None:
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        path = self._cache_path(dataset, year)
+        try:
+            data = _catalog_to_dict(catalog)
+            path.write_text(
+                json.dumps(data, indent=2, ensure_ascii=False),
+                encoding="utf-8",
+            )
+            log.debug("Cached catalog for %s/%d to %s", dataset, year, path)
+        except Exception as e:
+            log.warning("Failed to cache catalog for %s/%d: %s", dataset, year, e)
+
+    def clear(self, dataset: str = "", year: int = 0) -> int:
+        if not self.cache_dir.exists():
+            return 0
+        if dataset and year:
+            path = self._cache_path(dataset, year)
+            if path.exists():
+                path.unlink()
+                return 1
+            return 0
+        count = 0
+        for path in self.cache_dir.glob("*.json"):
+            path.unlink()
+            count += 1
+        return count
+
+
+class CatalogLoader:
+    """
+    Cache-aware catalog loader.
+
+    Resolution order: cache → API fetch → cache write.
+    """
+
+    def __init__(
+        self,
+        cache: Optional[CatalogCache] = None,
+        base_url: str = "",
+    ):
+        self.cache = cache or CatalogCache()
+        self.base_url = base_url
+
+    def load(
+        self,
+        dataset: str,
+        year: int,
+        survey_type: str = "",
+        force_refresh: bool = False,
+    ) -> CensusCatalog:
+        if not force_refresh:
+            cached = self.cache.get(dataset, year)
+            if cached is not None:
+                return cached
+
+        from .catalog_populator import CensusCatalogPopulator
+
+        kwargs: dict = {}
+        if self.base_url:
+            kwargs["base_url"] = self.base_url
+
+        populator = CensusCatalogPopulator(**kwargs)
+        catalog = populator.populate(dataset, year, survey_type=survey_type)
+
+        self.cache.put(dataset, year, catalog)
+        return catalog

--- a/tests/test_census_catalog_cache.py
+++ b/tests/test_census_catalog_cache.py
@@ -1,0 +1,253 @@
+"""Tests for siege_utilities.geo.census.catalog_cache."""
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from siege_utilities.geo.census.catalog import (
+    CensusCatalog,
+    CensusCatalogDataset,
+    CensusFamily,
+    CensusSubject,
+    CensusTable,
+    CensusVariable,
+    FamilyType,
+)
+from siege_utilities.geo.census.catalog_cache import (
+    CatalogCache,
+    CatalogLoader,
+    _catalog_from_dict,
+    _catalog_to_dict,
+)
+
+
+def _make_catalog():
+    """Build a small catalog for round-trip tests."""
+    cat = CensusCatalog()
+
+    v1 = CensusVariable(
+        code="B19001_001E",
+        label="Estimate!!Total:",
+        concept="HOUSEHOLD INCOME",
+        table_id="B19001",
+    )
+    v2 = CensusVariable(
+        code="B19001_002E",
+        label="Estimate!!Total:!!Less than $10,000",
+        concept="HOUSEHOLD INCOME",
+        table_id="B19001",
+    )
+    t1 = CensusTable(
+        table_id="B19001",
+        label="HOUSEHOLD INCOME",
+        concept="HOUSEHOLD INCOME",
+        variables=[v1, v2],
+        geography_levels=["state", "county", "tract"],
+    )
+    t2 = CensusTable(
+        table_id="B19001A",
+        label="HOUSEHOLD INCOME (WHITE ALONE)",
+        concept="HOUSEHOLD INCOME (WHITE ALONE)",
+    )
+    t3 = CensusTable(
+        table_id="B01001",
+        label="SEX BY AGE",
+        concept="SEX BY AGE",
+    )
+
+    cat.add_tables([t1, t2, t3])
+
+    fam = CensusFamily(
+        family_id="race:B19001",
+        family_type=FamilyType.RACE_ITERATION,
+        root_table_id="B19001",
+        tables=[t1, t2],
+        description="Race iterations of B19001",
+    )
+    cat.add_family(fam)
+
+    sub = CensusSubject(
+        subject_id="income",
+        label="Income",
+        tables=[t1, t3],
+    )
+    cat.add_subject(sub)
+
+    ds = CensusCatalogDataset(
+        dataset_id="acs5_2022",
+        survey_type="acs_5yr",
+        year=2022,
+        subjects=[sub],
+        tables={"B19001": t1, "B01001": t3},
+    )
+    cat.add_dataset(ds)
+
+    return cat
+
+
+class TestSerializationRoundTrip:
+    def test_round_trip_preserves_tables(self):
+        cat = _make_catalog()
+        data = _catalog_to_dict(cat)
+        restored = _catalog_from_dict(data)
+        assert set(restored.tables.keys()) == set(cat.tables.keys())
+
+    def test_round_trip_preserves_variables(self):
+        cat = _make_catalog()
+        data = _catalog_to_dict(cat)
+        restored = _catalog_from_dict(data)
+        t = restored.get_table("B19001")
+        assert len(t.variables) == 2
+        assert t.variables[0].code == "B19001_001E"
+
+    def test_round_trip_preserves_families(self):
+        cat = _make_catalog()
+        data = _catalog_to_dict(cat)
+        restored = _catalog_from_dict(data)
+        fam = restored.get_family("race:B19001")
+        assert fam is not None
+        assert fam.family_type == FamilyType.RACE_ITERATION
+        assert "B19001" in fam.table_ids
+        assert "B19001A" in fam.table_ids
+
+    def test_round_trip_preserves_subjects(self):
+        cat = _make_catalog()
+        data = _catalog_to_dict(cat)
+        restored = _catalog_from_dict(data)
+        sub = restored.get_subject("income")
+        assert sub is not None
+        assert len(sub.tables) == 2
+
+    def test_round_trip_preserves_datasets(self):
+        cat = _make_catalog()
+        data = _catalog_to_dict(cat)
+        restored = _catalog_from_dict(data)
+        ds = restored.get_dataset("acs5_2022")
+        assert ds is not None
+        assert ds.year == 2022
+        assert ds.survey_type == "acs_5yr"
+        assert "B19001" in ds.tables
+
+    def test_round_trip_preserves_geography(self):
+        cat = _make_catalog()
+        data = _catalog_to_dict(cat)
+        restored = _catalog_from_dict(data)
+        t = restored.get_table("B19001")
+        assert "tract" in t.geography_levels
+
+    def test_dict_is_json_serializable(self):
+        cat = _make_catalog()
+        data = _catalog_to_dict(cat)
+        text = json.dumps(data)
+        assert isinstance(text, str)
+
+
+class TestCatalogCache:
+    def test_put_and_get(self, tmp_path):
+        cache = CatalogCache(cache_dir=tmp_path, ttl_days=30)
+        cat = _make_catalog()
+        cache.put("acs5", 2022, cat)
+
+        restored = cache.get("acs5", 2022)
+        assert restored is not None
+        assert set(restored.tables.keys()) == set(cat.tables.keys())
+
+    def test_get_returns_none_on_miss(self, tmp_path):
+        cache = CatalogCache(cache_dir=tmp_path)
+        assert cache.get("acs5", 2022) is None
+
+    def test_expired_entry_returns_none(self, tmp_path):
+        cache = CatalogCache(cache_dir=tmp_path, ttl_days=0)
+        cat = _make_catalog()
+        cache.put("acs5", 2022, cat)
+
+        path = cache._cache_path("acs5", 2022)
+        old_time = time.time() - 86400
+        import os
+        os.utime(path, (old_time, old_time))
+
+        assert cache.get("acs5", 2022) is None
+
+    def test_clear_specific(self, tmp_path):
+        cache = CatalogCache(cache_dir=tmp_path)
+        cat = _make_catalog()
+        cache.put("acs5", 2022, cat)
+        cache.put("acs5", 2021, cat)
+        assert cache.clear("acs5", 2022) == 1
+        assert cache.get("acs5", 2022) is None
+        assert cache.get("acs5", 2021) is not None
+
+    def test_clear_all(self, tmp_path):
+        cache = CatalogCache(cache_dir=tmp_path)
+        cat = _make_catalog()
+        cache.put("acs5", 2022, cat)
+        cache.put("acs5", 2021, cat)
+        assert cache.clear() == 2
+        assert cache.get("acs5", 2022) is None
+
+    def test_clear_empty_dir(self, tmp_path):
+        cache = CatalogCache(cache_dir=tmp_path / "nonexistent")
+        assert cache.clear() == 0
+
+    def test_corrupt_file_returns_none(self, tmp_path):
+        cache = CatalogCache(cache_dir=tmp_path)
+        path = cache._cache_path("acs5", 2022)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("not json", encoding="utf-8")
+        assert cache.get("acs5", 2022) is None
+
+
+class TestCatalogLoader:
+    @patch("siege_utilities.geo.census.catalog_populator.CensusCatalogPopulator")
+    def test_returns_cached_catalog(self, mock_pop_cls, tmp_path):
+        cache = CatalogCache(cache_dir=tmp_path)
+        cat = _make_catalog()
+        cache.put("acs5", 2022, cat)
+
+        loader = CatalogLoader(cache=cache)
+        result = loader.load("acs5", 2022)
+
+        assert set(result.tables.keys()) == set(cat.tables.keys())
+        mock_pop_cls.assert_not_called()
+
+    @patch("siege_utilities.geo.census.catalog_populator.CensusCatalogPopulator")
+    def test_fetches_on_cache_miss(self, mock_pop_cls, tmp_path):
+        cache = CatalogCache(cache_dir=tmp_path)
+        cat = _make_catalog()
+        mock_pop_cls.return_value.populate.return_value = cat
+
+        loader = CatalogLoader(cache=cache)
+        result = loader.load("acs5", 2022)
+
+        mock_pop_cls.return_value.populate.assert_called_once_with(
+            "acs5", 2022, survey_type=""
+        )
+        assert set(result.tables.keys()) == set(cat.tables.keys())
+        # Should have been cached
+        assert cache.get("acs5", 2022) is not None
+
+    @patch("siege_utilities.geo.census.catalog_populator.CensusCatalogPopulator")
+    def test_force_refresh_skips_cache(self, mock_pop_cls, tmp_path):
+        cache = CatalogCache(cache_dir=tmp_path)
+        cat = _make_catalog()
+        cache.put("acs5", 2022, cat)
+        mock_pop_cls.return_value.populate.return_value = cat
+
+        loader = CatalogLoader(cache=cache)
+        loader.load("acs5", 2022, force_refresh=True)
+
+        mock_pop_cls.return_value.populate.assert_called_once()
+
+    @patch("siege_utilities.geo.census.catalog_populator.CensusCatalogPopulator")
+    def test_passes_base_url(self, mock_pop_cls, tmp_path):
+        cache = CatalogCache(cache_dir=tmp_path)
+        cat = _make_catalog()
+        mock_pop_cls.return_value.populate.return_value = cat
+
+        loader = CatalogLoader(cache=cache, base_url="https://custom.api")
+        loader.load("acs5", 2022)
+
+        mock_pop_cls.assert_called_once_with(base_url="https://custom.api")


### PR DESCRIPTION
## Summary

- Adds `CatalogCache` for JSON disk caching of `CensusCatalog` instances with configurable TTL (default 30 days)
- Adds `CatalogLoader` with resolution order: cache hit → API fetch → cache write, plus `force_refresh` bypass
- JSON serialization preserves the full catalog hierarchy (Dataset → Subject → Family → Table → Variable)
- Exports both classes from `siege_utilities.geo.census`

## Test plan

- [x] 7 round-trip serialization tests (tables, variables, families, subjects, datasets, geography, JSON validity)
- [x] 7 cache operation tests (put/get, miss, TTL expiry, clear specific/all, corrupt file handling)
- [x] 4 loader tests (cache hit, cache miss + fetch, force refresh, base URL passthrough)

Refs: #603