### PR TITLE
feat(geo): Census catalog full-text search (SU#604)

### DIFF
--- a/.review/su604-census-catalog-search.md
+++ b/.review/su604-census-catalog-search.md
@@ -1,0 +1,33 @@
+# Self-Review: SU#604 — Catalog Search
+
+**Domain:** software engineering
+**Geospatial cross-cut:** no
+**Trivial-against-state:** no — adds search to the core data model
+
+## Assumptions
+
+1. Token-based keyword matching is sufficient for catalog search; no stemming or fuzzy matching needed at this stage.
+2. Stop words reuse the existing `_CONCEPT_STOP_WORDS` set from concept keyword extraction.
+3. Scoring weights (exact word match = 1.0, substring = 0.5, ID exact = 2.0) provide reasonable ranking without over-engineering.
+4. Variable-level search iterates all tables' variables — acceptable for catalog-sized data (thousands, not millions).
+
+## Peer Review (Junior)
+
+- Search works across all 5 levels: Dataset, Subject, Family, Table, Variable.
+- Level filter, dataset filter, and max_results all work correctly.
+- Results are sorted by score descending, then by ID for stability.
+- 20 tests covering tokenization, each level individually, cross-level, ranking, filtering.
+- No new dependencies. No I/O — pure in-memory search.
+
+## Lead Review (Adversarial)
+
+- **Q: Why not use a proper full-text search library?** A: The catalog has at most ~30k entries. Linear scan with keyword matching is fast enough and avoids adding a dependency. If performance becomes an issue, we can add an inverted index later.
+- **Q: The `_CONCEPT_STOP_WORDS` set is shared with family detection — is that appropriate?** A: Yes, Census concept strings use the same vocabulary across both use cases.
+- **Q: Does adding SearchLevel/SearchResult to catalog.py bloat the data model?** A: They're lightweight (enum + dataclass), and search is a core query feature of the catalog, not a separate concern.
+
+## Quantified Claims
+
+- 20 new tests, all passing
+- 32 existing catalog tests still pass
+- 18 existing cache tests still pass
+- ~80 lines of scoring functions + ~80 lines of search method

--- a/siege_utilities/geo/census/__init__.py
+++ b/siege_utilities/geo/census/__init__.py
@@ -23,6 +23,8 @@ from .catalog import (
     CensusTable,
     CensusVariable,
     FamilyType,
+    SearchLevel,
+    SearchResult,
 )
 from . import tiger_state
 
@@ -39,6 +41,8 @@ __all__ = [
     "CensusVariable",
     "DatasetSelector",
     "FamilyType",
+    "SearchLevel",
+    "SearchResult",
     "VariableRegistry",
     "tiger_state",
 ]

--- a/siege_utilities/geo/census/catalog.py
+++ b/siege_utilities/geo/census/catalog.py
@@ -42,6 +42,23 @@ _VARIABLE_CODE_RE = re.compile(
 )
 
 
+class SearchLevel(Enum):
+    DATASET = "dataset"
+    SUBJECT = "subject"
+    FAMILY = "family"
+    TABLE = "table"
+    VARIABLE = "variable"
+
+
+@dataclass
+class SearchResult:
+    level: SearchLevel
+    id: str
+    label: str
+    score: float
+    obj: object = field(repr=False)
+
+
 class FamilyType(Enum):
     RACE_ITERATION = "race_iteration"
     TOPICAL_KINSHIP = "topical_kinship"
@@ -302,6 +319,70 @@ def _find_table_by_id(
     return None
 
 
+def _tokenize_query(query: str) -> list[str]:
+    return [w for w in query.upper().split() if w not in _CONCEPT_STOP_WORDS]
+
+
+def _text_score(text: str, tokens: list[str]) -> float:
+    upper = text.upper()
+    words = set(upper.split())
+    score = 0.0
+    for token in tokens:
+        if token in words:
+            score += 1.0
+        elif token in upper:
+            score += 0.5
+    return score
+
+
+def _id_score(obj_id: str, tokens: list[str]) -> float:
+    upper = obj_id.upper()
+    for token in tokens:
+        if token == upper:
+            return 2.0
+        if token in upper:
+            return 1.0
+    return 0.0
+
+
+def _score_table(table: CensusTable, tokens: list[str]) -> float:
+    score = _id_score(table.table_id, tokens)
+    score += _text_score(table.concept, tokens)
+    score += _text_score(table.label, tokens) * 0.5
+    return score
+
+
+def _score_family(family: CensusFamily, tokens: list[str]) -> float:
+    score = _text_score(family.description, tokens)
+    score += _id_score(family.root_table_id, tokens)
+    for table in family.tables:
+        ts = _text_score(table.concept, tokens)
+        if ts > 0:
+            score += ts * 0.3
+            break
+    return score
+
+
+def _score_subject(subject: CensusSubject, tokens: list[str]) -> float:
+    return _text_score(subject.label, tokens) + _id_score(subject.subject_id, tokens)
+
+
+def _score_variable(var: CensusVariable, tokens: list[str]) -> float:
+    score = _id_score(var.code, tokens)
+    score += _text_score(var.label, tokens) * 0.8
+    score += _text_score(var.concept, tokens) * 0.3
+    return score
+
+
+def _score_dataset(ds: CensusCatalogDataset, tokens: list[str]) -> float:
+    score = _id_score(ds.dataset_id, tokens)
+    score += _text_score(ds.survey_type, tokens)
+    for token in tokens:
+        if token == str(ds.year):
+            score += 1.0
+    return score
+
+
 class CensusCatalog:
     def __init__(self) -> None:
         self._datasets: dict[str, CensusCatalogDataset] = {}
@@ -378,6 +459,95 @@ class CensusCatalog:
             for f in self._families.values()
             if table_id in f.table_ids
         ]
+
+    # -- Search --
+
+    def search(
+        self,
+        query: str,
+        level: Optional[SearchLevel] = None,
+        dataset: Optional[str] = None,
+        max_results: int = 25,
+    ) -> list[SearchResult]:
+        tokens = _tokenize_query(query)
+        if not tokens:
+            return []
+
+        dataset_table_ids: Optional[set[str]] = None
+        if dataset:
+            ds = self._datasets.get(dataset)
+            if ds is not None:
+                dataset_table_ids = set(ds.tables.keys())
+
+        results: list[SearchResult] = []
+
+        if level is None or level == SearchLevel.TABLE:
+            for table in self._tables.values():
+                if dataset_table_ids is not None and table.table_id not in dataset_table_ids:
+                    continue
+                score = _score_table(table, tokens)
+                if score > 0:
+                    results.append(SearchResult(
+                        level=SearchLevel.TABLE,
+                        id=table.table_id,
+                        label=table.label or table.concept,
+                        score=score,
+                        obj=table,
+                    ))
+
+        if level is None or level == SearchLevel.FAMILY:
+            for family in self._families.values():
+                score = _score_family(family, tokens)
+                if score > 0:
+                    results.append(SearchResult(
+                        level=SearchLevel.FAMILY,
+                        id=family.family_id,
+                        label=family.description,
+                        score=score,
+                        obj=family,
+                    ))
+
+        if level is None or level == SearchLevel.SUBJECT:
+            for subject in self._subjects.values():
+                score = _score_subject(subject, tokens)
+                if score > 0:
+                    results.append(SearchResult(
+                        level=SearchLevel.SUBJECT,
+                        id=subject.subject_id,
+                        label=subject.label,
+                        score=score,
+                        obj=subject,
+                    ))
+
+        if level is None or level == SearchLevel.VARIABLE:
+            for table in self._tables.values():
+                if dataset_table_ids is not None and table.table_id not in dataset_table_ids:
+                    continue
+                for var in table.variables:
+                    score = _score_variable(var, tokens)
+                    if score > 0:
+                        results.append(SearchResult(
+                            level=SearchLevel.VARIABLE,
+                            id=var.code,
+                            label=var.label,
+                            score=score,
+                            obj=var,
+                        ))
+
+        if level is None or level == SearchLevel.DATASET:
+            for ds in self._datasets.values():
+                score = _score_dataset(ds, tokens)
+                if score > 0:
+                    results.append(SearchResult(
+                        level=SearchLevel.DATASET,
+                        id=ds.dataset_id,
+                        label=f"{ds.survey_type} {ds.year}",
+                        score=score,
+                        obj=ds,
+                    ))
+
+        results.sort(key=lambda r: (-r.score, r.id))
+        return results[:max_results]
 
     # -- Bulk operations --
 

--- a/tests/test_census_catalog_search.py
+++ b/tests/test_census_catalog_search.py
@@ -1,0 +1,185 @@
+"""Tests for CensusCatalog.search() — full-text search across catalog levels."""
+
+import pytest
+
+from siege_utilities.geo.census.catalog import (
+    CensusCatalog,
+    CensusCatalogDataset,
+    CensusFamily,
+    CensusSubject,
+    CensusTable,
+    CensusVariable,
+    FamilyType,
+    SearchLevel,
+    SearchResult,
+    _tokenize_query,
+)
+
+
+def _make_variable(code, label, concept, table_id):
+    return CensusVariable(
+        code=code, label=label, concept=concept, table_id=table_id,
+    )
+
+
+def _make_table(table_id, concept="", label="", variables=None, geo=None):
+    return CensusTable(
+        table_id=table_id,
+        label=label or concept,
+        concept=concept,
+        variables=variables or [],
+        geography_levels=geo or [],
+    )
+
+
+@pytest.fixture()
+def search_catalog():
+    cat = CensusCatalog()
+
+    v_income_total = _make_variable("B19001_001E", "Estimate!!Total:", "HOUSEHOLD INCOME IN THE PAST 12 MONTHS", "B19001")
+    v_income_bin = _make_variable("B19001_002E", "Estimate!!Total:!!Less than $10,000", "HOUSEHOLD INCOME IN THE PAST 12 MONTHS", "B19001")
+    v_age_total = _make_variable("B01001_001E", "Estimate!!Total:", "SEX BY AGE", "B01001")
+    v_age_male = _make_variable("B01001_002E", "Estimate!!Total:!!Male", "SEX BY AGE", "B01001")
+
+    t_income = _make_table("B19001", "HOUSEHOLD INCOME IN THE PAST 12 MONTHS", variables=[v_income_total, v_income_bin])
+    t_income_white = _make_table("B19001A", "HOUSEHOLD INCOME IN THE PAST 12 MONTHS (WHITE ALONE HOUSEHOLDER)")
+    t_income_black = _make_table("B19001B", "HOUSEHOLD INCOME IN THE PAST 12 MONTHS (BLACK ALONE HOUSEHOLDER)")
+    t_median = _make_table("B19013", "MEDIAN HOUSEHOLD INCOME IN THE PAST 12 MONTHS")
+    t_age = _make_table("B01001", "SEX BY AGE", variables=[v_age_total, v_age_male])
+    t_race = _make_table("B02001", "RACE")
+
+    cat.add_tables([t_income, t_income_white, t_income_black, t_median, t_age, t_race])
+
+    fam_race = CensusFamily(
+        family_id="race:B19001",
+        family_type=FamilyType.RACE_ITERATION,
+        root_table_id="B19001",
+        tables=[t_income, t_income_white, t_income_black],
+        description="Race/ethnicity iterations of B19001",
+    )
+    cat.add_family(fam_race)
+
+    sub_income = CensusSubject(subject_id="income", label="Income and Poverty")
+    sub_age = CensusSubject(subject_id="age-sex", label="Age and Sex")
+    cat.add_subject(sub_income)
+    cat.add_subject(sub_age)
+
+    ds = CensusCatalogDataset(
+        dataset_id="acs5_2022",
+        survey_type="acs_5yr",
+        year=2022,
+        subjects=[sub_income, sub_age],
+        tables={"B19001": t_income, "B19013": t_median, "B01001": t_age},
+    )
+    cat.add_dataset(ds)
+
+    return cat
+
+
+class TestTokenizeQuery:
+    def test_splits_and_uppercases(self):
+        assert _tokenize_query("household income") == ["HOUSEHOLD", "INCOME"]
+
+    def test_removes_stop_words(self):
+        assert _tokenize_query("income in the past 12") == ["INCOME"]
+
+    def test_empty_query(self):
+        assert _tokenize_query("") == []
+
+
+class TestSearchByTable:
+    def test_finds_table_by_concept_keyword(self, search_catalog):
+        results = search_catalog.search("household income", level=SearchLevel.TABLE)
+        ids = [r.id for r in results]
+        assert "B19001" in ids
+        assert "B19013" in ids
+
+    def test_finds_table_by_id(self, search_catalog):
+        results = search_catalog.search("B19001", level=SearchLevel.TABLE)
+        assert results[0].id == "B19001"
+
+    def test_race_tables_match_income(self, search_catalog):
+        results = search_catalog.search("income", level=SearchLevel.TABLE)
+        ids = [r.id for r in results]
+        assert "B19001A" in ids
+        assert "B19001B" in ids
+
+    def test_no_match_returns_empty(self, search_catalog):
+        results = search_catalog.search("zzzyyyxxx", level=SearchLevel.TABLE)
+        assert results == []
+
+
+class TestSearchByFamily:
+    def test_finds_race_family(self, search_catalog):
+        results = search_catalog.search("race B19001", level=SearchLevel.FAMILY)
+        assert len(results) >= 1
+        assert results[0].id == "race:B19001"
+
+    def test_finds_family_by_concept(self, search_catalog):
+        results = search_catalog.search("income race", level=SearchLevel.FAMILY)
+        assert len(results) >= 1
+
+
+class TestSearchBySubject:
+    def test_finds_income_subject(self, search_catalog):
+        results = search_catalog.search("income", level=SearchLevel.SUBJECT)
+        assert any(r.id == "income" for r in results)
+
+    def test_finds_age_subject(self, search_catalog):
+        results = search_catalog.search("age sex", level=SearchLevel.SUBJECT)
+        assert any(r.id == "age-sex" for r in results)
+
+
+class TestSearchByVariable:
+    def test_finds_variable_by_label(self, search_catalog):
+        results = search_catalog.search("Male", level=SearchLevel.VARIABLE)
+        assert any(r.id == "B01001_002E" for r in results)
+
+    def test_finds_variable_by_code(self, search_catalog):
+        results = search_catalog.search("B19001_001E", level=SearchLevel.VARIABLE)
+        assert results[0].id == "B19001_001E"
+
+
+class TestSearchByDataset:
+    def test_finds_dataset_by_year(self, search_catalog):
+        results = search_catalog.search("2022", level=SearchLevel.DATASET)
+        assert any(r.id == "acs5_2022" for r in results)
+
+    def test_finds_dataset_by_type(self, search_catalog):
+        results = search_catalog.search("acs_5yr", level=SearchLevel.DATASET)
+        assert any(r.id == "acs5_2022" for r in results)
+
+
+class TestSearchCrossLevel:
+    def test_all_levels_searched_by_default(self, search_catalog):
+        results = search_catalog.search("income")
+        levels = {r.level for r in results}
+        assert SearchLevel.TABLE in levels
+        assert SearchLevel.SUBJECT in levels
+
+    def test_results_ranked_by_score(self, search_catalog):
+        results = search_catalog.search("household income")
+        scores = [r.score for r in results]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_max_results_limits_output(self, search_catalog):
+        results = search_catalog.search("income", max_results=2)
+        assert len(results) <= 2
+
+    def test_dataset_filter_narrows_tables(self, search_catalog):
+        all_results = search_catalog.search("income", level=SearchLevel.TABLE)
+        filtered = search_catalog.search("income", level=SearchLevel.TABLE, dataset="acs5_2022")
+        # Dataset only has B19001 and B19013 for income, not B19001A/B
+        filtered_ids = {r.id for r in filtered}
+        assert "B19001A" not in filtered_ids
+        assert "B19001" in filtered_ids
+
+
+class TestSearchResult:
+    def test_search_result_fields(self, search_catalog):
+        results = search_catalog.search("B19001", level=SearchLevel.TABLE)
+        r = results[0]
+        assert r.level == SearchLevel.TABLE
+        assert r.id == "B19001"
+        assert r.score > 0
+        assert isinstance(r.obj, CensusTable)


### PR DESCRIPTION
## Summary

- Adds `CensusCatalog.search(query, level, dataset, max_results)` for token-based keyword search across all catalog levels
- Searches Dataset, Subject, Family, Table, and Variable levels with configurable filtering
- Results ranked by keyword overlap score; supports level restriction and dataset scoping
- Adds `SearchLevel` enum and `SearchResult` dataclass to the catalog module

## Test plan

- [x] 20 new tests covering tokenization, per-level search, cross-level queries, ranking, dataset filtering
- [x] 32 existing catalog tests still pass
- [x] 18 existing cache tests still pass

Refs: #604