### PR TITLE
feat(geo): deprecate VARIABLE_GROUPS (SU#606)

### DIFF
--- a/.review/su606-variable-groups-deprecation.md
+++ b/.review/su606-variable-groups-deprecation.md
@@ -1,0 +1,27 @@
+# Self-Review: SU#606 — VARIABLE_GROUPS Deprecation
+
+**Domain:** software engineering
+**Geospatial cross-cut:** no
+**Trivial-against-state:** yes — behavioral change is warning-only, no functional change
+
+## Assumptions
+
+1. `_DeprecatedDict` wrapper emits warning on first access only (not every access).
+2. Internal `VariableRegistry` uses `_VARIABLE_GROUPS_DATA` directly, avoiding the warning.
+3. External callers accessing `VARIABLE_GROUPS` get a clear deprecation message pointing to `CensusCatalog`.
+
+## Peer Review (Junior)
+
+- 6 tests: warning emission, warn-once, data accessibility, iteration, get, registry-no-warn.
+- `_DeprecatedDict` is minimal — subclasses `dict`, overrides access methods.
+- Existing code continues to work; only the warning is new.
+
+## Lead Review (Adversarial)
+
+- **Q: Why not `__getattr__` module-level?** A: Module-level `__getattr__` wouldn't work for an already-defined name. The dict wrapper is cleaner and more explicit.
+- **Q: `_warned` is class-level — thread-safe?** A: Boolean assignment is atomic in CPython. Worst case: two threads both see `False` and both warn once. Acceptable.
+
+## Quantified Claims
+
+- 6 tests, all passing
+- 0 functional changes to existing behavior

--- a/siege_utilities/geo/census/variable_registry.py
+++ b/siege_utilities/geo/census/variable_registry.py
@@ -5,6 +5,7 @@ Pure data + lookup logic — no I/O except optional API calls for unknown variab
 """
 
 import logging
+import warnings
 from typing import Dict, List, Optional, Union, Any
 
 import pandas as pd
@@ -12,11 +13,51 @@ import pandas as pd
 log = logging.getLogger(__name__)
 
 
+class _DeprecatedDict(dict):
+    """Dict wrapper that warns on first access, directing users to CensusCatalog."""
+
+    _warned = False
+
+    def _warn(self):
+        if not _DeprecatedDict._warned:
+            _DeprecatedDict._warned = True
+            warnings.warn(
+                "VARIABLE_GROUPS is deprecated and will be removed in v5.0. "
+                "Use CensusCatalog from siege_utilities.geo.census.catalog instead.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+
+    def __getitem__(self, key):
+        self._warn()
+        return super().__getitem__(key)
+
+    def __iter__(self):
+        self._warn()
+        return super().__iter__()
+
+    def keys(self):
+        self._warn()
+        return super().keys()
+
+    def values(self):
+        self._warn()
+        return super().values()
+
+    def items(self):
+        self._warn()
+        return super().items()
+
+    def get(self, key, default=None):
+        self._warn()
+        return super().get(key, default)
+
+
 # =============================================================================
-# PREDEFINED VARIABLE GROUPS
+# PREDEFINED VARIABLE GROUPS (deprecated — use CensusCatalog)
 # =============================================================================
 
-VARIABLE_GROUPS: Dict[str, List[str]] = {
+_VARIABLE_GROUPS_DATA: Dict[str, List[str]] = {
     # Basic population count
     'total_population': ['B01001_001E'],
 
@@ -211,6 +252,8 @@ VARIABLE_GROUPS: Dict[str, List[str]] = {
     ],
 }
 
+VARIABLE_GROUPS: Dict[str, List[str]] = _DeprecatedDict(_VARIABLE_GROUPS_DATA)
+
 # Variable descriptions for metadata
 VARIABLE_DESCRIPTIONS: Dict[str, str] = {
     'B01001_001E': 'Total Population',
@@ -320,7 +363,7 @@ class VariableRegistry:
 
     def __init__(self, groups: Optional[Dict[str, List[str]]] = None,
                  descriptions: Optional[Dict[str, str]] = None):
-        self.groups = groups or VARIABLE_GROUPS
+        self.groups = groups or dict(_VARIABLE_GROUPS_DATA)
         self.descriptions = descriptions or VARIABLE_DESCRIPTIONS
 
     def resolve_variables(self, variables: Union[str, List[str]]) -> List[str]:

--- a/tests/test_variable_groups_deprecation.py
+++ b/tests/test_variable_groups_deprecation.py
@@ -1,0 +1,65 @@
+"""Tests for VARIABLE_GROUPS deprecation warning."""
+
+import warnings
+
+import pytest
+
+
+def _reset_warned():
+    from siege_utilities.geo.census.variable_registry import _DeprecatedDict
+    _DeprecatedDict._warned = False
+
+
+class TestVariableGroupsDeprecation:
+    def test_access_emits_deprecation_warning(self):
+        _reset_warned()
+        from siege_utilities.geo.census.variable_registry import VARIABLE_GROUPS
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _ = VARIABLE_GROUPS["total_population"]
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "CensusCatalog" in str(w[0].message)
+
+    def test_warns_only_once(self):
+        _reset_warned()
+        from siege_utilities.geo.census.variable_registry import VARIABLE_GROUPS
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _ = VARIABLE_GROUPS["total_population"]
+            _ = VARIABLE_GROUPS["demographics_basic"]
+            assert len(w) == 1
+
+    def test_data_still_accessible(self):
+        _reset_warned()
+        from siege_utilities.geo.census.variable_registry import VARIABLE_GROUPS
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            assert "B01001_001E" in VARIABLE_GROUPS["total_population"]
+
+    def test_iteration_emits_warning(self):
+        _reset_warned()
+        from siege_utilities.geo.census.variable_registry import VARIABLE_GROUPS
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            keys = list(VARIABLE_GROUPS.keys())
+            assert len(w) == 1
+            assert len(keys) > 0
+
+    def test_get_emits_warning(self):
+        _reset_warned()
+        from siege_utilities.geo.census.variable_registry import VARIABLE_GROUPS
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = VARIABLE_GROUPS.get("total_population")
+            assert len(w) == 1
+            assert result is not None
+
+    def test_registry_init_does_not_warn(self):
+        _reset_warned()
+        from siege_utilities.geo.census.variable_registry import VariableRegistry
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            reg = VariableRegistry()
+            _ = reg.resolve_variables("total_population")
+            assert len(w) == 0


### PR DESCRIPTION
## Summary

- Wraps `VARIABLE_GROUPS` in `_DeprecatedDict` that emits `DeprecationWarning` on first access
- Directs users to `CensusCatalog` from `siege_utilities.geo.census.catalog`
- Internal `VariableRegistry` uses raw data dict directly — no warning for existing code paths

## Test plan

- [x] 6 tests: warning emission, warn-once, data still accessible, iteration warns, get warns, registry init does not warn

Refs: #606