### PR TITLE
feat(geo): batch polygon classification (SU#615)

### DIFF
--- a/.review/su615-polygon-classification.md
+++ b/.review/su615-polygon-classification.md
@@ -1,0 +1,28 @@
+# Self-Review: SU#615 — Polygon Batch Classification
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (GeoDataFrame polygon operations)
+**Trivial-against-state:** yes — thin wrapper following existing classify_points() pattern
+
+## Assumptions
+
+1. `classify_polygons()` mirrors `classify_points()` — iterate rows, call single-polygon method, collect results.
+2. For majority method: add locale_code, locale_label, locale_category, locale_subcategory columns.
+3. For distribution method: add locale_distribution column with per-row dicts.
+4. Input GDF is not mutated (copy-on-write).
+
+## Peer Review (Junior)
+
+- 3 new tests: majority columns, distribution column, input immutability.
+- All 40 locale tests pass (37 existing + 3 new).
+- Follows the exact same iteration pattern as classify_points().
+
+## Lead Review (Adversarial)
+
+- **Q: Row-by-row iteration is O(n*m) where m is UA/UC count — slow for large GDFs?** A: Yes, but this matches the existing classify_points() pattern. Spatial-join-based batch optimization is a separate enhancement.
+- **Q: Why not spatial overlay for polygon batch?** A: classify_polygon() already handles the intersection logic. The batch wrapper is intentionally thin to avoid reimplementing that logic.
+
+## Quantified Claims
+
+- 3 new tests, 40 total passing
+- ~45 lines of implementation

--- a/siege_utilities/geo/locale.py
+++ b/siege_utilities/geo/locale.py
@@ -473,6 +473,55 @@ class NCESLocaleClassifier:
         # "distribution" or "area_weighted"
         return distribution
 
+    def classify_polygons(
+        self,
+        gdf: Any,
+        method: str = "majority",
+        geometry_col: str = "geometry",
+    ) -> Any:
+        """Bulk classify a GeoDataFrame of polygons.
+
+        For ``method="majority"``, adds columns: ``locale_code`` (int),
+        ``locale_label`` (str).
+
+        For ``method="distribution"`` or ``"area_weighted"``, adds a
+        ``locale_distribution`` column containing per-row dicts of
+        ``{code: fraction}`` pairs.
+
+        Args:
+            gdf: GeoDataFrame with polygon geometries.
+            method: ``"majority"``, ``"distribution"``, or ``"area_weighted"``.
+            geometry_col: Name of the geometry column.
+
+        Returns:
+            The input GeoDataFrame with locale columns added.
+        """
+        gdf = gdf.copy()
+
+        if method == "majority":
+            codes = []
+            labels = []
+            for _, row in gdf.iterrows():
+                result = self.classify_polygon(row[geometry_col], method="majority")
+                codes.append(result["locale_code"])
+                labels.append(result["locale_label"])
+            gdf["locale_code"] = codes
+            gdf["locale_label"] = labels
+            gdf["locale_category"] = [
+                locale_from_code(c).category for c in codes
+            ]
+            gdf["locale_subcategory"] = [
+                locale_from_code(c).subcategory for c in codes
+            ]
+        else:
+            distributions = []
+            for _, row in gdf.iterrows():
+                dist = self.classify_polygon(row[geometry_col], method=method)
+                distributions.append(dist)
+            gdf["locale_distribution"] = distributions
+
+        return gdf
+
     # ------------------------------------------------------------------
     # Factory methods
     # ------------------------------------------------------------------

--- a/tests/test_locale.py
+++ b/tests/test_locale.py
@@ -374,6 +374,70 @@ class TestClassifyPolygon:
         assert abs(total - 1.0) < 0.01  # fractions sum to ~1
 
 
+class TestClassifyPolygons:
+    """Test bulk polygon classification."""
+
+    def test_majority_adds_columns(self):
+        """classify_polygons with majority adds locale_code/label/category/subcategory."""
+        ua = _make_ua((-78, 38, -76, 40), pop=500_000)
+        classifier = NCESLocaleClassifier(
+            urbanized_areas=ua,
+            urban_clusters=None,
+            principal_cities=_empty_gdf(),
+            place_populations={},
+            ua_populations={"00001": 500_000},
+        )
+        polys = gpd.GeoDataFrame(
+            {"name": ["A", "B"]},
+            geometry=[box(-77.5, 38.5, -76.5, 39.5), box(-77.5, 38.5, -76.5, 39.5)],
+            crs="EPSG:4269",
+        )
+        result = classifier.classify_polygons(polys, method="majority")
+        assert "locale_code" in result.columns
+        assert "locale_label" in result.columns
+        assert "locale_category" in result.columns
+        assert "locale_subcategory" in result.columns
+        assert len(result) == 2
+
+    def test_distribution_adds_column(self):
+        """classify_polygons with distribution adds locale_distribution column."""
+        ua = _make_ua((-78, 38, -77, 39), pop=500_000)
+        classifier = NCESLocaleClassifier(
+            urbanized_areas=ua,
+            urban_clusters=None,
+            principal_cities=_empty_gdf(),
+            place_populations={},
+        )
+        polys = gpd.GeoDataFrame(
+            {"name": ["A"]},
+            geometry=[box(-77.5, 38.5, -76.5, 39.5)],
+            crs="EPSG:4269",
+        )
+        result = classifier.classify_polygons(polys, method="distribution")
+        assert "locale_distribution" in result.columns
+        dist = result["locale_distribution"].iloc[0]
+        assert isinstance(dist, dict)
+        assert abs(sum(dist.values()) - 1.0) < 0.01
+
+    def test_does_not_mutate_input(self):
+        """classify_polygons should return a copy, not mutate the input."""
+        ua = _make_ua((-78, 38, -76, 40), pop=500_000)
+        classifier = NCESLocaleClassifier(
+            urbanized_areas=ua,
+            urban_clusters=None,
+            principal_cities=_empty_gdf(),
+            place_populations={},
+        )
+        polys = gpd.GeoDataFrame(
+            {"name": ["A"]},
+            geometry=[box(-77.5, 38.5, -76.5, 39.5)],
+            crs="EPSG:4269",
+        )
+        original_cols = set(polys.columns)
+        classifier.classify_polygons(polys, method="majority")
+        assert set(polys.columns) == original_cols
+
+
 class TestLocaleLabel:
     """Test the static locale_label helper."""
 


### PR DESCRIPTION
## Summary

- Adds `NCESLocaleClassifier.classify_polygons(gdf, method)` for bulk polygon classification
- Majority method: adds locale_code, locale_label, locale_category, locale_subcategory columns
- Distribution method: adds locale_distribution column with per-row fraction dicts
- Mirrors existing `classify_points()` iteration pattern

## Test plan

- [x] 3 new tests: majority columns, distribution column, input immutability
- [x] 40 total locale tests passing (37 existing + 3 new)

Refs: #615