### PR TITLE
feat(geo): GEOID lookup for locale classification (SU#616)

### DIFF
--- a/.review/su616-geoid-lookup.md
+++ b/.review/su616-geoid-lookup.md
@@ -1,0 +1,28 @@
+# Self-Review: SU#616 — GEOID Lookup Mode
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (GEOID-to-locale mapping)
+**Trivial-against-state:** no — new LocaleIndex class + classify_geoid methods
+
+## Assumptions
+
+1. LocaleIndex is a simple dict wrapper — GEOIDs are strings, locale codes are ints.
+2. `from_dataframe()` factory skips invalid locale codes silently (log warning would add noise for large datasets).
+3. `classify_geoid_or_point()` tries index first, falls back to spatial — caller provides both GEOID and coordinates.
+4. The index is set externally (e.g., from NCES district data) rather than auto-built, keeping the classifier I/O-free.
+
+## Peer Review (Junior)
+
+- LocaleIndex: 7 tests (add/get, missing, bulk, contains, from_dataframe, invalid codes, custom columns).
+- ClassifyGeoid: 5 tests (with index, without index, missing GEOID, fallback priority, fallback to spatial).
+- 52 total locale tests passing.
+
+## Lead Review (Adversarial)
+
+- **Q: Why not auto-build the index from NCES data?** A: That would couple the classifier to I/O. The index is populated externally — from district data, school locations, or a precomputed Parquet file. Same separation as CensusCatalog/CensusCatalogPopulator.
+- **Q: What about tract-level GEOIDs?** A: The index accepts any GEOID format. Tract-level mapping would come from a spatial join (classify each tract centroid once, store the results). That's a data-preparation step, not a classifier concern.
+
+## Quantified Claims
+
+- 12 new tests, 52 total passing
+- ~80 lines of LocaleIndex + ~25 lines of classifier methods

--- a/siege_utilities/geo/locale.py
+++ b/siege_utilities/geo/locale.py
@@ -162,6 +162,53 @@ def locale_from_code(code: int) -> LocaleCode:
 # NCESLocaleClassifier
 # ---------------------------------------------------------------------------
 
+class LocaleIndex:
+    """Precomputed GEOID → LocaleCode mapping for fast lookup.
+
+    Built from any data source that pairs GEOIDs with NCES locale codes
+    (e.g., NCES district data, school locations, or Census tract assignments).
+    """
+
+    def __init__(self, mapping: Optional[Dict[str, int]] = None):
+        self._mapping: Dict[str, int] = mapping or {}
+
+    def add(self, geoid: str, locale_code: int) -> None:
+        self._mapping[geoid] = locale_code
+
+    def add_bulk(self, pairs: Dict[str, int]) -> None:
+        self._mapping.update(pairs)
+
+    def get(self, geoid: str) -> Optional[LocaleCode]:
+        code = self._mapping.get(geoid)
+        if code is None:
+            return None
+        return locale_from_code(code)
+
+    def __len__(self) -> int:
+        return len(self._mapping)
+
+    def __contains__(self, geoid: str) -> bool:
+        return geoid in self._mapping
+
+    @classmethod
+    def from_dataframe(
+        cls,
+        df: Any,
+        geoid_col: str = "geoid",
+        locale_col: str = "locale_code",
+    ) -> "LocaleIndex":
+        mapping = {}
+        for _, row in df.iterrows():
+            geoid = str(row[geoid_col]).strip()
+            try:
+                code = int(row[locale_col])
+                if validate_locale_code(code):
+                    mapping[geoid] = code
+            except (ValueError, TypeError):
+                continue
+        return cls(mapping)
+
+
 class NCESLocaleClassifier:
     """Classify geographic points and polygons into NCES locale codes.
 
@@ -207,6 +254,8 @@ class NCESLocaleClassifier:
         self._ua_populations = ua_populations or {}
         self._projection_crs = projection_crs or settings.PROJECTION_CRS
 
+        self._locale_index: Optional[LocaleIndex] = None
+
         # Lazily projected copies (created on first classify call)
         self._ua_proj = None
         self._uc_proj = None
@@ -220,6 +269,39 @@ class NCESLocaleClassifier:
             self._ua_proj = self._ua.to_crs(crs_string)
         if self._uc_proj is None and self._uc is not None:
             self._uc_proj = self._uc.to_crs(crs_string)
+
+    # ------------------------------------------------------------------
+    # GEOID lookup
+    # ------------------------------------------------------------------
+
+    @property
+    def locale_index(self) -> Optional[LocaleIndex]:
+        return self._locale_index
+
+    @locale_index.setter
+    def locale_index(self, index: LocaleIndex) -> None:
+        self._locale_index = index
+
+    def classify_geoid(self, geoid: str) -> Optional[LocaleCode]:
+        """Fast-path locale lookup by Census GEOID.
+
+        Returns the precomputed locale code if the GEOID is in the index,
+        or ``None`` if no index is set or the GEOID is not found.
+        Use ``classify_geoid_or_point()`` for automatic fallback to
+        spatial classification.
+        """
+        if self._locale_index is None:
+            return None
+        return self._locale_index.get(geoid)
+
+    def classify_geoid_or_point(
+        self, geoid: str, lon: float, lat: float,
+    ) -> LocaleCode:
+        """Classify by GEOID if available, falling back to spatial."""
+        result = self.classify_geoid(geoid)
+        if result is not None:
+            return result
+        return self.classify_point(lon, lat)
 
     # ------------------------------------------------------------------
     # Point classification

--- a/tests/test_locale.py
+++ b/tests/test_locale.py
@@ -20,6 +20,7 @@ from siege_utilities.geo.locale import (
     TOWN_FRINGE,
     TOWN_REMOTE,
     LocaleCode,
+    LocaleIndex,
     LocaleType,
     NCESLocaleClassifier,
     locale_from_code,
@@ -372,6 +373,121 @@ class TestClassifyPolygon:
         assert isinstance(result, dict)
         total = sum(result.values())
         assert abs(total - 1.0) < 0.01  # fractions sum to ~1
+
+
+class TestLocaleIndex:
+    """Tests for the LocaleIndex precomputed mapping."""
+
+    def test_add_and_get(self):
+        idx = LocaleIndex()
+        idx.add("48453001100", 11)
+        result = idx.get("48453001100")
+        assert result is not None
+        assert result.code == 11
+
+    def test_get_returns_none_for_missing(self):
+        idx = LocaleIndex()
+        assert idx.get("nonexistent") is None
+
+    def test_add_bulk(self):
+        idx = LocaleIndex()
+        idx.add_bulk({"01001": 11, "01002": 43})
+        assert len(idx) == 2
+        assert idx.get("01001").code == 11
+        assert idx.get("01002").code == 43
+
+    def test_contains(self):
+        idx = LocaleIndex({"01001": 11})
+        assert "01001" in idx
+        assert "99999" not in idx
+
+    def test_from_dataframe(self):
+        df = pd.DataFrame({
+            "geoid": ["01001", "01002", "01003"],
+            "locale_code": [11, 43, 21],
+        })
+        idx = LocaleIndex.from_dataframe(df)
+        assert len(idx) == 3
+        assert idx.get("01001").code == 11
+
+    def test_from_dataframe_skips_invalid_codes(self):
+        df = pd.DataFrame({
+            "geoid": ["01001", "01002"],
+            "locale_code": [11, 99],
+        })
+        idx = LocaleIndex.from_dataframe(df)
+        assert len(idx) == 1
+
+    def test_from_dataframe_custom_columns(self):
+        df = pd.DataFrame({
+            "tract_id": ["48453001100"],
+            "nces_code": [21],
+        })
+        idx = LocaleIndex.from_dataframe(df, geoid_col="tract_id", locale_col="nces_code")
+        assert idx.get("48453001100").code == 21
+
+
+class TestClassifyGeoid:
+    """Tests for GEOID-based classification."""
+
+    def test_classify_geoid_with_index(self):
+        classifier = NCESLocaleClassifier(
+            urbanized_areas=_empty_gdf(),
+            urban_clusters=_empty_gdf(),
+            principal_cities=_empty_gdf(),
+            place_populations={},
+        )
+        classifier.locale_index = LocaleIndex({"48453001100": 11})
+        result = classifier.classify_geoid("48453001100")
+        assert result is not None
+        assert result.code == 11
+
+    def test_classify_geoid_returns_none_without_index(self):
+        classifier = NCESLocaleClassifier(
+            urbanized_areas=_empty_gdf(),
+            urban_clusters=_empty_gdf(),
+            principal_cities=_empty_gdf(),
+            place_populations={},
+        )
+        assert classifier.classify_geoid("48453001100") is None
+
+    def test_classify_geoid_returns_none_for_missing(self):
+        classifier = NCESLocaleClassifier(
+            urbanized_areas=_empty_gdf(),
+            urban_clusters=_empty_gdf(),
+            principal_cities=_empty_gdf(),
+            place_populations={},
+        )
+        classifier.locale_index = LocaleIndex({"48453001100": 11})
+        assert classifier.classify_geoid("nonexistent") is None
+
+    def test_classify_geoid_or_point_uses_index(self):
+        ua = _make_ua((-78, 38, -76, 40), pop=500_000)
+        pc = _make_principal_cities((-78, 38, -76, 40), pop=300_000)
+        classifier = NCESLocaleClassifier(
+            urbanized_areas=ua,
+            urban_clusters=None,
+            principal_cities=pc,
+            place_populations={"00100": 300_000},
+        )
+        classifier.locale_index = LocaleIndex({"48453001100": 43})
+        # GEOID maps to Rural-Remote (43), but point would be City-Large (11)
+        result = classifier.classify_geoid_or_point("48453001100", -77.0, 39.0)
+        assert result.code == 43
+
+    def test_classify_geoid_or_point_falls_back(self):
+        ua = _make_ua((-78, 38, -76, 40), pop=500_000)
+        pc = _make_principal_cities((-78, 38, -76, 40), pop=300_000)
+        classifier = NCESLocaleClassifier(
+            urbanized_areas=ua,
+            urban_clusters=None,
+            principal_cities=pc,
+            place_populations={"00100": 300_000},
+        )
+        classifier.locale_index = LocaleIndex({})
+        # GEOID not in index → falls back to spatial → City-Large
+        result = classifier.classify_geoid_or_point("nonexistent", -77.0, 39.0)
+        assert result.code == 11
 
 
 class TestClassifyPolygons:


### PR DESCRIPTION
## Summary

- Adds `LocaleIndex` class for precomputed GEOID→LocaleCode mapping with `from_dataframe()` factory
- Adds `classify_geoid()` for fast-path GEOID lookup
- Adds `classify_geoid_or_point()` with automatic spatial fallback when GEOID not in index
- Index populated externally (NCES district data, school locations, etc.) — classifier stays I/O-free

## Test plan

- [x] 7 LocaleIndex tests: add/get, missing, bulk, contains, from_dataframe, invalid codes, custom columns
- [x] 5 classify_geoid tests: with index, without index, missing GEOID, fallback priority, spatial fallback
- [x] 52 total locale tests passing

Refs: #616