### PR TITLE
feat(geo): add NLRB data source clients (SU#617)

### DIFF
--- a/.review/su617-nlrb-data-clients.md
+++ b/.review/su617-nlrb-data-clients.md
@@ -1,0 +1,39 @@
+# Self-Review: SU#617 — NLRB Data Source Clients
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (NLRB region extraction from case numbers)
+**Trivial-against-state:** no — new provider module with 3 clients + facade
+
+## Assumptions
+
+1. data.gov XML schema uses camelCase or snake_case field names — parser handles both.
+2. labordata GitHub repo CSV files are at `/data/{cases,elections,charges}.csv` under main branch.
+3. NxGen HTML scraping is best-effort; marked fragile. Uses stdlib HTMLParser to avoid BeautifulSoup dependency.
+4. `requests` is lazy-imported — clients accept an injected `session` parameter for testability without requests installed.
+5. Source priority for deduplication: labordata > data.gov > NxGen (labordata has cleanest data).
+
+## Peer Review (Junior)
+
+- NLRBCaseRecord: 3 tests (minimal, full, to_dict)
+- ElectionRecord: 1 test
+- ULPRecord: 1 test
+- NLRBFetchResult: 3 tests (empty, errors, total_records)
+- CaseType enum: 2 tests
+- Helpers: 8 date parsing, 6 safe_int, 5 region extraction
+- NLRBDatagovClient: 7 tests (single case, empty, HTTP error, malformed XML, missing number, alternate fields, multiple)
+- NLRBLabordataClient: 6 tests (cases, elections, ULP charges, failure, empty number, alternate fields)
+- NLRBNxGenClient: 3 tests (HTTP error, empty HTML, table parsing)
+- NLRBDataClient facade: 7 tests (dedup, priority, elections, errors, nxgen toggle, priority order)
+- 52 total tests passing
+
+## Lead Review (Adversarial)
+
+- **Q: Why catch `Exception` instead of `requests.RequestException`?** A: Because `requests` is lazy-imported and may not be available. The `session` parameter allows mock injection in tests. In production with requests installed, the broad catch still works correctly.
+- **Q: NxGen HTML parser assumes specific CSS classes — what if they change?** A: That's exactly why the client is marked fragile. The parser returns an empty list on failure with a warning log. No exception propagation.
+- **Q: Why not use pandas for CSV parsing?** A: stdlib csv.DictReader has zero dependencies. The records are parsed into dataclasses, not DataFrames. DataFrame export is WS4-T2's concern.
+
+## Quantified Claims
+
+- 52 new tests, all passing
+- ~350 lines of implementation (records, helpers, 3 clients, facade)
+- Zero new dependencies (requests is lazy, HTML parsing uses stdlib)

--- a/siege_utilities/geo/providers/__init__.py
+++ b/siege_utilities/geo/providers/__init__.py
@@ -12,6 +12,8 @@ Current providers:
 - :mod:`nces_download` — NCES school-district and locale boundaries
 - :mod:`redistricting_data_hub` — RDH API client (precincts, plans, CVAP,
   PL 94-171, compactness metrics)
+- :mod:`nlrb_clients` — NLRB case data from data.gov, labordata GitHub,
+  and NxGen search
 
 Not yet migrated (planned for the interface-unification follow-up epic):
 

--- a/siege_utilities/geo/providers/nlrb_clients.py
+++ b/siege_utilities/geo/providers/nlrb_clients.py
@@ -1,0 +1,639 @@
+"""NLRB data source clients for case, election, and ULP data.
+
+Three backends:
+
+- **data.gov** — XML dumps of C-Cases (ULP) and R-Cases (representation).
+- **labordata GitHub** — cleaned CSV/Parquet exports from labordata/nlrb-data.
+- **NxGen Advanced Search** — HTML scraping of the NLRB case search
+  (fragile; marked as best-effort).
+
+A unified :class:`NLRBDataClient` facade reconciles records across sources.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import logging
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field, asdict
+from datetime import date, datetime
+from enum import Enum
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+
+def _requests():
+    import requests
+    return requests
+
+
+# ---------------------------------------------------------------------------
+# Enums & records
+# ---------------------------------------------------------------------------
+
+
+class CaseType(str, Enum):
+    """NLRB case type prefix codes."""
+
+    R = "R"       # Representation
+    C = "C"       # Unfair Labor Practice (charged against employer)
+    CB = "CB"     # ULP charged against union
+    CD = "CD"     # ULP charged against union (duty of fair representation)
+    CE = "CE"     # ULP charged against union (excessive fees)
+    CA = "CA"     # ULP charged against employer (alias for C in older data)
+    AC = "AC"     # Amendment of Certification
+    UC = "UC"     # Unit Clarification
+    UD = "UD"     # Unit De-authorization
+    WH = "WH"     # Wage-Hour (historical)
+    RM = "RM"     # Employer-filed representation
+    RD = "RD"     # Decertification
+    RC = "RC"     # Certification (union-filed)
+
+
+class CaseStatus(str, Enum):
+    """High-level case statuses."""
+
+    OPEN = "Open"
+    CLOSED = "Closed"
+    PENDING = "Pending"
+    UNKNOWN = "Unknown"
+
+
+@dataclass
+class NLRBCaseRecord:
+    """A single NLRB case record from any data source."""
+
+    case_number: str
+    case_type: str
+    case_name: str = ""
+    status: str = CaseStatus.UNKNOWN.value
+    date_filed: Optional[date] = None
+    date_closed: Optional[date] = None
+    region: Optional[int] = None
+    city: str = ""
+    state: str = ""
+    union_name: str = ""
+    unit_description: str = ""
+    naics_code: str = ""
+    employee_count: Optional[int] = None
+    source: str = ""
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class ElectionRecord:
+    """Election tally result linked to a case."""
+
+    case_number: str
+    tally_date: Optional[date] = None
+    eligible_voters: Optional[int] = None
+    votes_for: Optional[int] = None
+    votes_against: Optional[int] = None
+    void_ballots: Optional[int] = None
+    union_name: str = ""
+    source: str = ""
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class ULPRecord:
+    """Unfair labor practice charge."""
+
+    case_number: str
+    allegation: str = ""
+    charging_party: str = ""
+    charged_party: str = ""
+    section_of_act: str = ""
+    date_filed: Optional[date] = None
+    source: str = ""
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class NLRBFetchResult:
+    """Result from a client fetch operation."""
+
+    cases: list[NLRBCaseRecord] = field(default_factory=list)
+    elections: list[ElectionRecord] = field(default_factory=list)
+    ulp_charges: list[ULPRecord] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    source: str = ""
+
+    @property
+    def success(self) -> bool:
+        return len(self.errors) == 0
+
+    @property
+    def total_records(self) -> int:
+        return len(self.cases) + len(self.elections) + len(self.ulp_charges)
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+_DATE_FORMATS = ("%Y-%m-%d", "%m/%d/%Y", "%m-%d-%Y", "%Y-%m-%dT%H:%M:%S")
+
+
+def _parse_date(value: Optional[str]) -> Optional[date]:
+    if not value or not value.strip():
+        return None
+    value = value.strip()
+    for fmt in _DATE_FORMATS:
+        try:
+            return datetime.strptime(value, fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+def _safe_int(value) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(float(str(value).strip()))
+    except (ValueError, TypeError):
+        return None
+
+
+def _extract_region(case_number: str) -> Optional[int]:
+    """Extract the region number from a case number like '05-RC-123456'."""
+    if not case_number:
+        return None
+    parts = case_number.split("-")
+    if parts:
+        try:
+            return int(parts[0])
+        except ValueError:
+            return None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# data.gov XML client
+# ---------------------------------------------------------------------------
+
+DATAGOV_CASES_URL = (
+    "https://data.nlrb.gov/data/cases"
+)
+
+
+class NLRBDatagovClient:
+    """Download and parse NLRB case data from data.gov XML exports.
+
+    The NLRB publishes case data through its open data portal. This client
+    fetches the XML feed and parses it into structured records.
+
+    Args:
+        timeout: HTTP request timeout in seconds.
+        base_url: Override the default data.gov endpoint.
+    """
+
+    def __init__(
+        self,
+        timeout: int = 60,
+        base_url: Optional[str] = None,
+        session: Optional[object] = None,
+    ):
+        self._timeout = timeout
+        self._base_url = base_url or DATAGOV_CASES_URL
+        self._session = session
+
+    def _get_session(self):
+        if self._session is None:
+            self._session = _requests().Session()
+            self._session.headers.update({"Accept": "application/xml"})
+        return self._session
+
+    def fetch_cases(self, params: Optional[dict] = None) -> NLRBFetchResult:
+        """Fetch case records from the data.gov XML endpoint.
+
+        Args:
+            params: Optional query parameters for filtering.
+
+        Returns:
+            NLRBFetchResult with parsed case records.
+        """
+        result = NLRBFetchResult(source="datagov")
+        try:
+            resp = self._get_session().get(
+                self._base_url,
+                params=params,
+                timeout=self._timeout,
+            )
+            resp.raise_for_status()
+        except Exception as exc:
+            result.errors.append(f"HTTP error fetching data.gov: {exc}")
+            return result
+
+        try:
+            root = ET.fromstring(resp.text)
+        except ET.ParseError as exc:
+            result.errors.append(f"XML parse error: {exc}")
+            return result
+
+        for case_el in root.iter("case"):
+            record = self._parse_case_element(case_el)
+            if record:
+                result.cases.append(record)
+
+        log.info("data.gov: parsed %d cases", len(result.cases))
+        return result
+
+    def _parse_case_element(self, el: ET.Element) -> Optional[NLRBCaseRecord]:
+        case_number = (el.findtext("caseNumber") or el.findtext("case_number") or "").strip()
+        if not case_number:
+            return None
+
+        return NLRBCaseRecord(
+            case_number=case_number,
+            case_type=el.findtext("caseType") or el.findtext("case_type") or "",
+            case_name=el.findtext("caseName") or el.findtext("case_name") or "",
+            status=el.findtext("status") or CaseStatus.UNKNOWN.value,
+            date_filed=_parse_date(el.findtext("dateFiled") or el.findtext("date_filed")),
+            date_closed=_parse_date(el.findtext("dateClosed") or el.findtext("date_closed")),
+            region=_extract_region(case_number),
+            city=el.findtext("city") or "",
+            state=el.findtext("state") or "",
+            union_name=el.findtext("unionName") or el.findtext("labor_union") or "",
+            unit_description=el.findtext("unitDescription") or "",
+            naics_code=el.findtext("naicsCode") or el.findtext("naics") or "",
+            employee_count=_safe_int(el.findtext("employeeCount") or el.findtext("num_employees")),
+            source="datagov",
+        )
+
+
+# ---------------------------------------------------------------------------
+# labordata GitHub CSV/Parquet client
+# ---------------------------------------------------------------------------
+
+LABORDATA_BASE_URL = (
+    "https://raw.githubusercontent.com/labordata/nlrb-data/main"
+)
+
+LABORDATA_FILES = {
+    "cases": "/data/cases.csv",
+    "elections": "/data/elections.csv",
+    "ulp_charges": "/data/charges.csv",
+}
+
+
+class NLRBLabordataClient:
+    """Download and parse NLRB data from the labordata/nlrb-data GitHub repo.
+
+    The labordata project maintains cleaned CSV exports of NLRB data. This
+    client downloads the CSV files and parses them into structured records.
+
+    Args:
+        timeout: HTTP request timeout in seconds.
+        base_url: Override the default GitHub raw content URL.
+    """
+
+    def __init__(
+        self,
+        timeout: int = 120,
+        base_url: Optional[str] = None,
+        session: Optional[object] = None,
+    ):
+        self._timeout = timeout
+        self._base_url = base_url or LABORDATA_BASE_URL
+        self._session = session
+
+    def _get_session(self):
+        if self._session is None:
+            self._session = _requests().Session()
+        return self._session
+
+    def fetch_cases(self) -> NLRBFetchResult:
+        """Fetch all available data from the labordata repository.
+
+        Downloads cases, elections, and ULP charges CSVs.
+        """
+        result = NLRBFetchResult(source="labordata")
+
+        cases_csv = self._download_csv("cases")
+        if cases_csv is not None:
+            for row in cases_csv:
+                record = self._parse_case_row(row)
+                if record:
+                    result.cases.append(record)
+
+        elections_csv = self._download_csv("elections")
+        if elections_csv is not None:
+            for row in elections_csv:
+                record = self._parse_election_row(row)
+                if record:
+                    result.elections.append(record)
+
+        charges_csv = self._download_csv("ulp_charges")
+        if charges_csv is not None:
+            for row in charges_csv:
+                record = self._parse_ulp_row(row)
+                if record:
+                    result.ulp_charges.append(record)
+        elif cases_csv is None:
+            result.errors.append("Failed to download any data from labordata")
+
+        log.info(
+            "labordata: %d cases, %d elections, %d charges",
+            len(result.cases),
+            len(result.elections),
+            len(result.ulp_charges),
+        )
+        return result
+
+    def _download_csv(self, dataset: str) -> Optional[list[dict]]:
+        path = LABORDATA_FILES.get(dataset)
+        if not path:
+            return None
+        url = self._base_url + path
+        try:
+            resp = self._get_session().get(url, timeout=self._timeout)
+            resp.raise_for_status()
+        except Exception as exc:
+            log.warning("labordata: failed to download %s: %s", dataset, exc)
+            return None
+
+        reader = csv.DictReader(io.StringIO(resp.text))
+        return list(reader)
+
+    def _parse_case_row(self, row: dict) -> Optional[NLRBCaseRecord]:
+        case_number = row.get("case_number", "").strip()
+        if not case_number:
+            return None
+
+        return NLRBCaseRecord(
+            case_number=case_number,
+            case_type=row.get("case_type", ""),
+            case_name=row.get("case_name", ""),
+            status=row.get("status", CaseStatus.UNKNOWN.value),
+            date_filed=_parse_date(row.get("date_filed")),
+            date_closed=_parse_date(row.get("date_closed")),
+            region=_extract_region(case_number),
+            city=row.get("city", ""),
+            state=row.get("state", ""),
+            union_name=row.get("union_name", row.get("labor_union", "")),
+            unit_description=row.get("unit_description", row.get("bargaining_unit", "")),
+            naics_code=row.get("naics_code", row.get("naics", "")),
+            employee_count=_safe_int(row.get("employee_count", row.get("num_employees"))),
+            source="labordata",
+        )
+
+    def _parse_election_row(self, row: dict) -> Optional[ElectionRecord]:
+        case_number = row.get("case_number", "").strip()
+        if not case_number:
+            return None
+
+        return ElectionRecord(
+            case_number=case_number,
+            tally_date=_parse_date(row.get("tally_date")),
+            eligible_voters=_safe_int(row.get("eligible_voters")),
+            votes_for=_safe_int(row.get("votes_for", row.get("votes_cast_for"))),
+            votes_against=_safe_int(row.get("votes_against", row.get("votes_cast_against"))),
+            void_ballots=_safe_int(row.get("void_ballots")),
+            union_name=row.get("union_name", row.get("labor_union", "")),
+            source="labordata",
+        )
+
+    def _parse_ulp_row(self, row: dict) -> Optional[ULPRecord]:
+        case_number = row.get("case_number", "").strip()
+        if not case_number:
+            return None
+
+        return ULPRecord(
+            case_number=case_number,
+            allegation=row.get("allegation", ""),
+            charging_party=row.get("charging_party", ""),
+            charged_party=row.get("charged_party", row.get("employer", "")),
+            section_of_act=row.get("section_of_act", row.get("nlra_section", "")),
+            date_filed=_parse_date(row.get("date_filed")),
+            source="labordata",
+        )
+
+
+# ---------------------------------------------------------------------------
+# NxGen Advanced Search client (fragile — web scraping)
+# ---------------------------------------------------------------------------
+
+NXGEN_SEARCH_URL = "https://www.nlrb.gov/search/case"
+
+
+class NLRBNxGenClient:
+    """Scrape NLRB case data from the NxGen Advanced Search page.
+
+    .. warning::
+        This client relies on HTML structure that may change without notice.
+        Use it as a fallback when data.gov or labordata sources are
+        insufficient. Prefer the other clients for bulk data.
+
+    Args:
+        timeout: HTTP request timeout in seconds.
+        base_url: Override the default NxGen search URL.
+    """
+
+    def __init__(
+        self,
+        timeout: int = 30,
+        base_url: Optional[str] = None,
+        session: Optional[object] = None,
+    ):
+        self._timeout = timeout
+        self._base_url = base_url or NXGEN_SEARCH_URL
+        self._session = session
+
+    def _get_session(self):
+        if self._session is None:
+            self._session = _requests().Session()
+            self._session.headers.update({
+                "User-Agent": "siege_utilities NLRB research client",
+            })
+        return self._session
+
+    def fetch_case(self, case_number: str) -> NLRBFetchResult:
+        """Fetch a single case by number from the NxGen search.
+
+        Args:
+            case_number: NLRB case number (e.g., '05-RC-123456').
+        """
+        result = NLRBFetchResult(source="nxgen")
+        url = f"{self._base_url}?f%5B0%5D=case_number%3A{case_number}"
+
+        try:
+            resp = self._get_session().get(url, timeout=self._timeout)
+            resp.raise_for_status()
+        except Exception as exc:
+            result.errors.append(f"NxGen HTTP error: {exc}")
+            return result
+
+        records = self._parse_search_results(resp.text)
+        result.cases.extend(records)
+        return result
+
+    def _parse_search_results(self, html: str) -> list[NLRBCaseRecord]:
+        """Best-effort HTML parsing — returns empty list on failure."""
+        records: list[NLRBCaseRecord] = []
+        try:
+            from html.parser import HTMLParser
+
+            class _CaseExtractor(HTMLParser):
+                def __init__(self):
+                    super().__init__()
+                    self._in_row = False
+                    self._current_field = ""
+                    self._fields: dict = {}
+                    self._rows: list[dict] = []
+
+                def handle_starttag(self, tag, attrs):
+                    attrs_dict = dict(attrs)
+                    if tag == "tr":
+                        self._in_row = True
+                        self._fields = {}
+                    elif tag == "td" and self._in_row:
+                        cls = attrs_dict.get("class", "")
+                        if "case-number" in cls:
+                            self._current_field = "case_number"
+                        elif "case-name" in cls:
+                            self._current_field = "case_name"
+                        elif "date-filed" in cls:
+                            self._current_field = "date_filed"
+                        elif "status" in cls:
+                            self._current_field = "status"
+                        elif "city" in cls:
+                            self._current_field = "city"
+                        elif "state" in cls:
+                            self._current_field = "state"
+
+                def handle_data(self, data):
+                    if self._current_field:
+                        self._fields[self._current_field] = data.strip()
+                        self._current_field = ""
+
+                def handle_endtag(self, tag):
+                    if tag == "tr" and self._in_row and self._fields.get("case_number"):
+                        self._rows.append(dict(self._fields))
+                        self._in_row = False
+                        self._fields = {}
+
+            parser = _CaseExtractor()
+            parser.feed(html)
+
+            for row_data in parser._rows:
+                case_num = row_data.get("case_number", "")
+                if case_num:
+                    records.append(NLRBCaseRecord(
+                        case_number=case_num,
+                        case_type=case_num.split("-")[1] if "-" in case_num else "",
+                        case_name=row_data.get("case_name", ""),
+                        status=row_data.get("status", CaseStatus.UNKNOWN.value),
+                        date_filed=_parse_date(row_data.get("date_filed")),
+                        city=row_data.get("city", ""),
+                        state=row_data.get("state", ""),
+                        region=_extract_region(case_num),
+                        source="nxgen",
+                    ))
+        except Exception as exc:
+            log.warning("NxGen parse failed (expected — page structure may have changed): %s", exc)
+
+        return records
+
+
+# ---------------------------------------------------------------------------
+# Unified facade
+# ---------------------------------------------------------------------------
+
+
+class NLRBDataClient:
+    """Unified NLRB data client that reconciles across multiple sources.
+
+    Fetches from available backends and deduplicates by case number. When
+    the same case appears in multiple sources, labordata is preferred
+    (cleaned data), then data.gov, then NxGen.
+
+    Args:
+        datagov_client: Optional pre-configured data.gov client.
+        labordata_client: Optional pre-configured labordata client.
+        nxgen_client: Optional pre-configured NxGen client.
+        use_nxgen: Whether to include the fragile NxGen source. Default False.
+    """
+
+    SOURCE_PRIORITY = ("labordata", "datagov", "nxgen")
+
+    def __init__(
+        self,
+        datagov_client: Optional[NLRBDatagovClient] = None,
+        labordata_client: Optional[NLRBLabordataClient] = None,
+        nxgen_client: Optional[NLRBNxGenClient] = None,
+        use_nxgen: bool = False,
+    ):
+        self._datagov = datagov_client or NLRBDatagovClient()
+        self._labordata = labordata_client or NLRBLabordataClient()
+        self._nxgen = nxgen_client or NLRBNxGenClient() if use_nxgen else None
+
+    def fetch_all(self, datagov_params: Optional[dict] = None) -> NLRBFetchResult:
+        """Fetch from all configured sources and reconcile.
+
+        Args:
+            datagov_params: Optional query parameters for the data.gov source.
+
+        Returns:
+            Merged NLRBFetchResult with deduplicated records.
+        """
+        results: list[NLRBFetchResult] = []
+
+        labordata_result = self._labordata.fetch_cases()
+        results.append(labordata_result)
+
+        datagov_result = self._datagov.fetch_cases(params=datagov_params)
+        results.append(datagov_result)
+
+        if self._nxgen:
+            nxgen_result = self._nxgen.fetch_case("")
+            results.append(nxgen_result)
+
+        return self._reconcile(results)
+
+    def _reconcile(self, results: list[NLRBFetchResult]) -> NLRBFetchResult:
+        """Merge results, preferring higher-priority sources."""
+        merged = NLRBFetchResult(source="unified")
+
+        case_map: dict[str, NLRBCaseRecord] = {}
+        election_map: dict[str, ElectionRecord] = {}
+        ulp_map: dict[str, ULPRecord] = {}
+
+        for source_name in self.SOURCE_PRIORITY:
+            for result in results:
+                if result.source != source_name:
+                    continue
+                for case in result.cases:
+                    if case.case_number not in case_map:
+                        case_map[case.case_number] = case
+                for election in result.elections:
+                    key = f"{election.case_number}:{election.tally_date}"
+                    if key not in election_map:
+                        election_map[key] = election
+                for ulp in result.ulp_charges:
+                    key = f"{ulp.case_number}:{ulp.allegation[:50]}"
+                    if key not in ulp_map:
+                        ulp_map[key] = ulp
+                merged.errors.extend(result.errors)
+
+        merged.cases = list(case_map.values())
+        merged.elections = list(election_map.values())
+        merged.ulp_charges = list(ulp_map.values())
+
+        log.info(
+            "unified: %d cases, %d elections, %d charges (%d errors)",
+            len(merged.cases),
+            len(merged.elections),
+            len(merged.ulp_charges),
+            len(merged.errors),
+        )
+        return merged

--- a/tests/test_nlrb_clients.py
+++ b/tests/test_nlrb_clients.py
@@ -1,0 +1,663 @@
+"""Tests for NLRB data source clients (SU#617)."""
+
+from __future__ import annotations
+
+import csv
+import io
+import textwrap
+import xml.etree.ElementTree as ET
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from siege_utilities.geo.providers.nlrb_clients import (
+    CaseStatus,
+    CaseType,
+    ElectionRecord,
+    NLRBCaseRecord,
+    NLRBDataClient,
+    NLRBDatagovClient,
+    NLRBFetchResult,
+    NLRBLabordataClient,
+    NLRBNxGenClient,
+    ULPRecord,
+    _extract_region,
+    _parse_date,
+    _safe_int,
+)
+
+
+def _mock_session():
+    return MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# Record dataclass tests
+# ---------------------------------------------------------------------------
+
+
+class TestNLRBCaseRecord:
+    def test_minimal_construction(self):
+        rec = NLRBCaseRecord(case_number="05-RC-123456", case_type="RC")
+        assert rec.case_number == "05-RC-123456"
+        assert rec.case_type == "RC"
+        assert rec.status == CaseStatus.UNKNOWN.value
+
+    def test_full_construction(self):
+        rec = NLRBCaseRecord(
+            case_number="05-RC-123456",
+            case_type="RC",
+            case_name="ACME Corp",
+            status="Open",
+            date_filed=date(2024, 1, 15),
+            date_closed=None,
+            region=5,
+            city="Chicago",
+            state="IL",
+            union_name="SEIU",
+            unit_description="Warehouse workers",
+            naics_code="493110",
+            employee_count=150,
+            source="labordata",
+        )
+        assert rec.city == "Chicago"
+        assert rec.employee_count == 150
+
+    def test_to_dict(self):
+        rec = NLRBCaseRecord(case_number="01-CA-999", case_type="CA")
+        d = rec.to_dict()
+        assert isinstance(d, dict)
+        assert d["case_number"] == "01-CA-999"
+        assert "source" in d
+
+
+class TestElectionRecord:
+    def test_construction_and_dict(self):
+        rec = ElectionRecord(
+            case_number="05-RC-123456",
+            tally_date=date(2024, 3, 1),
+            eligible_voters=200,
+            votes_for=120,
+            votes_against=75,
+            union_name="UAW",
+        )
+        assert rec.votes_for == 120
+        d = rec.to_dict()
+        assert d["eligible_voters"] == 200
+
+
+class TestULPRecord:
+    def test_construction_and_dict(self):
+        rec = ULPRecord(
+            case_number="01-CA-888",
+            allegation="8(a)(1) interference",
+            charging_party="Local 123",
+            charged_party="ACME Corp",
+            section_of_act="8(a)(1)",
+        )
+        assert rec.section_of_act == "8(a)(1)"
+        d = rec.to_dict()
+        assert d["charging_party"] == "Local 123"
+
+
+class TestNLRBFetchResult:
+    def test_empty_is_success(self):
+        r = NLRBFetchResult()
+        assert r.success
+        assert r.total_records == 0
+
+    def test_with_errors(self):
+        r = NLRBFetchResult(errors=["something failed"])
+        assert not r.success
+
+    def test_total_records(self):
+        r = NLRBFetchResult(
+            cases=[NLRBCaseRecord(case_number="1", case_type="RC")],
+            elections=[ElectionRecord(case_number="1")],
+            ulp_charges=[ULPRecord(case_number="2"), ULPRecord(case_number="3")],
+        )
+        assert r.total_records == 4
+
+
+# ---------------------------------------------------------------------------
+# Enum tests
+# ---------------------------------------------------------------------------
+
+
+class TestCaseType:
+    def test_representation(self):
+        assert CaseType.R.value == "R"
+        assert CaseType.RC.value == "RC"
+
+    def test_ulp_types(self):
+        assert CaseType.C.value == "C"
+        assert CaseType.CA.value == "CA"
+        assert CaseType.CB.value == "CB"
+
+
+# ---------------------------------------------------------------------------
+# Helper function tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseDate:
+    def test_iso_format(self):
+        assert _parse_date("2024-01-15") == date(2024, 1, 15)
+
+    def test_us_format(self):
+        assert _parse_date("01/15/2024") == date(2024, 1, 15)
+
+    def test_us_dash_format(self):
+        assert _parse_date("01-15-2024") == date(2024, 1, 15)
+
+    def test_iso_datetime(self):
+        assert _parse_date("2024-01-15T10:30:00") == date(2024, 1, 15)
+
+    def test_none_input(self):
+        assert _parse_date(None) is None
+
+    def test_empty_string(self):
+        assert _parse_date("") is None
+
+    def test_whitespace(self):
+        assert _parse_date("  ") is None
+
+    def test_invalid_format(self):
+        assert _parse_date("not-a-date") is None
+
+
+class TestSafeInt:
+    def test_int(self):
+        assert _safe_int(42) == 42
+
+    def test_string_int(self):
+        assert _safe_int("42") == 42
+
+    def test_float_string(self):
+        assert _safe_int("42.7") == 42
+
+    def test_none(self):
+        assert _safe_int(None) is None
+
+    def test_invalid(self):
+        assert _safe_int("abc") is None
+
+    def test_empty(self):
+        assert _safe_int("") is None
+
+
+class TestExtractRegion:
+    def test_standard_format(self):
+        assert _extract_region("05-RC-123456") == 5
+
+    def test_two_digit_region(self):
+        assert _extract_region("28-CA-999999") == 28
+
+    def test_empty(self):
+        assert _extract_region("") is None
+
+    def test_none(self):
+        assert _extract_region(None) is None
+
+    def test_no_dash(self):
+        assert _extract_region("ABC") is None
+
+
+# ---------------------------------------------------------------------------
+# data.gov client tests
+# ---------------------------------------------------------------------------
+
+
+class TestNLRBDatagovClient:
+    def _make_xml(self, cases: list[dict]) -> str:
+        root = ET.Element("cases")
+        for c in cases:
+            el = ET.SubElement(root, "case")
+            for k, v in c.items():
+                child = ET.SubElement(el, k)
+                child.text = str(v)
+        return ET.tostring(root, encoding="unicode")
+
+    def test_parse_single_case(self):
+        xml = self._make_xml([{
+            "caseNumber": "05-RC-100001",
+            "caseType": "RC",
+            "caseName": "Acme Corp",
+            "status": "Closed",
+            "dateFiled": "2024-01-10",
+            "dateClosed": "2024-06-15",
+            "city": "Chicago",
+            "state": "IL",
+        }])
+        session = _mock_session()
+        session.get.return_value.text = xml
+        session.get.return_value.raise_for_status = MagicMock()
+        client = NLRBDatagovClient(session=session)
+
+        result = client.fetch_cases()
+
+        assert result.success
+        assert len(result.cases) == 1
+        case = result.cases[0]
+        assert case.case_number == "05-RC-100001"
+        assert case.region == 5
+        assert case.date_filed == date(2024, 1, 10)
+        assert case.source == "datagov"
+
+    def test_empty_xml(self):
+        xml = "<cases></cases>"
+        session = _mock_session()
+        session.get.return_value.text = xml
+        session.get.return_value.raise_for_status = MagicMock()
+        client = NLRBDatagovClient(session=session)
+
+        result = client.fetch_cases()
+
+        assert result.success
+        assert len(result.cases) == 0
+
+    def test_http_error(self):
+        session = _mock_session()
+        session.get.side_effect = ConnectionError("timeout")
+        client = NLRBDatagovClient(session=session)
+
+        result = client.fetch_cases()
+
+        assert not result.success
+        assert "HTTP error" in result.errors[0]
+
+    def test_malformed_xml(self):
+        session = _mock_session()
+        session.get.return_value.text = "not xml at all <<<"
+        session.get.return_value.raise_for_status = MagicMock()
+        client = NLRBDatagovClient(session=session)
+
+        result = client.fetch_cases()
+
+        assert not result.success
+        assert "XML parse error" in result.errors[0]
+
+    def test_skips_case_without_number(self):
+        xml = self._make_xml([{"caseType": "RC", "status": "Open"}])
+        session = _mock_session()
+        session.get.return_value.text = xml
+        session.get.return_value.raise_for_status = MagicMock()
+        client = NLRBDatagovClient(session=session)
+
+        result = client.fetch_cases()
+
+        assert result.success
+        assert len(result.cases) == 0
+
+    def test_alternate_field_names(self):
+        xml = self._make_xml([{
+            "case_number": "12-CA-555555",
+            "case_type": "CA",
+            "case_name": "Test Co",
+            "date_filed": "03/15/2024",
+            "labor_union": "IBEW",
+            "naics": "238210",
+            "num_employees": "45",
+        }])
+        session = _mock_session()
+        session.get.return_value.text = xml
+        session.get.return_value.raise_for_status = MagicMock()
+        client = NLRBDatagovClient(session=session)
+
+        result = client.fetch_cases()
+
+        assert len(result.cases) == 1
+        case = result.cases[0]
+        assert case.union_name == "IBEW"
+        assert case.naics_code == "238210"
+        assert case.employee_count == 45
+
+    def test_multiple_cases(self):
+        xml = self._make_xml([
+            {"caseNumber": "05-RC-100001", "caseType": "RC"},
+            {"caseNumber": "05-RC-100002", "caseType": "RC"},
+            {"caseNumber": "01-CA-200001", "caseType": "CA"},
+        ])
+        session = _mock_session()
+        session.get.return_value.text = xml
+        session.get.return_value.raise_for_status = MagicMock()
+        client = NLRBDatagovClient(session=session)
+
+        result = client.fetch_cases()
+        assert len(result.cases) == 3
+
+
+# ---------------------------------------------------------------------------
+# labordata client tests
+# ---------------------------------------------------------------------------
+
+
+class TestNLRBLabordataClient:
+    def _make_csv(self, rows: list[dict]) -> str:
+        if not rows:
+            return ""
+        output = io.StringIO()
+        writer = csv.DictWriter(output, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+        return output.getvalue()
+
+    def _make_session(self, file_contents: dict[str, str]):
+        """Create a mock session that returns different content per URL."""
+        session = _mock_session()
+
+        def side_effect(url, timeout=None):
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.text = ""
+            for key, content in file_contents.items():
+                if key in url:
+                    resp.text = content
+                    break
+            return resp
+
+        session.get.side_effect = side_effect
+        return session
+
+    def test_parse_cases(self):
+        csv_text = self._make_csv([{
+            "case_number": "05-RC-200001",
+            "case_type": "RC",
+            "case_name": "Test Corp",
+            "status": "Open",
+            "date_filed": "2024-02-01",
+            "city": "Austin",
+            "state": "TX",
+        }])
+        session = self._make_session({"cases.csv": csv_text})
+        client = NLRBLabordataClient(session=session)
+
+        result = client.fetch_cases()
+
+        assert result.success
+        assert len(result.cases) == 1
+        assert result.cases[0].city == "Austin"
+        assert result.source == "labordata"
+
+    def test_parse_elections(self):
+        cases_csv = self._make_csv([{
+            "case_number": "05-RC-200001",
+            "case_type": "RC",
+            "case_name": "Test",
+            "status": "Closed",
+        }])
+        elections_csv = self._make_csv([{
+            "case_number": "05-RC-200001",
+            "tally_date": "2024-04-01",
+            "eligible_voters": "100",
+            "votes_for": "60",
+            "votes_against": "35",
+            "union_name": "SEIU",
+        }])
+        session = self._make_session({
+            "cases.csv": cases_csv,
+            "elections.csv": elections_csv,
+        })
+        client = NLRBLabordataClient(session=session)
+
+        result = client.fetch_cases()
+
+        assert len(result.elections) == 1
+        assert result.elections[0].votes_for == 60
+        assert result.elections[0].eligible_voters == 100
+
+    def test_parse_ulp_charges(self):
+        charges_csv = self._make_csv([{
+            "case_number": "01-CA-300001",
+            "allegation": "8(a)(1) interference",
+            "charging_party": "Local 999",
+            "employer": "Bad Corp",
+            "nlra_section": "8(a)(1)",
+            "date_filed": "2024-05-01",
+        }])
+        session = self._make_session({"charges.csv": charges_csv})
+        client = NLRBLabordataClient(session=session)
+
+        result = client.fetch_cases()
+
+        assert len(result.ulp_charges) == 1
+        assert result.ulp_charges[0].charged_party == "Bad Corp"
+        assert result.ulp_charges[0].section_of_act == "8(a)(1)"
+
+    def test_handles_download_failure(self):
+        session = _mock_session()
+        session.get.side_effect = ConnectionError("network down")
+        client = NLRBLabordataClient(session=session)
+
+        result = client.fetch_cases()
+
+        assert not result.success
+
+    def test_skips_empty_case_number(self):
+        csv_text = self._make_csv([{
+            "case_number": "",
+            "case_type": "RC",
+        }])
+        session = self._make_session({"cases.csv": csv_text})
+        client = NLRBLabordataClient(session=session)
+
+        result = client.fetch_cases()
+
+        assert len(result.cases) == 0
+
+    def test_alternate_field_names(self):
+        csv_text = self._make_csv([{
+            "case_number": "07-RC-400001",
+            "case_type": "RC",
+            "labor_union": "UFCW",
+            "bargaining_unit": "Grocery workers",
+            "naics": "445110",
+            "num_employees": "85",
+        }])
+        session = self._make_session({"cases.csv": csv_text})
+        client = NLRBLabordataClient(session=session)
+
+        result = client.fetch_cases()
+
+        assert len(result.cases) == 1
+        case = result.cases[0]
+        assert case.union_name == "UFCW"
+        assert case.unit_description == "Grocery workers"
+        assert case.naics_code == "445110"
+        assert case.employee_count == 85
+
+
+# ---------------------------------------------------------------------------
+# NxGen client tests
+# ---------------------------------------------------------------------------
+
+
+class TestNLRBNxGenClient:
+    def test_http_error(self):
+        session = _mock_session()
+        session.get.side_effect = ConnectionError("blocked")
+        client = NLRBNxGenClient(session=session)
+
+        result = client.fetch_case("05-RC-000001")
+
+        assert not result.success
+        assert "NxGen HTTP error" in result.errors[0]
+
+    def test_empty_html_returns_empty(self):
+        session = _mock_session()
+        session.get.return_value.text = "<html><body>No results</body></html>"
+        session.get.return_value.raise_for_status = MagicMock()
+        client = NLRBNxGenClient(session=session)
+
+        result = client.fetch_case("05-RC-000001")
+
+        assert result.success
+        assert len(result.cases) == 0
+
+    def test_parses_table_rows(self):
+        html = textwrap.dedent("""\
+            <html><body><table>
+            <tr>
+                <td class="case-number">05-RC-111111</td>
+                <td class="case-name">Test Corp</td>
+                <td class="date-filed">2024-01-01</td>
+                <td class="status">Open</td>
+                <td class="city">Dallas</td>
+                <td class="state">TX</td>
+            </tr>
+            </table></body></html>
+        """)
+        session = _mock_session()
+        session.get.return_value.text = html
+        session.get.return_value.raise_for_status = MagicMock()
+        client = NLRBNxGenClient(session=session)
+
+        result = client.fetch_case("05-RC-111111")
+
+        assert len(result.cases) == 1
+        assert result.cases[0].case_number == "05-RC-111111"
+        assert result.cases[0].city == "Dallas"
+        assert result.cases[0].source == "nxgen"
+
+
+# ---------------------------------------------------------------------------
+# Unified facade tests
+# ---------------------------------------------------------------------------
+
+
+class TestNLRBDataClient:
+    def _mock_labordata_result(self):
+        return NLRBFetchResult(
+            source="labordata",
+            cases=[
+                NLRBCaseRecord(
+                    case_number="05-RC-100001",
+                    case_type="RC",
+                    city="Chicago",
+                    state="IL",
+                    source="labordata",
+                ),
+                NLRBCaseRecord(
+                    case_number="01-CA-200001",
+                    case_type="CA",
+                    source="labordata",
+                ),
+            ],
+            elections=[
+                ElectionRecord(
+                    case_number="05-RC-100001",
+                    tally_date=date(2024, 3, 1),
+                    votes_for=100,
+                    source="labordata",
+                ),
+            ],
+        )
+
+    def _mock_datagov_result(self):
+        return NLRBFetchResult(
+            source="datagov",
+            cases=[
+                NLRBCaseRecord(
+                    case_number="05-RC-100001",
+                    case_type="RC",
+                    city="Chicago",
+                    state="IL",
+                    source="datagov",
+                ),
+                NLRBCaseRecord(
+                    case_number="12-RC-300001",
+                    case_type="RC",
+                    source="datagov",
+                ),
+            ],
+        )
+
+    def test_deduplicates_by_case_number(self):
+        datagov = MagicMock(spec=NLRBDatagovClient)
+        labordata = MagicMock(spec=NLRBLabordataClient)
+
+        labordata.fetch_cases.return_value = self._mock_labordata_result()
+        datagov.fetch_cases.return_value = self._mock_datagov_result()
+
+        client = NLRBDataClient(
+            datagov_client=datagov,
+            labordata_client=labordata,
+        )
+        result = client.fetch_all()
+
+        assert len(result.cases) == 3
+        case_numbers = {c.case_number for c in result.cases}
+        assert case_numbers == {"05-RC-100001", "01-CA-200001", "12-RC-300001"}
+
+    def test_prefers_labordata(self):
+        datagov = MagicMock(spec=NLRBDatagovClient)
+        labordata = MagicMock(spec=NLRBLabordataClient)
+
+        labordata.fetch_cases.return_value = self._mock_labordata_result()
+        datagov.fetch_cases.return_value = self._mock_datagov_result()
+
+        client = NLRBDataClient(
+            datagov_client=datagov,
+            labordata_client=labordata,
+        )
+        result = client.fetch_all()
+
+        shared_case = next(c for c in result.cases if c.case_number == "05-RC-100001")
+        assert shared_case.source == "labordata"
+
+    def test_merges_elections(self):
+        datagov = MagicMock(spec=NLRBDatagovClient)
+        labordata = MagicMock(spec=NLRBLabordataClient)
+
+        labordata.fetch_cases.return_value = self._mock_labordata_result()
+        datagov.fetch_cases.return_value = self._mock_datagov_result()
+
+        client = NLRBDataClient(
+            datagov_client=datagov,
+            labordata_client=labordata,
+        )
+        result = client.fetch_all()
+        assert len(result.elections) == 1
+
+    def test_collects_errors(self):
+        datagov = MagicMock(spec=NLRBDatagovClient)
+        labordata = MagicMock(spec=NLRBLabordataClient)
+
+        labordata.fetch_cases.return_value = NLRBFetchResult(
+            source="labordata", errors=["lab error"]
+        )
+        datagov.fetch_cases.return_value = NLRBFetchResult(
+            source="datagov", errors=["gov error"]
+        )
+
+        client = NLRBDataClient(
+            datagov_client=datagov,
+            labordata_client=labordata,
+        )
+        result = client.fetch_all()
+        assert len(result.errors) == 2
+
+    def test_nxgen_disabled_by_default(self):
+        datagov = MagicMock(spec=NLRBDatagovClient)
+        labordata = MagicMock(spec=NLRBLabordataClient)
+        client = NLRBDataClient(
+            datagov_client=datagov,
+            labordata_client=labordata,
+        )
+        assert client._nxgen is None
+
+    def test_nxgen_enabled(self):
+        datagov = MagicMock(spec=NLRBDatagovClient)
+        labordata = MagicMock(spec=NLRBLabordataClient)
+        nxgen = MagicMock(spec=NLRBNxGenClient)
+        client = NLRBDataClient(
+            datagov_client=datagov,
+            labordata_client=labordata,
+            nxgen_client=nxgen,
+            use_nxgen=True,
+        )
+        assert client._nxgen is not None
+
+    def test_source_priority_order(self):
+        assert NLRBDataClient.SOURCE_PRIORITY == ("labordata", "datagov", "nxgen")


### PR DESCRIPTION
## Summary
- Three backend clients for NLRB case data: data.gov XML, labordata GitHub CSV, NxGen HTML scraping
- Unified `NLRBDataClient` facade deduplicates across sources with priority: labordata > data.gov > NxGen
- Dataclass records: `NLRBCaseRecord`, `ElectionRecord`, `ULPRecord`, `NLRBFetchResult`
- Lazy HTTP session init for testability without `requests` installed

## Test plan
- [x] 52 tests covering all clients, records, helpers, facade reconciliation
- [x] Tests run without `requests` installed (mock session injection)
- [x] Error handling: HTTP failures, malformed XML, empty results