### PR TITLE
feat(geo): add NLRB case Django models and DataFrame export (SU#618)

### DIFF
--- a/.review/su618-nlrb-data-models.md
+++ b/.review/su618-nlrb-data-models.md
@@ -1,0 +1,34 @@
+# Self-Review: SU#618 — NLRB Data Models
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (FK to NLRBRegion spatial boundary)
+**Trivial-against-state:** no — 4 new Django models + export module
+
+## Assumptions
+
+1. NLRB case models are non-spatial (no geometry) — they link to NLRBRegion via FK.
+2. Dataclass equivalents already exist in nlrb_clients.py (NLRBCaseRecord, ElectionRecord, ULPRecord) from SU#617. Models provide to_record()/from_record() converters.
+3. BargainingUnit stores soc_codes as JSONField (list of strings) since a unit can map to multiple SOC codes.
+4. DataFrame export uses lazy pandas import — no hard dependency.
+
+## Peer Review (Junior)
+
+- NLRBCase model: 10 tests (import, fields, FK, str, from_record, to_record)
+- ElectionResult model: 3 tests
+- ULPCharge model: 3 tests
+- BargainingUnit model: 3 tests
+- DataFrame export: 6 tests (cases, elections, ULP, empty, fetch_result)
+- 25 total tests (skip when Django/pandas unavailable, matching existing pattern)
+
+## Lead Review (Adversarial)
+
+- **Q: Why separate nlrb_cases.py from federal.py?** A: federal.py has spatial boundary models (TemporalBoundary subclasses). Case data is non-spatial — plain Django models. Different base class, different concerns.
+- **Q: Why not store case_type as a Django choice field with CaseType enum?** A: NLRB introduces new case type codes occasionally. CharField is more flexible than constraining to a known set.
+- **Q: Why dual region/region_number fields?** A: region_number is extracted from case number (always available). region FK links to the NLRBRegion spatial model (only populated when region boundaries exist in DB).
+
+## Quantified Claims
+
+- 25 new tests, all collected (skipped in non-Django env, matching existing pattern)
+- 4 Django models: NLRBCase, ElectionResult, ULPCharge, BargainingUnit
+- 1 export module with 4 functions
+- ~250 lines of model code + ~75 lines of export code

--- a/siege_utilities/geo/django/models/__init__.py
+++ b/siege_utilities/geo/django/models/__init__.py
@@ -75,6 +75,12 @@ from .federal import (
     NLRBRegion,
     FederalJudicialDistrict,
 )
+from .nlrb_cases import (
+    NLRBCase,
+    ElectionResult,
+    ULPCharge,
+    BargainingUnit,
+)
 from .timezone import (
     TimezoneGeometry,
 )
@@ -173,6 +179,11 @@ __all__ = [
     # Federal
     "NLRBRegion",
     "FederalJudicialDistrict",
+    # NLRB Cases
+    "NLRBCase",
+    "ElectionResult",
+    "ULPCharge",
+    "BargainingUnit",
     # Timezone
     "TimezoneGeometry",
     # Isochrone

--- a/siege_utilities/geo/django/models/nlrb_cases.py
+++ b/siege_utilities/geo/django/models/nlrb_cases.py
@@ -1,0 +1,239 @@
+"""NLRB case, election, ULP, and bargaining unit Django models.
+
+Non-spatial models for NLRB case data. These link to NLRBRegion via FK
+but don't carry their own geometry.
+"""
+
+from django.db import models
+
+
+class NLRBCase(models.Model):
+    """An NLRB case (representation petition, ULP charge, etc.)."""
+
+    case_number = models.CharField(
+        max_length=20,
+        unique=True,
+        db_index=True,
+        help_text="NLRB case number (e.g. '05-RC-123456')",
+    )
+    case_type = models.CharField(
+        max_length=10,
+        db_index=True,
+        help_text="Case type code (R, RC, CA, CB, etc.)",
+    )
+    case_name = models.CharField(
+        max_length=500,
+        blank=True,
+        default="",
+        help_text="Employer or party name",
+    )
+    status = models.CharField(
+        max_length=50,
+        blank=True,
+        default="Unknown",
+        db_index=True,
+    )
+    date_filed = models.DateField(null=True, blank=True, db_index=True)
+    date_closed = models.DateField(null=True, blank=True)
+    region = models.ForeignKey(
+        "NLRBRegion",
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="cases",
+    )
+    region_number = models.PositiveSmallIntegerField(
+        null=True,
+        blank=True,
+        db_index=True,
+        help_text="Region number extracted from case number",
+    )
+    city = models.CharField(max_length=100, blank=True, default="")
+    state = models.CharField(max_length=2, blank=True, default="", db_index=True)
+    union_name = models.CharField(max_length=300, blank=True, default="")
+    unit_description = models.TextField(blank=True, default="")
+    naics_code = models.CharField(
+        max_length=10,
+        blank=True,
+        default="",
+        db_index=True,
+    )
+    employee_count = models.PositiveIntegerField(null=True, blank=True)
+    source = models.CharField(
+        max_length=50,
+        blank=True,
+        default="",
+        help_text="Data source: 'datagov', 'labordata', 'nxgen'",
+    )
+
+    class Meta:
+        verbose_name = "NLRB Case"
+        verbose_name_plural = "NLRB Cases"
+        indexes = [
+            models.Index(fields=["case_type", "status"]),
+            models.Index(fields=["date_filed"]),
+            models.Index(fields=["state"]),
+        ]
+
+    def __str__(self):
+        return f"{self.case_number} ({self.case_name})"
+
+    def to_record(self):
+        """Convert to NLRBCaseRecord dataclass."""
+        from siege_utilities.geo.providers.nlrb_clients import NLRBCaseRecord
+
+        return NLRBCaseRecord(
+            case_number=self.case_number,
+            case_type=self.case_type,
+            case_name=self.case_name,
+            status=self.status,
+            date_filed=self.date_filed,
+            date_closed=self.date_closed,
+            region=self.region_number,
+            city=self.city,
+            state=self.state,
+            union_name=self.union_name,
+            unit_description=self.unit_description,
+            naics_code=self.naics_code,
+            employee_count=self.employee_count,
+            source=self.source,
+        )
+
+    @classmethod
+    def from_record(cls, record):
+        """Create model instance from NLRBCaseRecord dataclass."""
+        return cls(
+            case_number=record.case_number,
+            case_type=record.case_type,
+            case_name=record.case_name,
+            status=record.status,
+            date_filed=record.date_filed,
+            date_closed=record.date_closed,
+            region_number=record.region,
+            city=record.city,
+            state=record.state,
+            union_name=record.union_name,
+            unit_description=record.unit_description,
+            naics_code=record.naics_code,
+            employee_count=record.employee_count,
+            source=record.source,
+        )
+
+
+class ElectionResult(models.Model):
+    """Election tally result for an NLRB representation case."""
+
+    case = models.ForeignKey(
+        NLRBCase,
+        on_delete=models.CASCADE,
+        related_name="election_results",
+    )
+    tally_date = models.DateField(null=True, blank=True, db_index=True)
+    eligible_voters = models.PositiveIntegerField(null=True, blank=True)
+    votes_for = models.PositiveIntegerField(null=True, blank=True)
+    votes_against = models.PositiveIntegerField(null=True, blank=True)
+    void_ballots = models.PositiveIntegerField(null=True, blank=True)
+    union_name = models.CharField(max_length=300, blank=True, default="")
+    source = models.CharField(max_length=50, blank=True, default="")
+
+    class Meta:
+        verbose_name = "Election Result"
+        verbose_name_plural = "Election Results"
+        indexes = [
+            models.Index(fields=["tally_date"]),
+        ]
+
+    def __str__(self):
+        return f"Election {self.case.case_number} ({self.tally_date})"
+
+    def to_record(self):
+        from siege_utilities.geo.providers.nlrb_clients import ElectionRecord
+
+        return ElectionRecord(
+            case_number=self.case.case_number,
+            tally_date=self.tally_date,
+            eligible_voters=self.eligible_voters,
+            votes_for=self.votes_for,
+            votes_against=self.votes_against,
+            void_ballots=self.void_ballots,
+            union_name=self.union_name,
+            source=self.source,
+        )
+
+
+class ULPCharge(models.Model):
+    """Unfair labor practice charge filed with the NLRB."""
+
+    case = models.ForeignKey(
+        NLRBCase,
+        on_delete=models.CASCADE,
+        related_name="ulp_charges",
+    )
+    allegation = models.TextField(blank=True, default="")
+    charging_party = models.CharField(max_length=300, blank=True, default="")
+    charged_party = models.CharField(max_length=300, blank=True, default="")
+    section_of_act = models.CharField(
+        max_length=50,
+        blank=True,
+        default="",
+        help_text="NLRA section cited (e.g. '8(a)(1)')",
+    )
+    date_filed = models.DateField(null=True, blank=True, db_index=True)
+    source = models.CharField(max_length=50, blank=True, default="")
+
+    class Meta:
+        verbose_name = "ULP Charge"
+        verbose_name_plural = "ULP Charges"
+        indexes = [
+            models.Index(fields=["date_filed"]),
+        ]
+
+    def __str__(self):
+        return f"ULP {self.case.case_number}: {self.section_of_act}"
+
+    def to_record(self):
+        from siege_utilities.geo.providers.nlrb_clients import ULPRecord
+
+        return ULPRecord(
+            case_number=self.case.case_number,
+            allegation=self.allegation,
+            charging_party=self.charging_party,
+            charged_party=self.charged_party,
+            section_of_act=self.section_of_act,
+            date_filed=self.date_filed,
+            source=self.source,
+        )
+
+
+class BargainingUnit(models.Model):
+    """Bargaining unit description with industry/occupation codes."""
+
+    case = models.ForeignKey(
+        NLRBCase,
+        on_delete=models.CASCADE,
+        related_name="bargaining_units",
+    )
+    unit_description = models.TextField(blank=True, default="")
+    naics_code = models.CharField(
+        max_length=10,
+        blank=True,
+        default="",
+        db_index=True,
+        help_text="NAICS industry code",
+    )
+    soc_codes = models.JSONField(
+        default=list,
+        blank=True,
+        help_text="List of SOC occupation codes",
+    )
+    employee_count = models.PositiveIntegerField(null=True, blank=True)
+
+    class Meta:
+        verbose_name = "Bargaining Unit"
+        verbose_name_plural = "Bargaining Units"
+        indexes = [
+            models.Index(fields=["naics_code"]),
+        ]
+
+    def __str__(self):
+        return f"Unit: {self.case.case_number} ({self.naics_code})"

--- a/siege_utilities/geo/providers/nlrb_export.py
+++ b/siege_utilities/geo/providers/nlrb_export.py
@@ -1,0 +1,71 @@
+"""DataFrame export for NLRB records.
+
+Converts NLRBFetchResult or lists of dataclass records into pandas
+DataFrames for analysis.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+
+
+def cases_to_dataframe(cases):
+    """Convert a list of NLRBCaseRecord to a DataFrame.
+
+    Args:
+        cases: List of NLRBCaseRecord instances, or an NLRBFetchResult.
+
+    Returns:
+        pandas DataFrame with one row per case.
+    """
+    import pandas as pd
+
+    from siege_utilities.geo.providers.nlrb_clients import NLRBFetchResult
+
+    if isinstance(cases, NLRBFetchResult):
+        cases = cases.cases
+    if not cases:
+        return pd.DataFrame()
+    return pd.DataFrame([c.to_dict() for c in cases])
+
+
+def elections_to_dataframe(elections):
+    """Convert a list of ElectionRecord to a DataFrame."""
+    import pandas as pd
+
+    from siege_utilities.geo.providers.nlrb_clients import NLRBFetchResult
+
+    if isinstance(elections, NLRBFetchResult):
+        elections = elections.elections
+    if not elections:
+        return pd.DataFrame()
+    return pd.DataFrame([e.to_dict() for e in elections])
+
+
+def ulp_charges_to_dataframe(charges):
+    """Convert a list of ULPRecord to a DataFrame."""
+    import pandas as pd
+
+    from siege_utilities.geo.providers.nlrb_clients import NLRBFetchResult
+
+    if isinstance(charges, NLRBFetchResult):
+        charges = charges.ulp_charges
+    if not charges:
+        return pd.DataFrame()
+    return pd.DataFrame([c.to_dict() for c in charges])
+
+
+def fetch_result_to_dataframes(result):
+    """Convert an NLRBFetchResult to a dict of DataFrames.
+
+    Returns:
+        Dict with keys 'cases', 'elections', 'ulp_charges', each a DataFrame.
+    """
+    return {
+        "cases": cases_to_dataframe(result),
+        "elections": elections_to_dataframe(result),
+        "ulp_charges": ulp_charges_to_dataframe(result),
+    }

--- a/tests/test_nlrb_models.py
+++ b/tests/test_nlrb_models.py
@@ -1,0 +1,262 @@
+"""Tests for NLRB case data models and DataFrame export (SU#618)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+try:
+    from django.db import models as django_models  # noqa: F401
+
+    _DJANGO_AVAILABLE = True
+except Exception:
+    _DJANGO_AVAILABLE = False
+
+try:
+    import pandas as pd
+
+    _PANDAS_AVAILABLE = True
+except ImportError:
+    _PANDAS_AVAILABLE = False
+
+from siege_utilities.geo.providers.nlrb_clients import (
+    ElectionRecord,
+    NLRBCaseRecord,
+    NLRBFetchResult,
+    ULPRecord,
+)
+
+
+# ---------------------------------------------------------------------------
+# Django model tests (skip if Django not available)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _DJANGO_AVAILABLE, reason="Django not available")
+class TestNLRBCaseModel:
+    def test_import(self):
+        from siege_utilities.geo.django.models.nlrb_cases import NLRBCase
+
+        assert NLRBCase is not None
+
+    def test_has_case_number(self):
+        from siege_utilities.geo.django.models.nlrb_cases import NLRBCase
+
+        field = NLRBCase._meta.get_field("case_number")
+        assert field is not None
+        assert field.unique
+
+    def test_has_case_type(self):
+        from siege_utilities.geo.django.models.nlrb_cases import NLRBCase
+
+        field = NLRBCase._meta.get_field("case_type")
+        assert field is not None
+
+    def test_has_date_fields(self):
+        from siege_utilities.geo.django.models.nlrb_cases import NLRBCase
+
+        assert NLRBCase._meta.get_field("date_filed") is not None
+        assert NLRBCase._meta.get_field("date_closed") is not None
+
+    def test_has_region_fk(self):
+        from siege_utilities.geo.django.models.nlrb_cases import NLRBCase
+
+        field = NLRBCase._meta.get_field("region")
+        assert field.related_model.__name__ == "NLRBRegion"
+
+    def test_has_location_fields(self):
+        from siege_utilities.geo.django.models.nlrb_cases import NLRBCase
+
+        assert NLRBCase._meta.get_field("city") is not None
+        assert NLRBCase._meta.get_field("state") is not None
+
+    def test_has_naics_code(self):
+        from siege_utilities.geo.django.models.nlrb_cases import NLRBCase
+
+        field = NLRBCase._meta.get_field("naics_code")
+        assert field is not None
+
+    def test_str_representation(self):
+        from siege_utilities.geo.django.models.nlrb_cases import NLRBCase
+
+        case = NLRBCase(case_number="05-RC-123456", case_name="Test Corp")
+        assert "05-RC-123456" in str(case)
+        assert "Test Corp" in str(case)
+
+    def test_from_record(self):
+        from siege_utilities.geo.django.models.nlrb_cases import NLRBCase
+
+        record = NLRBCaseRecord(
+            case_number="05-RC-100001",
+            case_type="RC",
+            case_name="Acme Corp",
+            status="Open",
+            date_filed=date(2024, 1, 15),
+            region=5,
+            city="Chicago",
+            state="IL",
+            source="labordata",
+        )
+        instance = NLRBCase.from_record(record)
+        assert instance.case_number == "05-RC-100001"
+        assert instance.region_number == 5
+        assert instance.city == "Chicago"
+
+    def test_to_record(self):
+        from siege_utilities.geo.django.models.nlrb_cases import NLRBCase
+
+        instance = NLRBCase(
+            case_number="05-RC-100001",
+            case_type="RC",
+            case_name="Acme Corp",
+            region_number=5,
+            city="Chicago",
+            state="IL",
+        )
+        record = instance.to_record()
+        assert record.case_number == "05-RC-100001"
+        assert record.region == 5
+        assert record.city == "Chicago"
+
+
+@pytest.mark.skipif(not _DJANGO_AVAILABLE, reason="Django not available")
+class TestElectionResultModel:
+    def test_import(self):
+        from siege_utilities.geo.django.models.nlrb_cases import ElectionResult
+
+        assert ElectionResult is not None
+
+    def test_has_case_fk(self):
+        from siege_utilities.geo.django.models.nlrb_cases import ElectionResult
+
+        field = ElectionResult._meta.get_field("case")
+        assert field.related_model.__name__ == "NLRBCase"
+
+    def test_has_tally_fields(self):
+        from siege_utilities.geo.django.models.nlrb_cases import ElectionResult
+
+        assert ElectionResult._meta.get_field("tally_date") is not None
+        assert ElectionResult._meta.get_field("eligible_voters") is not None
+        assert ElectionResult._meta.get_field("votes_for") is not None
+        assert ElectionResult._meta.get_field("votes_against") is not None
+
+
+@pytest.mark.skipif(not _DJANGO_AVAILABLE, reason="Django not available")
+class TestULPChargeModel:
+    def test_import(self):
+        from siege_utilities.geo.django.models.nlrb_cases import ULPCharge
+
+        assert ULPCharge is not None
+
+    def test_has_case_fk(self):
+        from siege_utilities.geo.django.models.nlrb_cases import ULPCharge
+
+        field = ULPCharge._meta.get_field("case")
+        assert field.related_model.__name__ == "NLRBCase"
+
+    def test_has_allegation_fields(self):
+        from siege_utilities.geo.django.models.nlrb_cases import ULPCharge
+
+        assert ULPCharge._meta.get_field("allegation") is not None
+        assert ULPCharge._meta.get_field("section_of_act") is not None
+
+
+@pytest.mark.skipif(not _DJANGO_AVAILABLE, reason="Django not available")
+class TestBargainingUnitModel:
+    def test_import(self):
+        from siege_utilities.geo.django.models.nlrb_cases import BargainingUnit
+
+        assert BargainingUnit is not None
+
+    def test_has_case_fk(self):
+        from siege_utilities.geo.django.models.nlrb_cases import BargainingUnit
+
+        field = BargainingUnit._meta.get_field("case")
+        assert field.related_model.__name__ == "NLRBCase"
+
+    def test_has_naics_soc_fields(self):
+        from siege_utilities.geo.django.models.nlrb_cases import BargainingUnit
+
+        assert BargainingUnit._meta.get_field("naics_code") is not None
+        assert BargainingUnit._meta.get_field("soc_codes") is not None
+        assert BargainingUnit._meta.get_field("employee_count") is not None
+
+
+# ---------------------------------------------------------------------------
+# DataFrame export tests (skip if pandas not available)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _PANDAS_AVAILABLE, reason="pandas not available")
+class TestDataFrameExport:
+    def test_cases_to_dataframe(self):
+        from siege_utilities.geo.providers.nlrb_export import cases_to_dataframe
+
+        cases = [
+            NLRBCaseRecord(case_number="05-RC-1", case_type="RC", city="Chicago"),
+            NLRBCaseRecord(case_number="01-CA-2", case_type="CA", city="Boston"),
+        ]
+        df = cases_to_dataframe(cases)
+        assert len(df) == 2
+        assert "case_number" in df.columns
+        assert "city" in df.columns
+        assert df.iloc[0]["city"] == "Chicago"
+
+    def test_cases_from_fetch_result(self):
+        from siege_utilities.geo.providers.nlrb_export import cases_to_dataframe
+
+        result = NLRBFetchResult(
+            cases=[NLRBCaseRecord(case_number="05-RC-1", case_type="RC")]
+        )
+        df = cases_to_dataframe(result)
+        assert len(df) == 1
+
+    def test_elections_to_dataframe(self):
+        from siege_utilities.geo.providers.nlrb_export import elections_to_dataframe
+
+        elections = [
+            ElectionRecord(
+                case_number="05-RC-1",
+                tally_date=date(2024, 3, 1),
+                votes_for=100,
+                votes_against=50,
+            ),
+        ]
+        df = elections_to_dataframe(elections)
+        assert len(df) == 1
+        assert df.iloc[0]["votes_for"] == 100
+
+    def test_ulp_to_dataframe(self):
+        from siege_utilities.geo.providers.nlrb_export import ulp_charges_to_dataframe
+
+        charges = [
+            ULPRecord(
+                case_number="01-CA-1",
+                allegation="8(a)(1)",
+                section_of_act="8(a)(1)",
+            ),
+        ]
+        df = ulp_charges_to_dataframe(charges)
+        assert len(df) == 1
+        assert df.iloc[0]["section_of_act"] == "8(a)(1)"
+
+    def test_empty_returns_empty_dataframe(self):
+        from siege_utilities.geo.providers.nlrb_export import cases_to_dataframe
+
+        df = cases_to_dataframe([])
+        assert len(df) == 0
+
+    def test_fetch_result_to_dataframes(self):
+        from siege_utilities.geo.providers.nlrb_export import fetch_result_to_dataframes
+
+        result = NLRBFetchResult(
+            cases=[NLRBCaseRecord(case_number="05-RC-1", case_type="RC")],
+            elections=[ElectionRecord(case_number="05-RC-1")],
+            ulp_charges=[ULPRecord(case_number="01-CA-1")],
+        )
+        dfs = fetch_result_to_dataframes(result)
+        assert "cases" in dfs
+        assert "elections" in dfs
+        assert "ulp_charges" in dfs
+        assert len(dfs["cases"]) == 1


### PR DESCRIPTION
## Summary
- Four Django models: NLRBCase, ElectionResult, ULPCharge, BargainingUnit
- Non-spatial models with FK to NLRBRegion for spatial linkage
- to_record()/from_record() converters for dataclass interop (from SU#617)
- DataFrame export module: cases, elections, ULP charges, batch export

## Test plan
- [x] 25 tests covering model fields, FK relationships, record conversion, DataFrame export
- [x] Tests skip gracefully when Django/pandas not available