### PR TITLE
feat(geo): add NLRB region lookup and case aggregation (SU#620)

### DIFF
--- a/.review/su620-region-boundaries.md
+++ b/.review/su620-region-boundaries.md
@@ -1,0 +1,31 @@
+# Self-Review: SU#620 — Region Boundary Integration
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (state → region spatial assignment)
+**Trivial-against-state:** partially — region population service already existed; this adds lookup/aggregation layer
+
+## Assumptions
+
+1. Region assignment uses state-based lookup as primary fallback when case number region is missing.
+2. Some states span multiple regions (e.g., NY → 2, 3, 29). First match is used for assignment when ambiguous.
+3. Pure-Python module (nlrb_regions.py) avoids Django dependency for portability.
+4. Region data is duplicated from nlrb_service.py to keep the non-Django module self-contained.
+
+## Peer Review (Junior)
+
+- NLRB_REGIONS registry: 5 tests (count, offices, states, range, specific)
+- State → region lookup: 6 tests (single, multi, case, unknown, whitespace, coverage)
+- assign_region: 7 tests (from region, from state, priority, none, dict variants)
+- aggregate_by_region: 3 tests (groups, unknown, empty)
+- region_summary: 4 tests (basic, sorted, unknown label, empty)
+- 25 total tests passing
+
+## Lead Review (Adversarial)
+
+- **Q: Region data is duplicated between nlrb_regions.py and nlrb_service.py — DRY violation?** A: Yes. The service depends on Django; the regions module is pure Python. A future refactor could have the service import from regions, but that changes the existing service's import chain. Not in scope for this ticket.
+- **Q: assign_region picks the first region for multi-region states — that's wrong for NY/PA/CA.** A: Correct, it's a heuristic. For precise assignment, the caller should use the region number from the case number (which is always available in NLRB data). The state fallback is for data that's missing the case number format.
+
+## Quantified Claims
+
+- 25 new tests, all passing
+- ~130 lines of implementation (region lookup, assignment, aggregation, summary)

--- a/siege_utilities/geo/providers/nlrb_regions.py
+++ b/siege_utilities/geo/providers/nlrb_regions.py
@@ -1,0 +1,144 @@
+"""NLRB region lookup, case-to-region assignment, and aggregation.
+
+Pure-Python utilities — no Django dependency. Works with NLRBCaseRecord
+dataclasses, dicts, or any object with ``region`` and ``state`` attributes.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Optional
+
+NLRB_REGIONS: dict[int, dict] = {
+    1: {"office": "Boston", "states": ["CT", "MA", "ME", "NH", "RI", "VT"]},
+    2: {"office": "New York", "states": ["NY"]},
+    3: {"office": "Buffalo", "states": ["NY"]},
+    4: {"office": "Philadelphia", "states": ["DE", "PA"]},
+    5: {"office": "Baltimore", "states": ["DC", "MD", "VA", "WV"]},
+    6: {"office": "Pittsburgh", "states": ["PA", "WV"]},
+    7: {"office": "Detroit", "states": ["MI"]},
+    8: {"office": "Cleveland", "states": ["OH"]},
+    9: {"office": "Cincinnati", "states": ["IN", "KY", "OH"]},
+    10: {"office": "Atlanta", "states": ["AL", "GA", "NC", "SC", "TN"]},
+    11: {"office": "Winston-Salem", "states": ["NC", "SC", "TN", "VA"]},
+    12: {"office": "Tampa", "states": ["FL", "PR", "VI"]},
+    13: {"office": "Chicago", "states": ["IL", "IN"]},
+    14: {"office": "St. Louis", "states": ["IL", "MO"]},
+    15: {"office": "New Orleans", "states": ["AL", "LA", "MS"]},
+    16: {"office": "Fort Worth", "states": ["TX"]},
+    17: {"office": "Kansas City", "states": ["IA", "KS", "MO", "NE"]},
+    18: {"office": "Minneapolis", "states": ["MN", "ND", "SD", "WI"]},
+    19: {"office": "Seattle", "states": ["AK", "ID", "MT", "OR", "WA", "WY"]},
+    20: {"office": "San Francisco", "states": ["CA", "HI", "NV"]},
+    21: {"office": "Los Angeles", "states": ["AZ", "CA", "HI", "NV"]},
+    22: {"office": "Newark", "states": ["NJ"]},
+    24: {"office": "Hato Rey", "states": ["PR", "VI"]},
+    25: {"office": "Indianapolis", "states": ["IN"]},
+    26: {"office": "Memphis", "states": ["AR", "MS", "TN"]},
+    27: {"office": "Denver", "states": ["CO", "NM", "UT", "WY"]},
+    28: {"office": "Memphis", "states": ["AL", "AR", "MS"]},
+    29: {"office": "Brooklyn", "states": ["NY"]},
+    31: {"office": "Los Angeles", "states": ["CA"]},
+}
+
+
+def _build_state_to_regions() -> dict[str, list[int]]:
+    state_map: dict[str, list[int]] = defaultdict(list)
+    for region_num, info in NLRB_REGIONS.items():
+        for state in info["states"]:
+            state_map[state].append(region_num)
+    return dict(state_map)
+
+
+STATE_TO_REGIONS: dict[str, list[int]] = _build_state_to_regions()
+
+
+def lookup_region_by_state(state: str) -> list[int]:
+    """Return NLRB region number(s) for a state abbreviation.
+
+    Args:
+        state: 2-letter state abbreviation (e.g., 'IL', 'NY').
+
+    Returns:
+        List of region numbers. May be >1 for states split across
+        multiple regions (e.g., NY → [2, 3, 29]).
+        Empty list if state not found.
+    """
+    return STATE_TO_REGIONS.get(state.upper().strip(), [])
+
+
+def assign_region(case_record) -> Optional[int]:
+    """Assign an NLRB region number to a case record.
+
+    Uses the region number from the case number if available,
+    otherwise falls back to state-based lookup (first match).
+
+    Args:
+        case_record: Object with ``region`` and ``state`` attributes,
+            or a dict with those keys.
+
+    Returns:
+        Region number or None if not determinable.
+    """
+    if isinstance(case_record, dict):
+        region = case_record.get("region")
+        state = case_record.get("state", "")
+    else:
+        region = getattr(case_record, "region", None)
+        state = getattr(case_record, "state", "")
+
+    if region:
+        return int(region)
+
+    if state:
+        regions = lookup_region_by_state(state)
+        if regions:
+            return regions[0]
+
+    return None
+
+
+def aggregate_by_region(records) -> dict[int, list]:
+    """Group records by their NLRB region number.
+
+    Args:
+        records: Iterable of case records (dataclass, model, or dict).
+
+    Returns:
+        Dict mapping region numbers to lists of records.
+        Records without a region are grouped under key 0.
+    """
+    groups: dict[int, list] = defaultdict(list)
+    for record in records:
+        region = assign_region(record)
+        groups[region or 0].append(record)
+    return dict(groups)
+
+
+def region_summary(records) -> list[dict]:
+    """Summarize case counts by region with office names.
+
+    Args:
+        records: Iterable of case records.
+
+    Returns:
+        List of dicts with keys: region_number, office, case_count.
+        Sorted by region_number.
+    """
+    groups = aggregate_by_region(records)
+    summary = []
+    for region_num, cases in sorted(groups.items()):
+        if region_num == 0:
+            summary.append({
+                "region_number": 0,
+                "office": "Unknown",
+                "case_count": len(cases),
+            })
+        else:
+            info = NLRB_REGIONS.get(region_num, {})
+            summary.append({
+                "region_number": region_num,
+                "office": info.get("office", "Unknown"),
+                "case_count": len(cases),
+            })
+    return summary

--- a/tests/test_nlrb_regions.py
+++ b/tests/test_nlrb_regions.py
@@ -1,0 +1,188 @@
+"""Tests for NLRB region boundary integration (SU#620)."""
+
+from __future__ import annotations
+
+import pytest
+
+from siege_utilities.geo.providers.nlrb_clients import NLRBCaseRecord
+from siege_utilities.geo.providers.nlrb_regions import (
+    NLRB_REGIONS,
+    STATE_TO_REGIONS,
+    aggregate_by_region,
+    assign_region,
+    lookup_region_by_state,
+    region_summary,
+)
+
+
+# ---------------------------------------------------------------------------
+# Region registry tests
+# ---------------------------------------------------------------------------
+
+
+class TestNLRBRegions:
+    def test_has_expected_regions(self):
+        assert len(NLRB_REGIONS) >= 26
+
+    def test_all_have_office(self):
+        for num, info in NLRB_REGIONS.items():
+            assert info["office"], f"Region {num} missing office"
+
+    def test_all_have_states(self):
+        for num, info in NLRB_REGIONS.items():
+            assert len(info["states"]) > 0, f"Region {num} has no states"
+
+    def test_region_numbers_in_range(self):
+        for num in NLRB_REGIONS:
+            assert 1 <= num <= 31
+
+    def test_known_region(self):
+        assert NLRB_REGIONS[13]["office"] == "Chicago"
+        assert "IL" in NLRB_REGIONS[13]["states"]
+
+
+# ---------------------------------------------------------------------------
+# State → Region lookup tests
+# ---------------------------------------------------------------------------
+
+
+class TestStateToRegions:
+    def test_single_region_state(self):
+        regions = lookup_region_by_state("FL")
+        assert 12 in regions
+
+    def test_multi_region_state(self):
+        regions = lookup_region_by_state("NY")
+        assert len(regions) > 1
+        assert 2 in regions
+        assert 3 in regions
+        assert 29 in regions
+
+    def test_case_insensitive(self):
+        assert lookup_region_by_state("il") == lookup_region_by_state("IL")
+
+    def test_unknown_state(self):
+        assert lookup_region_by_state("XX") == []
+
+    def test_whitespace_stripped(self):
+        assert lookup_region_by_state(" TX ") == lookup_region_by_state("TX")
+
+    def test_all_states_covered(self):
+        all_states = set()
+        for info in NLRB_REGIONS.values():
+            all_states.update(info["states"])
+        assert len(all_states) > 40
+
+
+# ---------------------------------------------------------------------------
+# assign_region tests
+# ---------------------------------------------------------------------------
+
+
+class TestAssignRegion:
+    def test_from_case_number_region(self):
+        case = NLRBCaseRecord(
+            case_number="05-RC-123456", case_type="RC", region=5
+        )
+        assert assign_region(case) == 5
+
+    def test_from_state_fallback(self):
+        case = NLRBCaseRecord(
+            case_number="test", case_type="RC", state="TX"
+        )
+        assert assign_region(case) == 16
+
+    def test_region_takes_priority(self):
+        case = NLRBCaseRecord(
+            case_number="test", case_type="RC", region=13, state="TX"
+        )
+        assert assign_region(case) == 13
+
+    def test_no_info_returns_none(self):
+        case = NLRBCaseRecord(
+            case_number="test", case_type="RC"
+        )
+        assert assign_region(case) is None
+
+    def test_works_with_dict(self):
+        d = {"region": 5, "state": "MD"}
+        assert assign_region(d) == 5
+
+    def test_dict_state_fallback(self):
+        d = {"state": "FL"}
+        assert assign_region(d) == 12
+
+    def test_dict_no_info(self):
+        d = {"case_number": "test"}
+        assert assign_region(d) is None
+
+
+# ---------------------------------------------------------------------------
+# aggregate_by_region tests
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateByRegion:
+    def test_groups_cases(self):
+        cases = [
+            NLRBCaseRecord(case_number="1", case_type="RC", region=5),
+            NLRBCaseRecord(case_number="2", case_type="CA", region=5),
+            NLRBCaseRecord(case_number="3", case_type="RC", region=13),
+        ]
+        groups = aggregate_by_region(cases)
+        assert len(groups[5]) == 2
+        assert len(groups[13]) == 1
+
+    def test_unknown_region_grouped_under_zero(self):
+        cases = [
+            NLRBCaseRecord(case_number="1", case_type="RC"),
+        ]
+        groups = aggregate_by_region(cases)
+        assert 0 in groups
+        assert len(groups[0]) == 1
+
+    def test_empty_input(self):
+        assert aggregate_by_region([]) == {}
+
+
+# ---------------------------------------------------------------------------
+# region_summary tests
+# ---------------------------------------------------------------------------
+
+
+class TestRegionSummary:
+    def test_basic_summary(self):
+        cases = [
+            NLRBCaseRecord(case_number="1", case_type="RC", region=5),
+            NLRBCaseRecord(case_number="2", case_type="CA", region=5),
+            NLRBCaseRecord(case_number="3", case_type="RC", region=13),
+        ]
+        summary = region_summary(cases)
+        assert len(summary) == 2
+
+        r5 = next(s for s in summary if s["region_number"] == 5)
+        assert r5["office"] == "Baltimore"
+        assert r5["case_count"] == 2
+
+        r13 = next(s for s in summary if s["region_number"] == 13)
+        assert r13["office"] == "Chicago"
+        assert r13["case_count"] == 1
+
+    def test_sorted_by_region(self):
+        cases = [
+            NLRBCaseRecord(case_number="1", case_type="RC", region=13),
+            NLRBCaseRecord(case_number="2", case_type="RC", region=5),
+        ]
+        summary = region_summary(cases)
+        assert summary[0]["region_number"] < summary[1]["region_number"]
+
+    def test_unknown_region_labeled(self):
+        cases = [
+            NLRBCaseRecord(case_number="1", case_type="RC"),
+        ]
+        summary = region_summary(cases)
+        assert summary[0]["office"] == "Unknown"
+        assert summary[0]["region_number"] == 0
+
+    def test_empty_input(self):
+        assert region_summary([]) == []


### PR DESCRIPTION
## Summary
- Pure-Python NLRB region module: state→region lookup, case assignment, aggregation
- `assign_region()` uses case number region or state fallback
- `aggregate_by_region()` and `region_summary()` for analysis
- No Django dependency — works with dataclasses, dicts, or model instances

## Test plan
- [x] 25 tests covering registry, lookup, assignment, aggregation, summary
- [x] Edge cases: multi-region states, unknown states, missing data, empty input