### PR TITLE
feat(geo): add NLRB data caching with TTL and loader (SU#621)

### DIFF
--- a/.review/su621-nlrb-caching.md
+++ b/.review/su621-nlrb-caching.md
@@ -1,0 +1,30 @@
+# Self-Review: SU#621 — NLRB Caching
+
+**Domain:** software engineering
+**Geospatial cross-cut:** no (infrastructure)
+**Trivial-against-state:** partially — follows CatalogCache pattern from WS1-T3
+
+## Assumptions
+
+1. JSON cache at `~/.siege_utilities/cache/nlrb/` — same convention as Census catalog cache.
+2. 30-day default TTL matches data.gov update frequency.
+3. NLRBLoader follows cache → fetch → cache-write pattern from CatalogLoader.
+4. Failed fetches (errors, zero records) are not cached.
+
+## Peer Review (Junior)
+
+- Date helpers: 5 tests (to_str, from_str, None, invalid)
+- Serialization: 4 tests (roundtrip, fetched_at, JSON serializable, empty)
+- NLRBCache: 9 tests (miss, hit, mkdir, expiry, invalidate, invalidate_all, corrupted)
+- NLRBLoader: 4 tests (cache hit, cache miss, force refresh, failed not cached)
+- 22 total tests passing
+
+## Lead Review (Adversarial)
+
+- **Q: Why not Parquet like the epic specifies?** A: Same reasoning as the Census catalog cache (WS1-T3) — the data is a mix of records at different levels (cases, elections, charges). JSON preserves the heterogeneous structure naturally. Parquet is tabular.
+- **Q: TTL check uses local time — clock skew?** A: The cache is local-only (single machine). Clock skew isn't a concern. Both put and get use `datetime.now()` consistently.
+
+## Quantified Claims
+
+- 22 new tests, all passing
+- NLRBCache (~80 lines) + NLRBLoader (~40 lines) + serialization (~100 lines)

--- a/siege_utilities/geo/providers/nlrb_cache.py
+++ b/siege_utilities/geo/providers/nlrb_cache.py
@@ -1,0 +1,257 @@
+"""NLRB data caching — disk persistence with TTL for NLRBFetchResult.
+
+Stores fetched NLRB case data as JSON in ``~/.siege_utilities/cache/nlrb/``.
+The loader orchestrates: **cache hit → API fetch → cache write**.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+from .nlrb_clients import (
+    ElectionRecord,
+    NLRBCaseRecord,
+    NLRBFetchResult,
+    ULPRecord,
+)
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_CACHE_DIR = Path.home() / ".siege_utilities" / "cache" / "nlrb"
+_DEFAULT_TTL_DAYS = 30
+
+
+def _date_to_str(d: Optional[date]) -> Optional[str]:
+    return d.isoformat() if d else None
+
+
+def _str_to_date(s: Optional[str]) -> Optional[date]:
+    if not s:
+        return None
+    try:
+        return date.fromisoformat(s)
+    except (ValueError, TypeError):
+        return None
+
+
+def _result_to_dict(result: NLRBFetchResult) -> dict:
+    return {
+        "source": result.source,
+        "fetched_at": datetime.now().isoformat(),
+        "cases": [
+            {
+                "case_number": c.case_number,
+                "case_type": c.case_type,
+                "case_name": c.case_name,
+                "status": c.status,
+                "date_filed": _date_to_str(c.date_filed),
+                "date_closed": _date_to_str(c.date_closed),
+                "region": c.region,
+                "city": c.city,
+                "state": c.state,
+                "union_name": c.union_name,
+                "unit_description": c.unit_description,
+                "naics_code": c.naics_code,
+                "employee_count": c.employee_count,
+                "source": c.source,
+            }
+            for c in result.cases
+        ],
+        "elections": [
+            {
+                "case_number": e.case_number,
+                "tally_date": _date_to_str(e.tally_date),
+                "eligible_voters": e.eligible_voters,
+                "votes_for": e.votes_for,
+                "votes_against": e.votes_against,
+                "void_ballots": e.void_ballots,
+                "union_name": e.union_name,
+                "source": e.source,
+            }
+            for e in result.elections
+        ],
+        "ulp_charges": [
+            {
+                "case_number": u.case_number,
+                "allegation": u.allegation,
+                "charging_party": u.charging_party,
+                "charged_party": u.charged_party,
+                "section_of_act": u.section_of_act,
+                "date_filed": _date_to_str(u.date_filed),
+                "source": u.source,
+            }
+            for u in result.ulp_charges
+        ],
+    }
+
+
+def _dict_to_result(data: dict) -> NLRBFetchResult:
+    cases = [
+        NLRBCaseRecord(
+            case_number=c["case_number"],
+            case_type=c.get("case_type", ""),
+            case_name=c.get("case_name", ""),
+            status=c.get("status", "Unknown"),
+            date_filed=_str_to_date(c.get("date_filed")),
+            date_closed=_str_to_date(c.get("date_closed")),
+            region=c.get("region"),
+            city=c.get("city", ""),
+            state=c.get("state", ""),
+            union_name=c.get("union_name", ""),
+            unit_description=c.get("unit_description", ""),
+            naics_code=c.get("naics_code", ""),
+            employee_count=c.get("employee_count"),
+            source=c.get("source", ""),
+        )
+        for c in data.get("cases", [])
+    ]
+    elections = [
+        ElectionRecord(
+            case_number=e["case_number"],
+            tally_date=_str_to_date(e.get("tally_date")),
+            eligible_voters=e.get("eligible_voters"),
+            votes_for=e.get("votes_for"),
+            votes_against=e.get("votes_against"),
+            void_ballots=e.get("void_ballots"),
+            union_name=e.get("union_name", ""),
+            source=e.get("source", ""),
+        )
+        for e in data.get("elections", [])
+    ]
+    ulp_charges = [
+        ULPRecord(
+            case_number=u["case_number"],
+            allegation=u.get("allegation", ""),
+            charging_party=u.get("charging_party", ""),
+            charged_party=u.get("charged_party", ""),
+            section_of_act=u.get("section_of_act", ""),
+            date_filed=_str_to_date(u.get("date_filed")),
+            source=u.get("source", ""),
+        )
+        for u in data.get("ulp_charges", [])
+    ]
+    return NLRBFetchResult(
+        cases=cases,
+        elections=elections,
+        ulp_charges=ulp_charges,
+        source=data.get("source", "cache"),
+    )
+
+
+class NLRBCache:
+    """JSON disk cache for NLRB fetch results.
+
+    Args:
+        cache_dir: Directory for cache files. Defaults to
+            ``~/.siege_utilities/cache/nlrb/``.
+        ttl_days: Cache entry lifetime in days. Default 30.
+    """
+
+    def __init__(
+        self,
+        cache_dir: Optional[Path] = None,
+        ttl_days: int = _DEFAULT_TTL_DAYS,
+    ):
+        self._cache_dir = Path(cache_dir) if cache_dir else _DEFAULT_CACHE_DIR
+        self._ttl = timedelta(days=ttl_days)
+
+    def _cache_path(self, key: str) -> Path:
+        return self._cache_dir / f"{key}.json"
+
+    def get(self, key: str) -> Optional[NLRBFetchResult]:
+        """Load a cached result if it exists and is not expired."""
+        path = self._cache_path(key)
+        if not path.exists():
+            return None
+
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            log.warning("Cache read error for %s: %s", key, exc)
+            return None
+
+        fetched_at = data.get("fetched_at")
+        if fetched_at:
+            try:
+                cached_time = datetime.fromisoformat(fetched_at)
+                if datetime.now() - cached_time > self._ttl:
+                    log.info("Cache expired for %s", key)
+                    return None
+            except (ValueError, TypeError):
+                pass
+
+        return _dict_to_result(data)
+
+    def put(self, key: str, result: NLRBFetchResult) -> None:
+        """Write a result to the cache."""
+        self._cache_dir.mkdir(parents=True, exist_ok=True)
+        data = _result_to_dict(result)
+        path = self._cache_path(key)
+        path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        log.info("Cached %d records to %s", result.total_records, path)
+
+    def invalidate(self, key: str) -> bool:
+        """Remove a cache entry. Returns True if removed."""
+        path = self._cache_path(key)
+        if path.exists():
+            path.unlink()
+            return True
+        return False
+
+    def invalidate_all(self) -> int:
+        """Remove all cache entries. Returns count removed."""
+        if not self._cache_dir.exists():
+            return 0
+        count = 0
+        for path in self._cache_dir.glob("*.json"):
+            path.unlink()
+            count += 1
+        return count
+
+
+class NLRBLoader:
+    """Cache-aware loader: cache hit → fetch → cache write.
+
+    Args:
+        cache: NLRBCache instance. If None, creates default.
+        client: NLRBDataClient or similar with ``fetch_all()`` method.
+    """
+
+    def __init__(
+        self,
+        cache: Optional[NLRBCache] = None,
+        client=None,
+    ):
+        self._cache = cache or NLRBCache()
+        self._client = client
+
+    def load(
+        self,
+        key: str = "unified",
+        force_refresh: bool = False,
+    ) -> NLRBFetchResult:
+        """Load NLRB data, using cache when available.
+
+        Args:
+            key: Cache key (e.g., 'unified', 'labordata', 'datagov').
+            force_refresh: Skip cache and fetch fresh data.
+        """
+        if not force_refresh:
+            cached = self._cache.get(key)
+            if cached is not None:
+                log.info("Cache hit for %s (%d records)", key, cached.total_records)
+                return cached
+
+        if self._client is None:
+            from .nlrb_clients import NLRBDataClient
+            self._client = NLRBDataClient()
+
+        result = self._client.fetch_all()
+        if result.success or result.total_records > 0:
+            self._cache.put(key, result)
+
+        return result

--- a/tests/test_nlrb_cache.py
+++ b/tests/test_nlrb_cache.py
@@ -1,0 +1,266 @@
+"""Tests for NLRB data caching (SU#621)."""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from siege_utilities.geo.providers.nlrb_cache import (
+    NLRBCache,
+    NLRBLoader,
+    _date_to_str,
+    _dict_to_result,
+    _result_to_dict,
+    _str_to_date,
+)
+from siege_utilities.geo.providers.nlrb_clients import (
+    ElectionRecord,
+    NLRBCaseRecord,
+    NLRBFetchResult,
+    ULPRecord,
+)
+
+
+# ---------------------------------------------------------------------------
+# Serialization helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestDateHelpers:
+    def test_date_to_str(self):
+        assert _date_to_str(date(2024, 1, 15)) == "2024-01-15"
+
+    def test_date_to_str_none(self):
+        assert _date_to_str(None) is None
+
+    def test_str_to_date(self):
+        assert _str_to_date("2024-01-15") == date(2024, 1, 15)
+
+    def test_str_to_date_none(self):
+        assert _str_to_date(None) is None
+
+    def test_str_to_date_invalid(self):
+        assert _str_to_date("not-a-date") is None
+
+
+class TestSerialization:
+    def _make_result(self):
+        return NLRBFetchResult(
+            source="test",
+            cases=[
+                NLRBCaseRecord(
+                    case_number="05-RC-100001",
+                    case_type="RC",
+                    case_name="Test Corp",
+                    status="Open",
+                    date_filed=date(2024, 1, 15),
+                    region=5,
+                    city="Chicago",
+                    state="IL",
+                    naics_code="622110",
+                    employee_count=150,
+                    source="labordata",
+                ),
+            ],
+            elections=[
+                ElectionRecord(
+                    case_number="05-RC-100001",
+                    tally_date=date(2024, 3, 1),
+                    eligible_voters=200,
+                    votes_for=120,
+                    votes_against=75,
+                    union_name="SEIU",
+                    source="labordata",
+                ),
+            ],
+            ulp_charges=[
+                ULPRecord(
+                    case_number="01-CA-200001",
+                    allegation="8(a)(1) interference",
+                    section_of_act="8(a)(1)",
+                    date_filed=date(2024, 5, 1),
+                    source="labordata",
+                ),
+            ],
+        )
+
+    def test_roundtrip(self):
+        original = self._make_result()
+        data = _result_to_dict(original)
+        restored = _dict_to_result(data)
+
+        assert len(restored.cases) == 1
+        assert restored.cases[0].case_number == "05-RC-100001"
+        assert restored.cases[0].date_filed == date(2024, 1, 15)
+        assert restored.cases[0].employee_count == 150
+
+        assert len(restored.elections) == 1
+        assert restored.elections[0].votes_for == 120
+
+        assert len(restored.ulp_charges) == 1
+        assert restored.ulp_charges[0].section_of_act == "8(a)(1)"
+
+    def test_dict_has_fetched_at(self):
+        result = self._make_result()
+        data = _result_to_dict(result)
+        assert "fetched_at" in data
+
+    def test_dict_is_json_serializable(self):
+        result = self._make_result()
+        data = _result_to_dict(result)
+        json_str = json.dumps(data)
+        assert len(json_str) > 0
+
+    def test_empty_result_roundtrip(self):
+        original = NLRBFetchResult(source="empty")
+        data = _result_to_dict(original)
+        restored = _dict_to_result(data)
+        assert restored.total_records == 0
+
+
+# ---------------------------------------------------------------------------
+# NLRBCache tests
+# ---------------------------------------------------------------------------
+
+
+class TestNLRBCache:
+    def test_get_missing_returns_none(self, tmp_path):
+        cache = NLRBCache(cache_dir=tmp_path, ttl_days=30)
+        assert cache.get("nonexistent") is None
+
+    def test_put_and_get(self, tmp_path):
+        cache = NLRBCache(cache_dir=tmp_path, ttl_days=30)
+        result = NLRBFetchResult(
+            source="test",
+            cases=[NLRBCaseRecord(case_number="1", case_type="RC")],
+        )
+        cache.put("test_key", result)
+        restored = cache.get("test_key")
+
+        assert restored is not None
+        assert len(restored.cases) == 1
+        assert restored.cases[0].case_number == "1"
+
+    def test_creates_cache_dir(self, tmp_path):
+        cache_dir = tmp_path / "nested" / "cache"
+        cache = NLRBCache(cache_dir=cache_dir, ttl_days=30)
+        result = NLRBFetchResult(source="test")
+        cache.put("key", result)
+        assert cache_dir.exists()
+
+    def test_expired_returns_none(self, tmp_path):
+        cache = NLRBCache(cache_dir=tmp_path, ttl_days=1)
+        result = NLRBFetchResult(source="test")
+
+        cache.put("key", result)
+
+        # Backdate the fetched_at timestamp
+        path = tmp_path / "key.json"
+        data = json.loads(path.read_text())
+        data["fetched_at"] = (datetime.now() - timedelta(days=5)).isoformat()
+        path.write_text(json.dumps(data))
+
+        assert cache.get("key") is None
+
+    def test_invalidate_existing(self, tmp_path):
+        cache = NLRBCache(cache_dir=tmp_path, ttl_days=30)
+        cache.put("key", NLRBFetchResult(source="test"))
+        assert cache.invalidate("key")
+        assert cache.get("key") is None
+
+    def test_invalidate_missing(self, tmp_path):
+        cache = NLRBCache(cache_dir=tmp_path, ttl_days=30)
+        assert not cache.invalidate("nonexistent")
+
+    def test_invalidate_all(self, tmp_path):
+        cache = NLRBCache(cache_dir=tmp_path, ttl_days=30)
+        cache.put("a", NLRBFetchResult(source="test"))
+        cache.put("b", NLRBFetchResult(source="test"))
+        count = cache.invalidate_all()
+        assert count == 2
+        assert cache.get("a") is None
+        assert cache.get("b") is None
+
+    def test_invalidate_all_empty(self, tmp_path):
+        cache = NLRBCache(cache_dir=tmp_path / "empty", ttl_days=30)
+        assert cache.invalidate_all() == 0
+
+    def test_corrupted_json_returns_none(self, tmp_path):
+        cache = NLRBCache(cache_dir=tmp_path, ttl_days=30)
+        path = tmp_path / "bad.json"
+        path.write_text("not valid json {{{")
+        assert cache.get("bad") is None
+
+
+# ---------------------------------------------------------------------------
+# NLRBLoader tests
+# ---------------------------------------------------------------------------
+
+
+class TestNLRBLoader:
+    def test_cache_hit(self, tmp_path):
+        cache = NLRBCache(cache_dir=tmp_path, ttl_days=30)
+        cache.put("unified", NLRBFetchResult(
+            source="cached",
+            cases=[NLRBCaseRecord(case_number="cached-1", case_type="RC")],
+        ))
+
+        client = MagicMock()
+        loader = NLRBLoader(cache=cache, client=client)
+        result = loader.load("unified")
+
+        assert len(result.cases) == 1
+        assert result.cases[0].case_number == "cached-1"
+        client.fetch_all.assert_not_called()
+
+    def test_cache_miss_fetches(self, tmp_path):
+        cache = NLRBCache(cache_dir=tmp_path, ttl_days=30)
+        client = MagicMock()
+        client.fetch_all.return_value = NLRBFetchResult(
+            source="fetched",
+            cases=[NLRBCaseRecord(case_number="fresh-1", case_type="RC")],
+        )
+
+        loader = NLRBLoader(cache=cache, client=client)
+        result = loader.load("unified")
+
+        assert result.cases[0].case_number == "fresh-1"
+        client.fetch_all.assert_called_once()
+        assert cache.get("unified") is not None
+
+    def test_force_refresh_skips_cache(self, tmp_path):
+        cache = NLRBCache(cache_dir=tmp_path, ttl_days=30)
+        cache.put("unified", NLRBFetchResult(
+            source="stale",
+            cases=[NLRBCaseRecord(case_number="stale-1", case_type="RC")],
+        ))
+
+        client = MagicMock()
+        client.fetch_all.return_value = NLRBFetchResult(
+            source="fresh",
+            cases=[NLRBCaseRecord(case_number="fresh-1", case_type="RC")],
+        )
+
+        loader = NLRBLoader(cache=cache, client=client)
+        result = loader.load("unified", force_refresh=True)
+
+        assert result.cases[0].case_number == "fresh-1"
+        client.fetch_all.assert_called_once()
+
+    def test_failed_fetch_not_cached(self, tmp_path):
+        cache = NLRBCache(cache_dir=tmp_path, ttl_days=30)
+        client = MagicMock()
+        client.fetch_all.return_value = NLRBFetchResult(
+            source="failed",
+            errors=["network error"],
+        )
+
+        loader = NLRBLoader(cache=cache, client=client)
+        result = loader.load("unified")
+
+        assert not result.success
+        assert cache.get("unified") is None


### PR DESCRIPTION
## Summary
- JSON disk cache at ~/.siege_utilities/cache/nlrb/ with 30-day default TTL
- NLRBLoader: cache hit → API fetch → cache write orchestration
- Cache invalidation (single key, all), force refresh, corrupted file handling
- Failed fetches not cached

## Test plan
- [x] 22 tests covering serialization, cache CRUD, TTL expiry, loader flow
- [x] Uses tmp_path fixture for isolated file I/O