### PR TITLE
feat(geo): add BatchGeocoder ABC and GeocodingResult schema (SU#622)

### DIFF
--- a/.review/su622-batch-geocoder-interface.md
+++ b/.review/su622-batch-geocoder-interface.md
@@ -1,0 +1,33 @@
+# Self-Review: SU#622 — BatchGeocoder Interface
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (geocoding, GEOID schemas)
+**Trivial-against-state:** no — new ABC + result schema + address normalization
+
+## Assumptions
+
+1. GeocodingResult carries block/tract/county/state GEOIDs as strings — not all backends provide all levels.
+2. MatchQuality enum covers the main quality tiers across Census (exact/non-exact), Nominatim (interpolated), and TAMU.
+3. AddressInput normalizes dict/string/dataclass inputs into a common format for all backends.
+4. BatchGeocodingResult provides both DataFrame and GeoDataFrame output (lazy pandas/geopandas import).
+5. is_available() defaults to True — override for backends needing API keys or connectivity checks.
+
+## Peer Review (Junior)
+
+- GeocodingResult: 5 tests (default, exact, block check, tract check, to_dict)
+- MatchQuality: 2 tests
+- BatchGeocodingResult: 3 tests (empty, counts, errors)
+- AddressInput: 3 tests (one_line, partial, empty)
+- normalize_addresses: 7 tests (dicts, strings, AddressInput, empty, address key, id key, unsupported)
+- BatchGeocoder ABC: 5 tests (no instantiate, concrete, strings, dicts, id preservation)
+- 25 total tests passing
+
+## Lead Review (Adversarial)
+
+- **Q: Why not reuse CensusGeocodeResult?** A: It's Census-specific (FIPS components, TIGER fields). The unified GeocodingResult uses composite GEOIDs and a backend-agnostic quality enum. A converter from CensusGeocodeResult to GeocodingResult is WS5-T2's responsibility.
+- **Q: GeoDataFrame output lazy-imports geopandas — what if it's not installed?** A: ImportError propagates naturally. The method is on BatchGeocodingResult, not the ABC, so backends don't need geopandas to function.
+
+## Quantified Claims
+
+- 25 new tests, all passing
+- ~220 lines of implementation (result schema, address normalization, ABC)

--- a/siege_utilities/geo/providers/batch_geocoder.py
+++ b/siege_utilities/geo/providers/batch_geocoder.py
@@ -1,0 +1,258 @@
+"""Unified batch geocoding interface.
+
+Defines the :class:`BatchGeocoder` abstract base class and
+:class:`GeocodingResult` schema for consistent geocoding across
+multiple backends (Census, Nominatim, TAMU, etc.).
+
+Usage::
+
+    from siege_utilities.geo.providers.batch_geocoder import (
+        BatchGeocoder, GeocodingResult, MatchQuality,
+    )
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from dataclasses import dataclass, field, asdict
+from enum import Enum
+from typing import Optional, Union
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Result schema
+# ---------------------------------------------------------------------------
+
+
+class MatchQuality(str, Enum):
+    """Geocoding match quality levels."""
+
+    EXACT = "exact"
+    INTERPOLATED = "interpolated"
+    APPROXIMATE = "approximate"
+    CENTROID = "centroid"
+    NO_MATCH = "no_match"
+
+
+@dataclass
+class GeocodingResult:
+    """Unified geocoding result across all backends.
+
+    Attributes:
+        input_address: Original address as submitted.
+        input_id: Caller-supplied identifier (preserved through geocoding).
+        matched_address: Standardized matched address from the geocoder.
+        lat: Latitude of the matched location.
+        lon: Longitude of the matched location.
+        match_quality: How precise the match is.
+        block_geoid: 15-digit Census block GEOID (if available).
+        tract_geoid: 11-digit Census tract GEOID (if available).
+        county_geoid: 5-digit county GEOID (if available).
+        state_geoid: 2-digit state GEOID (if available).
+        backend: Name of the geocoding backend that produced this result.
+    """
+
+    input_address: str = ""
+    input_id: str = ""
+    matched_address: str = ""
+    lat: Optional[float] = None
+    lon: Optional[float] = None
+    match_quality: str = MatchQuality.NO_MATCH.value
+    block_geoid: str = ""
+    tract_geoid: str = ""
+    county_geoid: str = ""
+    state_geoid: str = ""
+    backend: str = ""
+
+    @property
+    def matched(self) -> bool:
+        return self.match_quality != MatchQuality.NO_MATCH.value
+
+    @property
+    def has_block(self) -> bool:
+        return len(self.block_geoid) == 15
+
+    @property
+    def has_tract(self) -> bool:
+        return len(self.tract_geoid) == 11
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d["matched"] = self.matched
+        return d
+
+
+@dataclass
+class BatchGeocodingResult:
+    """Container for a batch geocoding run."""
+
+    results: list[GeocodingResult] = field(default_factory=list)
+    backend: str = ""
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return len(self.results)
+
+    @property
+    def matched_count(self) -> int:
+        return sum(1 for r in self.results if r.matched)
+
+    @property
+    def match_rate(self) -> float:
+        if not self.results:
+            return 0.0
+        return self.matched_count / len(self.results)
+
+    def to_dataframe(self):
+        """Convert results to a pandas DataFrame.
+
+        Returns:
+            DataFrame with one row per result, including all fields.
+        """
+        import pandas as pd
+
+        if not self.results:
+            return pd.DataFrame()
+        return pd.DataFrame([r.to_dict() for r in self.results])
+
+    def to_geodataframe(self):
+        """Convert results to a GeoDataFrame with point geometry.
+
+        Only includes matched results (those with lat/lon coordinates).
+
+        Returns:
+            GeoDataFrame with point geometry in EPSG:4326.
+        """
+        import geopandas as gpd
+        import pandas as pd
+        from shapely.geometry import Point
+
+        matched = [r for r in self.results if r.matched and r.lat and r.lon]
+        if not matched:
+            return gpd.GeoDataFrame()
+
+        df = pd.DataFrame([r.to_dict() for r in matched])
+        geometry = [Point(r.lon, r.lat) for r in matched]
+        return gpd.GeoDataFrame(df, geometry=geometry, crs="EPSG:4326")
+
+
+# ---------------------------------------------------------------------------
+# Address normalization
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AddressInput:
+    """Normalized address input for batch geocoding."""
+
+    street: str = ""
+    city: str = ""
+    state: str = ""
+    zipcode: str = ""
+    input_id: str = ""
+
+    @property
+    def one_line(self) -> str:
+        parts = [self.street, self.city, self.state, self.zipcode]
+        return ", ".join(p for p in parts if p)
+
+
+def normalize_addresses(
+    addresses: Union[list[dict], list[str], list[AddressInput]],
+) -> list[AddressInput]:
+    """Normalize address input to a list of AddressInput.
+
+    Accepts:
+    - List of dicts with keys: street, city, state, zipcode, id (optional)
+    - List of one-line address strings
+    - List of AddressInput instances (returned as-is)
+    """
+    if not addresses:
+        return []
+
+    first = addresses[0]
+
+    if isinstance(first, AddressInput):
+        return list(addresses)
+
+    if isinstance(first, str):
+        return [
+            AddressInput(street=addr, input_id=str(i))
+            for i, addr in enumerate(addresses)
+        ]
+
+    if isinstance(first, dict):
+        result = []
+        for i, addr in enumerate(addresses):
+            result.append(AddressInput(
+                street=addr.get("street", addr.get("address", "")),
+                city=addr.get("city", ""),
+                state=addr.get("state", ""),
+                zipcode=addr.get("zipcode", addr.get("zip", "")),
+                input_id=addr.get("id", addr.get("input_id", str(i))),
+            ))
+        return result
+
+    raise TypeError(f"Unsupported address type: {type(first)}")
+
+
+# ---------------------------------------------------------------------------
+# Abstract base class
+# ---------------------------------------------------------------------------
+
+
+class BatchGeocoder(abc.ABC):
+    """Abstract base class for batch geocoding backends.
+
+    Subclasses implement :meth:`geocode` to process a list of addresses
+    through a specific geocoding service. The interface accepts flexible
+    input formats and returns a :class:`BatchGeocodingResult`.
+
+    Example::
+
+        class MyGeocoder(BatchGeocoder):
+            @property
+            def backend_name(self) -> str:
+                return "my_service"
+
+            def geocode(self, addresses, **kwargs):
+                normalized = normalize_addresses(addresses)
+                results = []
+                for addr in normalized:
+                    # ... call service ...
+                    results.append(GeocodingResult(...))
+                return BatchGeocodingResult(results=results, backend=self.backend_name)
+    """
+
+    @property
+    @abc.abstractmethod
+    def backend_name(self) -> str:
+        """Short identifier for this backend (e.g., 'census', 'nominatim')."""
+
+    @abc.abstractmethod
+    def geocode(
+        self,
+        addresses: Union[list[dict], list[str], list[AddressInput]],
+        **kwargs,
+    ) -> BatchGeocodingResult:
+        """Geocode a batch of addresses.
+
+        Args:
+            addresses: List of addresses in any supported format.
+            **kwargs: Backend-specific options.
+
+        Returns:
+            BatchGeocodingResult with one GeocodingResult per input address.
+        """
+
+    def is_available(self) -> bool:
+        """Check if this backend is currently available.
+
+        Default returns True. Override for backends that need API keys
+        or network connectivity checks.
+        """
+        return True

--- a/tests/test_batch_geocoder.py
+++ b/tests/test_batch_geocoder.py
@@ -1,0 +1,234 @@
+"""Tests for BatchGeocoder interface and GeocodingResult schema (SU#622)."""
+
+from __future__ import annotations
+
+from typing import Union
+
+import pytest
+
+from siege_utilities.geo.providers.batch_geocoder import (
+    AddressInput,
+    BatchGeocoder,
+    BatchGeocodingResult,
+    GeocodingResult,
+    MatchQuality,
+    normalize_addresses,
+)
+
+
+# ---------------------------------------------------------------------------
+# GeocodingResult tests
+# ---------------------------------------------------------------------------
+
+
+class TestGeocodingResult:
+    def test_default_is_no_match(self):
+        r = GeocodingResult()
+        assert not r.matched
+        assert r.match_quality == MatchQuality.NO_MATCH.value
+
+    def test_exact_match(self):
+        r = GeocodingResult(
+            input_address="123 Main St",
+            matched_address="123 MAIN ST",
+            lat=41.8781,
+            lon=-87.6298,
+            match_quality=MatchQuality.EXACT.value,
+            block_geoid="170310101001001",
+            tract_geoid="17031010100",
+            county_geoid="17031",
+            state_geoid="17",
+            backend="census",
+        )
+        assert r.matched
+        assert r.has_block
+        assert r.has_tract
+        assert r.backend == "census"
+
+    def test_has_block_requires_15_digits(self):
+        r = GeocodingResult(block_geoid="1703101")
+        assert not r.has_block
+
+    def test_has_tract_requires_11_digits(self):
+        r = GeocodingResult(tract_geoid="1703101")
+        assert not r.has_tract
+
+    def test_to_dict(self):
+        r = GeocodingResult(
+            input_address="test",
+            match_quality=MatchQuality.EXACT.value,
+        )
+        d = r.to_dict()
+        assert isinstance(d, dict)
+        assert d["matched"] is True
+        assert d["input_address"] == "test"
+
+
+class TestMatchQuality:
+    def test_values(self):
+        assert MatchQuality.EXACT.value == "exact"
+        assert MatchQuality.NO_MATCH.value == "no_match"
+
+    def test_all_levels(self):
+        levels = [e.value for e in MatchQuality]
+        assert "exact" in levels
+        assert "interpolated" in levels
+        assert "approximate" in levels
+        assert "centroid" in levels
+        assert "no_match" in levels
+
+
+# ---------------------------------------------------------------------------
+# BatchGeocodingResult tests
+# ---------------------------------------------------------------------------
+
+
+class TestBatchGeocodingResult:
+    def test_empty(self):
+        b = BatchGeocodingResult()
+        assert b.total == 0
+        assert b.matched_count == 0
+        assert b.match_rate == 0.0
+
+    def test_counts(self):
+        b = BatchGeocodingResult(results=[
+            GeocodingResult(match_quality=MatchQuality.EXACT.value),
+            GeocodingResult(match_quality=MatchQuality.EXACT.value),
+            GeocodingResult(match_quality=MatchQuality.NO_MATCH.value),
+        ])
+        assert b.total == 3
+        assert b.matched_count == 2
+        assert abs(b.match_rate - 2 / 3) < 0.01
+
+    def test_with_errors(self):
+        b = BatchGeocodingResult(errors=["some error"])
+        assert len(b.errors) == 1
+
+
+# ---------------------------------------------------------------------------
+# AddressInput tests
+# ---------------------------------------------------------------------------
+
+
+class TestAddressInput:
+    def test_one_line(self):
+        a = AddressInput(
+            street="123 Main St",
+            city="Chicago",
+            state="IL",
+            zipcode="60601",
+        )
+        assert a.one_line == "123 Main St, Chicago, IL, 60601"
+
+    def test_one_line_partial(self):
+        a = AddressInput(street="123 Main St", state="IL")
+        assert a.one_line == "123 Main St, IL"
+
+    def test_empty(self):
+        a = AddressInput()
+        assert a.one_line == ""
+
+
+# ---------------------------------------------------------------------------
+# normalize_addresses tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeAddresses:
+    def test_from_dicts(self):
+        addrs = [
+            {"street": "123 Main St", "city": "Chicago", "state": "IL", "zipcode": "60601"},
+            {"street": "456 Oak Ave", "city": "Boston", "state": "MA", "zip": "02101"},
+        ]
+        result = normalize_addresses(addrs)
+        assert len(result) == 2
+        assert result[0].street == "123 Main St"
+        assert result[1].zipcode == "02101"
+
+    def test_from_strings(self):
+        addrs = ["123 Main St, Chicago, IL", "456 Oak Ave, Boston, MA"]
+        result = normalize_addresses(addrs)
+        assert len(result) == 2
+        assert result[0].street == "123 Main St, Chicago, IL"
+        assert result[0].input_id == "0"
+
+    def test_from_address_inputs(self):
+        addrs = [AddressInput(street="123 Main St")]
+        result = normalize_addresses(addrs)
+        assert len(result) == 1
+        assert result[0].street == "123 Main St"
+
+    def test_empty_list(self):
+        assert normalize_addresses([]) == []
+
+    def test_dict_with_address_key(self):
+        addrs = [{"address": "123 Main St"}]
+        result = normalize_addresses(addrs)
+        assert result[0].street == "123 Main St"
+
+    def test_dict_with_id_key(self):
+        addrs = [{"street": "123 Main St", "id": "ABC"}]
+        result = normalize_addresses(addrs)
+        assert result[0].input_id == "ABC"
+
+    def test_unsupported_type_raises(self):
+        with pytest.raises(TypeError):
+            normalize_addresses([42, 43])
+
+
+# ---------------------------------------------------------------------------
+# BatchGeocoder ABC tests
+# ---------------------------------------------------------------------------
+
+
+class _TestGeocoder(BatchGeocoder):
+    """Concrete implementation for testing the ABC."""
+
+    @property
+    def backend_name(self) -> str:
+        return "test"
+
+    def geocode(self, addresses, **kwargs):
+        normalized = normalize_addresses(addresses)
+        results = [
+            GeocodingResult(
+                input_address=a.one_line,
+                input_id=a.input_id,
+                match_quality=MatchQuality.EXACT.value,
+                lat=0.0,
+                lon=0.0,
+                backend=self.backend_name,
+            )
+            for a in normalized
+        ]
+        return BatchGeocodingResult(results=results, backend=self.backend_name)
+
+
+class TestBatchGeocoderABC:
+    def test_cannot_instantiate_abc(self):
+        with pytest.raises(TypeError):
+            BatchGeocoder()
+
+    def test_concrete_implementation(self):
+        g = _TestGeocoder()
+        assert g.backend_name == "test"
+        assert g.is_available()
+
+    def test_geocode_strings(self):
+        g = _TestGeocoder()
+        result = g.geocode(["123 Main St", "456 Oak Ave"])
+        assert result.total == 2
+        assert result.matched_count == 2
+        assert result.backend == "test"
+
+    def test_geocode_dicts(self):
+        g = _TestGeocoder()
+        result = g.geocode([
+            {"street": "123 Main St", "city": "Chicago", "state": "IL"},
+        ])
+        assert result.total == 1
+
+    def test_geocode_preserves_id(self):
+        g = _TestGeocoder()
+        result = g.geocode([{"street": "test", "id": "MY-ID"}])
+        assert result.results[0].input_id == "MY-ID"


### PR DESCRIPTION
## Summary
- BatchGeocoder ABC with `geocode(addresses)` → `BatchGeocodingResult`
- GeocodingResult schema with GEOID fields and MatchQuality enum
- AddressInput normalizer: accepts dicts, strings, or dataclasses
- BatchGeocodingResult with DataFrame/GeoDataFrame export methods

## Test plan
- [x] 25 tests covering result schema, match quality, address normalization, ABC contract
- [x] Tests run without pandas/geopandas (lazy imports in output methods)