### PR TITLE
feat(geo): add Census batch geocoder backend (SU#623)

### DIFF
--- a/.review/su623-census-batch-backend.md
+++ b/.review/su623-census-batch-backend.md
@@ -1,0 +1,27 @@
+# Self-Review: SU#623 — Census Batch Backend
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (Census geocoding, block-level GEOID)
+**Trivial-against-state:** partially — thin wrapper around existing geocode_batch_chunked
+
+## Assumptions
+
+1. CensusBatchGeocoder wraps existing geocode_batch_chunked() — no new API logic.
+2. CensusGeocodeResult → GeocodingResult conversion maps Exact→exact, Non_Exact→interpolated, No_Match→no_match.
+3. Default vintage is CensusVintage.CURRENT; caller can override.
+4. Chunk size passed through; default 10,000 matches Census API limit.
+
+## Peer Review (Junior)
+
+- Converter: 5 tests (exact, non-exact, no-match, input_id, GEOID hierarchy)
+- CensusBatchGeocoder: 8 tests (name, empty, strings, dicts, error, multiple, chunk_size, available)
+- 13 total tests passing
+
+## Lead Review (Adversarial)
+
+- **Q: Why wrap the existing functions instead of refactoring them?** A: The existing functions have their own test suite and are used directly elsewhere. The wrapper converts to the unified schema without touching working code.
+
+## Quantified Claims
+
+- 13 new tests, all passing
+- ~80 lines of implementation (converter + class)

--- a/siege_utilities/geo/providers/census_batch.py
+++ b/siege_utilities/geo/providers/census_batch.py
@@ -1,0 +1,126 @@
+"""Census Bureau batch geocoder backend.
+
+Wraps :func:`geocode_batch_chunked` behind the :class:`BatchGeocoder` ABC,
+converting :class:`CensusGeocodeResult` to the unified
+:class:`GeocodingResult` schema.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional, Union
+
+from .batch_geocoder import (
+    AddressInput,
+    BatchGeocoder,
+    BatchGeocodingResult,
+    GeocodingResult,
+    MatchQuality,
+    normalize_addresses,
+)
+
+log = logging.getLogger(__name__)
+
+_MATCH_TYPE_MAP = {
+    "Exact": MatchQuality.EXACT.value,
+    "Non_Exact": MatchQuality.INTERPOLATED.value,
+    "No_Match": MatchQuality.NO_MATCH.value,
+}
+
+
+def _census_result_to_geocoding_result(cr) -> GeocodingResult:
+    """Convert a CensusGeocodeResult to a unified GeocodingResult."""
+    return GeocodingResult(
+        input_address=cr.input_address,
+        input_id=cr.input_id,
+        matched_address=cr.matched_address,
+        lat=cr.lat,
+        lon=cr.lon,
+        match_quality=_MATCH_TYPE_MAP.get(cr.match_type, MatchQuality.NO_MATCH.value),
+        block_geoid=cr.block_geoid,
+        tract_geoid=cr.tract_geoid,
+        county_geoid=cr.county_geoid,
+        state_geoid=cr.state_geoid,
+        backend="census",
+    )
+
+
+class CensusBatchGeocoder(BatchGeocoder):
+    """Census Bureau batch geocoding backend.
+
+    Wraps the existing Census geocoder functions with automatic chunking
+    for datasets larger than 10,000 addresses. Returns block-level GEOIDs
+    directly from the Census API (no spatial join needed).
+
+    Args:
+        vintage: Census vintage to use. Defaults to Current.
+        chunk_size: Max addresses per API call. Default 10,000.
+    """
+
+    def __init__(
+        self,
+        vintage=None,
+        chunk_size: int = 10_000,
+    ):
+        self._vintage = vintage
+        self._chunk_size = chunk_size
+
+    @property
+    def backend_name(self) -> str:
+        return "census"
+
+    def geocode(
+        self,
+        addresses: Union[list[dict], list[str], list[AddressInput]],
+        **kwargs,
+    ) -> BatchGeocodingResult:
+        """Geocode addresses via the Census Bureau batch API.
+
+        Args:
+            addresses: Addresses in any supported format.
+            **kwargs: Passed through to geocode_batch_chunked.
+        """
+        from .census_geocoder import (
+            CensusVintage,
+            geocode_batch_chunked,
+        )
+
+        normalized = normalize_addresses(addresses)
+        if not normalized:
+            return BatchGeocodingResult(backend=self.backend_name)
+
+        vintage = self._vintage or CensusVintage.CURRENT
+
+        batch_input = [
+            {
+                "id": addr.input_id,
+                "street": addr.street,
+                "city": addr.city,
+                "state": addr.state,
+                "zipcode": addr.zipcode,
+            }
+            for addr in normalized
+        ]
+
+        result = BatchGeocodingResult(backend=self.backend_name)
+        try:
+            census_results = geocode_batch_chunked(
+                batch_input,
+                vintage=vintage,
+                chunk_size=self._chunk_size,
+            )
+            result.results = [
+                _census_result_to_geocoding_result(cr)
+                for cr in census_results
+            ]
+        except Exception as exc:
+            result.errors.append(f"Census batch geocode error: {exc}")
+            log.error("Census batch geocode failed: %s", exc)
+
+        log.info(
+            "Census batch: %d/%d matched (%.1f%%)",
+            result.matched_count,
+            result.total,
+            result.match_rate * 100,
+        )
+        return result

--- a/tests/test_census_batch.py
+++ b/tests/test_census_batch.py
@@ -1,0 +1,180 @@
+"""Tests for Census batch geocoder backend (SU#623)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from siege_utilities.geo.providers.batch_geocoder import (
+    GeocodingResult,
+    MatchQuality,
+)
+from siege_utilities.geo.providers.census_batch import (
+    CensusBatchGeocoder,
+    _census_result_to_geocoding_result,
+)
+
+
+# ---------------------------------------------------------------------------
+# Mock CensusGeocodeResult
+# ---------------------------------------------------------------------------
+
+
+class _MockCensusResult:
+    def __init__(self, **kwargs):
+        self.matched = kwargs.get("matched", True)
+        self.input_address = kwargs.get("input_address", "123 Main St")
+        self.input_id = kwargs.get("input_id", "1")
+        self.matched_address = kwargs.get("matched_address", "123 MAIN ST")
+        self.lat = kwargs.get("lat", 41.8781)
+        self.lon = kwargs.get("lon", -87.6298)
+        self.match_type = kwargs.get("match_type", "Exact")
+        self.state_fips = kwargs.get("state_fips", "17")
+        self.county_fips = kwargs.get("county_fips", "031")
+        self.tract = kwargs.get("tract", "010100")
+        self.block = kwargs.get("block", "1001")
+
+    @property
+    def state_geoid(self):
+        return self.state_fips
+
+    @property
+    def county_geoid(self):
+        return f"{self.state_fips}{self.county_fips}" if self.state_fips and self.county_fips else ""
+
+    @property
+    def tract_geoid(self):
+        if self.state_fips and self.county_fips and self.tract:
+            return f"{self.state_fips}{self.county_fips}{self.tract}"
+        return ""
+
+    @property
+    def block_geoid(self):
+        if self.state_fips and self.county_fips and self.tract and self.block:
+            return f"{self.state_fips}{self.county_fips}{self.tract}{self.block}"
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Converter tests
+# ---------------------------------------------------------------------------
+
+
+class TestCensusResultConverter:
+    def test_exact_match(self):
+        cr = _MockCensusResult(match_type="Exact")
+        gr = _census_result_to_geocoding_result(cr)
+        assert gr.match_quality == MatchQuality.EXACT.value
+        assert gr.matched
+        assert gr.block_geoid == "170310101001001"
+        assert gr.backend == "census"
+
+    def test_non_exact(self):
+        cr = _MockCensusResult(match_type="Non_Exact")
+        gr = _census_result_to_geocoding_result(cr)
+        assert gr.match_quality == MatchQuality.INTERPOLATED.value
+        assert gr.matched
+
+    def test_no_match(self):
+        cr = _MockCensusResult(
+            matched=False,
+            match_type="No_Match",
+            lat=None,
+            lon=None,
+            state_fips="",
+            county_fips="",
+            tract="",
+            block="",
+        )
+        gr = _census_result_to_geocoding_result(cr)
+        assert not gr.matched
+        assert gr.block_geoid == ""
+
+    def test_preserves_input_id(self):
+        cr = _MockCensusResult(input_id="MY-ID-123")
+        gr = _census_result_to_geocoding_result(cr)
+        assert gr.input_id == "MY-ID-123"
+
+    def test_geoid_hierarchy(self):
+        cr = _MockCensusResult()
+        gr = _census_result_to_geocoding_result(cr)
+        assert gr.state_geoid == "17"
+        assert gr.county_geoid == "17031"
+        assert gr.tract_geoid == "17031010100"
+        assert gr.has_block
+        assert gr.has_tract
+
+
+# ---------------------------------------------------------------------------
+# CensusBatchGeocoder tests
+# ---------------------------------------------------------------------------
+
+
+class TestCensusBatchGeocoder:
+    def test_backend_name(self):
+        g = CensusBatchGeocoder()
+        assert g.backend_name == "census"
+
+    def test_empty_input(self):
+        g = CensusBatchGeocoder()
+        result = g.geocode([])
+        assert result.total == 0
+
+    @patch("siege_utilities.geo.providers.census_geocoder.geocode_batch_chunked")
+    def test_geocode_strings(self, mock_chunked):
+        mock_chunked.return_value = [
+            _MockCensusResult(input_address="123 Main St", input_id="0"),
+        ]
+        g = CensusBatchGeocoder()
+        result = g.geocode(["123 Main St, Chicago, IL"])
+        assert result.total == 1
+        assert result.results[0].matched
+        mock_chunked.assert_called_once()
+
+    @patch("siege_utilities.geo.providers.census_geocoder.geocode_batch_chunked")
+    def test_geocode_dicts(self, mock_chunked):
+        mock_chunked.return_value = [
+            _MockCensusResult(input_address="123 Main St", input_id="ABC"),
+        ]
+        g = CensusBatchGeocoder()
+        result = g.geocode([
+            {"street": "123 Main St", "city": "Chicago", "state": "IL", "zipcode": "60601", "id": "ABC"},
+        ])
+        assert result.total == 1
+        call_args = mock_chunked.call_args[0][0]
+        assert call_args[0]["id"] == "ABC"
+
+    @patch("siege_utilities.geo.providers.census_geocoder.geocode_batch_chunked")
+    def test_handles_api_error(self, mock_chunked):
+        mock_chunked.side_effect = RuntimeError("API down")
+        g = CensusBatchGeocoder()
+        result = g.geocode(["123 Main St"])
+        assert len(result.errors) == 1
+        assert "Census batch geocode error" in result.errors[0]
+
+    @patch("siege_utilities.geo.providers.census_geocoder.geocode_batch_chunked")
+    def test_multiple_results(self, mock_chunked):
+        mock_chunked.return_value = [
+            _MockCensusResult(input_id="0", match_type="Exact"),
+            _MockCensusResult(input_id="1", match_type="No_Match", matched=False,
+                              lat=None, lon=None, state_fips="", county_fips="",
+                              tract="", block=""),
+        ]
+        g = CensusBatchGeocoder()
+        result = g.geocode(["addr1", "addr2"])
+        assert result.total == 2
+        assert result.matched_count == 1
+        assert abs(result.match_rate - 0.5) < 0.01
+
+    @patch("siege_utilities.geo.providers.census_geocoder.geocode_batch_chunked")
+    def test_custom_chunk_size(self, mock_chunked):
+        mock_chunked.return_value = []
+        g = CensusBatchGeocoder(chunk_size=5000)
+        g.geocode(["addr"])
+        _, kwargs = mock_chunked.call_args
+        assert kwargs["chunk_size"] == 5000
+
+    def test_is_available(self):
+        g = CensusBatchGeocoder()
+        assert g.is_available()


### PR DESCRIPTION
## Summary
- CensusBatchGeocoder wraps existing geocode_batch_chunked() behind BatchGeocoder ABC
- Converts CensusGeocodeResult to unified GeocodingResult schema
- Match quality mapping: Exact→exact, Non_Exact→interpolated, No_Match→no_match

## Test plan
- [x] 13 tests covering converter, geocoder class, error handling, chunk size