### PR TITLE
feat(geo): add Nominatim batch geocoder backend (SU#624)

### DIFF
--- a/.review/su624-nominatim-batch-backend.md
+++ b/.review/su624-nominatim-batch-backend.md
@@ -1,0 +1,34 @@
+# Self-Review: SU#624 — Nominatim Batch Backend
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (geocoding, rate limiting, Nominatim API)
+**Trivial-against-state:** no — new HTTP client with retry logic and rate limiting
+
+## Assumptions
+
+1. NominatimBatchGeocoder wraps Nominatim's `/search` endpoint (no true batch API).
+2. Rate limiting defaults: 1.0s for public instance, 0.05s for self-hosted (auto-detected from URL).
+3. Match quality is always APPROXIMATE — Nominatim doesn't report exact/interpolated distinction.
+4. No GEOIDs returned — Nominatim doesn't provide Census geography; spatial join needed downstream.
+5. Uses stdlib `urllib.request` instead of `requests` to avoid pandas dependency chain via geocoding.py.
+
+## Peer Review (Junior)
+
+- Config: 7 tests (backend name, rate limits ×3, server URLs ×2, country codes ×2)
+- Geocoding: 5 tests (single match, no match, multiple, exception, empty query)
+- Quality: 2 tests (approximate quality, no block GEOID)
+- HTTP layer: 4 tests (successful response, empty response, retry on failure, raises after max retries)
+- Availability: 1 test
+- 21 total tests passing
+
+## Lead Review (Adversarial)
+
+- **Q: Why not use `get_coordinates` from `geocoding.py`?** A: `geocoding.py` eagerly imports pandas at module level. Importing it — even to mock — fails in the test env. Using `urllib.request` directly keeps the module pandas-free.
+- **Q: Is `urllib.request` sufficient vs `requests`?** A: For a simple GET with JSON response, yes. The retry loop and timeout cover the essential reliability needs. Self-hosted users who need connection pooling can subclass.
+- **Q: Why APPROXIMATE for all matches?** A: Nominatim's response doesn't distinguish match precision. The caller can post-process if finer quality is needed.
+
+## Quantified Claims
+
+- 21 new tests, all passing
+- ~170 lines of implementation (class + HTTP request method)
+- ~170 lines of tests (2 test classes)

--- a/siege_utilities/geo/providers/nominatim_batch.py
+++ b/siege_utilities/geo/providers/nominatim_batch.py
@@ -1,0 +1,168 @@
+"""Nominatim batch geocoder backend.
+
+Wraps Nominatim geocoding (public or self-hosted) behind the
+:class:`BatchGeocoder` ABC with configurable rate limiting.
+
+Nominatim does not return Census GEOIDs — those must be assigned
+via spatial join if needed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import urllib.parse
+import urllib.request
+from typing import Optional, Union
+
+from .batch_geocoder import (
+    AddressInput,
+    BatchGeocoder,
+    BatchGeocodingResult,
+    GeocodingResult,
+    MatchQuality,
+    normalize_addresses,
+)
+
+log = logging.getLogger(__name__)
+
+PUBLIC_NOMINATIM_URL = "https://nominatim.openstreetmap.org"
+DEFAULT_RATE_LIMIT = 1.0  # seconds between requests for public instance
+SELF_HOSTED_RATE_LIMIT = 0.05
+
+
+class NominatimBatchGeocoder(BatchGeocoder):
+    """Nominatim geocoding backend with rate limiting.
+
+    Uses the existing geocoding infrastructure to query Nominatim
+    one address at a time (Nominatim has no true batch API).
+
+    Args:
+        server_url: Nominatim endpoint. Defaults to public instance.
+        rate_limit: Seconds between requests. Default 1.0 for public,
+            0.05 for self-hosted (auto-detected from URL).
+        country_codes: Restrict results to these countries (e.g., ['us']).
+        max_retries: Max retries per address on transient failure.
+    """
+
+    def __init__(
+        self,
+        server_url: Optional[str] = None,
+        rate_limit: Optional[float] = None,
+        country_codes: Optional[list[str]] = None,
+        max_retries: int = 2,
+    ):
+        self._server_url = server_url or PUBLIC_NOMINATIM_URL
+        if rate_limit is not None:
+            self._rate_limit = rate_limit
+        elif self._server_url == PUBLIC_NOMINATIM_URL:
+            self._rate_limit = DEFAULT_RATE_LIMIT
+        else:
+            self._rate_limit = SELF_HOSTED_RATE_LIMIT
+        self._country_codes = country_codes or ["us"]
+        self._max_retries = max_retries
+
+    @property
+    def backend_name(self) -> str:
+        return "nominatim"
+
+    def geocode(
+        self,
+        addresses: Union[list[dict], list[str], list[AddressInput]],
+        **kwargs,
+    ) -> BatchGeocodingResult:
+        """Geocode addresses via Nominatim (one at a time with rate limiting).
+
+        Args:
+            addresses: Addresses in any supported format.
+        """
+        normalized = normalize_addresses(addresses)
+        if not normalized:
+            return BatchGeocodingResult(backend=self.backend_name)
+
+        result = BatchGeocodingResult(backend=self.backend_name)
+        last_request_time = 0.0
+
+        for addr in normalized:
+            elapsed = time.monotonic() - last_request_time
+            if elapsed < self._rate_limit:
+                time.sleep(self._rate_limit - elapsed)
+
+            gr = self._geocode_single(addr)
+            result.results.append(gr)
+            last_request_time = time.monotonic()
+
+        log.info(
+            "Nominatim batch: %d/%d matched (%.1f%%)",
+            result.matched_count,
+            result.total,
+            result.match_rate * 100,
+        )
+        return result
+
+    def _geocode_single(self, addr: AddressInput) -> GeocodingResult:
+        """Geocode a single address via Nominatim HTTP API."""
+        query = addr.one_line
+        if not query:
+            return GeocodingResult(
+                input_address=query,
+                input_id=addr.input_id,
+                match_quality=MatchQuality.NO_MATCH.value,
+                backend=self.backend_name,
+            )
+
+        try:
+            coords = self._nominatim_request(query)
+            if coords is not None:
+                lat, lon = coords
+                return GeocodingResult(
+                    input_address=query,
+                    input_id=addr.input_id,
+                    lat=lat,
+                    lon=lon,
+                    match_quality=MatchQuality.APPROXIMATE.value,
+                    backend=self.backend_name,
+                )
+        except Exception as exc:
+            log.warning("Nominatim geocode failed for %s: %s", addr.input_id, exc)
+
+        return GeocodingResult(
+            input_address=query,
+            input_id=addr.input_id,
+            match_quality=MatchQuality.NO_MATCH.value,
+            backend=self.backend_name,
+        )
+
+    def _nominatim_request(self, query: str) -> Optional[tuple[float, float]]:
+        """Make a single Nominatim search request.
+
+        Returns (lat, lon) or None if no match.
+        """
+        params = urllib.parse.urlencode({
+            "q": query,
+            "format": "json",
+            "limit": "1",
+            "countrycodes": ",".join(self._country_codes),
+        })
+        url = f"{self._server_url}/search?{params}"
+
+        req = urllib.request.Request(url, headers={
+            "User-Agent": "siege_utilities geocoder",
+        })
+
+        for attempt in range(self._max_retries + 1):
+            try:
+                with urllib.request.urlopen(req, timeout=10) as resp:
+                    data = json.loads(resp.read().decode("utf-8"))
+                    if data and len(data) > 0:
+                        lat = float(data[0]["lat"])
+                        lon = float(data[0]["lon"])
+                        return (lat, lon)
+                    return None
+            except Exception:
+                if attempt == self._max_retries:
+                    raise
+                time.sleep(self._rate_limit)
+
+        return None

--- a/tests/test_nominatim_batch.py
+++ b/tests/test_nominatim_batch.py
@@ -1,0 +1,190 @@
+"""Tests for Nominatim batch geocoder backend (SU#624)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from siege_utilities.geo.providers.batch_geocoder import MatchQuality
+from siege_utilities.geo.providers.nominatim_batch import (
+    DEFAULT_RATE_LIMIT,
+    NominatimBatchGeocoder,
+    PUBLIC_NOMINATIM_URL,
+    SELF_HOSTED_RATE_LIMIT,
+)
+
+
+class TestNominatimBatchGeocoder:
+    def test_backend_name(self):
+        g = NominatimBatchGeocoder()
+        assert g.backend_name == "nominatim"
+
+    def test_default_rate_limit_public(self):
+        g = NominatimBatchGeocoder()
+        assert g._rate_limit == DEFAULT_RATE_LIMIT
+
+    def test_self_hosted_rate_limit(self):
+        g = NominatimBatchGeocoder(server_url="http://my-nominatim:8080")
+        assert g._rate_limit == SELF_HOSTED_RATE_LIMIT
+
+    def test_custom_rate_limit(self):
+        g = NominatimBatchGeocoder(rate_limit=0.5)
+        assert g._rate_limit == 0.5
+
+    def test_empty_input(self):
+        g = NominatimBatchGeocoder()
+        result = g.geocode([])
+        assert result.total == 0
+
+    @patch("siege_utilities.geo.providers.nominatim_batch.time.sleep")
+    @patch.object(NominatimBatchGeocoder, "_nominatim_request")
+    def test_geocode_single_match(self, mock_request, mock_sleep):
+        mock_request.return_value = (41.8781, -87.6298)
+        g = NominatimBatchGeocoder(rate_limit=0.0)
+        result = g.geocode(["123 Main St, Chicago, IL"])
+
+        assert result.total == 1
+        assert result.results[0].matched
+        assert result.results[0].lat == 41.8781
+        assert result.results[0].lon == -87.6298
+        assert result.results[0].backend == "nominatim"
+
+    @patch("siege_utilities.geo.providers.nominatim_batch.time.sleep")
+    @patch.object(NominatimBatchGeocoder, "_nominatim_request")
+    def test_geocode_no_match(self, mock_request, mock_sleep):
+        mock_request.return_value = None
+        g = NominatimBatchGeocoder(rate_limit=0.0)
+        result = g.geocode(["fake address nowhere"])
+
+        assert result.total == 1
+        assert not result.results[0].matched
+
+    @patch("siege_utilities.geo.providers.nominatim_batch.time.sleep")
+    @patch.object(NominatimBatchGeocoder, "_nominatim_request")
+    def test_geocode_multiple(self, mock_request, mock_sleep):
+        mock_request.side_effect = [
+            (41.8781, -87.6298),
+            None,
+            (42.3601, -71.0589),
+        ]
+        g = NominatimBatchGeocoder(rate_limit=0.0)
+        result = g.geocode(["addr1", "addr2", "addr3"])
+
+        assert result.total == 3
+        assert result.matched_count == 2
+
+    @patch("siege_utilities.geo.providers.nominatim_batch.time.sleep")
+    @patch.object(NominatimBatchGeocoder, "_nominatim_request")
+    def test_handles_exception(self, mock_request, mock_sleep):
+        mock_request.side_effect = Exception("network error")
+        g = NominatimBatchGeocoder(rate_limit=0.0)
+        result = g.geocode(["123 Main St"])
+
+        assert result.total == 1
+        assert not result.results[0].matched
+
+    @patch("siege_utilities.geo.providers.nominatim_batch.time.sleep")
+    @patch.object(NominatimBatchGeocoder, "_nominatim_request")
+    def test_match_quality_is_approximate(self, mock_request, mock_sleep):
+        mock_request.return_value = (41.0, -87.0)
+        g = NominatimBatchGeocoder(rate_limit=0.0)
+        result = g.geocode(["test"])
+        assert result.results[0].match_quality == MatchQuality.APPROXIMATE.value
+
+    @patch("siege_utilities.geo.providers.nominatim_batch.time.sleep")
+    @patch.object(NominatimBatchGeocoder, "_nominatim_request")
+    def test_no_block_geoid(self, mock_request, mock_sleep):
+        mock_request.return_value = (41.0, -87.0)
+        g = NominatimBatchGeocoder(rate_limit=0.0)
+        result = g.geocode(["test"])
+        assert result.results[0].block_geoid == ""
+
+    def test_default_country_codes(self):
+        g = NominatimBatchGeocoder()
+        assert g._country_codes == ["us"]
+
+    def test_is_available(self):
+        g = NominatimBatchGeocoder()
+        assert g.is_available()
+
+    def test_default_server_url(self):
+        g = NominatimBatchGeocoder()
+        assert g._server_url == PUBLIC_NOMINATIM_URL
+
+    def test_custom_server_url(self):
+        g = NominatimBatchGeocoder(server_url="http://local:8080")
+        assert g._server_url == "http://local:8080"
+
+    def test_custom_country_codes(self):
+        g = NominatimBatchGeocoder(country_codes=["de", "at"])
+        assert g._country_codes == ["de", "at"]
+
+    @patch("siege_utilities.geo.providers.nominatim_batch.time.sleep")
+    @patch.object(NominatimBatchGeocoder, "_nominatim_request")
+    def test_empty_query_returns_no_match(self, mock_request, mock_sleep):
+        g = NominatimBatchGeocoder(rate_limit=0.0)
+        result = g.geocode([{"street": "", "city": "", "state": "", "zipcode": ""}])
+        assert result.total == 1
+        assert not result.results[0].matched
+        mock_request.assert_not_called()
+
+
+class TestNominatimRequest:
+    """Tests for the low-level _nominatim_request method."""
+
+    @patch("siege_utilities.geo.providers.nominatim_batch.urllib.request.urlopen")
+    def test_successful_response(self, mock_urlopen):
+        import json
+        resp_data = json.dumps([{"lat": "41.8781", "lon": "-87.6298"}]).encode()
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = resp_data
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        g = NominatimBatchGeocoder(rate_limit=0.0)
+        result = g._nominatim_request("123 Main St, Chicago, IL")
+        assert result == (41.8781, -87.6298)
+
+    @patch("siege_utilities.geo.providers.nominatim_batch.urllib.request.urlopen")
+    def test_empty_response(self, mock_urlopen):
+        import json
+        resp_data = json.dumps([]).encode()
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = resp_data
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        g = NominatimBatchGeocoder(rate_limit=0.0)
+        result = g._nominatim_request("nonexistent place")
+        assert result is None
+
+    @patch("siege_utilities.geo.providers.nominatim_batch.time.sleep")
+    @patch("siege_utilities.geo.providers.nominatim_batch.urllib.request.urlopen")
+    def test_retries_on_failure(self, mock_urlopen, mock_sleep):
+        import json
+        resp_data = json.dumps([{"lat": "41.0", "lon": "-87.0"}]).encode()
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = resp_data
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        mock_urlopen.side_effect = [
+            Exception("timeout"),
+            mock_resp,
+        ]
+        g = NominatimBatchGeocoder(rate_limit=0.0, max_retries=2)
+        result = g._nominatim_request("test")
+        assert result == (41.0, -87.0)
+        assert mock_urlopen.call_count == 2
+
+    @patch("siege_utilities.geo.providers.nominatim_batch.time.sleep")
+    @patch("siege_utilities.geo.providers.nominatim_batch.urllib.request.urlopen")
+    def test_raises_after_max_retries(self, mock_urlopen, mock_sleep):
+        mock_urlopen.side_effect = Exception("persistent failure")
+        g = NominatimBatchGeocoder(rate_limit=0.0, max_retries=1)
+        with pytest.raises(Exception, match="persistent failure"):
+            g._nominatim_request("test")
+        assert mock_urlopen.call_count == 2


### PR DESCRIPTION
## Summary

- Adds `NominatimBatchGeocoder` implementing the `BatchGeocoder` ABC for Nominatim's `/search` endpoint
- Configurable rate limiting: 1.0s for public instance, 0.05s for self-hosted (auto-detected from URL)
- Uses stdlib `urllib.request` with retry logic instead of `requests`/`geocoding.py` (avoids pandas dependency chain)
- 21 tests covering config, geocoding flow, HTTP layer, and retry behavior

## Test Plan

- [x] 21 tests passing (`pytest tests/test_nominatim_batch.py -v`)
- [x] Rate limit auto-detection verified (public vs self-hosted URLs)
- [x] Retry logic tested (succeeds after transient failure, raises after max retries)
- [x] Empty/missing address handling verified