### PR TITLE
feat(geo): add TAMU batch geocoder backend (SU#625)

### DIFF
--- a/.review/su625-tamu-batch-backend.md
+++ b/.review/su625-tamu-batch-backend.md
@@ -1,0 +1,34 @@
+# Self-Review: SU#625 — TAMU Batch Backend
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (geocoding, Census geography extraction, TAMU API)
+**Trivial-against-state:** no — new HTTP client with response parsing and GEOID extraction
+
+## Assumptions
+
+1. TAMUBatchGeocoder wraps TAMU's HTTP geocoding API (one address at a time, no true batch endpoint).
+2. API key required — from constructor or TAMU_API_KEY env var. `is_available()` returns False without key.
+3. TAMU returns Census geography directly — state/county/tract/block FIPS codes extracted from CensusValues.
+4. Match quality mapping: Exact/NearExact→exact, Interpolated→interpolated, Approximate→approximate.
+5. Zero lat/lon treated as no match (TAMU returns 0,0 for failures).
+6. Uses stdlib urllib.request to avoid requests/pandas dependency.
+
+## Peer Review (Junior)
+
+- Config: 9 tests (backend name, availability ×2, API key sources ×2, rate limits ×2, census year ×2)
+- Geocoding: 6 tests (empty, no key, single match, no match, multiple, exception, empty query)
+- Response parser: 11 tests (match types ×4, empty geocodes, missing lat/lon, zero lat/lon, no census, partial GEOID, input_id, matched_address)
+- HTTP layer: 3 tests (successful, retry, max retries)
+- 30 total tests passing
+
+## Lead Review (Adversarial)
+
+- **Q: Why 0,0 rejection?** A: TAMU returns (0,0) when it can't geocode rather than omitting coordinates. Treating it as a match would place addresses at Null Island.
+- **Q: Should the API key be validated on construction?** A: No — `is_available()` and the early return in `geocode()` handle this. Fail-fast at use time, not construction time, allows configuration before key is set.
+- **Q: Why not use the TAMU batch endpoint?** A: TAMU's batch endpoint requires file upload and asynchronous polling. The single-address endpoint is simpler and sufficient for the volumes we handle. A batch adapter could be added later if needed.
+
+## Quantified Claims
+
+- 30 new tests, all passing
+- ~200 lines of implementation
+- ~220 lines of tests

--- a/siege_utilities/geo/providers/tamu_batch.py
+++ b/siege_utilities/geo/providers/tamu_batch.py
@@ -1,0 +1,236 @@
+"""Texas A&M Geoservices batch geocoder backend.
+
+Wraps the TAMU geocoding API behind the :class:`BatchGeocoder` ABC.
+TAMU returns Census geography (state, county, tract, block GEOIDs)
+directly in its response, so no spatial join is needed.
+
+Requires an API key — get one at https://geoservices.tamu.edu/.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import urllib.parse
+import urllib.request
+from typing import Optional, Union
+
+from .batch_geocoder import (
+    AddressInput,
+    BatchGeocoder,
+    BatchGeocodingResult,
+    GeocodingResult,
+    MatchQuality,
+    normalize_addresses,
+)
+
+log = logging.getLogger(__name__)
+
+TAMU_BASE_URL = "https://geoservices.tamu.edu/Services/Geocode/WebService/GeocoderWebServiceHttpNonParsed_V04_01.aspx"
+DEFAULT_RATE_LIMIT = 0.25
+ENV_API_KEY = "TAMU_API_KEY"
+
+_MATCH_QUALITY_MAP = {
+    "exact": MatchQuality.EXACT.value,
+    "nearexact": MatchQuality.EXACT.value,
+    "interpolated": MatchQuality.INTERPOLATED.value,
+    "approximate": MatchQuality.APPROXIMATE.value,
+}
+
+
+class TAMUBatchGeocoder(BatchGeocoder):
+    """Texas A&M Geoservices geocoding backend.
+
+    Geocodes addresses one at a time via TAMU's HTTP API.
+    Returns Census geography (block-level GEOIDs) directly.
+
+    Args:
+        api_key: TAMU API key. Falls back to TAMU_API_KEY env var.
+        rate_limit: Seconds between requests. Default 0.25.
+        census_year: Census year for geography lookup. Default "2020".
+        max_retries: Max retries per address on transient failure.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        rate_limit: float = DEFAULT_RATE_LIMIT,
+        census_year: str = "2020",
+        max_retries: int = 2,
+    ):
+        self._api_key = api_key or os.environ.get(ENV_API_KEY, "")
+        self._rate_limit = rate_limit
+        self._census_year = census_year
+        self._max_retries = max_retries
+
+    @property
+    def backend_name(self) -> str:
+        return "tamu"
+
+    def is_available(self) -> bool:
+        return bool(self._api_key)
+
+    def geocode(
+        self,
+        addresses: Union[list[dict], list[str], list[AddressInput]],
+        **kwargs,
+    ) -> BatchGeocodingResult:
+        """Geocode addresses via the TAMU Geoservices API.
+
+        Args:
+            addresses: Addresses in any supported format.
+        """
+        normalized = normalize_addresses(addresses)
+        if not normalized:
+            return BatchGeocodingResult(backend=self.backend_name)
+
+        if not self._api_key:
+            result = BatchGeocodingResult(backend=self.backend_name)
+            result.errors.append("TAMU API key not configured")
+            return result
+
+        result = BatchGeocodingResult(backend=self.backend_name)
+        last_request_time = 0.0
+
+        for addr in normalized:
+            elapsed = time.monotonic() - last_request_time
+            if elapsed < self._rate_limit:
+                time.sleep(self._rate_limit - elapsed)
+
+            gr = self._geocode_single(addr)
+            result.results.append(gr)
+            last_request_time = time.monotonic()
+
+        log.info(
+            "TAMU batch: %d/%d matched (%.1f%%)",
+            result.matched_count,
+            result.total,
+            result.match_rate * 100,
+        )
+        return result
+
+    def _geocode_single(self, addr: AddressInput) -> GeocodingResult:
+        """Geocode a single address via TAMU."""
+        query = addr.one_line
+        if not query:
+            return GeocodingResult(
+                input_address=query,
+                input_id=addr.input_id,
+                match_quality=MatchQuality.NO_MATCH.value,
+                backend=self.backend_name,
+            )
+
+        try:
+            resp = self._tamu_request(addr)
+            if resp is not None:
+                return resp
+        except Exception as exc:
+            log.warning("TAMU geocode failed for %s: %s", addr.input_id, exc)
+
+        return GeocodingResult(
+            input_address=query,
+            input_id=addr.input_id,
+            match_quality=MatchQuality.NO_MATCH.value,
+            backend=self.backend_name,
+        )
+
+    def _tamu_request(self, addr: AddressInput) -> Optional[GeocodingResult]:
+        """Make a single TAMU geocoding request.
+
+        Returns a GeocodingResult or None if no match.
+        """
+        params = {
+            "streetAddress": addr.street,
+            "city": addr.city,
+            "state": addr.state,
+            "zip": addr.zipcode,
+            "apiKey": self._api_key,
+            "format": "json",
+            "census": "true",
+            "censusYear": self._census_year,
+            "version": "4.01",
+        }
+        url = f"{TAMU_BASE_URL}?{urllib.parse.urlencode(params)}"
+
+        req = urllib.request.Request(url, headers={
+            "User-Agent": "siege_utilities geocoder",
+        })
+
+        for attempt in range(self._max_retries + 1):
+            try:
+                with urllib.request.urlopen(req, timeout=15) as resp:
+                    data = json.loads(resp.read().decode("utf-8"))
+                    return self._parse_response(data, addr)
+            except Exception:
+                if attempt == self._max_retries:
+                    raise
+                time.sleep(self._rate_limit)
+
+        return None
+
+    def _parse_response(
+        self, data: dict, addr: AddressInput
+    ) -> Optional[GeocodingResult]:
+        """Parse TAMU JSON response into a GeocodingResult."""
+        output_geocodes = data.get("OutputGeocodes", [])
+        if not output_geocodes:
+            return None
+
+        geocode = output_geocodes[0]
+        geocode_attrs = geocode.get("OutputGeocode", {})
+        matched_address = geocode_attrs.get("MatchedAddress", "")
+        lat_str = geocode_attrs.get("Latitude", "")
+        lon_str = geocode_attrs.get("Longitude", "")
+
+        match_type = geocode_attrs.get("MatchType", "").lower()
+        quality = _MATCH_QUALITY_MAP.get(match_type, MatchQuality.APPROXIMATE.value)
+
+        if not lat_str or not lon_str:
+            return None
+
+        try:
+            lat = float(lat_str)
+            lon = float(lon_str)
+        except (ValueError, TypeError):
+            return None
+
+        if lat == 0.0 and lon == 0.0:
+            return None
+
+        state_geoid = ""
+        county_geoid = ""
+        tract_geoid = ""
+        block_geoid = ""
+
+        census_values = geocode.get("CensusValues", [])
+        if census_values:
+            cv = census_values[0].get("CensusValue1", {})
+            state_fips = cv.get("CensusStateFips", "")
+            county_fips = cv.get("CensusCountyFips", "")
+            tract = cv.get("CensusTract", "")
+            block = cv.get("CensusBlock", "")
+
+            if state_fips:
+                state_geoid = state_fips
+            if state_fips and county_fips:
+                county_geoid = f"{state_fips}{county_fips}"
+            if state_fips and county_fips and tract:
+                tract_geoid = f"{state_fips}{county_fips}{tract}"
+            if state_fips and county_fips and tract and block:
+                block_geoid = f"{state_fips}{county_fips}{tract}{block}"
+
+        return GeocodingResult(
+            input_address=addr.one_line,
+            input_id=addr.input_id,
+            matched_address=matched_address,
+            lat=lat,
+            lon=lon,
+            match_quality=quality,
+            state_geoid=state_geoid,
+            county_geoid=county_geoid,
+            tract_geoid=tract_geoid,
+            block_geoid=block_geoid,
+            backend=self.backend_name,
+        )

--- a/tests/test_tamu_batch.py
+++ b/tests/test_tamu_batch.py
@@ -1,0 +1,348 @@
+"""Tests for TAMU batch geocoder backend (SU#625)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from siege_utilities.geo.providers.batch_geocoder import MatchQuality
+from siege_utilities.geo.providers.tamu_batch import (
+    DEFAULT_RATE_LIMIT,
+    ENV_API_KEY,
+    TAMU_BASE_URL,
+    TAMUBatchGeocoder,
+)
+
+
+def _tamu_response(
+    lat="41.8781",
+    lon="-87.6298",
+    matched_address="123 MAIN ST, CHICAGO, IL 60601",
+    match_type="Exact",
+    state_fips="17",
+    county_fips="031",
+    tract="010100",
+    block="1001",
+):
+    """Build a mock TAMU JSON response."""
+    return {
+        "OutputGeocodes": [
+            {
+                "OutputGeocode": {
+                    "Latitude": lat,
+                    "Longitude": lon,
+                    "MatchedAddress": matched_address,
+                    "MatchType": match_type,
+                },
+                "CensusValues": [
+                    {
+                        "CensusValue1": {
+                            "CensusStateFips": state_fips,
+                            "CensusCountyFips": county_fips,
+                            "CensusTract": tract,
+                            "CensusBlock": block,
+                        }
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def _mock_urlopen(response_data):
+    """Create a mock urlopen context manager returning given JSON data."""
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = json.dumps(response_data).encode()
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+class TestTAMUBatchGeocoderConfig:
+    def test_backend_name(self):
+        g = TAMUBatchGeocoder(api_key="test-key")
+        assert g.backend_name == "tamu"
+
+    def test_is_available_with_key(self):
+        g = TAMUBatchGeocoder(api_key="test-key")
+        assert g.is_available()
+
+    def test_not_available_without_key(self):
+        g = TAMUBatchGeocoder(api_key="")
+        assert not g.is_available()
+
+    @patch.dict("os.environ", {ENV_API_KEY: "env-key"})
+    def test_api_key_from_env(self):
+        g = TAMUBatchGeocoder()
+        assert g._api_key == "env-key"
+        assert g.is_available()
+
+    def test_explicit_key_overrides_env(self):
+        g = TAMUBatchGeocoder(api_key="explicit")
+        assert g._api_key == "explicit"
+
+    def test_default_rate_limit(self):
+        g = TAMUBatchGeocoder(api_key="k")
+        assert g._rate_limit == DEFAULT_RATE_LIMIT
+
+    def test_custom_rate_limit(self):
+        g = TAMUBatchGeocoder(api_key="k", rate_limit=1.0)
+        assert g._rate_limit == 1.0
+
+    def test_default_census_year(self):
+        g = TAMUBatchGeocoder(api_key="k")
+        assert g._census_year == "2020"
+
+    def test_custom_census_year(self):
+        g = TAMUBatchGeocoder(api_key="k", census_year="2010")
+        assert g._census_year == "2010"
+
+
+class TestTAMUBatchGeocoderGeocode:
+    def test_empty_input(self):
+        g = TAMUBatchGeocoder(api_key="k")
+        result = g.geocode([])
+        assert result.total == 0
+
+    def test_no_api_key_returns_error(self):
+        g = TAMUBatchGeocoder(api_key="")
+        result = g.geocode(["123 Main St"])
+        assert len(result.errors) == 1
+        assert "API key" in result.errors[0]
+
+    @patch("siege_utilities.geo.providers.tamu_batch.time.sleep")
+    @patch.object(TAMUBatchGeocoder, "_tamu_request")
+    def test_single_match(self, mock_request, mock_sleep):
+        mock_request.return_value = GeocodingResult(
+            input_address="123 Main St, Chicago, IL",
+            input_id="0",
+            matched_address="123 MAIN ST",
+            lat=41.8781,
+            lon=-87.6298,
+            match_quality=MatchQuality.EXACT.value,
+            state_geoid="17",
+            county_geoid="17031",
+            tract_geoid="17031010100",
+            block_geoid="170310101001001",
+            backend="tamu",
+        )
+        g = TAMUBatchGeocoder(api_key="k", rate_limit=0.0)
+        result = g.geocode(["123 Main St, Chicago, IL"])
+
+        assert result.total == 1
+        assert result.results[0].matched
+        assert result.results[0].lat == 41.8781
+        assert result.results[0].backend == "tamu"
+        assert result.results[0].block_geoid == "170310101001001"
+
+    @patch("siege_utilities.geo.providers.tamu_batch.time.sleep")
+    @patch.object(TAMUBatchGeocoder, "_tamu_request")
+    def test_no_match(self, mock_request, mock_sleep):
+        mock_request.return_value = None
+        g = TAMUBatchGeocoder(api_key="k", rate_limit=0.0)
+        result = g.geocode(["fake address"])
+
+        assert result.total == 1
+        assert not result.results[0].matched
+
+    @patch("siege_utilities.geo.providers.tamu_batch.time.sleep")
+    @patch.object(TAMUBatchGeocoder, "_tamu_request")
+    def test_multiple_results(self, mock_request, mock_sleep):
+        gr_match = GeocodingResult(
+            input_address="a", input_id="0",
+            lat=41.0, lon=-87.0,
+            match_quality=MatchQuality.EXACT.value, backend="tamu",
+        )
+        mock_request.side_effect = [gr_match, None, gr_match]
+        g = TAMUBatchGeocoder(api_key="k", rate_limit=0.0)
+        result = g.geocode(["a", "b", "c"])
+
+        assert result.total == 3
+        assert result.matched_count == 2
+
+    @patch("siege_utilities.geo.providers.tamu_batch.time.sleep")
+    @patch.object(TAMUBatchGeocoder, "_tamu_request")
+    def test_handles_exception(self, mock_request, mock_sleep):
+        mock_request.side_effect = Exception("API error")
+        g = TAMUBatchGeocoder(api_key="k", rate_limit=0.0)
+        result = g.geocode(["123 Main St"])
+
+        assert result.total == 1
+        assert not result.results[0].matched
+
+    @patch("siege_utilities.geo.providers.tamu_batch.time.sleep")
+    @patch.object(TAMUBatchGeocoder, "_tamu_request")
+    def test_empty_query_returns_no_match(self, mock_request, mock_sleep):
+        g = TAMUBatchGeocoder(api_key="k", rate_limit=0.0)
+        result = g.geocode([{"street": "", "city": "", "state": "", "zipcode": ""}])
+        assert result.total == 1
+        assert not result.results[0].matched
+        mock_request.assert_not_called()
+
+
+# Need to import GeocodingResult for test construction
+from siege_utilities.geo.providers.batch_geocoder import GeocodingResult
+
+
+class TestTAMUParseResponse:
+    """Tests for the TAMU response parser."""
+
+    def _make_geocoder(self):
+        return TAMUBatchGeocoder(api_key="test-key", rate_limit=0.0)
+
+    def _make_addr(self):
+        from siege_utilities.geo.providers.batch_geocoder import AddressInput
+        return AddressInput(
+            street="123 Main St", city="Chicago", state="IL",
+            zipcode="60601", input_id="test-1",
+        )
+
+    def test_exact_match(self):
+        g = self._make_geocoder()
+        addr = self._make_addr()
+        data = _tamu_response(match_type="Exact")
+        result = g._parse_response(data, addr)
+
+        assert result is not None
+        assert result.lat == 41.8781
+        assert result.lon == -87.6298
+        assert result.match_quality == MatchQuality.EXACT.value
+        assert result.state_geoid == "17"
+        assert result.county_geoid == "17031"
+        assert result.tract_geoid == "17031010100"
+        assert result.block_geoid == "170310101001001"
+
+    def test_interpolated_match(self):
+        g = self._make_geocoder()
+        addr = self._make_addr()
+        data = _tamu_response(match_type="Interpolated")
+        result = g._parse_response(data, addr)
+
+        assert result is not None
+        assert result.match_quality == MatchQuality.INTERPOLATED.value
+
+    def test_approximate_match(self):
+        g = self._make_geocoder()
+        addr = self._make_addr()
+        data = _tamu_response(match_type="Approximate")
+        result = g._parse_response(data, addr)
+
+        assert result is not None
+        assert result.match_quality == MatchQuality.APPROXIMATE.value
+
+    def test_nearexact_maps_to_exact(self):
+        g = self._make_geocoder()
+        addr = self._make_addr()
+        data = _tamu_response(match_type="NearExact")
+        result = g._parse_response(data, addr)
+
+        assert result is not None
+        assert result.match_quality == MatchQuality.EXACT.value
+
+    def test_empty_geocodes(self):
+        g = self._make_geocoder()
+        addr = self._make_addr()
+        result = g._parse_response({"OutputGeocodes": []}, addr)
+        assert result is None
+
+    def test_missing_lat_lon(self):
+        g = self._make_geocoder()
+        addr = self._make_addr()
+        data = _tamu_response(lat="", lon="")
+        result = g._parse_response(data, addr)
+        assert result is None
+
+    def test_zero_lat_lon_treated_as_no_match(self):
+        g = self._make_geocoder()
+        addr = self._make_addr()
+        data = _tamu_response(lat="0.0", lon="0.0")
+        result = g._parse_response(data, addr)
+        assert result is None
+
+    def test_no_census_values(self):
+        g = self._make_geocoder()
+        addr = self._make_addr()
+        data = _tamu_response()
+        data["OutputGeocodes"][0]["CensusValues"] = []
+        result = g._parse_response(data, addr)
+
+        assert result is not None
+        assert result.lat == 41.8781
+        assert result.state_geoid == ""
+        assert result.block_geoid == ""
+
+    def test_partial_geoid_hierarchy(self):
+        g = self._make_geocoder()
+        addr = self._make_addr()
+        data = _tamu_response(tract="", block="")
+        result = g._parse_response(data, addr)
+
+        assert result is not None
+        assert result.state_geoid == "17"
+        assert result.county_geoid == "17031"
+        assert result.tract_geoid == ""
+        assert result.block_geoid == ""
+
+    def test_preserves_input_id(self):
+        g = self._make_geocoder()
+        addr = self._make_addr()
+        data = _tamu_response()
+        result = g._parse_response(data, addr)
+        assert result.input_id == "test-1"
+
+    def test_matched_address_preserved(self):
+        g = self._make_geocoder()
+        addr = self._make_addr()
+        data = _tamu_response(matched_address="123 MAIN ST, CHICAGO IL")
+        result = g._parse_response(data, addr)
+        assert result.matched_address == "123 MAIN ST, CHICAGO IL"
+
+
+class TestTAMURequest:
+    """Tests for the low-level _tamu_request method."""
+
+    @patch("siege_utilities.geo.providers.tamu_batch.urllib.request.urlopen")
+    def test_successful_request(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_urlopen(_tamu_response())
+        g = TAMUBatchGeocoder(api_key="test-key", rate_limit=0.0)
+        from siege_utilities.geo.providers.batch_geocoder import AddressInput
+        addr = AddressInput(
+            street="123 Main St", city="Chicago", state="IL",
+            zipcode="60601", input_id="0",
+        )
+        result = g._tamu_request(addr)
+        assert result is not None
+        assert result.lat == 41.8781
+
+    @patch("siege_utilities.geo.providers.tamu_batch.time.sleep")
+    @patch("siege_utilities.geo.providers.tamu_batch.urllib.request.urlopen")
+    def test_retries_on_failure(self, mock_urlopen, mock_sleep):
+        mock_urlopen.side_effect = [
+            Exception("timeout"),
+            _mock_urlopen(_tamu_response()),
+        ]
+        g = TAMUBatchGeocoder(api_key="test-key", rate_limit=0.0, max_retries=2)
+        from siege_utilities.geo.providers.batch_geocoder import AddressInput
+        addr = AddressInput(
+            street="123 Main St", city="Chicago", state="IL",
+            zipcode="60601", input_id="0",
+        )
+        result = g._tamu_request(addr)
+        assert result is not None
+        assert mock_urlopen.call_count == 2
+
+    @patch("siege_utilities.geo.providers.tamu_batch.time.sleep")
+    @patch("siege_utilities.geo.providers.tamu_batch.urllib.request.urlopen")
+    def test_raises_after_max_retries(self, mock_urlopen, mock_sleep):
+        mock_urlopen.side_effect = Exception("persistent failure")
+        g = TAMUBatchGeocoder(api_key="test-key", rate_limit=0.0, max_retries=1)
+        from siege_utilities.geo.providers.batch_geocoder import AddressInput
+        addr = AddressInput(
+            street="123 Main St", city="Chicago", state="IL",
+            zipcode="60601", input_id="0",
+        )
+        with pytest.raises(Exception, match="persistent failure"):
+            g._tamu_request(addr)
+        assert mock_urlopen.call_count == 2


### PR DESCRIPTION
## Summary

- Adds `TAMUBatchGeocoder` implementing the `BatchGeocoder` ABC for Texas A&M Geoservices API
- Extracts Census geography (state/county/tract/block GEOIDs) directly from TAMU response
- API key from constructor or `TAMU_API_KEY` env var; `is_available()` returns False without key
- Match quality mapping: Exact/NearExact→exact, Interpolated→interpolated, Approximate→approximate
- 30 tests covering config, geocoding flow, response parsing, GEOID extraction, and HTTP retry

## Test Plan

- [x] 30 tests passing (`pytest tests/test_tamu_batch.py -v`)
- [x] GEOID hierarchy extraction verified (full and partial)
- [x] Zero lat/lon rejection verified (Null Island guard)
- [x] API key absence handled gracefully (error in result, not exception)