### PR TITLE
feat(geo): add composite batch geocoder with fallback (SU#626)

### DIFF
--- a/.review/su626-composite-geocoder.md
+++ b/.review/su626-composite-geocoder.md
@@ -1,0 +1,33 @@
+# Self-Review: SU#626 — Composite Geocoder
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (multi-backend geocoding orchestration)
+**Trivial-against-state:** no — new composition logic with quality-based fallback
+
+## Assumptions
+
+1. CompositeBatchGeocoder chains backends in priority order (e.g., Census→Nominatim→TAMU).
+2. Fallback triggered when match quality is below configurable threshold (default: approximate).
+3. Best result across all tried backends is kept per address.
+4. Unavailable backends skipped by default (configurable).
+5. Backend exceptions caught and logged; processing continues to next backend.
+6. Addresses resolved above threshold are not re-sent to subsequent backends (early exit optimization).
+
+## Peer Review (Junior)
+
+- Quality rank: 2 tests (ordering, unknown)
+- Config: 4 tests (backend name, requires backends, empty input, all unavailable)
+- Fallback: 14 tests (first succeeds, fallback, best result, partial, exception, skip unavailable, don't skip, all fail, quality threshold, exact threshold, three-chain, input_ids, early stop, multi-address)
+- 20 total tests passing
+
+## Lead Review (Adversarial)
+
+- **Q: What if backends return different numbers of results than addresses?** A: The zip in the loop pairs results by position. If a backend returns fewer results, the remaining addresses stay in the pending set and fall through to the next backend.
+- **Q: Why keep best rather than first-acceptable?** A: A later backend might return a higher-quality match. Since we already pay the API call for pending addresses, keeping the best is free.
+- **Q: Why not merge GEOIDs from one backend with coordinates from another?** A: Cross-backend merging introduces correctness risk (different backends may geocode to different locations). The caller can post-process if needed.
+
+## Quantified Claims
+
+- 20 new tests, all passing
+- ~130 lines of implementation
+- ~220 lines of tests

--- a/siege_utilities/geo/providers/composite_geocoder.py
+++ b/siege_utilities/geo/providers/composite_geocoder.py
@@ -1,0 +1,149 @@
+"""Composite batch geocoder with fallback chaining.
+
+Chains multiple :class:`BatchGeocoder` backends by priority,
+falling back to the next backend for addresses that fail or
+match below a quality threshold.
+
+Typical usage: Census first (free, returns GEOIDs), then
+Nominatim or TAMU for failures.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional, Union
+
+from .batch_geocoder import (
+    AddressInput,
+    BatchGeocoder,
+    BatchGeocodingResult,
+    GeocodingResult,
+    MatchQuality,
+    normalize_addresses,
+)
+
+log = logging.getLogger(__name__)
+
+_QUALITY_RANK = {
+    MatchQuality.EXACT.value: 4,
+    MatchQuality.INTERPOLATED.value: 3,
+    MatchQuality.APPROXIMATE.value: 2,
+    MatchQuality.CENTROID.value: 1,
+    MatchQuality.NO_MATCH.value: 0,
+}
+
+
+def _quality_rank(quality: str) -> int:
+    return _QUALITY_RANK.get(quality, 0)
+
+
+class CompositeBatchGeocoder(BatchGeocoder):
+    """Chains geocoding backends by priority with fallback.
+
+    For each address, tries backends in order. If a backend returns
+    a match below the minimum quality threshold, the next backend
+    is tried. The best result across all backends is kept.
+
+    Args:
+        backends: Ordered list of geocoder backends (highest priority first).
+        min_quality: Minimum match quality to accept without fallback.
+            Default "approximate" — only "centroid" and "no_match" trigger fallback.
+        skip_unavailable: Skip backends where is_available() returns False.
+            Default True.
+    """
+
+    def __init__(
+        self,
+        backends: list[BatchGeocoder],
+        min_quality: str = MatchQuality.APPROXIMATE.value,
+        skip_unavailable: bool = True,
+    ):
+        if not backends:
+            raise ValueError("At least one backend is required")
+        self._backends = backends
+        self._min_quality_rank = _quality_rank(min_quality)
+        self._skip_unavailable = skip_unavailable
+
+    @property
+    def backend_name(self) -> str:
+        return "composite"
+
+    def geocode(
+        self,
+        addresses: Union[list[dict], list[str], list[AddressInput]],
+        **kwargs,
+    ) -> BatchGeocodingResult:
+        """Geocode addresses through chained backends.
+
+        Each address is tried against backends in order until a result
+        meeting the quality threshold is found, or all backends are
+        exhausted. The best result is kept.
+        """
+        normalized = normalize_addresses(addresses)
+        if not normalized:
+            return BatchGeocodingResult(backend=self.backend_name)
+
+        available = self._get_available_backends()
+        if not available:
+            result = BatchGeocodingResult(backend=self.backend_name)
+            result.errors.append("No available geocoding backends")
+            return result
+
+        best: dict[int, GeocodingResult] = {}
+        pending = set(range(len(normalized)))
+
+        for backend in available:
+            if not pending:
+                break
+
+            pending_addrs = [normalized[i] for i in sorted(pending)]
+            pending_indices = sorted(pending)
+
+            try:
+                batch_result = backend.geocode(pending_addrs, **kwargs)
+            except Exception as exc:
+                log.warning(
+                    "Backend %s failed: %s", backend.backend_name, exc
+                )
+                continue
+
+            for idx, gr in zip(pending_indices, batch_result.results):
+                current_rank = _quality_rank(gr.match_quality)
+                prev = best.get(idx)
+
+                if prev is None or current_rank > _quality_rank(prev.match_quality):
+                    best[idx] = gr
+
+                if current_rank >= self._min_quality_rank:
+                    pending.discard(idx)
+
+        results = []
+        for i in range(len(normalized)):
+            if i in best:
+                results.append(best[i])
+            else:
+                results.append(GeocodingResult(
+                    input_address=normalized[i].one_line,
+                    input_id=normalized[i].input_id,
+                    match_quality=MatchQuality.NO_MATCH.value,
+                    backend=self.backend_name,
+                ))
+
+        result = BatchGeocodingResult(
+            results=results,
+            backend=self.backend_name,
+        )
+
+        log.info(
+            "Composite batch: %d/%d matched (%.1f%%) across %d backends",
+            result.matched_count,
+            result.total,
+            result.match_rate * 100,
+            len(available),
+        )
+        return result
+
+    def _get_available_backends(self) -> list[BatchGeocoder]:
+        if self._skip_unavailable:
+            return [b for b in self._backends if b.is_available()]
+        return list(self._backends)

--- a/tests/test_composite_geocoder.py
+++ b/tests/test_composite_geocoder.py
@@ -1,0 +1,299 @@
+"""Tests for composite batch geocoder (SU#626)."""
+
+from __future__ import annotations
+
+import pytest
+
+from siege_utilities.geo.providers.batch_geocoder import (
+    AddressInput,
+    BatchGeocoder,
+    BatchGeocodingResult,
+    GeocodingResult,
+    MatchQuality,
+)
+from siege_utilities.geo.providers.composite_geocoder import (
+    CompositeBatchGeocoder,
+    _quality_rank,
+)
+
+
+# ---------------------------------------------------------------------------
+# Stub backends for testing
+# ---------------------------------------------------------------------------
+
+
+class _StubGeocoder(BatchGeocoder):
+    """Configurable stub backend for testing."""
+
+    def __init__(self, name, results=None, available=True, raises=None):
+        self._name = name
+        self._results = results or {}
+        self._available = available
+        self._raises = raises
+        self.called_with = None
+
+    @property
+    def backend_name(self):
+        return self._name
+
+    def is_available(self):
+        return self._available
+
+    def geocode(self, addresses, **kwargs):
+        if self._raises:
+            raise self._raises
+        self.called_with = addresses
+        result = BatchGeocodingResult(backend=self._name)
+        for addr in addresses:
+            key = addr.input_id if isinstance(addr, AddressInput) else str(addr)
+            if key in self._results:
+                result.results.append(self._results[key])
+            else:
+                result.results.append(GeocodingResult(
+                    input_address=addr.one_line if isinstance(addr, AddressInput) else str(addr),
+                    input_id=key,
+                    match_quality=MatchQuality.NO_MATCH.value,
+                    backend=self._name,
+                ))
+        return result
+
+
+def _gr(input_id, quality, backend, lat=41.0, lon=-87.0, **kw):
+    return GeocodingResult(
+        input_address=f"addr-{input_id}",
+        input_id=input_id,
+        lat=lat,
+        lon=lon,
+        match_quality=quality,
+        backend=backend,
+        **kw,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Quality rank tests
+# ---------------------------------------------------------------------------
+
+
+class TestQualityRank:
+    def test_ordering(self):
+        assert _quality_rank(MatchQuality.EXACT.value) > _quality_rank(MatchQuality.INTERPOLATED.value)
+        assert _quality_rank(MatchQuality.INTERPOLATED.value) > _quality_rank(MatchQuality.APPROXIMATE.value)
+        assert _quality_rank(MatchQuality.APPROXIMATE.value) > _quality_rank(MatchQuality.CENTROID.value)
+        assert _quality_rank(MatchQuality.CENTROID.value) > _quality_rank(MatchQuality.NO_MATCH.value)
+
+    def test_unknown_quality(self):
+        assert _quality_rank("unknown") == 0
+
+
+# ---------------------------------------------------------------------------
+# Configuration tests
+# ---------------------------------------------------------------------------
+
+
+class TestCompositeConfig:
+    def test_backend_name(self):
+        g = CompositeBatchGeocoder(backends=[_StubGeocoder("a")])
+        assert g.backend_name == "composite"
+
+    def test_requires_at_least_one_backend(self):
+        with pytest.raises(ValueError, match="At least one backend"):
+            CompositeBatchGeocoder(backends=[])
+
+    def test_empty_input(self):
+        g = CompositeBatchGeocoder(backends=[_StubGeocoder("a")])
+        result = g.geocode([])
+        assert result.total == 0
+
+    def test_all_unavailable_returns_error(self):
+        g = CompositeBatchGeocoder(backends=[
+            _StubGeocoder("a", available=False),
+            _StubGeocoder("b", available=False),
+        ])
+        result = g.geocode(["123 Main St"])
+        assert len(result.errors) == 1
+        assert "No available" in result.errors[0]
+
+
+# ---------------------------------------------------------------------------
+# Fallback behavior tests
+# ---------------------------------------------------------------------------
+
+
+class TestCompositeFallback:
+    def test_first_backend_succeeds(self):
+        b1 = _StubGeocoder("census", results={
+            "0": _gr("0", MatchQuality.EXACT.value, "census"),
+        })
+        b2 = _StubGeocoder("nominatim")
+        g = CompositeBatchGeocoder(backends=[b1, b2])
+        result = g.geocode(["123 Main St"])
+
+        assert result.total == 1
+        assert result.results[0].backend == "census"
+        assert result.results[0].match_quality == MatchQuality.EXACT.value
+        assert b2.called_with is None
+
+    def test_fallback_to_second_backend(self):
+        b1 = _StubGeocoder("census", results={})
+        b2 = _StubGeocoder("nominatim", results={
+            "0": _gr("0", MatchQuality.APPROXIMATE.value, "nominatim"),
+        })
+        g = CompositeBatchGeocoder(backends=[b1, b2])
+        result = g.geocode(["123 Main St"])
+
+        assert result.total == 1
+        assert result.results[0].backend == "nominatim"
+        assert result.results[0].matched
+
+    def test_keeps_best_result_across_backends(self):
+        b1 = _StubGeocoder("census", results={
+            "0": _gr("0", MatchQuality.CENTROID.value, "census"),
+        })
+        b2 = _StubGeocoder("nominatim", results={
+            "0": _gr("0", MatchQuality.APPROXIMATE.value, "nominatim"),
+        })
+        g = CompositeBatchGeocoder(
+            backends=[b1, b2],
+            min_quality=MatchQuality.INTERPOLATED.value,
+        )
+        result = g.geocode(["123 Main St"])
+
+        assert result.results[0].backend == "nominatim"
+        assert result.results[0].match_quality == MatchQuality.APPROXIMATE.value
+
+    def test_mixed_results_partial_fallback(self):
+        b1 = _StubGeocoder("census", results={
+            "0": _gr("0", MatchQuality.EXACT.value, "census"),
+        })
+        b2 = _StubGeocoder("nominatim", results={
+            "1": _gr("1", MatchQuality.APPROXIMATE.value, "nominatim"),
+        })
+        g = CompositeBatchGeocoder(backends=[b1, b2])
+        result = g.geocode(["addr1", "addr2"])
+
+        assert result.total == 2
+        assert result.results[0].backend == "census"
+        assert result.results[1].backend == "nominatim"
+
+    def test_backend_exception_continues_to_next(self):
+        b1 = _StubGeocoder("census", raises=RuntimeError("API down"))
+        b2 = _StubGeocoder("nominatim", results={
+            "0": _gr("0", MatchQuality.APPROXIMATE.value, "nominatim"),
+        })
+        g = CompositeBatchGeocoder(backends=[b1, b2])
+        result = g.geocode(["123 Main St"])
+
+        assert result.total == 1
+        assert result.results[0].backend == "nominatim"
+
+    def test_skip_unavailable_backends(self):
+        b1 = _StubGeocoder("tamu", available=False)
+        b2 = _StubGeocoder("nominatim", results={
+            "0": _gr("0", MatchQuality.APPROXIMATE.value, "nominatim"),
+        })
+        g = CompositeBatchGeocoder(backends=[b1, b2])
+        result = g.geocode(["123 Main St"])
+
+        assert result.results[0].backend == "nominatim"
+        assert b1.called_with is None
+
+    def test_dont_skip_unavailable_when_disabled(self):
+        b1 = _StubGeocoder("tamu", available=False, results={
+            "0": _gr("0", MatchQuality.EXACT.value, "tamu"),
+        })
+        g = CompositeBatchGeocoder(backends=[b1], skip_unavailable=False)
+        result = g.geocode(["123 Main St"])
+
+        assert result.results[0].backend == "tamu"
+
+    def test_all_backends_fail_returns_no_match(self):
+        b1 = _StubGeocoder("census", results={})
+        b2 = _StubGeocoder("nominatim", results={})
+        g = CompositeBatchGeocoder(backends=[b1, b2])
+        result = g.geocode(["123 Main St"])
+
+        assert result.total == 1
+        assert not result.results[0].matched
+
+    def test_quality_threshold_triggers_fallback(self):
+        b1 = _StubGeocoder("census", results={
+            "0": _gr("0", MatchQuality.CENTROID.value, "census"),
+        })
+        b2 = _StubGeocoder("nominatim", results={
+            "0": _gr("0", MatchQuality.INTERPOLATED.value, "nominatim"),
+        })
+        g = CompositeBatchGeocoder(
+            backends=[b1, b2],
+            min_quality=MatchQuality.APPROXIMATE.value,
+        )
+        result = g.geocode(["123 Main St"])
+
+        assert result.results[0].backend == "nominatim"
+
+    def test_exact_threshold_only_accepts_exact(self):
+        b1 = _StubGeocoder("census", results={
+            "0": _gr("0", MatchQuality.INTERPOLATED.value, "census"),
+        })
+        b2 = _StubGeocoder("nominatim", results={
+            "0": _gr("0", MatchQuality.EXACT.value, "nominatim"),
+        })
+        g = CompositeBatchGeocoder(
+            backends=[b1, b2],
+            min_quality=MatchQuality.EXACT.value,
+        )
+        result = g.geocode(["123 Main St"])
+
+        assert result.results[0].backend == "nominatim"
+
+    def test_three_backends_chain(self):
+        b1 = _StubGeocoder("census", results={})
+        b2 = _StubGeocoder("nominatim", results={
+            "0": _gr("0", MatchQuality.CENTROID.value, "nominatim"),
+        })
+        b3 = _StubGeocoder("tamu", results={
+            "0": _gr("0", MatchQuality.EXACT.value, "tamu"),
+        })
+        g = CompositeBatchGeocoder(backends=[b1, b2, b3])
+        result = g.geocode(["123 Main St"])
+
+        assert result.results[0].backend == "tamu"
+
+    def test_preserves_input_ids(self):
+        b1 = _StubGeocoder("census", results={
+            "MY-ID": _gr("MY-ID", MatchQuality.EXACT.value, "census"),
+        })
+        g = CompositeBatchGeocoder(backends=[b1])
+        result = g.geocode([
+            {"street": "123 Main St", "city": "Chicago", "state": "IL", "id": "MY-ID"},
+        ])
+
+        assert result.results[0].input_id == "MY-ID"
+
+    def test_stops_early_when_all_resolved(self):
+        b1 = _StubGeocoder("census", results={
+            "0": _gr("0", MatchQuality.EXACT.value, "census"),
+            "1": _gr("1", MatchQuality.EXACT.value, "census"),
+        })
+        b2 = _StubGeocoder("nominatim")
+        g = CompositeBatchGeocoder(backends=[b1, b2])
+        result = g.geocode(["a", "b"])
+
+        assert result.matched_count == 2
+        assert b2.called_with is None
+
+    def test_multiple_addresses_different_backends(self):
+        b1 = _StubGeocoder("census", results={
+            "0": _gr("0", MatchQuality.EXACT.value, "census"),
+            "2": _gr("2", MatchQuality.EXACT.value, "census"),
+        })
+        b2 = _StubGeocoder("nominatim", results={
+            "1": _gr("1", MatchQuality.APPROXIMATE.value, "nominatim"),
+        })
+        g = CompositeBatchGeocoder(backends=[b1, b2])
+        result = g.geocode(["a", "b", "c"])
+
+        assert result.total == 3
+        assert result.results[0].backend == "census"
+        assert result.results[1].backend == "nominatim"
+        assert result.results[2].backend == "census"


### PR DESCRIPTION
## Summary

- Adds `CompositeBatchGeocoder` that chains multiple backends by priority with quality-based fallback
- Tries backends in order; falls back when match quality is below configurable threshold (default: approximate)
- Keeps best result per address across all tried backends; early exit when all addresses resolved
- Skips unavailable backends by default; catches and logs backend exceptions without aborting

## Test Plan

- [x] 20 tests passing (`pytest tests/test_composite_geocoder.py -v`)
- [x] Fallback chain verified (Census→Nominatim→TAMU pattern)
- [x] Quality threshold tested at multiple levels (approximate, interpolated, exact)
- [x] Early exit optimization verified (second backend not called when first resolves all)
- [x] Backend exception handling verified (continues to next backend)