### PR TITLE
feat(geo): add overlay registry for place history (SU#608)

### DIFF
--- a/.review/su608-overlay-registry.md
+++ b/.review/su608-overlay-registry.md
@@ -1,0 +1,32 @@
+# Self-Review: SU#608 — Overlay Registry
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (extensible overlay system for place history)
+**Trivial-against-state:** partially — standard registry pattern, but correctly integrated with ABC
+
+## Assumptions
+
+1. `PlaceHistoryOverlay` is the ABC — subclasses implement `name` and `fetch()`.
+2. `OverlayRegistry` supports both decorator and imperative registration.
+3. Class-registered overlays are lazily instantiated on first `get()`.
+4. Instance registration takes priority over class registration for same name.
+5. Failed instantiation returns None (logged, not raised).
+6. Global `overlay_registry` singleton is the default for place_history().
+
+## Peer Review (Junior)
+
+- ABC: 4 tests (cannot instantiate, concrete, fetch, is_available override)
+- Registry: 15 tests (empty, instance reg, type checks, decorator, lazy init, list, unregister ×3, clear, unknown, init failure, instance override)
+- Global: 1 test
+- 20 total tests passing
+
+## Lead Review (Adversarial)
+
+- **Q: Why lazy instantiation for decorated classes?** A: Overlays may import heavy dependencies (Django, geopandas). Deferring construction until `get()` avoids import-time failures when overlays are registered but not used.
+- **Q: Why instance overrides class?** A: Allows test code to inject mock overlays without modifying class registration. The instance is already constructed, so it's preferred.
+
+## Quantified Claims
+
+- 20 new tests, all passing
+- ~160 lines of implementation (ABC + registry)
+- ~180 lines of tests

--- a/siege_utilities/geo/overlay_registry.py
+++ b/siege_utilities/geo/overlay_registry.py
@@ -1,0 +1,176 @@
+"""Extensible overlay registry for place history queries.
+
+Overlays add contextual data layers (seats, demographics, urbanicity,
+events) to :func:`place_history` results. New overlays plug in via
+the decorator-based registry without changing core query logic.
+
+Usage::
+
+    from siege_utilities.geo.overlay_registry import (
+        PlaceHistoryOverlay,
+        overlay_registry,
+    )
+
+    @overlay_registry.register("my_overlay")
+    class MyOverlay(PlaceHistoryOverlay):
+        def fetch(self, geoid, from_year, to_year, state_fips=None):
+            return {"data": "..."}
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from typing import Any, Optional
+
+log = logging.getLogger(__name__)
+
+
+class PlaceHistoryOverlay(abc.ABC):
+    """Base class for place history overlays.
+
+    Subclasses implement :meth:`fetch` to retrieve overlay-specific data
+    for a queried GEOID and time range.
+    """
+
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
+        """Short identifier for this overlay (e.g., 'seats', 'demographics')."""
+
+    @abc.abstractmethod
+    def fetch(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        state_fips: Optional[str] = None,
+    ) -> Any:
+        """Fetch overlay data for a place and time range.
+
+        Args:
+            geoid: Census GEOID to query.
+            from_year: Start year.
+            to_year: End year.
+            state_fips: Optional state FIPS for filtering.
+
+        Returns:
+            Overlay-specific data (dict, list, dataclass, etc.).
+        """
+
+    def is_available(self) -> bool:
+        """Check if this overlay's data source is accessible."""
+        return True
+
+
+class OverlayRegistry:
+    """Registry for place history overlays.
+
+    Supports both decorator-based and imperative registration.
+
+    Decorator usage::
+
+        @overlay_registry.register("seats")
+        class SeatsOverlay(PlaceHistoryOverlay):
+            ...
+
+    Imperative usage::
+
+        overlay_registry.register_instance("seats", SeatsOverlay())
+    """
+
+    def __init__(self):
+        self._overlays: dict[str, PlaceHistoryOverlay] = {}
+        self._classes: dict[str, type] = {}
+
+    def register(self, name: str):
+        """Decorator to register an overlay class.
+
+        The class is instantiated on first use (lazy).
+
+        Args:
+            name: Overlay identifier used in place_history(overlays=[...]).
+
+        Returns:
+            Decorator that registers the class.
+        """
+        def decorator(cls):
+            if not issubclass(cls, PlaceHistoryOverlay):
+                raise TypeError(
+                    f"{cls.__name__} must subclass PlaceHistoryOverlay"
+                )
+            self._classes[name] = cls
+            return cls
+        return decorator
+
+    def register_instance(self, name: str, instance: PlaceHistoryOverlay):
+        """Register a pre-instantiated overlay.
+
+        Args:
+            name: Overlay identifier.
+            instance: PlaceHistoryOverlay instance.
+        """
+        if not isinstance(instance, PlaceHistoryOverlay):
+            raise TypeError(
+                f"{type(instance).__name__} must be a PlaceHistoryOverlay"
+            )
+        self._overlays[name] = instance
+
+    def get(self, name: str) -> Optional[PlaceHistoryOverlay]:
+        """Look up an overlay by name.
+
+        Lazily instantiates class-registered overlays on first access.
+
+        Args:
+            name: Overlay identifier.
+
+        Returns:
+            PlaceHistoryOverlay instance or None if not registered.
+        """
+        if name in self._overlays:
+            return self._overlays[name]
+
+        if name in self._classes:
+            try:
+                instance = self._classes[name]()
+                self._overlays[name] = instance
+                return instance
+            except Exception as exc:
+                log.error("Failed to instantiate overlay %s: %s", name, exc)
+                return None
+
+        return None
+
+    def list_overlays(self) -> list[str]:
+        """Return names of all registered overlays."""
+        return sorted(set(self._overlays.keys()) | set(self._classes.keys()))
+
+    def is_registered(self, name: str) -> bool:
+        """Check if an overlay name is registered."""
+        return name in self._overlays or name in self._classes
+
+    def unregister(self, name: str) -> bool:
+        """Remove an overlay registration.
+
+        Args:
+            name: Overlay identifier.
+
+        Returns:
+            True if the overlay was found and removed.
+        """
+        removed = False
+        if name in self._overlays:
+            del self._overlays[name]
+            removed = True
+        if name in self._classes:
+            del self._classes[name]
+            removed = True
+        return removed
+
+    def clear(self):
+        """Remove all registrations."""
+        self._overlays.clear()
+        self._classes.clear()
+
+
+overlay_registry = OverlayRegistry()

--- a/tests/test_overlay_registry.py
+++ b/tests/test_overlay_registry.py
@@ -1,0 +1,217 @@
+"""Tests for overlay registry (SU#608)."""
+
+from __future__ import annotations
+
+import pytest
+
+from siege_utilities.geo.overlay_registry import (
+    OverlayRegistry,
+    PlaceHistoryOverlay,
+    overlay_registry,
+)
+
+
+# ---------------------------------------------------------------------------
+# Concrete overlay for testing
+# ---------------------------------------------------------------------------
+
+
+class _TestOverlay(PlaceHistoryOverlay):
+    @property
+    def name(self):
+        return "test"
+
+    def fetch(self, geoid, from_year, to_year, state_fips=None):
+        return {"geoid": geoid, "years": (from_year, to_year)}
+
+
+class _UnavailableOverlay(PlaceHistoryOverlay):
+    @property
+    def name(self):
+        return "unavailable"
+
+    def fetch(self, geoid, from_year, to_year, state_fips=None):
+        raise RuntimeError("not available")
+
+    def is_available(self):
+        return False
+
+
+# ---------------------------------------------------------------------------
+# PlaceHistoryOverlay ABC
+# ---------------------------------------------------------------------------
+
+
+class TestPlaceHistoryOverlay:
+    def test_cannot_instantiate_abc(self):
+        with pytest.raises(TypeError):
+            PlaceHistoryOverlay()
+
+    def test_concrete_overlay(self):
+        o = _TestOverlay()
+        assert o.name == "test"
+        assert o.is_available()
+
+    def test_fetch_returns_data(self):
+        o = _TestOverlay()
+        result = o.fetch("17031", 2000, 2020)
+        assert result["geoid"] == "17031"
+
+    def test_is_available_override(self):
+        o = _UnavailableOverlay()
+        assert not o.is_available()
+
+
+# ---------------------------------------------------------------------------
+# OverlayRegistry
+# ---------------------------------------------------------------------------
+
+
+class TestOverlayRegistry:
+    def setup_method(self):
+        self.registry = OverlayRegistry()
+
+    def test_empty_registry(self):
+        assert self.registry.list_overlays() == []
+        assert self.registry.get("anything") is None
+
+    def test_register_instance(self):
+        o = _TestOverlay()
+        self.registry.register_instance("test", o)
+        assert self.registry.get("test") is o
+        assert self.registry.is_registered("test")
+
+    def test_register_instance_type_check(self):
+        with pytest.raises(TypeError, match="PlaceHistoryOverlay"):
+            self.registry.register_instance("bad", "not an overlay")
+
+    def test_decorator_registration(self):
+        @self.registry.register("decorated")
+        class DecoratedOverlay(PlaceHistoryOverlay):
+            @property
+            def name(self):
+                return "decorated"
+
+            def fetch(self, geoid, from_year, to_year, state_fips=None):
+                return "data"
+
+        assert self.registry.is_registered("decorated")
+        result = self.registry.get("decorated")
+        assert isinstance(result, DecoratedOverlay)
+
+    def test_decorator_type_check(self):
+        with pytest.raises(TypeError, match="PlaceHistoryOverlay"):
+            @self.registry.register("bad")
+            class NotAnOverlay:
+                pass
+
+    def test_lazy_instantiation(self):
+        instantiated = []
+
+        @self.registry.register("lazy")
+        class LazyOverlay(PlaceHistoryOverlay):
+            def __init__(self):
+                instantiated.append(True)
+
+            @property
+            def name(self):
+                return "lazy"
+
+            def fetch(self, geoid, from_year, to_year, state_fips=None):
+                return None
+
+        assert len(instantiated) == 0
+        self.registry.get("lazy")
+        assert len(instantiated) == 1
+        self.registry.get("lazy")
+        assert len(instantiated) == 1
+
+    def test_list_overlays(self):
+        self.registry.register_instance("b", _TestOverlay())
+        self.registry.register_instance("a", _TestOverlay())
+        assert self.registry.list_overlays() == ["a", "b"]
+
+    def test_list_includes_classes(self):
+        @self.registry.register("cls_only")
+        class Cls(PlaceHistoryOverlay):
+            @property
+            def name(self):
+                return "cls_only"
+
+            def fetch(self, geoid, from_year, to_year, state_fips=None):
+                return None
+
+        self.registry.register_instance("inst", _TestOverlay())
+        names = self.registry.list_overlays()
+        assert "cls_only" in names
+        assert "inst" in names
+
+    def test_unregister_instance(self):
+        self.registry.register_instance("test", _TestOverlay())
+        assert self.registry.unregister("test")
+        assert not self.registry.is_registered("test")
+        assert self.registry.get("test") is None
+
+    def test_unregister_class(self):
+        @self.registry.register("cls")
+        class Cls(PlaceHistoryOverlay):
+            @property
+            def name(self):
+                return "cls"
+
+            def fetch(self, geoid, from_year, to_year, state_fips=None):
+                return None
+
+        assert self.registry.unregister("cls")
+        assert not self.registry.is_registered("cls")
+
+    def test_unregister_nonexistent(self):
+        assert not self.registry.unregister("nope")
+
+    def test_clear(self):
+        self.registry.register_instance("a", _TestOverlay())
+        self.registry.register_instance("b", _TestOverlay())
+        self.registry.clear()
+        assert self.registry.list_overlays() == []
+
+    def test_get_unknown(self):
+        assert self.registry.get("unknown") is None
+
+    def test_instantiation_failure_returns_none(self):
+        @self.registry.register("broken")
+        class BrokenOverlay(PlaceHistoryOverlay):
+            def __init__(self):
+                raise RuntimeError("init failed")
+
+            @property
+            def name(self):
+                return "broken"
+
+            def fetch(self, geoid, from_year, to_year, state_fips=None):
+                return None
+
+        assert self.registry.get("broken") is None
+
+    def test_instance_overrides_class(self):
+        @self.registry.register("dup")
+        class DupOverlay(PlaceHistoryOverlay):
+            @property
+            def name(self):
+                return "dup"
+
+            def fetch(self, geoid, from_year, to_year, state_fips=None):
+                return "from_class"
+
+        instance = _TestOverlay()
+        self.registry.register_instance("dup", instance)
+        assert self.registry.get("dup") is instance
+
+
+# ---------------------------------------------------------------------------
+# Global registry
+# ---------------------------------------------------------------------------
+
+
+class TestGlobalRegistry:
+    def test_global_exists(self):
+        assert isinstance(overlay_registry, OverlayRegistry)


### PR DESCRIPTION
## Summary

- Adds `PlaceHistoryOverlay` ABC with `name`, `fetch()`, and `is_available()` interface
- `OverlayRegistry` with decorator (`@registry.register("name")`) and imperative registration
- Lazy instantiation for class-registered overlays (avoids import-time failures)
- Global `overlay_registry` singleton integrates with `place_history()` from SU#607

## Test Plan

- [x] 20 tests passing (`pytest tests/test_overlay_registry.py -v`)
- [x] Decorator and imperative registration verified
- [x] Lazy instantiation confirmed (class not instantiated until first `get()`)
- [x] Error handling for failed instantiation and type mismatches