### PR TITLE
feat(geo): add seats overlay for place history (SU#609)

### DIFF
--- a/.review/su609-seats-overlay.md
+++ b/.review/su609-seats-overlay.md
@@ -1,0 +1,33 @@
+# Self-Review: SU#609 — Seats Overlay
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (political geography, redistricting plans, seat containment)
+**Trivial-against-state:** no — new overlay bridging redistricting models to place history
+
+## Assumptions
+
+1. SeatsOverlay implements PlaceHistoryOverlay and returns SeatAssignment timeline.
+2. "Seat is identity, not geography" — returns Seat + Plan, not CD geometry.
+3. Provider pattern (SeatsDataProvider ABC) decouples from Django for testability.
+4. DictSeatsProvider enables full testing with time range and state_fips filtering.
+5. Partial containment supported (containment_pct for geographies split across districts).
+6. Multiple offices (US_HOUSE, STATE_UPPER, STATE_LOWER) coexist in results.
+
+## Peer Review (Junior)
+
+- SeatAssignment: 2 tests (defaults, fields)
+- SeatsOverlayResult: 4 tests (empty, current districts, offices, for_office)
+- DictSeatsProvider: 6 tests (empty, add/get, time range, state_fips, sorted, reverse range)
+- SeatsOverlay: 9 tests (is_overlay, fetch, empty, no provider, multiple offices, state_fips, multi-plan, registry, partial containment)
+- 21 total tests passing
+
+## Lead Review (Adversarial)
+
+- **Q: Why not query BoundaryIntersection directly?** A: BoundaryIntersection provides spatial overlap; PlanDistrictAssignment provides the Seat→Boundary mapping with plan context. The Django provider will join both. The overlay abstraction lets us test the timeline logic without either.
+- **Q: How does this handle a GEOID that spans two districts?** A: Multiple SeatAssignments with containment_pct < 1.0. The test verifies partial containment sums to 1.0.
+
+## Quantified Claims
+
+- 21 new tests, all passing
+- ~190 lines of implementation (result types + provider + overlay)
+- ~190 lines of tests

--- a/siege_utilities/geo/overlays/__init__.py
+++ b/siege_utilities/geo/overlays/__init__.py
@@ -1,0 +1,1 @@
+"""Place history overlay implementations."""

--- a/siege_utilities/geo/overlays/seats.py
+++ b/siege_utilities/geo/overlays/seats.py
@@ -1,0 +1,183 @@
+"""Seats overlay for place history.
+
+Shows which congressional/state legislative districts contained a
+geography over time, under which redistricting plans.
+
+Key design constraint from the ST model: "Seat is identity, not
+geography." The overlay returns Seat + Plan, not raw CD geometry.
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from siege_utilities.geo.overlay_registry import PlaceHistoryOverlay
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SeatAssignment:
+    """A seat-to-geography assignment for a time period.
+
+    Attributes:
+        seat_label: Human-readable seat label (e.g., "US House CA-12").
+        office: Office type (US_HOUSE, US_SENATE, STATE_UPPER, STATE_LOWER).
+        district_label: District number/label.
+        state_fips: State FIPS code.
+        plan_name: Name of the redistricting plan.
+        plan_year: Year the plan took effect.
+        from_year: Start year of this assignment.
+        to_year: End year of this assignment.
+        containment_pct: Fraction of the queried geography in this district.
+    """
+
+    seat_label: str = ""
+    office: str = ""
+    district_label: str = ""
+    state_fips: str = ""
+    plan_name: str = ""
+    plan_year: Optional[int] = None
+    from_year: Optional[int] = None
+    to_year: Optional[int] = None
+    containment_pct: float = 1.0
+
+
+@dataclass
+class SeatsOverlayResult:
+    """Result of the seats overlay query.
+
+    Attributes:
+        geoid: Queried GEOID.
+        assignments: Seat assignments ordered by time.
+        current_districts: Districts containing the GEOID now.
+    """
+
+    geoid: str = ""
+    assignments: list[SeatAssignment] = field(default_factory=list)
+
+    @property
+    def current_districts(self) -> list[SeatAssignment]:
+        if not self.assignments:
+            return []
+        max_year = max(
+            (a.to_year or a.from_year or 0) for a in self.assignments
+        )
+        return [
+            a for a in self.assignments
+            if (a.to_year or a.from_year or 0) == max_year
+        ]
+
+    @property
+    def offices(self) -> list[str]:
+        return sorted(set(a.office for a in self.assignments if a.office))
+
+    def for_office(self, office: str) -> list[SeatAssignment]:
+        return [a for a in self.assignments if a.office == office]
+
+
+# ---------------------------------------------------------------------------
+# Data provider protocol
+# ---------------------------------------------------------------------------
+
+
+class SeatsDataProvider(abc.ABC):
+    """Protocol for fetching seat assignment data.
+
+    Implementations query PlanDistrictAssignment + BoundaryIntersection
+    to find which districts contained a GEOID over time.
+    """
+
+    @abc.abstractmethod
+    def get_assignments(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        state_fips: Optional[str] = None,
+    ) -> list[SeatAssignment]:
+        """Get seat assignments for a GEOID and time range."""
+
+
+class DictSeatsProvider(SeatsDataProvider):
+    """In-memory seats provider for testing."""
+
+    def __init__(self):
+        self._assignments: list[SeatAssignment] = []
+
+    def add(self, assignment: SeatAssignment):
+        self._assignments.append(assignment)
+
+    def get_assignments(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        state_fips: Optional[str] = None,
+    ) -> list[SeatAssignment]:
+        lo = min(from_year, to_year)
+        hi = max(from_year, to_year)
+        results = []
+        for a in self._assignments:
+            a_from = a.from_year or 0
+            a_to = a.to_year or 9999
+            if a_to >= lo and a_from <= hi:
+                if state_fips and a.state_fips and a.state_fips != state_fips:
+                    continue
+                results.append(a)
+        return sorted(results, key=lambda x: x.from_year or 0)
+
+
+# ---------------------------------------------------------------------------
+# Overlay implementation
+# ---------------------------------------------------------------------------
+
+
+class SeatsOverlay(PlaceHistoryOverlay):
+    """Place history overlay showing district/seat assignments over time.
+
+    Args:
+        provider: SeatsDataProvider for fetching assignment data.
+            If None, attempts to use the Django-backed provider.
+    """
+
+    def __init__(self, provider: Optional[SeatsDataProvider] = None):
+        self._provider = provider
+
+    @property
+    def name(self) -> str:
+        return "seats"
+
+    def fetch(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        state_fips: Optional[str] = None,
+    ) -> SeatsOverlayResult:
+        provider = self._provider or self._get_default_provider()
+        if provider is None:
+            raise RuntimeError("No seats data provider available")
+
+        assignments = provider.get_assignments(
+            geoid, from_year, to_year, state_fips
+        )
+        return SeatsOverlayResult(
+            geoid=geoid,
+            assignments=assignments,
+        )
+
+    def _get_default_provider(self) -> Optional[SeatsDataProvider]:
+        try:
+            from siege_utilities.geo.django.providers import DjangoSeatsProvider
+            return DjangoSeatsProvider()
+        except Exception:
+            return None

--- a/tests/test_seats_overlay.py
+++ b/tests/test_seats_overlay.py
@@ -1,0 +1,235 @@
+"""Tests for seats overlay (SU#609)."""
+
+from __future__ import annotations
+
+import pytest
+
+from siege_utilities.geo.overlay_registry import OverlayRegistry, PlaceHistoryOverlay
+from siege_utilities.geo.overlays.seats import (
+    DictSeatsProvider,
+    SeatAssignment,
+    SeatsOverlay,
+    SeatsOverlayResult,
+)
+
+
+def _sa(
+    seat_label="US House IL-7",
+    office="US_HOUSE",
+    district_label="7",
+    state_fips="17",
+    plan_name="2020 Plan",
+    plan_year=2022,
+    from_year=2022,
+    to_year=2032,
+    containment_pct=1.0,
+):
+    return SeatAssignment(
+        seat_label=seat_label,
+        office=office,
+        district_label=district_label,
+        state_fips=state_fips,
+        plan_name=plan_name,
+        plan_year=plan_year,
+        from_year=from_year,
+        to_year=to_year,
+        containment_pct=containment_pct,
+    )
+
+
+# ---------------------------------------------------------------------------
+# SeatAssignment dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestSeatAssignment:
+    def test_defaults(self):
+        a = SeatAssignment()
+        assert a.seat_label == ""
+        assert a.containment_pct == 1.0
+
+    def test_fields(self):
+        a = _sa()
+        assert a.office == "US_HOUSE"
+        assert a.district_label == "7"
+        assert a.plan_year == 2022
+
+
+# ---------------------------------------------------------------------------
+# SeatsOverlayResult
+# ---------------------------------------------------------------------------
+
+
+class TestSeatsOverlayResult:
+    def test_empty_result(self):
+        r = SeatsOverlayResult(geoid="A")
+        assert r.current_districts == []
+        assert r.offices == []
+
+    def test_current_districts(self):
+        r = SeatsOverlayResult(
+            geoid="A",
+            assignments=[
+                _sa(from_year=2012, to_year=2022, plan_name="2010 Plan"),
+                _sa(from_year=2022, to_year=2032, plan_name="2020 Plan"),
+            ],
+        )
+        current = r.current_districts
+        assert len(current) == 1
+        assert current[0].plan_name == "2020 Plan"
+
+    def test_offices(self):
+        r = SeatsOverlayResult(
+            geoid="A",
+            assignments=[
+                _sa(office="US_HOUSE"),
+                _sa(office="STATE_UPPER"),
+                _sa(office="US_HOUSE"),
+            ],
+        )
+        assert r.offices == ["STATE_UPPER", "US_HOUSE"]
+
+    def test_for_office(self):
+        r = SeatsOverlayResult(
+            geoid="A",
+            assignments=[
+                _sa(office="US_HOUSE", district_label="7"),
+                _sa(office="STATE_UPPER", district_label="3"),
+                _sa(office="US_HOUSE", district_label="4"),
+            ],
+        )
+        house = r.for_office("US_HOUSE")
+        assert len(house) == 2
+        assert all(a.office == "US_HOUSE" for a in house)
+
+
+# ---------------------------------------------------------------------------
+# DictSeatsProvider
+# ---------------------------------------------------------------------------
+
+
+class TestDictSeatsProvider:
+    def test_empty(self):
+        p = DictSeatsProvider()
+        assert p.get_assignments("A", 2000, 2020) == []
+
+    def test_add_and_get(self):
+        p = DictSeatsProvider()
+        p.add(_sa(from_year=2012, to_year=2022))
+        results = p.get_assignments("A", 2010, 2025)
+        assert len(results) == 1
+
+    def test_time_range_filtering(self):
+        p = DictSeatsProvider()
+        p.add(_sa(from_year=2012, to_year=2022))
+        p.add(_sa(from_year=2022, to_year=2032))
+
+        assert len(p.get_assignments("A", 2010, 2015)) == 1
+        assert len(p.get_assignments("A", 2010, 2025)) == 2
+        assert len(p.get_assignments("A", 2025, 2030)) == 1
+
+    def test_state_fips_filtering(self):
+        p = DictSeatsProvider()
+        p.add(_sa(state_fips="17", from_year=2020, to_year=2030))
+        p.add(_sa(state_fips="06", from_year=2020, to_year=2030))
+
+        results = p.get_assignments("A", 2020, 2025, state_fips="17")
+        assert len(results) == 1
+        assert results[0].state_fips == "17"
+
+    def test_sorted_by_from_year(self):
+        p = DictSeatsProvider()
+        p.add(_sa(from_year=2022, to_year=2032))
+        p.add(_sa(from_year=2012, to_year=2022))
+        results = p.get_assignments("A", 2010, 2030)
+        assert results[0].from_year == 2012
+        assert results[1].from_year == 2022
+
+    def test_reverse_year_range(self):
+        p = DictSeatsProvider()
+        p.add(_sa(from_year=2015, to_year=2025))
+        results = p.get_assignments("A", 2025, 2015)
+        assert len(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# SeatsOverlay
+# ---------------------------------------------------------------------------
+
+
+class TestSeatsOverlay:
+    def test_is_overlay(self):
+        o = SeatsOverlay(provider=DictSeatsProvider())
+        assert isinstance(o, PlaceHistoryOverlay)
+        assert o.name == "seats"
+
+    def test_fetch_returns_result(self):
+        p = DictSeatsProvider()
+        p.add(_sa(from_year=2020, to_year=2030))
+        o = SeatsOverlay(provider=p)
+
+        result = o.fetch("17031010100", 2020, 2025)
+        assert isinstance(result, SeatsOverlayResult)
+        assert result.geoid == "17031010100"
+        assert len(result.assignments) == 1
+
+    def test_fetch_empty(self):
+        p = DictSeatsProvider()
+        o = SeatsOverlay(provider=p)
+        result = o.fetch("A", 2000, 2020)
+        assert result.assignments == []
+
+    def test_no_provider_raises(self):
+        o = SeatsOverlay(provider=None)
+        with pytest.raises(RuntimeError, match="No seats data provider"):
+            o.fetch("A", 2000, 2020)
+
+    def test_fetch_multiple_offices(self):
+        p = DictSeatsProvider()
+        p.add(_sa(office="US_HOUSE", from_year=2020, to_year=2030))
+        p.add(_sa(office="STATE_UPPER", from_year=2020, to_year=2030))
+        o = SeatsOverlay(provider=p)
+
+        result = o.fetch("A", 2020, 2025)
+        assert len(result.assignments) == 2
+
+    def test_fetch_passes_state_fips(self):
+        p = DictSeatsProvider()
+        p.add(_sa(state_fips="17", from_year=2020, to_year=2030))
+        p.add(_sa(state_fips="06", from_year=2020, to_year=2030))
+        o = SeatsOverlay(provider=p)
+
+        result = o.fetch("A", 2020, 2025, state_fips="17")
+        assert len(result.assignments) == 1
+
+    def test_multi_plan_timeline(self):
+        p = DictSeatsProvider()
+        p.add(_sa(plan_name="2010 Plan", from_year=2012, to_year=2022))
+        p.add(_sa(plan_name="2020 Plan", from_year=2022, to_year=2032))
+        o = SeatsOverlay(provider=p)
+
+        result = o.fetch("A", 2010, 2030)
+        assert len(result.assignments) == 2
+        assert result.assignments[0].plan_name == "2010 Plan"
+        assert result.assignments[1].plan_name == "2020 Plan"
+
+    def test_registry_integration(self):
+        registry = OverlayRegistry()
+        p = DictSeatsProvider()
+        p.add(_sa(from_year=2020, to_year=2030))
+        registry.register_instance("seats", SeatsOverlay(provider=p))
+
+        overlay = registry.get("seats")
+        assert overlay is not None
+        result = overlay.fetch("A", 2020, 2025)
+        assert isinstance(result, SeatsOverlayResult)
+
+    def test_partial_containment(self):
+        p = DictSeatsProvider()
+        p.add(_sa(containment_pct=0.7, district_label="7", from_year=2020, to_year=2030))
+        p.add(_sa(containment_pct=0.3, district_label="4", from_year=2020, to_year=2030))
+        o = SeatsOverlay(provider=p)
+
+        result = o.fetch("A", 2020, 2025)
+        assert len(result.assignments) == 2
+        assert sum(a.containment_pct for a in result.assignments) == pytest.approx(1.0)


### PR DESCRIPTION
## Summary

- Adds `SeatsOverlay` implementing `PlaceHistoryOverlay` for district/seat assignment timelines
- `SeatAssignment` dataclass with seat label, office, plan, time range, and containment percentage
- `SeatsOverlayResult` with `current_districts`, `offices`, and `for_office()` accessors
- Provider-based (`SeatsDataProvider` ABC) with `DictSeatsProvider` for testing
- Supports multi-office, multi-plan timelines and partial containment

## Test Plan

- [x] 21 tests passing (`pytest tests/test_seats_overlay.py -v`)
- [x] Time range filtering verified (overlapping, non-overlapping, reverse)
- [x] State FIPS filtering tested
- [x] Partial containment (split districts) verified
- [x] Registry integration tested