### PR TITLE
feat(geo): add demographics overlay for place history (SU#610)

### DIFF
--- a/.review/su610-demographics-overlay.md
+++ b/.review/su610-demographics-overlay.md
@@ -1,0 +1,33 @@
+# Self-Review: SU#610 — Demographics Overlay
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (Census demographics, time series, crosswalk-aware GEOID querying)
+**Trivial-against-state:** partially — standard provider pattern, key value is crosswalk-aware querying
+
+## Assumptions
+
+1. DemographicsOverlay queries DemographicSnapshot data for a GEOID + time range.
+2. Accepts terminal_geoids from lineage to query across crosswalk-changed GEOIDs.
+3. Provider pattern (DemographicsDataProvider ABC) decouples from Django.
+4. Results sorted by (year, geoid) for consistent timeline output.
+5. Optional dataset filter (acs5, acs1, dec, dec_pl).
+6. DemographicPoint stores summary fields + full values dict for flexibility.
+
+## Peer Review (Junior)
+
+- DemographicPoint: 2 tests (defaults, fields)
+- DemographicsOverlayResult: 6 tests (empty, years, for_year, population series ×2, has_data)
+- DictDemographicsProvider: 7 tests (empty, add/get, geoid filter, year range, dataset, sorted, reverse)
+- DemographicsOverlay: 9 tests (is_overlay, single geoid, empty, no provider, terminal geoids, dedup, dataset filter, sorted, multi-year)
+- 24 total tests passing
+
+## Lead Review (Adversarial)
+
+- **Q: How does this handle split GEOIDs (one GEOID becomes two)?** A: The caller passes terminal_geoids from the lineage. Both target GEOIDs are queried, and both sets of data appear in the time series. Population allocation is the caller's responsibility (or handled by LongitudinalAligner if needed).
+- **Q: Why not integrate directly with LongitudinalAligner?** A: LongitudinalAligner requires pandas. The overlay stays pandas-free for testability. When Django + pandas are available, the Django provider can use LongitudinalAligner internally.
+
+## Quantified Claims
+
+- 24 new tests, all passing
+- ~180 lines of implementation
+- ~170 lines of tests

--- a/siege_utilities/geo/overlays/demographics.py
+++ b/siege_utilities/geo/overlays/demographics.py
@@ -1,0 +1,195 @@
+"""Demographics overlay for place history.
+
+Assembles DemographicSnapshot time series for a queried geography,
+handling GEOID changes via the crosswalk chain from the lineage.
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from siege_utilities.geo.overlay_registry import PlaceHistoryOverlay
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DemographicPoint:
+    """A single demographic data point for a year.
+
+    Attributes:
+        year: Data year.
+        geoid: GEOID this data belongs to.
+        dataset: Dataset identifier (acs5, acs1, dec, dec_pl).
+        total_population: Total population if available.
+        median_household_income: Median HH income if available.
+        median_age: Median age if available.
+        values: Full variable code → value mapping.
+    """
+
+    year: int = 0
+    geoid: str = ""
+    dataset: str = ""
+    total_population: Optional[int] = None
+    median_household_income: Optional[float] = None
+    median_age: Optional[float] = None
+    values: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class DemographicsOverlayResult:
+    """Result of the demographics overlay query.
+
+    Attributes:
+        geoid: Queried GEOID.
+        time_series: Ordered list of demographic data points.
+        geoids_queried: All GEOIDs queried (includes crosswalk targets).
+    """
+
+    geoid: str = ""
+    time_series: list[DemographicPoint] = field(default_factory=list)
+    geoids_queried: list[str] = field(default_factory=list)
+
+    @property
+    def years(self) -> list[int]:
+        return sorted(set(p.year for p in self.time_series))
+
+    @property
+    def has_data(self) -> bool:
+        return len(self.time_series) > 0
+
+    def for_year(self, year: int) -> list[DemographicPoint]:
+        return [p for p in self.time_series if p.year == year]
+
+    def population_series(self) -> list[tuple[int, Optional[int]]]:
+        return [
+            (p.year, p.total_population)
+            for p in self.time_series
+            if p.total_population is not None
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Data provider protocol
+# ---------------------------------------------------------------------------
+
+
+class DemographicsDataProvider(abc.ABC):
+    """Protocol for fetching demographic snapshot data."""
+
+    @abc.abstractmethod
+    def get_snapshots(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        dataset: Optional[str] = None,
+    ) -> list[DemographicPoint]:
+        """Get demographic data points for a GEOID and year range."""
+
+
+class DictDemographicsProvider(DemographicsDataProvider):
+    """In-memory demographics provider for testing."""
+
+    def __init__(self):
+        self._data: list[DemographicPoint] = []
+
+    def add(self, point: DemographicPoint):
+        self._data.append(point)
+
+    def get_snapshots(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        dataset: Optional[str] = None,
+    ) -> list[DemographicPoint]:
+        lo = min(from_year, to_year)
+        hi = max(from_year, to_year)
+        results = []
+        for p in self._data:
+            if p.geoid != geoid:
+                continue
+            if p.year < lo or p.year > hi:
+                continue
+            if dataset and p.dataset != dataset:
+                continue
+            results.append(p)
+        return sorted(results, key=lambda x: x.year)
+
+
+# ---------------------------------------------------------------------------
+# Overlay implementation
+# ---------------------------------------------------------------------------
+
+
+class DemographicsOverlay(PlaceHistoryOverlay):
+    """Place history overlay for demographic time series.
+
+    Queries DemographicSnapshot data for the queried GEOID and any
+    related GEOIDs from the crosswalk chain (when a GEOID changes
+    across decades).
+
+    Args:
+        provider: DemographicsDataProvider for fetching snapshot data.
+        dataset: Restrict to a specific dataset (e.g., "acs5").
+        terminal_geoids: Additional GEOIDs to query (from lineage).
+    """
+
+    def __init__(
+        self,
+        provider: Optional[DemographicsDataProvider] = None,
+        dataset: Optional[str] = None,
+    ):
+        self._provider = provider
+        self._dataset = dataset
+
+    @property
+    def name(self) -> str:
+        return "demographics"
+
+    def fetch(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        state_fips: Optional[str] = None,
+        terminal_geoids: Optional[list[str]] = None,
+    ) -> DemographicsOverlayResult:
+        provider = self._provider or self._get_default_provider()
+        if provider is None:
+            raise RuntimeError("No demographics data provider available")
+
+        all_geoids = [geoid]
+        if terminal_geoids:
+            for g in terminal_geoids:
+                if g not in all_geoids:
+                    all_geoids.append(g)
+
+        all_points = []
+        for g in all_geoids:
+            points = provider.get_snapshots(g, from_year, to_year, self._dataset)
+            all_points.extend(points)
+
+        all_points.sort(key=lambda p: (p.year, p.geoid))
+
+        return DemographicsOverlayResult(
+            geoid=geoid,
+            time_series=all_points,
+            geoids_queried=all_geoids,
+        )
+
+    def _get_default_provider(self) -> Optional[DemographicsDataProvider]:
+        try:
+            from siege_utilities.geo.django.providers import DjangoDemographicsProvider
+            return DjangoDemographicsProvider()
+        except Exception:
+            return None

--- a/tests/test_demographics_overlay.py
+++ b/tests/test_demographics_overlay.py
@@ -1,0 +1,224 @@
+"""Tests for demographics overlay (SU#610)."""
+
+from __future__ import annotations
+
+import pytest
+
+from siege_utilities.geo.overlay_registry import PlaceHistoryOverlay
+from siege_utilities.geo.overlays.demographics import (
+    DemographicPoint,
+    DemographicsOverlay,
+    DemographicsOverlayResult,
+    DictDemographicsProvider,
+)
+
+
+def _dp(year=2020, geoid="17031010100", dataset="acs5",
+        total_population=5000, median_household_income=65000.0,
+        median_age=35.0, values=None):
+    return DemographicPoint(
+        year=year, geoid=geoid, dataset=dataset,
+        total_population=total_population,
+        median_household_income=median_household_income,
+        median_age=median_age,
+        values=values or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# DemographicPoint
+# ---------------------------------------------------------------------------
+
+
+class TestDemographicPoint:
+    def test_defaults(self):
+        p = DemographicPoint()
+        assert p.year == 0
+        assert p.total_population is None
+
+    def test_fields(self):
+        p = _dp()
+        assert p.year == 2020
+        assert p.total_population == 5000
+        assert p.dataset == "acs5"
+
+
+# ---------------------------------------------------------------------------
+# DemographicsOverlayResult
+# ---------------------------------------------------------------------------
+
+
+class TestDemographicsOverlayResult:
+    def test_empty(self):
+        r = DemographicsOverlayResult(geoid="A")
+        assert not r.has_data
+        assert r.years == []
+
+    def test_years(self):
+        r = DemographicsOverlayResult(
+            geoid="A",
+            time_series=[_dp(year=2010), _dp(year=2020), _dp(year=2015)],
+        )
+        assert r.years == [2010, 2015, 2020]
+
+    def test_for_year(self):
+        r = DemographicsOverlayResult(
+            geoid="A",
+            time_series=[_dp(year=2010), _dp(year=2020)],
+        )
+        assert len(r.for_year(2020)) == 1
+        assert len(r.for_year(2015)) == 0
+
+    def test_population_series(self):
+        r = DemographicsOverlayResult(
+            geoid="A",
+            time_series=[
+                _dp(year=2010, total_population=4000),
+                _dp(year=2020, total_population=5000),
+            ],
+        )
+        series = r.population_series()
+        assert series == [(2010, 4000), (2020, 5000)]
+
+    def test_population_series_skips_none(self):
+        r = DemographicsOverlayResult(
+            geoid="A",
+            time_series=[
+                _dp(year=2010, total_population=None),
+                _dp(year=2020, total_population=5000),
+            ],
+        )
+        assert len(r.population_series()) == 1
+
+    def test_has_data(self):
+        r = DemographicsOverlayResult(
+            geoid="A", time_series=[_dp()],
+        )
+        assert r.has_data
+
+
+# ---------------------------------------------------------------------------
+# DictDemographicsProvider
+# ---------------------------------------------------------------------------
+
+
+class TestDictDemographicsProvider:
+    def test_empty(self):
+        p = DictDemographicsProvider()
+        assert p.get_snapshots("A", 2000, 2020) == []
+
+    def test_add_and_get(self):
+        p = DictDemographicsProvider()
+        p.add(_dp(geoid="A", year=2020))
+        results = p.get_snapshots("A", 2018, 2022)
+        assert len(results) == 1
+
+    def test_geoid_filtering(self):
+        p = DictDemographicsProvider()
+        p.add(_dp(geoid="A", year=2020))
+        p.add(_dp(geoid="B", year=2020))
+        assert len(p.get_snapshots("A", 2018, 2022)) == 1
+
+    def test_year_range_filtering(self):
+        p = DictDemographicsProvider()
+        p.add(_dp(geoid="A", year=2010))
+        p.add(_dp(geoid="A", year=2015))
+        p.add(_dp(geoid="A", year=2020))
+        assert len(p.get_snapshots("A", 2012, 2018)) == 1
+
+    def test_dataset_filtering(self):
+        p = DictDemographicsProvider()
+        p.add(_dp(geoid="A", year=2020, dataset="acs5"))
+        p.add(_dp(geoid="A", year=2020, dataset="dec"))
+        assert len(p.get_snapshots("A", 2018, 2022, dataset="acs5")) == 1
+
+    def test_sorted_by_year(self):
+        p = DictDemographicsProvider()
+        p.add(_dp(geoid="A", year=2020))
+        p.add(_dp(geoid="A", year=2010))
+        results = p.get_snapshots("A", 2005, 2025)
+        assert results[0].year == 2010
+        assert results[1].year == 2020
+
+    def test_reverse_year_range(self):
+        p = DictDemographicsProvider()
+        p.add(_dp(geoid="A", year=2015))
+        results = p.get_snapshots("A", 2020, 2010)
+        assert len(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# DemographicsOverlay
+# ---------------------------------------------------------------------------
+
+
+class TestDemographicsOverlay:
+    def test_is_overlay(self):
+        o = DemographicsOverlay(provider=DictDemographicsProvider())
+        assert isinstance(o, PlaceHistoryOverlay)
+        assert o.name == "demographics"
+
+    def test_fetch_single_geoid(self):
+        p = DictDemographicsProvider()
+        p.add(_dp(geoid="A", year=2020))
+        o = DemographicsOverlay(provider=p)
+        result = o.fetch("A", 2018, 2022)
+        assert result.geoid == "A"
+        assert len(result.time_series) == 1
+        assert result.geoids_queried == ["A"]
+
+    def test_fetch_empty(self):
+        p = DictDemographicsProvider()
+        o = DemographicsOverlay(provider=p)
+        result = o.fetch("A", 2000, 2020)
+        assert not result.has_data
+
+    def test_no_provider_raises(self):
+        o = DemographicsOverlay(provider=None)
+        with pytest.raises(RuntimeError, match="No demographics data provider"):
+            o.fetch("A", 2000, 2020)
+
+    def test_with_terminal_geoids(self):
+        p = DictDemographicsProvider()
+        p.add(_dp(geoid="A", year=2010))
+        p.add(_dp(geoid="B", year=2020))
+        o = DemographicsOverlay(provider=p)
+        result = o.fetch("A", 2005, 2025, terminal_geoids=["B"])
+        assert len(result.time_series) == 2
+        assert set(result.geoids_queried) == {"A", "B"}
+
+    def test_deduplicates_geoids(self):
+        p = DictDemographicsProvider()
+        p.add(_dp(geoid="A", year=2020))
+        o = DemographicsOverlay(provider=p)
+        result = o.fetch("A", 2018, 2022, terminal_geoids=["A", "A"])
+        assert result.geoids_queried == ["A"]
+
+    def test_dataset_filter(self):
+        p = DictDemographicsProvider()
+        p.add(_dp(geoid="A", year=2020, dataset="acs5"))
+        p.add(_dp(geoid="A", year=2020, dataset="dec"))
+        o = DemographicsOverlay(provider=p, dataset="acs5")
+        result = o.fetch("A", 2018, 2022)
+        assert len(result.time_series) == 1
+        assert result.time_series[0].dataset == "acs5"
+
+    def test_sorted_output(self):
+        p = DictDemographicsProvider()
+        p.add(_dp(geoid="B", year=2020))
+        p.add(_dp(geoid="A", year=2010))
+        o = DemographicsOverlay(provider=p)
+        result = o.fetch("A", 2005, 2025, terminal_geoids=["B"])
+        assert result.time_series[0].year == 2010
+        assert result.time_series[1].year == 2020
+
+    def test_multi_year_timeline(self):
+        p = DictDemographicsProvider()
+        for yr in [2010, 2012, 2015, 2018, 2020]:
+            p.add(_dp(geoid="A", year=yr, total_population=yr * 2))
+        o = DemographicsOverlay(provider=p)
+        result = o.fetch("A", 2010, 2020)
+        assert len(result.time_series) == 5
+        series = result.population_series()
+        assert len(series) == 5
+        assert series[0] == (2010, 4020)


### PR DESCRIPTION
## Summary

- Adds `DemographicsOverlay` implementing `PlaceHistoryOverlay` for demographic time series
- Queries DemographicSnapshot data with crosswalk-aware multi-GEOID support via `terminal_geoids`
- `DemographicPoint` with summary fields (population, income, age) and full values dict
- `DemographicsOverlayResult` with `years`, `for_year()`, and `population_series()` accessors
- Provider-based with `DictDemographicsProvider` for testing

## Test Plan

- [x] 24 tests passing (`pytest tests/test_demographics_overlay.py -v`)
- [x] Multi-GEOID querying verified (terminal geoids from crosswalk chain)
- [x] Dataset filtering and year range filtering tested
- [x] GEOID deduplication verified
- [x] Time series sorting and population series extraction tested