### PR TITLE
feat(geo): add urbanicity overlay for place history (SU#611)

### DIFF
--- a/.review/su611-urbanicity-overlay.md
+++ b/.review/su611-urbanicity-overlay.md
@@ -1,0 +1,27 @@
+# Self-Review: SU#611 — Urbanicity Overlay
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (NCES locale classification, Census vintages)
+**Trivial-against-state:** partially — thin overlay wrapping NCES classifier per vintage
+
+## Assumptions
+
+1. UrbanicityOverlay calls NCESLocaleClassifier (WS3) for each vintage in the range.
+2. Default vintages: 2000, 2010, 2020 (configurable).
+3. Provider pattern (UrbanicityDataProvider ABC) decouples from Django/WS3 classifier.
+4. `changed` property detects urbanicity shifts across vintages.
+5. Missing vintages silently skipped (not all GEOIDs classified at every vintage).
+
+## Peer Review (Junior)
+
+- UrbanicityPoint: 2 tests
+- UrbanicityOverlayResult: 7 tests (empty, years, for_year, changed ×2, current_category, has_data)
+- DictUrbanicityProvider: 4 tests
+- UrbanicityOverlay: 10 tests (is_overlay, single/multi vintage, range filter, empty, no provider, reverse, custom years, sorted, missing)
+- 23 total tests passing
+
+## Quantified Claims
+
+- 23 new tests, all passing
+- ~165 lines of implementation
+- ~165 lines of tests

--- a/siege_utilities/geo/overlays/urbanicity.py
+++ b/siege_utilities/geo/overlays/urbanicity.py
@@ -1,0 +1,181 @@
+"""Urbanicity overlay for place history.
+
+NCES locale classification per vintage for a queried geography.
+Calls NCESLocaleClassifier (WS3) for each vintage in the range.
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from dataclasses import dataclass, field
+from typing import Optional
+
+from siege_utilities.geo.overlay_registry import PlaceHistoryOverlay
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class UrbanicityPoint:
+    """NCES locale classification for a single vintage.
+
+    Attributes:
+        year: Vintage year of the classification.
+        geoid: GEOID classified.
+        locale_code: NCES 2-digit locale code (e.g., "11" for City-Large).
+        locale_label: Human-readable label (e.g., "City-Large").
+        category: Top-level category (city, suburb, town, rural).
+        size: Size qualifier (large, midsize, small, fringe, distant, remote).
+    """
+
+    year: int = 0
+    geoid: str = ""
+    locale_code: str = ""
+    locale_label: str = ""
+    category: str = ""
+    size: str = ""
+
+
+@dataclass
+class UrbanicityOverlayResult:
+    """Result of the urbanicity overlay query.
+
+    Attributes:
+        geoid: Queried GEOID.
+        classifications: Ordered list of urbanicity points by year.
+    """
+
+    geoid: str = ""
+    classifications: list[UrbanicityPoint] = field(default_factory=list)
+
+    @property
+    def years(self) -> list[int]:
+        return sorted(set(p.year for p in self.classifications))
+
+    @property
+    def has_data(self) -> bool:
+        return len(self.classifications) > 0
+
+    def for_year(self, year: int) -> Optional[UrbanicityPoint]:
+        for p in self.classifications:
+            if p.year == year:
+                return p
+        return None
+
+    @property
+    def changed(self) -> bool:
+        codes = set(p.locale_code for p in self.classifications)
+        return len(codes) > 1
+
+    @property
+    def current_category(self) -> str:
+        if not self.classifications:
+            return ""
+        return self.classifications[-1].category
+
+
+# ---------------------------------------------------------------------------
+# Data provider protocol
+# ---------------------------------------------------------------------------
+
+
+class UrbanicityDataProvider(abc.ABC):
+    """Protocol for fetching NCES locale classification data."""
+
+    @abc.abstractmethod
+    def classify(
+        self,
+        geoid: str,
+        year: int,
+    ) -> Optional[UrbanicityPoint]:
+        """Classify a GEOID for a given vintage year."""
+
+
+class DictUrbanicityProvider(UrbanicityDataProvider):
+    """In-memory urbanicity provider for testing."""
+
+    def __init__(self):
+        self._data: dict[tuple[str, int], UrbanicityPoint] = {}
+
+    def add(self, point: UrbanicityPoint):
+        self._data[(point.geoid, point.year)] = point
+
+    def classify(
+        self,
+        geoid: str,
+        year: int,
+    ) -> Optional[UrbanicityPoint]:
+        return self._data.get((geoid, year))
+
+
+# ---------------------------------------------------------------------------
+# Overlay implementation
+# ---------------------------------------------------------------------------
+
+NCES_VINTAGE_YEARS = [2000, 2010, 2020]
+
+
+class UrbanicityOverlay(PlaceHistoryOverlay):
+    """Place history overlay for NCES urbanicity classification.
+
+    Classifies the queried GEOID using the NCES 12-code locale system
+    for each relevant vintage in the query range.
+
+    Args:
+        provider: UrbanicityDataProvider for classification.
+        vintage_years: Years to check. Defaults to NCES vintages.
+    """
+
+    def __init__(
+        self,
+        provider: Optional[UrbanicityDataProvider] = None,
+        vintage_years: Optional[list[int]] = None,
+    ):
+        self._provider = provider
+        self._vintage_years = vintage_years or NCES_VINTAGE_YEARS
+
+    @property
+    def name(self) -> str:
+        return "urbanicity"
+
+    def fetch(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        state_fips: Optional[str] = None,
+    ) -> UrbanicityOverlayResult:
+        provider = self._provider or self._get_default_provider()
+        if provider is None:
+            raise RuntimeError("No urbanicity data provider available")
+
+        lo = min(from_year, to_year)
+        hi = max(from_year, to_year)
+
+        classifications = []
+        for vintage in self._vintage_years:
+            if vintage < lo or vintage > hi:
+                continue
+            point = provider.classify(geoid, vintage)
+            if point is not None:
+                classifications.append(point)
+
+        classifications.sort(key=lambda p: p.year)
+
+        return UrbanicityOverlayResult(
+            geoid=geoid,
+            classifications=classifications,
+        )
+
+    def _get_default_provider(self) -> Optional[UrbanicityDataProvider]:
+        try:
+            from siege_utilities.geo.django.providers import DjangoUrbanicityProvider
+            return DjangoUrbanicityProvider()
+        except Exception:
+            return None

--- a/tests/test_urbanicity_overlay.py
+++ b/tests/test_urbanicity_overlay.py
@@ -1,0 +1,207 @@
+"""Tests for urbanicity overlay (SU#611)."""
+
+from __future__ import annotations
+
+import pytest
+
+from siege_utilities.geo.overlay_registry import PlaceHistoryOverlay
+from siege_utilities.geo.overlays.urbanicity import (
+    DictUrbanicityProvider,
+    UrbanicityOverlay,
+    UrbanicityOverlayResult,
+    UrbanicityPoint,
+)
+
+
+def _up(year=2020, geoid="17031010100", locale_code="11",
+        locale_label="City-Large", category="city", size="large"):
+    return UrbanicityPoint(
+        year=year, geoid=geoid, locale_code=locale_code,
+        locale_label=locale_label, category=category, size=size,
+    )
+
+
+# ---------------------------------------------------------------------------
+# UrbanicityPoint
+# ---------------------------------------------------------------------------
+
+
+class TestUrbanicityPoint:
+    def test_defaults(self):
+        p = UrbanicityPoint()
+        assert p.year == 0
+        assert p.locale_code == ""
+
+    def test_fields(self):
+        p = _up()
+        assert p.locale_code == "11"
+        assert p.category == "city"
+
+
+# ---------------------------------------------------------------------------
+# UrbanicityOverlayResult
+# ---------------------------------------------------------------------------
+
+
+class TestUrbanicityOverlayResult:
+    def test_empty(self):
+        r = UrbanicityOverlayResult(geoid="A")
+        assert not r.has_data
+        assert r.years == []
+        assert r.current_category == ""
+
+    def test_years(self):
+        r = UrbanicityOverlayResult(
+            geoid="A",
+            classifications=[_up(year=2000), _up(year=2020), _up(year=2010)],
+        )
+        assert r.years == [2000, 2010, 2020]
+
+    def test_for_year(self):
+        r = UrbanicityOverlayResult(
+            geoid="A", classifications=[_up(year=2010), _up(year=2020)],
+        )
+        assert r.for_year(2020).year == 2020
+        assert r.for_year(2015) is None
+
+    def test_changed_true(self):
+        r = UrbanicityOverlayResult(
+            geoid="A",
+            classifications=[
+                _up(year=2010, locale_code="11"),
+                _up(year=2020, locale_code="21"),
+            ],
+        )
+        assert r.changed
+
+    def test_changed_false(self):
+        r = UrbanicityOverlayResult(
+            geoid="A",
+            classifications=[
+                _up(year=2010, locale_code="11"),
+                _up(year=2020, locale_code="11"),
+            ],
+        )
+        assert not r.changed
+
+    def test_current_category(self):
+        r = UrbanicityOverlayResult(
+            geoid="A",
+            classifications=[
+                _up(year=2010, category="city"),
+                _up(year=2020, category="suburb"),
+            ],
+        )
+        assert r.current_category == "suburb"
+
+    def test_has_data(self):
+        r = UrbanicityOverlayResult(geoid="A", classifications=[_up()])
+        assert r.has_data
+
+
+# ---------------------------------------------------------------------------
+# DictUrbanicityProvider
+# ---------------------------------------------------------------------------
+
+
+class TestDictUrbanicityProvider:
+    def test_empty(self):
+        p = DictUrbanicityProvider()
+        assert p.classify("A", 2020) is None
+
+    def test_add_and_classify(self):
+        p = DictUrbanicityProvider()
+        p.add(_up(geoid="A", year=2020))
+        result = p.classify("A", 2020)
+        assert result is not None
+        assert result.locale_code == "11"
+
+    def test_wrong_geoid(self):
+        p = DictUrbanicityProvider()
+        p.add(_up(geoid="A", year=2020))
+        assert p.classify("B", 2020) is None
+
+    def test_wrong_year(self):
+        p = DictUrbanicityProvider()
+        p.add(_up(geoid="A", year=2020))
+        assert p.classify("A", 2010) is None
+
+
+# ---------------------------------------------------------------------------
+# UrbanicityOverlay
+# ---------------------------------------------------------------------------
+
+
+class TestUrbanicityOverlay:
+    def test_is_overlay(self):
+        o = UrbanicityOverlay(provider=DictUrbanicityProvider())
+        assert isinstance(o, PlaceHistoryOverlay)
+        assert o.name == "urbanicity"
+
+    def test_fetch_single_vintage(self):
+        p = DictUrbanicityProvider()
+        p.add(_up(geoid="A", year=2020))
+        o = UrbanicityOverlay(provider=p)
+        result = o.fetch("A", 2015, 2025)
+        assert len(result.classifications) == 1
+
+    def test_fetch_multiple_vintages(self):
+        p = DictUrbanicityProvider()
+        p.add(_up(geoid="A", year=2000))
+        p.add(_up(geoid="A", year=2010))
+        p.add(_up(geoid="A", year=2020))
+        o = UrbanicityOverlay(provider=p)
+        result = o.fetch("A", 1995, 2025)
+        assert len(result.classifications) == 3
+
+    def test_fetch_filters_by_range(self):
+        p = DictUrbanicityProvider()
+        p.add(_up(geoid="A", year=2000))
+        p.add(_up(geoid="A", year=2010))
+        p.add(_up(geoid="A", year=2020))
+        o = UrbanicityOverlay(provider=p)
+        result = o.fetch("A", 2005, 2015)
+        assert len(result.classifications) == 1
+        assert result.classifications[0].year == 2010
+
+    def test_fetch_empty(self):
+        p = DictUrbanicityProvider()
+        o = UrbanicityOverlay(provider=p)
+        result = o.fetch("A", 2000, 2020)
+        assert not result.has_data
+
+    def test_no_provider_raises(self):
+        o = UrbanicityOverlay(provider=None)
+        with pytest.raises(RuntimeError, match="No urbanicity data provider"):
+            o.fetch("A", 2000, 2020)
+
+    def test_reverse_year_range(self):
+        p = DictUrbanicityProvider()
+        p.add(_up(geoid="A", year=2010))
+        o = UrbanicityOverlay(provider=p)
+        result = o.fetch("A", 2020, 2005)
+        assert len(result.classifications) == 1
+
+    def test_custom_vintage_years(self):
+        p = DictUrbanicityProvider()
+        p.add(_up(geoid="A", year=2015))
+        o = UrbanicityOverlay(provider=p, vintage_years=[2005, 2015, 2025])
+        result = o.fetch("A", 2010, 2020)
+        assert len(result.classifications) == 1
+
+    def test_sorted_output(self):
+        p = DictUrbanicityProvider()
+        p.add(_up(geoid="A", year=2020))
+        p.add(_up(geoid="A", year=2010))
+        p.add(_up(geoid="A", year=2000))
+        o = UrbanicityOverlay(provider=p)
+        result = o.fetch("A", 1995, 2025)
+        years = [c.year for c in result.classifications]
+        assert years == [2000, 2010, 2020]
+
+    def test_missing_vintage_skipped(self):
+        p = DictUrbanicityProvider()
+        p.add(_up(geoid="A", year=2010))
+        o = UrbanicityOverlay(provider=p)
+        result = o.fetch("A", 1995, 2025)
+        assert len(result.classifications) == 1


### PR DESCRIPTION
## Summary

- Adds `UrbanicityOverlay` implementing `PlaceHistoryOverlay` for NCES locale classification
- Classifies GEOIDs using the NCES 12-code locale system per Census vintage
- `UrbanicityOverlayResult` with `changed` detection, `current_category`, and `for_year()` lookup
- Configurable vintage years (default: 2000, 2010, 2020); missing vintages silently skipped

## Test Plan

- [x] 23 tests passing (`pytest tests/test_urbanicity_overlay.py -v`)
- [x] Multi-vintage classification and range filtering verified
- [x] Urbanicity change detection tested (same vs different locale codes)
- [x] Custom vintage years and sorted output verified