### PR TITLE
feat(geo): add events overlay for place history (SU#612)

### DIFF
--- a/.review/su612-events-overlay.md
+++ b/.review/su612-events-overlay.md
@@ -1,0 +1,27 @@
+# Self-Review: SU#612 — Events Overlay
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (spatio-temporal events, geographic intersection)
+**Trivial-against-state:** partially — follows established overlay pattern
+
+## Assumptions
+
+1. EventsOverlay finds SpatioTemporalEvents intersecting a GEOID + time range.
+2. EventRecord stores event_type, date/end_date, geoids_affected, metadata.
+3. Provider pattern (EventsDataProvider ABC) decouples from Django.
+4. Events can affect multiple GEOIDs (multi-geoid events).
+5. Optional event_type filtering at overlay construction time.
+
+## Peer Review (Junior)
+
+- EventRecord: 4 tests (defaults, year, has_duration ×2)
+- EventsOverlayResult: 4 tests (empty, has_events, event_types, for_type)
+- DictEventsProvider: 8 tests (empty, add/get, geoid/year/type filter, sorted, reverse, multi-geoid)
+- EventsOverlay: 6 tests (is_overlay, fetch, empty, no provider, type filter, multiple)
+- 22 total tests passing
+
+## Quantified Claims
+
+- 22 new tests, all passing
+- ~170 lines of implementation
+- ~170 lines of tests

--- a/siege_utilities/geo/overlays/events.py
+++ b/siege_utilities/geo/overlays/events.py
@@ -1,0 +1,187 @@
+"""Events overlay for place history.
+
+SpatioTemporalEvents intersecting the queried geography and time range.
+Events include court rulings, natural disasters, redistricting actions,
+and other discrete occurrences with both spatial and temporal extent.
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Any, Optional
+
+from siege_utilities.geo.overlay_registry import PlaceHistoryOverlay
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class EventRecord:
+    """A single spatio-temporal event.
+
+    Attributes:
+        event_id: Unique identifier.
+        event_type: Category (e.g., "court_ruling", "natural_disaster",
+            "redistricting", "election", "policy_change").
+        title: Short description.
+        description: Longer description.
+        date: Event date.
+        end_date: End date for events with duration.
+        geoids_affected: GEOIDs intersecting this event's geography.
+        source: Data source or citation.
+        metadata: Additional event-specific data.
+    """
+
+    event_id: str = ""
+    event_type: str = ""
+    title: str = ""
+    description: str = ""
+    date: Optional[date] = None
+    end_date: Optional[date] = None
+    geoids_affected: list[str] = field(default_factory=list)
+    source: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def year(self) -> int:
+        return self.date.year if self.date else 0
+
+    @property
+    def has_duration(self) -> bool:
+        return self.end_date is not None and self.date is not None
+
+
+@dataclass
+class EventsOverlayResult:
+    """Result of the events overlay query.
+
+    Attributes:
+        geoid: Queried GEOID.
+        events: Events intersecting the geography and time range.
+    """
+
+    geoid: str = ""
+    events: list[EventRecord] = field(default_factory=list)
+
+    @property
+    def has_events(self) -> bool:
+        return len(self.events) > 0
+
+    @property
+    def event_types(self) -> list[str]:
+        return sorted(set(e.event_type for e in self.events if e.event_type))
+
+    def for_type(self, event_type: str) -> list[EventRecord]:
+        return [e for e in self.events if e.event_type == event_type]
+
+    @property
+    def count(self) -> int:
+        return len(self.events)
+
+
+# ---------------------------------------------------------------------------
+# Data provider protocol
+# ---------------------------------------------------------------------------
+
+
+class EventsDataProvider(abc.ABC):
+    """Protocol for fetching spatio-temporal event data."""
+
+    @abc.abstractmethod
+    def get_events(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        event_types: Optional[list[str]] = None,
+    ) -> list[EventRecord]:
+        """Get events intersecting a GEOID within a time range."""
+
+
+class DictEventsProvider(EventsDataProvider):
+    """In-memory events provider for testing."""
+
+    def __init__(self):
+        self._events: list[EventRecord] = []
+
+    def add(self, event: EventRecord):
+        self._events.append(event)
+
+    def get_events(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        event_types: Optional[list[str]] = None,
+    ) -> list[EventRecord]:
+        lo = min(from_year, to_year)
+        hi = max(from_year, to_year)
+        results = []
+        for e in self._events:
+            if geoid not in e.geoids_affected:
+                continue
+            if e.year < lo or e.year > hi:
+                continue
+            if event_types and e.event_type not in event_types:
+                continue
+            results.append(e)
+        return sorted(results, key=lambda e: (e.date or date.min))
+
+
+# ---------------------------------------------------------------------------
+# Overlay implementation
+# ---------------------------------------------------------------------------
+
+
+class EventsOverlay(PlaceHistoryOverlay):
+    """Place history overlay for spatio-temporal events.
+
+    Finds events that intersect the queried geography and time range.
+
+    Args:
+        provider: EventsDataProvider for fetching events.
+        event_types: Optional filter for specific event types.
+    """
+
+    def __init__(
+        self,
+        provider: Optional[EventsDataProvider] = None,
+        event_types: Optional[list[str]] = None,
+    ):
+        self._provider = provider
+        self._event_types = event_types
+
+    @property
+    def name(self) -> str:
+        return "events"
+
+    def fetch(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        state_fips: Optional[str] = None,
+    ) -> EventsOverlayResult:
+        provider = self._provider or self._get_default_provider()
+        if provider is None:
+            raise RuntimeError("No events data provider available")
+
+        events = provider.get_events(
+            geoid, from_year, to_year, self._event_types
+        )
+        return EventsOverlayResult(geoid=geoid, events=events)
+
+    def _get_default_provider(self) -> Optional[EventsDataProvider]:
+        try:
+            from siege_utilities.geo.django.providers import DjangoEventsProvider
+            return DjangoEventsProvider()
+        except Exception:
+            return None

--- a/tests/test_events_overlay.py
+++ b/tests/test_events_overlay.py
@@ -1,0 +1,204 @@
+"""Tests for events overlay (SU#612)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from siege_utilities.geo.overlay_registry import PlaceHistoryOverlay
+from siege_utilities.geo.overlays.events import (
+    DictEventsProvider,
+    EventRecord,
+    EventsOverlay,
+    EventsOverlayResult,
+)
+
+
+def _er(
+    event_id="EVT-1",
+    event_type="court_ruling",
+    title="Redistricting ruling",
+    event_date=date(2020, 6, 15),
+    geoids_affected=None,
+    end_date=None,
+):
+    return EventRecord(
+        event_id=event_id,
+        event_type=event_type,
+        title=title,
+        date=event_date,
+        end_date=end_date,
+        geoids_affected=geoids_affected or ["17031010100"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# EventRecord
+# ---------------------------------------------------------------------------
+
+
+class TestEventRecord:
+    def test_defaults(self):
+        e = EventRecord()
+        assert e.event_id == ""
+        assert e.year == 0
+        assert not e.has_duration
+
+    def test_year(self):
+        e = _er(event_date=date(2020, 3, 1))
+        assert e.year == 2020
+
+    def test_has_duration(self):
+        e = _er(event_date=date(2020, 1, 1), end_date=date(2020, 12, 31))
+        assert e.has_duration
+
+    def test_no_duration(self):
+        e = _er(end_date=None)
+        assert not e.has_duration
+
+
+# ---------------------------------------------------------------------------
+# EventsOverlayResult
+# ---------------------------------------------------------------------------
+
+
+class TestEventsOverlayResult:
+    def test_empty(self):
+        r = EventsOverlayResult(geoid="A")
+        assert not r.has_events
+        assert r.count == 0
+        assert r.event_types == []
+
+    def test_has_events(self):
+        r = EventsOverlayResult(geoid="A", events=[_er()])
+        assert r.has_events
+        assert r.count == 1
+
+    def test_event_types(self):
+        r = EventsOverlayResult(
+            geoid="A",
+            events=[
+                _er(event_type="court_ruling"),
+                _er(event_type="natural_disaster"),
+                _er(event_type="court_ruling"),
+            ],
+        )
+        assert r.event_types == ["court_ruling", "natural_disaster"]
+
+    def test_for_type(self):
+        r = EventsOverlayResult(
+            geoid="A",
+            events=[
+                _er(event_type="court_ruling", event_id="1"),
+                _er(event_type="natural_disaster", event_id="2"),
+                _er(event_type="court_ruling", event_id="3"),
+            ],
+        )
+        rulings = r.for_type("court_ruling")
+        assert len(rulings) == 2
+
+
+# ---------------------------------------------------------------------------
+# DictEventsProvider
+# ---------------------------------------------------------------------------
+
+
+class TestDictEventsProvider:
+    def test_empty(self):
+        p = DictEventsProvider()
+        assert p.get_events("A", 2000, 2020) == []
+
+    def test_add_and_get(self):
+        p = DictEventsProvider()
+        p.add(_er(geoids_affected=["A"]))
+        results = p.get_events("A", 2018, 2022)
+        assert len(results) == 1
+
+    def test_geoid_filtering(self):
+        p = DictEventsProvider()
+        p.add(_er(geoids_affected=["A"]))
+        assert len(p.get_events("B", 2018, 2022)) == 0
+
+    def test_year_range_filtering(self):
+        p = DictEventsProvider()
+        p.add(_er(event_date=date(2015, 1, 1), geoids_affected=["A"]))
+        p.add(_er(event_date=date(2020, 1, 1), geoids_affected=["A"]))
+        assert len(p.get_events("A", 2018, 2022)) == 1
+
+    def test_event_type_filtering(self):
+        p = DictEventsProvider()
+        p.add(_er(event_type="court_ruling", geoids_affected=["A"]))
+        p.add(_er(event_type="natural_disaster", geoids_affected=["A"]))
+        results = p.get_events("A", 2018, 2022, event_types=["court_ruling"])
+        assert len(results) == 1
+
+    def test_sorted_by_date(self):
+        p = DictEventsProvider()
+        p.add(_er(event_date=date(2020, 12, 1), event_id="2", geoids_affected=["A"]))
+        p.add(_er(event_date=date(2020, 1, 1), event_id="1", geoids_affected=["A"]))
+        results = p.get_events("A", 2019, 2021)
+        assert results[0].event_id == "1"
+        assert results[1].event_id == "2"
+
+    def test_reverse_year_range(self):
+        p = DictEventsProvider()
+        p.add(_er(event_date=date(2015, 1, 1), geoids_affected=["A"]))
+        results = p.get_events("A", 2020, 2010)
+        assert len(results) == 1
+
+    def test_multi_geoid_event(self):
+        p = DictEventsProvider()
+        p.add(_er(geoids_affected=["A", "B", "C"]))
+        assert len(p.get_events("A", 2018, 2022)) == 1
+        assert len(p.get_events("B", 2018, 2022)) == 1
+        assert len(p.get_events("D", 2018, 2022)) == 0
+
+
+# ---------------------------------------------------------------------------
+# EventsOverlay
+# ---------------------------------------------------------------------------
+
+
+class TestEventsOverlay:
+    def test_is_overlay(self):
+        o = EventsOverlay(provider=DictEventsProvider())
+        assert isinstance(o, PlaceHistoryOverlay)
+        assert o.name == "events"
+
+    def test_fetch_returns_result(self):
+        p = DictEventsProvider()
+        p.add(_er(geoids_affected=["A"]))
+        o = EventsOverlay(provider=p)
+        result = o.fetch("A", 2018, 2022)
+        assert isinstance(result, EventsOverlayResult)
+        assert result.geoid == "A"
+        assert result.has_events
+
+    def test_fetch_empty(self):
+        p = DictEventsProvider()
+        o = EventsOverlay(provider=p)
+        result = o.fetch("A", 2000, 2020)
+        assert not result.has_events
+
+    def test_no_provider_raises(self):
+        o = EventsOverlay(provider=None)
+        with pytest.raises(RuntimeError, match="No events data provider"):
+            o.fetch("A", 2000, 2020)
+
+    def test_event_type_filter(self):
+        p = DictEventsProvider()
+        p.add(_er(event_type="court_ruling", geoids_affected=["A"]))
+        p.add(_er(event_type="natural_disaster", geoids_affected=["A"]))
+        o = EventsOverlay(provider=p, event_types=["court_ruling"])
+        result = o.fetch("A", 2018, 2022)
+        assert len(result.events) == 1
+
+    def test_multiple_events(self):
+        p = DictEventsProvider()
+        p.add(_er(event_id="1", event_date=date(2020, 1, 1), geoids_affected=["A"]))
+        p.add(_er(event_id="2", event_date=date(2020, 6, 1), geoids_affected=["A"]))
+        p.add(_er(event_id="3", event_date=date(2021, 1, 1), geoids_affected=["A"]))
+        o = EventsOverlay(provider=p)
+        result = o.fetch("A", 2020, 2021)
+        assert result.count == 3


### PR DESCRIPTION
## Summary

- Adds `EventsOverlay` implementing `PlaceHistoryOverlay` for spatio-temporal events
- `EventRecord` with event_type, date/end_date, geoids_affected, and metadata
- Supports multi-GEOID events, event type filtering, and date-sorted results
- Completes WS2 (Place History) — all 6 tickets (#607-#612) now merged

## Test Plan

- [x] 22 tests passing (`pytest tests/test_events_overlay.py -v`)
- [x] GEOID, year range, and event type filtering verified
- [x] Multi-GEOID events tested
- [x] Date sorting verified