### PR TITLE
feat(geo): add block assignment for codification (SU#628)

### DIFF
--- a/.review/su628-block-assignment.md
+++ b/.review/su628-block-assignment.md
@@ -1,0 +1,17 @@
+# Self-Review: SU#628 — Block Assignment
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (geocoding results → block-level grouping, spatial spread)
+
+## Assumptions
+
+1. assign_blocks() converts GeocodingResult to BlockAssignment, filtering unmatched.
+2. group_by_block() groups by block GEOID with centroid calculation, sorted by count.
+3. compute_spread() provides Herfindahl concentration index, bounding box, and geographic hierarchy counts.
+4. Missing block GEOIDs fall back to tract or county.
+
+## Tests: 18 passing
+
+- assign_blocks: 5 tests (empty, skip unmatched, convert, input_id, multiple)
+- group_by_block: 6 tests (empty, single, multiple, sorted, centroid, fallback)
+- compute_spread: 7 tests (empty, single block, two equal, counts, bbox, precomputed, skewed)

--- a/siege_utilities/geo/codification_blocks.py
+++ b/siege_utilities/geo/codification_blocks.py
@@ -1,0 +1,207 @@
+"""Block assignment for codification.
+
+Groups geocoded addresses by Census block GEOID and computes
+geographic spread metrics (block count, spatial extent, concentration).
+"""
+
+from __future__ import annotations
+
+import math
+import logging
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class BlockAssignment:
+    """Geocoded address assigned to a Census block.
+
+    Attributes:
+        block_geoid: 15-digit block GEOID.
+        tract_geoid: 11-digit tract GEOID.
+        county_geoid: 5-digit county GEOID.
+        state_geoid: 2-digit state GEOID.
+        lat: Latitude.
+        lon: Longitude.
+        input_id: Caller's address identifier.
+    """
+
+    block_geoid: str = ""
+    tract_geoid: str = ""
+    county_geoid: str = ""
+    state_geoid: str = ""
+    lat: Optional[float] = None
+    lon: Optional[float] = None
+    input_id: str = ""
+
+
+@dataclass
+class BlockGroup:
+    """Addresses grouped by Census block.
+
+    Attributes:
+        block_geoid: Block identifier.
+        tract_geoid: Parent tract.
+        county_geoid: Parent county.
+        state_geoid: Parent state.
+        address_count: Number of addresses in this block.
+        centroid_lat: Mean latitude of addresses.
+        centroid_lon: Mean longitude of addresses.
+    """
+
+    block_geoid: str = ""
+    tract_geoid: str = ""
+    county_geoid: str = ""
+    state_geoid: str = ""
+    address_count: int = 0
+    centroid_lat: Optional[float] = None
+    centroid_lon: Optional[float] = None
+
+
+@dataclass
+class SpreadMetrics:
+    """Geographic spread metrics for a set of block assignments.
+
+    Attributes:
+        block_count: Distinct blocks with addresses.
+        tract_count: Distinct tracts.
+        county_count: Distinct counties.
+        state_count: Distinct states.
+        concentration: Herfindahl index of block address distribution
+            (0=evenly spread, 1=all in one block).
+        max_block_pct: Fraction of addresses in the most populated block.
+        bbox_lat_range: Latitude range (max - min) of all addresses.
+        bbox_lon_range: Longitude range (max - min) of all addresses.
+    """
+
+    block_count: int = 0
+    tract_count: int = 0
+    county_count: int = 0
+    state_count: int = 0
+    concentration: float = 0.0
+    max_block_pct: float = 0.0
+    bbox_lat_range: float = 0.0
+    bbox_lon_range: float = 0.0
+
+
+def assign_blocks(geocoded_results) -> list[BlockAssignment]:
+    """Convert geocoding results to block assignments.
+
+    Args:
+        geocoded_results: List of GeocodingResult from a BatchGeocoder.
+
+    Returns:
+        List of BlockAssignment for matched results with coordinates.
+    """
+    assignments = []
+    for gr in geocoded_results:
+        if not gr.matched or gr.lat is None or gr.lon is None:
+            continue
+        assignments.append(BlockAssignment(
+            block_geoid=gr.block_geoid,
+            tract_geoid=gr.tract_geoid,
+            county_geoid=gr.county_geoid,
+            state_geoid=gr.state_geoid,
+            lat=gr.lat,
+            lon=gr.lon,
+            input_id=gr.input_id,
+        ))
+    return assignments
+
+
+def group_by_block(assignments: list[BlockAssignment]) -> list[BlockGroup]:
+    """Group block assignments by block GEOID.
+
+    Returns groups sorted by address count (descending).
+    """
+    counts: Counter = Counter()
+    meta: dict[str, dict] = {}
+    lats: dict[str, list[float]] = {}
+    lons: dict[str, list[float]] = {}
+
+    for a in assignments:
+        geoid = a.block_geoid or a.tract_geoid or a.county_geoid or "unknown"
+        counts[geoid] += 1
+
+        if geoid not in meta:
+            meta[geoid] = {
+                "block_geoid": a.block_geoid,
+                "tract_geoid": a.tract_geoid,
+                "county_geoid": a.county_geoid,
+                "state_geoid": a.state_geoid,
+            }
+            lats[geoid] = []
+            lons[geoid] = []
+
+        if a.lat is not None:
+            lats[geoid].append(a.lat)
+        if a.lon is not None:
+            lons[geoid].append(a.lon)
+
+    groups = []
+    for geoid, count in counts.most_common():
+        m = meta[geoid]
+        clat = sum(lats[geoid]) / len(lats[geoid]) if lats[geoid] else None
+        clon = sum(lons[geoid]) / len(lons[geoid]) if lons[geoid] else None
+        groups.append(BlockGroup(
+            block_geoid=m["block_geoid"],
+            tract_geoid=m["tract_geoid"],
+            county_geoid=m["county_geoid"],
+            state_geoid=m["state_geoid"],
+            address_count=count,
+            centroid_lat=clat,
+            centroid_lon=clon,
+        ))
+
+    return groups
+
+
+def compute_spread(
+    assignments: list[BlockAssignment],
+    groups: Optional[list[BlockGroup]] = None,
+) -> SpreadMetrics:
+    """Compute geographic spread metrics for block assignments.
+
+    Args:
+        assignments: All block assignments.
+        groups: Pre-computed block groups (optional, computed if not provided).
+    """
+    if not assignments:
+        return SpreadMetrics()
+
+    if groups is None:
+        groups = group_by_block(assignments)
+
+    total = sum(g.address_count for g in groups)
+    blocks = set(g.block_geoid for g in groups if g.block_geoid)
+    tracts = set(g.tract_geoid for g in groups if g.tract_geoid)
+    counties = set(g.county_geoid for g in groups if g.county_geoid)
+    states = set(g.state_geoid for g in groups if g.state_geoid)
+
+    hhi = 0.0
+    max_pct = 0.0
+    if total > 0:
+        for g in groups:
+            pct = g.address_count / total
+            hhi += pct * pct
+            max_pct = max(max_pct, pct)
+
+    all_lats = [a.lat for a in assignments if a.lat is not None]
+    all_lons = [a.lon for a in assignments if a.lon is not None]
+
+    lat_range = (max(all_lats) - min(all_lats)) if all_lats else 0.0
+    lon_range = (max(all_lons) - min(all_lons)) if all_lons else 0.0
+
+    return SpreadMetrics(
+        block_count=len(blocks),
+        tract_count=len(tracts),
+        county_count=len(counties),
+        state_count=len(states),
+        concentration=hhi,
+        max_block_pct=max_pct,
+        bbox_lat_range=lat_range,
+        bbox_lon_range=lon_range,
+    )

--- a/tests/test_codification_blocks.py
+++ b/tests/test_codification_blocks.py
@@ -1,0 +1,155 @@
+"""Tests for block assignment (SU#628)."""
+
+from __future__ import annotations
+
+import pytest
+
+from siege_utilities.geo.providers.batch_geocoder import GeocodingResult, MatchQuality
+from siege_utilities.geo.codification_blocks import (
+    BlockAssignment,
+    BlockGroup,
+    SpreadMetrics,
+    assign_blocks,
+    compute_spread,
+    group_by_block,
+)
+
+
+def _gr(block="B1", tract="T1", county="C1", state="S1",
+        lat=41.0, lon=-87.0, matched=True, input_id="0"):
+    return GeocodingResult(
+        input_address="addr",
+        input_id=input_id,
+        lat=lat if matched else None,
+        lon=lon if matched else None,
+        match_quality=MatchQuality.EXACT.value if matched else MatchQuality.NO_MATCH.value,
+        block_geoid=block if matched else "",
+        tract_geoid=tract if matched else "",
+        county_geoid=county if matched else "",
+        state_geoid=state if matched else "",
+        backend="test",
+    )
+
+
+def _ba(block="B1", tract="T1", county="C1", state="S1",
+        lat=41.0, lon=-87.0, input_id="0"):
+    return BlockAssignment(
+        block_geoid=block, tract_geoid=tract, county_geoid=county,
+        state_geoid=state, lat=lat, lon=lon, input_id=input_id,
+    )
+
+
+class TestAssignBlocks:
+    def test_empty(self):
+        assert assign_blocks([]) == []
+
+    def test_skips_unmatched(self):
+        results = [_gr(matched=False)]
+        assert assign_blocks(results) == []
+
+    def test_converts_matched(self):
+        results = [_gr(block="B1", lat=41.0, lon=-87.0)]
+        assignments = assign_blocks(results)
+        assert len(assignments) == 1
+        assert assignments[0].block_geoid == "B1"
+        assert assignments[0].lat == 41.0
+
+    def test_preserves_input_id(self):
+        results = [_gr(input_id="MY-ID")]
+        assert assign_blocks(results)[0].input_id == "MY-ID"
+
+    def test_multiple(self):
+        results = [_gr(block="A"), _gr(block="B"), _gr(matched=False)]
+        assert len(assign_blocks(results)) == 2
+
+
+class TestGroupByBlock:
+    def test_empty(self):
+        assert group_by_block([]) == []
+
+    def test_single_group(self):
+        assignments = [_ba(block="B1"), _ba(block="B1"), _ba(block="B1")]
+        groups = group_by_block(assignments)
+        assert len(groups) == 1
+        assert groups[0].address_count == 3
+
+    def test_multiple_groups(self):
+        assignments = [_ba(block="A"), _ba(block="A"), _ba(block="B")]
+        groups = group_by_block(assignments)
+        assert len(groups) == 2
+        assert groups[0].block_geoid == "A"
+        assert groups[0].address_count == 2
+
+    def test_sorted_by_count(self):
+        assignments = [_ba(block="B"), _ba(block="A"), _ba(block="A"), _ba(block="A")]
+        groups = group_by_block(assignments)
+        assert groups[0].block_geoid == "A"
+
+    def test_centroid(self):
+        assignments = [
+            _ba(block="B1", lat=40.0, lon=-86.0),
+            _ba(block="B1", lat=42.0, lon=-88.0),
+        ]
+        groups = group_by_block(assignments)
+        assert groups[0].centroid_lat == pytest.approx(41.0)
+        assert groups[0].centroid_lon == pytest.approx(-87.0)
+
+    def test_falls_back_to_tract(self):
+        assignments = [_ba(block="", tract="T1")]
+        groups = group_by_block(assignments)
+        assert len(groups) == 1
+        assert groups[0].tract_geoid == "T1"
+
+
+class TestComputeSpread:
+    def test_empty(self):
+        m = compute_spread([])
+        assert m.block_count == 0
+        assert m.concentration == 0.0
+
+    def test_single_block(self):
+        assignments = [_ba(block="B1"), _ba(block="B1")]
+        m = compute_spread(assignments)
+        assert m.block_count == 1
+        assert m.concentration == pytest.approx(1.0)
+        assert m.max_block_pct == pytest.approx(1.0)
+
+    def test_two_equal_blocks(self):
+        assignments = [_ba(block="A"), _ba(block="B")]
+        m = compute_spread(assignments)
+        assert m.block_count == 2
+        assert m.concentration == pytest.approx(0.5)
+        assert m.max_block_pct == pytest.approx(0.5)
+
+    def test_geographic_counts(self):
+        assignments = [
+            _ba(block="A1", tract="A", county="X", state="1"),
+            _ba(block="A2", tract="A", county="X", state="1"),
+            _ba(block="B1", tract="B", county="Y", state="2"),
+        ]
+        m = compute_spread(assignments)
+        assert m.block_count == 3
+        assert m.tract_count == 2
+        assert m.county_count == 2
+        assert m.state_count == 2
+
+    def test_bbox(self):
+        assignments = [
+            _ba(lat=40.0, lon=-86.0, block="A"),
+            _ba(lat=42.0, lon=-88.0, block="B"),
+        ]
+        m = compute_spread(assignments)
+        assert m.bbox_lat_range == pytest.approx(2.0)
+        assert m.bbox_lon_range == pytest.approx(2.0)
+
+    def test_accepts_precomputed_groups(self):
+        assignments = [_ba(block="A"), _ba(block="B")]
+        groups = group_by_block(assignments)
+        m = compute_spread(assignments, groups=groups)
+        assert m.block_count == 2
+
+    def test_concentration_skewed(self):
+        assignments = [_ba(block="A")] * 9 + [_ba(block="B")]
+        m = compute_spread(assignments)
+        assert m.max_block_pct == pytest.approx(0.9)
+        assert m.concentration == pytest.approx(0.82)


### PR DESCRIPTION
## Summary

- `assign_blocks()` converts GeocodingResult to BlockAssignment (filters unmatched)
- `group_by_block()` groups by block GEOID with centroid, sorted by address count
- `compute_spread()` computes Herfindahl concentration, bounding box, hierarchy counts
- 18 tests

## Test Plan

- [x] 18 tests passing