### PR TITLE
feat(geo): add demographic enrichment for codification (SU#629)

### DIFF
--- a/.review/su629-demographic-enrichment.md
+++ b/.review/su629-demographic-enrichment.md
@@ -1,0 +1,13 @@
+# Self-Review: SU#629 — Demographic Enrichment
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (PL 94-171, block-level demographics, address weighting)
+
+## Assumptions
+
+1. BlockDemographics stores PL 94-171 fields: race, VAP, housing.
+2. compute_demographic_signature() address-weights block percentages.
+3. Blocks with zero population or missing demographics are skipped.
+4. Provider pattern for testability.
+
+## Tests: 13 passing

--- a/siege_utilities/geo/codification_demographics.py
+++ b/siege_utilities/geo/codification_demographics.py
@@ -1,0 +1,174 @@
+"""Demographic enrichment for codification.
+
+Fetches block-level demographics for matched blocks and produces
+an address-weighted demographic signature: race/ethnicity distribution,
+housing occupancy, voting-age composition.
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class BlockDemographics:
+    """PL 94-171 demographics for a single Census block.
+
+    Attributes:
+        block_geoid: Block GEOID.
+        total_population: Total population.
+        voting_age_population: 18+ population.
+        white: White alone.
+        black: Black alone.
+        hispanic: Hispanic or Latino.
+        asian: Asian alone.
+        other_race: All other races.
+        housing_total: Total housing units.
+        housing_occupied: Occupied housing units.
+        housing_vacant: Vacant housing units.
+    """
+
+    block_geoid: str = ""
+    total_population: int = 0
+    voting_age_population: int = 0
+    white: int = 0
+    black: int = 0
+    hispanic: int = 0
+    asian: int = 0
+    other_race: int = 0
+    housing_total: int = 0
+    housing_occupied: int = 0
+    housing_vacant: int = 0
+
+
+@dataclass
+class DemographicSignature:
+    """Address-weighted demographic signature for a codified area.
+
+    All percentages are weighted by address count per block.
+
+    Attributes:
+        total_block_population: Sum of block populations (unweighted).
+        weighted_blocks: Number of blocks with both addresses and demographics.
+        pct_white: Address-weighted white percentage.
+        pct_black: Address-weighted black percentage.
+        pct_hispanic: Address-weighted Hispanic percentage.
+        pct_asian: Address-weighted Asian percentage.
+        pct_other: Address-weighted other race percentage.
+        pct_voting_age: Address-weighted voting-age percentage.
+        pct_housing_occupied: Address-weighted housing occupancy rate.
+        pct_housing_vacant: Address-weighted vacancy rate.
+    """
+
+    total_block_population: int = 0
+    weighted_blocks: int = 0
+    pct_white: float = 0.0
+    pct_black: float = 0.0
+    pct_hispanic: float = 0.0
+    pct_asian: float = 0.0
+    pct_other: float = 0.0
+    pct_voting_age: float = 0.0
+    pct_housing_occupied: float = 0.0
+    pct_housing_vacant: float = 0.0
+
+
+class BlockDemographicsProvider(abc.ABC):
+    """Protocol for fetching block-level demographics."""
+
+    @abc.abstractmethod
+    def get_demographics(
+        self,
+        block_geoids: list[str],
+        census_year: Optional[int] = None,
+    ) -> dict[str, BlockDemographics]:
+        """Fetch demographics for given block GEOIDs.
+
+        Returns dict of block_geoid → BlockDemographics.
+        """
+
+
+class DictBlockDemographicsProvider(BlockDemographicsProvider):
+    """In-memory demographics provider for testing."""
+
+    def __init__(self):
+        self._data: dict[str, BlockDemographics] = {}
+
+    def add(self, demo: BlockDemographics):
+        self._data[demo.block_geoid] = demo
+
+    def get_demographics(
+        self,
+        block_geoids: list[str],
+        census_year: Optional[int] = None,
+    ) -> dict[str, BlockDemographics]:
+        return {g: self._data[g] for g in block_geoids if g in self._data}
+
+
+def compute_demographic_signature(
+    block_address_counts: dict[str, int],
+    demographics: dict[str, BlockDemographics],
+) -> DemographicSignature:
+    """Compute address-weighted demographic signature.
+
+    Args:
+        block_address_counts: Dict of block_geoid → address count.
+        demographics: Dict of block_geoid → BlockDemographics.
+
+    Returns:
+        DemographicSignature with address-weighted percentages.
+    """
+    total_addresses = 0
+    weighted_pct_white = 0.0
+    weighted_pct_black = 0.0
+    weighted_pct_hispanic = 0.0
+    weighted_pct_asian = 0.0
+    weighted_pct_other = 0.0
+    weighted_pct_vap = 0.0
+    weighted_pct_occupied = 0.0
+    weighted_pct_vacant = 0.0
+    total_pop = 0
+    matched_blocks = 0
+
+    for geoid, addr_count in block_address_counts.items():
+        demo = demographics.get(geoid)
+        if demo is None or demo.total_population == 0:
+            continue
+
+        matched_blocks += 1
+        total_addresses += addr_count
+        total_pop += demo.total_population
+
+        pop = demo.total_population
+        weighted_pct_white += addr_count * (demo.white / pop)
+        weighted_pct_black += addr_count * (demo.black / pop)
+        weighted_pct_hispanic += addr_count * (demo.hispanic / pop)
+        weighted_pct_asian += addr_count * (demo.asian / pop)
+        weighted_pct_other += addr_count * (demo.other_race / pop)
+
+        if pop > 0:
+            weighted_pct_vap += addr_count * (demo.voting_age_population / pop)
+
+        if demo.housing_total > 0:
+            weighted_pct_occupied += addr_count * (demo.housing_occupied / demo.housing_total)
+            weighted_pct_vacant += addr_count * (demo.housing_vacant / demo.housing_total)
+
+    if total_addresses == 0:
+        return DemographicSignature()
+
+    return DemographicSignature(
+        total_block_population=total_pop,
+        weighted_blocks=matched_blocks,
+        pct_white=weighted_pct_white / total_addresses,
+        pct_black=weighted_pct_black / total_addresses,
+        pct_hispanic=weighted_pct_hispanic / total_addresses,
+        pct_asian=weighted_pct_asian / total_addresses,
+        pct_other=weighted_pct_other / total_addresses,
+        pct_voting_age=weighted_pct_vap / total_addresses,
+        pct_housing_occupied=weighted_pct_occupied / total_addresses,
+        pct_housing_vacant=weighted_pct_vacant / total_addresses,
+    )

--- a/tests/test_codification_demographics.py
+++ b/tests/test_codification_demographics.py
@@ -1,0 +1,118 @@
+"""Tests for demographic enrichment (SU#629)."""
+
+from __future__ import annotations
+
+import pytest
+
+from siege_utilities.geo.codification_demographics import (
+    BlockDemographics,
+    DemographicSignature,
+    DictBlockDemographicsProvider,
+    compute_demographic_signature,
+)
+
+
+def _bd(block="B1", pop=1000, vap=750, white=600, black=200,
+        hispanic=100, asian=50, other=50,
+        housing_total=400, housing_occupied=360, housing_vacant=40):
+    return BlockDemographics(
+        block_geoid=block,
+        total_population=pop,
+        voting_age_population=vap,
+        white=white, black=black, hispanic=hispanic,
+        asian=asian, other_race=other,
+        housing_total=housing_total,
+        housing_occupied=housing_occupied,
+        housing_vacant=housing_vacant,
+    )
+
+
+class TestBlockDemographics:
+    def test_defaults(self):
+        d = BlockDemographics()
+        assert d.total_population == 0
+
+    def test_fields(self):
+        d = _bd(pop=5000)
+        assert d.total_population == 5000
+
+
+class TestDictBlockDemographicsProvider:
+    def test_empty(self):
+        p = DictBlockDemographicsProvider()
+        assert p.get_demographics(["B1"]) == {}
+
+    def test_add_and_get(self):
+        p = DictBlockDemographicsProvider()
+        p.add(_bd(block="B1"))
+        result = p.get_demographics(["B1"])
+        assert "B1" in result
+
+    def test_missing_blocks(self):
+        p = DictBlockDemographicsProvider()
+        p.add(_bd(block="B1"))
+        result = p.get_demographics(["B1", "B2"])
+        assert len(result) == 1
+
+
+class TestComputeDemographicSignature:
+    def test_empty(self):
+        sig = compute_demographic_signature({}, {})
+        assert sig.weighted_blocks == 0
+        assert sig.pct_white == 0.0
+
+    def test_single_block(self):
+        counts = {"B1": 10}
+        demos = {"B1": _bd(pop=1000, white=600, black=200, hispanic=100, asian=50, other=50)}
+        sig = compute_demographic_signature(counts, demos)
+        assert sig.weighted_blocks == 1
+        assert sig.pct_white == pytest.approx(0.6)
+        assert sig.pct_black == pytest.approx(0.2)
+        assert sig.pct_hispanic == pytest.approx(0.1)
+
+    def test_address_weighted(self):
+        counts = {"B1": 9, "B2": 1}
+        demos = {
+            "B1": _bd(block="B1", pop=1000, white=1000, black=0, hispanic=0, asian=0, other=0),
+            "B2": _bd(block="B2", pop=1000, white=0, black=1000, hispanic=0, asian=0, other=0),
+        }
+        sig = compute_demographic_signature(counts, demos)
+        assert sig.pct_white == pytest.approx(0.9)
+        assert sig.pct_black == pytest.approx(0.1)
+
+    def test_skips_zero_population(self):
+        counts = {"B1": 10, "B2": 5}
+        demos = {
+            "B1": _bd(block="B1", pop=1000, white=500),
+            "B2": _bd(block="B2", pop=0),
+        }
+        sig = compute_demographic_signature(counts, demos)
+        assert sig.weighted_blocks == 1
+
+    def test_skips_missing_demographics(self):
+        counts = {"B1": 10, "B2": 5}
+        demos = {"B1": _bd(block="B1")}
+        sig = compute_demographic_signature(counts, demos)
+        assert sig.weighted_blocks == 1
+
+    def test_voting_age(self):
+        counts = {"B1": 10}
+        demos = {"B1": _bd(pop=1000, vap=750)}
+        sig = compute_demographic_signature(counts, demos)
+        assert sig.pct_voting_age == pytest.approx(0.75)
+
+    def test_housing(self):
+        counts = {"B1": 10}
+        demos = {"B1": _bd(housing_total=400, housing_occupied=360, housing_vacant=40)}
+        sig = compute_demographic_signature(counts, demos)
+        assert sig.pct_housing_occupied == pytest.approx(0.9)
+        assert sig.pct_housing_vacant == pytest.approx(0.1)
+
+    def test_total_population(self):
+        counts = {"B1": 5, "B2": 5}
+        demos = {
+            "B1": _bd(block="B1", pop=1000),
+            "B2": _bd(block="B2", pop=2000),
+        }
+        sig = compute_demographic_signature(counts, demos)
+        assert sig.total_block_population == 3000


### PR DESCRIPTION
## Summary

- `BlockDemographics` for PL 94-171 block-level data (race, VAP, housing)
- `compute_demographic_signature()` produces address-weighted percentages
- Provider pattern with `DictBlockDemographicsProvider` for testing
- 13 tests

## Test Plan

- [x] 13 tests passing