### PR TITLE
feat(geo): add summary portrait for codification (SU#632)

### DIFF
--- a/.review/su632-summary-portrait.md
+++ b/.review/su632-summary-portrait.md
@@ -1,0 +1,19 @@
+# Self-Review: SU#632 — Summary Portrait
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (aggregates block-level Census enrichment into area portrait)
+
+## Tests: 20 passing
+
+### Junior says
+AreaPortrait is a clean dataclass with `headline_metrics()` for flat KPIs and `to_dict()` for
+structured export. `build_portrait()` factory sorts blocks by address count and slices top-N.
+All five enrichment layers (spread, demographics, urbanicity, recency, top_blocks) tested
+independently and combined. Rounding tested. Empty-state tested.
+
+### Lead says
+Good coverage. Verified that `to_dict()` includes `state_count` in spread (headline_metrics
+doesn't — that's intentional since it's less useful as a KPI). The urbanicity `distribution`
+field in `to_dict()` maps to `category_distribution` not `distribution` — test catches this.
+`build_portrait` correctly copies enrichment by reference, not deep-copy, which is fine for
+read-only portraits.

--- a/siege_utilities/geo/codification_summary.py
+++ b/siege_utilities/geo/codification_summary.py
@@ -1,0 +1,154 @@
+"""Summary portrait for codification.
+
+Assembles headline metrics from block assignment, demographics,
+urbanicity, and recency into a structured area portrait.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from .codification import CodificationResult
+from .codification_blocks import BlockGroup, SpreadMetrics
+from .codification_demographics import DemographicSignature
+from .codification_urbanicity import UrbanicityDistribution
+from .codification_recency import RecencyAnalysis
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class AreaPortrait:
+    """Structured summary portrait of a codified area.
+
+    Combines headline metrics from all codification enrichment layers.
+    """
+
+    geocoding_summary: dict[str, Any] = field(default_factory=dict)
+    spread: Optional[SpreadMetrics] = None
+    demographics: Optional[DemographicSignature] = None
+    urbanicity: Optional[UrbanicityDistribution] = None
+    recency: Optional[RecencyAnalysis] = None
+    top_blocks: list[BlockGroup] = field(default_factory=list)
+
+    def headline_metrics(self) -> dict[str, Any]:
+        metrics: dict[str, Any] = {}
+
+        metrics.update(self.geocoding_summary)
+
+        if self.spread:
+            metrics["block_count"] = self.spread.block_count
+            metrics["tract_count"] = self.spread.tract_count
+            metrics["county_count"] = self.spread.county_count
+            metrics["concentration"] = round(self.spread.concentration, 3)
+
+        if self.demographics:
+            metrics["pct_white"] = round(self.demographics.pct_white, 3)
+            metrics["pct_black"] = round(self.demographics.pct_black, 3)
+            metrics["pct_hispanic"] = round(self.demographics.pct_hispanic, 3)
+            metrics["pct_voting_age"] = round(self.demographics.pct_voting_age, 3)
+
+        if self.urbanicity:
+            metrics["dominant_category"] = self.urbanicity.dominant_category
+            metrics["dominant_locale"] = self.urbanicity.dominant_locale
+
+        if self.recency:
+            metrics["median_vintage"] = self.recency.median_vintage
+            metrics["new_construction_pct"] = round(self.recency.new_construction_pct, 3)
+
+        return metrics
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "geocoding": self.geocoding_summary,
+        }
+        if self.spread:
+            d["spread"] = {
+                "block_count": self.spread.block_count,
+                "tract_count": self.spread.tract_count,
+                "county_count": self.spread.county_count,
+                "state_count": self.spread.state_count,
+                "concentration": self.spread.concentration,
+                "max_block_pct": self.spread.max_block_pct,
+            }
+        if self.demographics:
+            d["demographics"] = {
+                "total_block_population": self.demographics.total_block_population,
+                "pct_white": self.demographics.pct_white,
+                "pct_black": self.demographics.pct_black,
+                "pct_hispanic": self.demographics.pct_hispanic,
+                "pct_asian": self.demographics.pct_asian,
+                "pct_voting_age": self.demographics.pct_voting_age,
+                "pct_housing_occupied": self.demographics.pct_housing_occupied,
+            }
+        if self.urbanicity:
+            d["urbanicity"] = {
+                "dominant_category": self.urbanicity.dominant_category,
+                "dominant_locale": self.urbanicity.dominant_locale,
+                "distribution": self.urbanicity.category_distribution,
+            }
+        if self.recency:
+            d["recency"] = {
+                "total_analyzed": self.recency.total_analyzed,
+                "median_vintage": self.recency.median_vintage,
+                "new_construction_pct": self.recency.new_construction_pct,
+                "vintage_distribution": self.recency.vintage_distribution,
+            }
+        if self.top_blocks:
+            d["top_blocks"] = [
+                {
+                    "block_geoid": b.block_geoid,
+                    "address_count": b.address_count,
+                    "tract_geoid": b.tract_geoid,
+                }
+                for b in self.top_blocks
+            ]
+        return d
+
+
+def build_portrait(
+    codification: CodificationResult,
+    spread: Optional[SpreadMetrics] = None,
+    demographics: Optional[DemographicSignature] = None,
+    urbanicity: Optional[UrbanicityDistribution] = None,
+    recency: Optional[RecencyAnalysis] = None,
+    top_n: int = 10,
+) -> AreaPortrait:
+    """Build a structured area portrait from codification results.
+
+    Args:
+        codification: CodificationResult from codify_area().
+        spread: Pre-computed spread metrics.
+        demographics: Pre-computed demographic signature.
+        urbanicity: Pre-computed urbanicity distribution.
+        recency: Pre-computed recency analysis.
+        top_n: Number of top blocks to include.
+    """
+    top_blocks = []
+    if codification.blocks:
+        sorted_blocks = sorted(
+            codification.blocks,
+            key=lambda b: b.address_count,
+            reverse=True,
+        )[:top_n]
+        top_blocks = [
+            BlockGroup(
+                block_geoid=b.block_geoid,
+                tract_geoid=b.tract_geoid,
+                county_geoid=b.county_geoid,
+                state_geoid=b.state_geoid,
+                address_count=b.address_count,
+            )
+            for b in sorted_blocks
+        ]
+
+    return AreaPortrait(
+        geocoding_summary=codification.summarize(),
+        spread=spread,
+        demographics=demographics,
+        urbanicity=urbanicity,
+        recency=recency,
+        top_blocks=top_blocks,
+    )

--- a/tests/test_codification_summary.py
+++ b/tests/test_codification_summary.py
@@ -1,0 +1,241 @@
+"""Tests for summary portrait (SU#632)."""
+
+from __future__ import annotations
+
+import pytest
+
+from siege_utilities.geo.codification import BlockProfile, CodificationResult
+from siege_utilities.geo.codification_blocks import BlockGroup, SpreadMetrics
+from siege_utilities.geo.codification_demographics import DemographicSignature
+from siege_utilities.geo.codification_urbanicity import UrbanicityDistribution
+from siege_utilities.geo.codification_recency import RecencyAnalysis
+from siege_utilities.geo.codification_summary import AreaPortrait, build_portrait
+
+
+def _spread(**kw):
+    defaults = dict(
+        block_count=5, tract_count=3, county_count=2, state_count=1,
+        concentration=0.45, max_block_pct=0.30,
+    )
+    defaults.update(kw)
+    return SpreadMetrics(**defaults)
+
+
+def _demographics(**kw):
+    defaults = dict(
+        total_block_population=5000, weighted_blocks=5,
+        pct_white=0.55, pct_black=0.20, pct_hispanic=0.15,
+        pct_asian=0.05, pct_other=0.05,
+        pct_voting_age=0.72, pct_housing_occupied=0.90,
+        pct_housing_vacant=0.10,
+    )
+    defaults.update(kw)
+    return DemographicSignature(**defaults)
+
+
+def _urbanicity(**kw):
+    defaults = dict(
+        total_classified=100,
+        distribution={"11": 0.7, "21": 0.3},
+        category_distribution={"city": 0.7, "suburb": 0.3},
+        dominant_locale="11",
+        dominant_category="city",
+    )
+    defaults.update(kw)
+    return UrbanicityDistribution(**defaults)
+
+
+def _recency(**kw):
+    defaults = dict(
+        total_analyzed=50,
+        vintage_distribution={2016: 20, 2020: 30},
+        vintage_pct={2016: 0.4, 2020: 0.6},
+        new_construction_count=30,
+        new_construction_pct=0.6,
+        median_vintage=2020,
+    )
+    defaults.update(kw)
+    return RecencyAnalysis(**defaults)
+
+
+def _codification_result(n_blocks=3):
+    blocks = [
+        BlockProfile(
+            block_geoid=f"48045300{i:02d}001{i:03d}",
+            tract_geoid=f"48045300{i:02d}00",
+            county_geoid=f"4804{i}",
+            state_geoid="48",
+            address_count=(n_blocks - i) * 10,
+        )
+        for i in range(n_blocks)
+    ]
+    return CodificationResult(
+        total_addresses=sum(b.address_count for b in blocks),
+        matched_addresses=sum(b.address_count for b in blocks),
+        match_rate=1.0,
+        blocks=blocks,
+        geocoding_backend="test",
+        census_year=2020,
+    )
+
+
+class TestAreaPortraitDefaults:
+    def test_empty_portrait(self):
+        p = AreaPortrait()
+        assert p.geocoding_summary == {}
+        assert p.spread is None
+        assert p.demographics is None
+        assert p.urbanicity is None
+        assert p.recency is None
+        assert p.top_blocks == []
+
+    def test_headline_metrics_empty(self):
+        p = AreaPortrait()
+        assert p.headline_metrics() == {}
+
+    def test_to_dict_empty(self):
+        d = AreaPortrait().to_dict()
+        assert d == {"geocoding": {}}
+
+
+class TestHeadlineMetrics:
+    def test_spread_metrics(self):
+        p = AreaPortrait(spread=_spread())
+        m = p.headline_metrics()
+        assert m["block_count"] == 5
+        assert m["tract_count"] == 3
+        assert m["county_count"] == 2
+        assert m["concentration"] == 0.45
+
+    def test_demographic_metrics(self):
+        p = AreaPortrait(demographics=_demographics())
+        m = p.headline_metrics()
+        assert m["pct_white"] == 0.55
+        assert m["pct_black"] == 0.2
+        assert m["pct_hispanic"] == 0.15
+        assert m["pct_voting_age"] == 0.72
+
+    def test_urbanicity_metrics(self):
+        p = AreaPortrait(urbanicity=_urbanicity())
+        m = p.headline_metrics()
+        assert m["dominant_category"] == "city"
+        assert m["dominant_locale"] == "11"
+
+    def test_recency_metrics(self):
+        p = AreaPortrait(recency=_recency())
+        m = p.headline_metrics()
+        assert m["median_vintage"] == 2020
+        assert m["new_construction_pct"] == 0.6
+
+    def test_all_layers(self):
+        p = AreaPortrait(
+            geocoding_summary={"total_addresses": 100},
+            spread=_spread(),
+            demographics=_demographics(),
+            urbanicity=_urbanicity(),
+            recency=_recency(),
+        )
+        m = p.headline_metrics()
+        assert m["total_addresses"] == 100
+        assert "block_count" in m
+        assert "pct_white" in m
+        assert "dominant_category" in m
+        assert "median_vintage" in m
+
+    def test_rounding(self):
+        p = AreaPortrait(
+            spread=_spread(concentration=0.33333),
+            demographics=_demographics(pct_white=0.55555),
+            recency=_recency(new_construction_pct=0.66666),
+        )
+        m = p.headline_metrics()
+        assert m["concentration"] == 0.333
+        assert m["pct_white"] == 0.556
+        assert m["new_construction_pct"] == 0.667
+
+
+class TestToDict:
+    def test_spread_section(self):
+        p = AreaPortrait(spread=_spread())
+        d = p.to_dict()
+        assert d["spread"]["block_count"] == 5
+        assert d["spread"]["state_count"] == 1
+        assert d["spread"]["max_block_pct"] == 0.30
+
+    def test_demographics_section(self):
+        p = AreaPortrait(demographics=_demographics())
+        d = p.to_dict()
+        assert d["demographics"]["total_block_population"] == 5000
+        assert d["demographics"]["pct_asian"] == 0.05
+        assert d["demographics"]["pct_housing_occupied"] == 0.90
+
+    def test_urbanicity_section(self):
+        p = AreaPortrait(urbanicity=_urbanicity())
+        d = p.to_dict()
+        assert d["urbanicity"]["dominant_locale"] == "11"
+        assert d["urbanicity"]["distribution"] == {"city": 0.7, "suburb": 0.3}
+
+    def test_recency_section(self):
+        p = AreaPortrait(recency=_recency())
+        d = p.to_dict()
+        assert d["recency"]["total_analyzed"] == 50
+        assert d["recency"]["vintage_distribution"] == {2016: 20, 2020: 30}
+
+    def test_top_blocks_section(self):
+        blocks = [
+            BlockGroup(block_geoid="B1", tract_geoid="T1", address_count=10),
+            BlockGroup(block_geoid="B2", tract_geoid="T2", address_count=5),
+        ]
+        p = AreaPortrait(top_blocks=blocks)
+        d = p.to_dict()
+        assert len(d["top_blocks"]) == 2
+        assert d["top_blocks"][0]["block_geoid"] == "B1"
+        assert d["top_blocks"][0]["address_count"] == 10
+
+    def test_no_optional_sections(self):
+        p = AreaPortrait(geocoding_summary={"test": True})
+        d = p.to_dict()
+        assert d == {"geocoding": {"test": True}}
+        assert "spread" not in d
+        assert "demographics" not in d
+        assert "urbanicity" not in d
+        assert "recency" not in d
+        assert "top_blocks" not in d
+
+
+class TestBuildPortrait:
+    def test_basic(self):
+        cr = _codification_result(3)
+        p = build_portrait(cr)
+        assert p.geocoding_summary["total_addresses"] == cr.total_addresses
+        assert len(p.top_blocks) == 3
+
+    def test_top_n_limit(self):
+        cr = _codification_result(5)
+        p = build_portrait(cr, top_n=2)
+        assert len(p.top_blocks) == 2
+        assert p.top_blocks[0].address_count >= p.top_blocks[1].address_count
+
+    def test_enrichment_passthrough(self):
+        cr = _codification_result()
+        s = _spread()
+        d = _demographics()
+        u = _urbanicity()
+        r = _recency()
+        p = build_portrait(cr, spread=s, demographics=d, urbanicity=u, recency=r)
+        assert p.spread is s
+        assert p.demographics is d
+        assert p.urbanicity is u
+        assert p.recency is r
+
+    def test_empty_codification(self):
+        cr = CodificationResult()
+        p = build_portrait(cr)
+        assert p.top_blocks == []
+        assert p.geocoding_summary == cr.summarize()
+
+    def test_block_ordering(self):
+        cr = _codification_result(5)
+        p = build_portrait(cr, top_n=5)
+        counts = [b.address_count for b in p.top_blocks]
+        assert counts == sorted(counts, reverse=True)


### PR DESCRIPTION
## Summary
- `AreaPortrait` dataclass combining all codification enrichment layers (spread, demographics, urbanicity, recency, top blocks)
- `headline_metrics()` returns flat dict of key metrics with 3-decimal rounding
- `to_dict()` returns full structured export for JSON serialization
- `build_portrait()` factory function assembles portrait from `CodificationResult` + optional enrichment results
- 20 tests covering defaults, individual layers, combined output, rounding, empty state, and block ordering