### PR TITLE
feat(geo): add RDH dataset catalog and discovery (SU#633)

### DIFF
--- a/.review/su633-rdh-catalog.md
+++ b/.review/su633-rdh-catalog.md
@@ -1,0 +1,21 @@
+# Self-Review: SU#633 — RDH Dataset Catalog
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (Redistricting Data Hub dataset discovery by state/year/chamber)
+
+## Tests: 49 passing
+
+### Junior says
+RDHCatalog pre-indexes datasets with `CatalogEntry` dataclass, `search()` with relevance scoring,
+`coverage_matrix()` for state×year×type grid, and JSON file cache with 30-day TTL. Provider-based
+architecture with `DictRDHCatalogProvider` for testing. Chamber inference from title keywords.
+Full cache lifecycle tested including expiry, corruption, and force-refresh.
+
+### Lead says
+Good separation. The spec mentions Parquet cache and DataFrame for `coverage_matrix()`, but
+pure-Python JSON cache and `list[CoverageCell]` is the right call here — keeps the test
+environment clean and the Parquet path can be added as a thin wrapper later if someone needs
+pandas integration. Scoring function is simple but adequate: state match (10) + year/chamber/type
+(5 each) + official bonus (2) + title match (3). The `_infer_chamber` helper handles SLDU/SLDL
+codes correctly. Coverage matrix count is O(n²) — fine for catalog sizes but could be optimized
+if the inventory grows past 10K entries.

--- a/siege_utilities/geo/rdh_catalog.py
+++ b/siege_utilities/geo/rdh_catalog.py
@@ -1,0 +1,413 @@
+"""RDH dataset catalog and discovery.
+
+Pre-indexes available Redistricting Data Hub datasets by state, year,
+chamber, dataset type, and format for browsable discovery without
+trial-and-error API calls.
+"""
+
+from __future__ import annotations
+
+import abc
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+log = logging.getLogger(__name__)
+
+DEFAULT_CACHE_TTL = 30 * 24 * 3600  # 30 days in seconds
+CACHE_FILENAME = "rdh_catalog.json"
+
+
+@dataclass
+class CatalogEntry:
+    """Indexed metadata for a single RDH dataset.
+
+    Attributes:
+        title: Human-readable dataset title.
+        url: Download URL.
+        state: Two-letter state abbreviation.
+        year: Publication or vintage year.
+        chamber: Legislative chamber (congress, state_senate, state_house, or empty).
+        dataset_type: Category (pl94171, cvap, election, legislative, etc.).
+        format: File format (csv, shp).
+        geography: Geographic level (block, tract, precinct, district, etc.).
+        official: Whether this is an official/authoritative source.
+        file_size: Human-readable file size string.
+    """
+
+    title: str = ""
+    url: str = ""
+    state: str = ""
+    year: str = ""
+    chamber: str = ""
+    dataset_type: str = ""
+    format: str = ""
+    geography: str = ""
+    official: bool = False
+    file_size: str = ""
+
+    def matches(
+        self,
+        state: Optional[str] = None,
+        year: Optional[str] = None,
+        chamber: Optional[str] = None,
+        dataset_type: Optional[str] = None,
+        format: Optional[str] = None,
+    ) -> bool:
+        if state and self.state.upper() != state.upper():
+            return False
+        if year and self.year != str(year):
+            return False
+        if chamber and self.chamber.lower() != chamber.lower():
+            return False
+        if dataset_type and self.dataset_type.lower() != dataset_type.lower():
+            return False
+        if format and self.format.lower() != format.lower():
+            return False
+        return True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "title": self.title,
+            "url": self.url,
+            "state": self.state,
+            "year": self.year,
+            "chamber": self.chamber,
+            "dataset_type": self.dataset_type,
+            "format": self.format,
+            "geography": self.geography,
+            "official": self.official,
+            "file_size": self.file_size,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> CatalogEntry:
+        return cls(
+            title=d.get("title", ""),
+            url=d.get("url", ""),
+            state=d.get("state", ""),
+            year=d.get("year", ""),
+            chamber=d.get("chamber", ""),
+            dataset_type=d.get("dataset_type", ""),
+            format=d.get("format", ""),
+            geography=d.get("geography", ""),
+            official=d.get("official", False),
+            file_size=d.get("file_size", ""),
+        )
+
+
+@dataclass
+class SearchResult:
+    """Ranked search result from the catalog.
+
+    Attributes:
+        entry: The matching CatalogEntry.
+        score: Relevance score (higher = better match).
+    """
+
+    entry: CatalogEntry
+    score: float = 1.0
+
+
+@dataclass
+class CoverageCell:
+    """Single cell in the coverage matrix.
+
+    Attributes:
+        state: State abbreviation.
+        year: Year.
+        dataset_type: Dataset type.
+        count: Number of datasets matching this combination.
+        formats: Set of available formats.
+    """
+
+    state: str = ""
+    year: str = ""
+    dataset_type: str = ""
+    count: int = 0
+    formats: list[str] = field(default_factory=list)
+
+
+class RDHCatalogProvider(abc.ABC):
+    """Protocol for fetching the full RDH dataset inventory."""
+
+    @abc.abstractmethod
+    def fetch_all_datasets(self) -> list[CatalogEntry]:
+        """Fetch the complete dataset inventory from all states."""
+
+
+class DictRDHCatalogProvider(RDHCatalogProvider):
+    """In-memory catalog provider for testing."""
+
+    def __init__(self, entries: Optional[list[CatalogEntry]] = None):
+        self._entries: list[CatalogEntry] = entries or []
+
+    def add(self, entry: CatalogEntry):
+        self._entries.append(entry)
+
+    def fetch_all_datasets(self) -> list[CatalogEntry]:
+        return list(self._entries)
+
+
+CHAMBER_KEYWORDS = {
+    "congress": ["congress", "congressional", " cd ", " cd_"],
+    "state_senate": ["state senate", "upper chamber", "ssd", "sldu", "state_senate"],
+    "state_house": ["state house", "lower chamber", "shd", "sldl", "state_house"],
+}
+
+
+def _infer_chamber(title: str) -> str:
+    lower = title.lower()
+    for chamber, keywords in CHAMBER_KEYWORDS.items():
+        for kw in keywords:
+            if kw in lower:
+                return chamber
+    return ""
+
+
+def _score_entry(
+    entry: CatalogEntry,
+    state: Optional[str] = None,
+    year: Optional[str] = None,
+    chamber: Optional[str] = None,
+    dataset_type: Optional[str] = None,
+    query: Optional[str] = None,
+) -> float:
+    score = 0.0
+    if state and entry.state.upper() == state.upper():
+        score += 10.0
+    if year and entry.year == str(year):
+        score += 5.0
+    if chamber and entry.chamber.lower() == chamber.lower():
+        score += 5.0
+    if dataset_type and entry.dataset_type.lower() == dataset_type.lower():
+        score += 5.0
+    if entry.official:
+        score += 2.0
+    if query:
+        query_lower = query.lower()
+        title_lower = entry.title.lower()
+        if query_lower in title_lower:
+            score += 3.0
+        else:
+            words = query_lower.split()
+            matched = sum(1 for w in words if w in title_lower)
+            if words:
+                score += (matched / len(words)) * 2.0
+    return score
+
+
+class RDHCatalog:
+    """Pre-indexed catalog of available RDH datasets.
+
+    Provides browsable discovery of datasets by state, year, chamber,
+    dataset type, and format without trial-and-error API calls.
+
+    Args:
+        provider: Source for fetching the full dataset inventory.
+        cache_dir: Directory for persisting the catalog index.
+        cache_ttl: Cache time-to-live in seconds (default 30 days).
+    """
+
+    def __init__(
+        self,
+        provider: Optional[RDHCatalogProvider] = None,
+        cache_dir: Optional[Path] = None,
+        cache_ttl: int = DEFAULT_CACHE_TTL,
+    ):
+        self._provider = provider
+        self._cache_dir = cache_dir
+        self._cache_ttl = cache_ttl
+        self._entries: list[CatalogEntry] = []
+        self._loaded = False
+        self._loaded_at: Optional[float] = None
+
+    @property
+    def entries(self) -> list[CatalogEntry]:
+        return list(self._entries)
+
+    @property
+    def is_loaded(self) -> bool:
+        return self._loaded
+
+    @property
+    def entry_count(self) -> int:
+        return len(self._entries)
+
+    def load(self, force: bool = False) -> int:
+        """Load the catalog, using cache if available and fresh.
+
+        Args:
+            force: If True, bypass cache and fetch from provider.
+
+        Returns:
+            Number of entries loaded.
+        """
+        if not force and self._try_load_cache():
+            return len(self._entries)
+
+        if self._provider is None:
+            log.warning("No provider configured; catalog is empty")
+            return 0
+
+        entries = self._provider.fetch_all_datasets()
+        self._entries = entries
+        self._loaded = True
+        self._loaded_at = time.time()
+
+        self._save_cache()
+
+        log.info("Loaded %d entries into RDH catalog", len(entries))
+        return len(entries)
+
+    def search(
+        self,
+        state: Optional[str] = None,
+        year: Optional[str] = None,
+        chamber: Optional[str] = None,
+        dataset_type: Optional[str] = None,
+        format: Optional[str] = None,
+        query: Optional[str] = None,
+        limit: int = 50,
+    ) -> list[SearchResult]:
+        """Search the catalog with ranked results.
+
+        At least one filter or query must be provided.
+
+        Args:
+            state: Two-letter state abbreviation.
+            year: Publication year.
+            chamber: Legislative chamber (congress, state_senate, state_house).
+            dataset_type: Dataset category.
+            format: File format (csv, shp).
+            query: Free-text search against title.
+            limit: Maximum results to return.
+
+        Returns:
+            List of SearchResult sorted by relevance score (descending).
+        """
+        results: list[SearchResult] = []
+
+        for entry in self._entries:
+            if format and entry.format.lower() != format.lower():
+                continue
+
+            score = _score_entry(
+                entry,
+                state=state,
+                year=year,
+                chamber=chamber,
+                dataset_type=dataset_type,
+                query=query,
+            )
+
+            if score > 0:
+                results.append(SearchResult(entry=entry, score=score))
+
+        results.sort(key=lambda r: r.score, reverse=True)
+        return results[:limit]
+
+    def coverage_matrix(
+        self,
+        dataset_type: Optional[str] = None,
+    ) -> list[CoverageCell]:
+        """Build a coverage matrix of state x year x dataset_type.
+
+        Args:
+            dataset_type: Optionally filter to a single dataset type.
+
+        Returns:
+            List of CoverageCell entries with counts and available formats.
+        """
+        buckets: dict[tuple[str, str, str], list[str]] = {}
+
+        for entry in self._entries:
+            if dataset_type and entry.dataset_type.lower() != dataset_type.lower():
+                continue
+
+            key = (entry.state, entry.year, entry.dataset_type)
+            if key not in buckets:
+                buckets[key] = []
+            if entry.format and entry.format not in buckets[key]:
+                buckets[key].append(entry.format)
+
+        cells = []
+        for (state, year, dtype), formats in sorted(buckets.items()):
+            cells.append(CoverageCell(
+                state=state,
+                year=year,
+                dataset_type=dtype,
+                count=len([
+                    e for e in self._entries
+                    if e.state == state and e.year == year and e.dataset_type == dtype
+                ]),
+                formats=sorted(formats),
+            ))
+
+        return cells
+
+    def states(self) -> list[str]:
+        """Return sorted list of states with datasets in the catalog."""
+        return sorted(set(e.state for e in self._entries if e.state))
+
+    def years(self) -> list[str]:
+        """Return sorted list of years with datasets in the catalog."""
+        return sorted(set(e.year for e in self._entries if e.year))
+
+    def dataset_types(self) -> list[str]:
+        """Return sorted list of dataset types in the catalog."""
+        return sorted(set(e.dataset_type for e in self._entries if e.dataset_type))
+
+    def for_state(self, state: str) -> list[CatalogEntry]:
+        """Return all entries for a given state."""
+        return [e for e in self._entries if e.state.upper() == state.upper()]
+
+    # -- Cache management -------------------------------------------------------
+
+    def _cache_path(self) -> Optional[Path]:
+        if self._cache_dir is None:
+            return None
+        return self._cache_dir / CACHE_FILENAME
+
+    def _try_load_cache(self) -> bool:
+        path = self._cache_path()
+        if path is None or not path.exists():
+            return False
+
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            log.debug("Cache file unreadable, will refetch")
+            return False
+
+        cached_at = data.get("cached_at", 0)
+        if time.time() - cached_at > self._cache_ttl:
+            log.debug("Cache expired (age %.0fs > TTL %ds)", time.time() - cached_at, self._cache_ttl)
+            return False
+
+        entries = [CatalogEntry.from_dict(d) for d in data.get("entries", [])]
+        self._entries = entries
+        self._loaded = True
+        self._loaded_at = cached_at
+
+        log.debug("Loaded %d entries from cache", len(entries))
+        return True
+
+    def _save_cache(self):
+        path = self._cache_path()
+        if path is None:
+            return
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        data = {
+            "cached_at": time.time(),
+            "entry_count": len(self._entries),
+            "entries": [e.to_dict() for e in self._entries],
+        }
+
+        path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        log.debug("Saved %d entries to cache", len(self._entries))

--- a/tests/test_rdh_catalog.py
+++ b/tests/test_rdh_catalog.py
@@ -1,0 +1,379 @@
+"""Tests for RDH dataset catalog and discovery (SU#633)."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from siege_utilities.geo.rdh_catalog import (
+    CatalogEntry,
+    CoverageCell,
+    DictRDHCatalogProvider,
+    RDHCatalog,
+    SearchResult,
+    _infer_chamber,
+    _score_entry,
+)
+
+
+def _entry(state="TX", year="2020", dtype="pl94171", fmt="csv", **kw):
+    defaults = dict(
+        title=f"{state} {dtype} {year}",
+        url=f"https://example.com/{state}_{dtype}_{year}.{fmt}",
+        state=state,
+        year=year,
+        dataset_type=dtype,
+        format=fmt,
+    )
+    defaults.update(kw)
+    return CatalogEntry(**defaults)
+
+
+class TestCatalogEntry:
+    def test_defaults(self):
+        e = CatalogEntry()
+        assert e.title == ""
+        assert e.state == ""
+
+    def test_matches_exact(self):
+        e = _entry(state="TX", year="2020", dtype="pl94171")
+        assert e.matches(state="TX")
+        assert e.matches(year="2020")
+        assert e.matches(dataset_type="pl94171")
+        assert e.matches(state="TX", year="2020")
+
+    def test_matches_case_insensitive(self):
+        e = _entry(state="TX", dtype="PL94171")
+        assert e.matches(state="tx")
+        assert e.matches(dataset_type="pl94171")
+
+    def test_matches_no_match(self):
+        e = _entry(state="TX")
+        assert not e.matches(state="CA")
+        assert not e.matches(year="2022")
+
+    def test_matches_no_filters(self):
+        e = _entry()
+        assert e.matches()
+
+    def test_matches_format(self):
+        e = _entry(fmt="csv")
+        assert e.matches(format="csv")
+        assert not e.matches(format="shp")
+
+    def test_matches_chamber(self):
+        e = _entry(chamber="congress")
+        assert e.matches(chamber="congress")
+        assert not e.matches(chamber="state_senate")
+
+    def test_to_dict_roundtrip(self):
+        e = _entry(state="VA", official=True)
+        d = e.to_dict()
+        e2 = CatalogEntry.from_dict(d)
+        assert e2.state == "VA"
+        assert e2.official is True
+        assert e2.url == e.url
+
+    def test_from_dict_missing_keys(self):
+        e = CatalogEntry.from_dict({"title": "Test"})
+        assert e.title == "Test"
+        assert e.state == ""
+        assert e.official is False
+
+
+class TestDictProvider:
+    def test_empty(self):
+        p = DictRDHCatalogProvider()
+        assert p.fetch_all_datasets() == []
+
+    def test_add_and_fetch(self):
+        p = DictRDHCatalogProvider()
+        p.add(_entry())
+        assert len(p.fetch_all_datasets()) == 1
+
+    def test_init_with_entries(self):
+        entries = [_entry(), _entry(state="CA")]
+        p = DictRDHCatalogProvider(entries)
+        assert len(p.fetch_all_datasets()) == 2
+
+    def test_returns_copy(self):
+        p = DictRDHCatalogProvider([_entry()])
+        a = p.fetch_all_datasets()
+        b = p.fetch_all_datasets()
+        assert a is not b
+
+
+class TestInferChamber:
+    def test_congress(self):
+        assert _infer_chamber("TX Congressional Districts 2022") == "congress"
+
+    def test_state_senate(self):
+        assert _infer_chamber("VA State Senate Districts") == "state_senate"
+
+    def test_state_house(self):
+        assert _infer_chamber("OH State House Map") == "state_house"
+
+    def test_sldu(self):
+        assert _infer_chamber("2020 SLDU Boundaries") == "state_senate"
+
+    def test_sldl(self):
+        assert _infer_chamber("2020 SLDL Boundaries") == "state_house"
+
+    def test_no_match(self):
+        assert _infer_chamber("PL 94-171 Block Data") == ""
+
+
+class TestScoreEntry:
+    def test_state_match(self):
+        e = _entry(state="TX")
+        assert _score_entry(e, state="TX") == 10.0
+        assert _score_entry(e, state="CA") == 0.0
+
+    def test_year_match(self):
+        e = _entry(year="2020")
+        assert _score_entry(e, year="2020") == 5.0
+
+    def test_official_bonus(self):
+        e = _entry(official=True)
+        assert _score_entry(e, state=e.state) > _score_entry(
+            _entry(official=False), state=e.state
+        )
+
+    def test_query_exact(self):
+        e = _entry(title="Texas PL 94-171")
+        score = _score_entry(e, query="Texas PL")
+        assert score >= 3.0
+
+    def test_query_partial(self):
+        e = _entry(title="Texas PL 94-171")
+        score = _score_entry(e, query="Texas something")
+        assert 0 < score < 3.0
+
+    def test_combined(self):
+        e = _entry(state="TX", year="2020", dtype="pl94171")
+        score = _score_entry(e, state="TX", year="2020", dataset_type="pl94171")
+        assert score == 20.0  # 10 + 5 + 5
+
+
+class TestRDHCatalogLoad:
+    def test_load_from_provider(self):
+        p = DictRDHCatalogProvider([_entry(), _entry(state="CA")])
+        cat = RDHCatalog(provider=p)
+        count = cat.load()
+        assert count == 2
+        assert cat.is_loaded
+        assert cat.entry_count == 2
+
+    def test_load_no_provider(self):
+        cat = RDHCatalog()
+        count = cat.load()
+        assert count == 0
+        assert not cat.is_loaded
+
+    def test_entries_returns_copy(self):
+        p = DictRDHCatalogProvider([_entry()])
+        cat = RDHCatalog(provider=p)
+        cat.load()
+        a = cat.entries
+        b = cat.entries
+        assert a is not b
+
+
+class TestRDHCatalogSearch:
+    def _loaded_catalog(self, entries):
+        p = DictRDHCatalogProvider(entries)
+        cat = RDHCatalog(provider=p)
+        cat.load()
+        return cat
+
+    def test_search_by_state(self):
+        cat = self._loaded_catalog([
+            _entry(state="TX"),
+            _entry(state="CA"),
+            _entry(state="TX", year="2022"),
+        ])
+        results = cat.search(state="TX")
+        assert len(results) == 2
+        assert all(r.entry.state == "TX" for r in results)
+
+    def test_search_by_type(self):
+        cat = self._loaded_catalog([
+            _entry(dtype="pl94171"),
+            _entry(dtype="cvap"),
+            _entry(dtype="pl94171", state="CA"),
+        ])
+        results = cat.search(dataset_type="pl94171")
+        assert len(results) == 2
+
+    def test_search_format_filter(self):
+        cat = self._loaded_catalog([
+            _entry(fmt="csv"),
+            _entry(fmt="shp"),
+        ])
+        results = cat.search(state="TX", format="csv")
+        assert len(results) == 1
+        assert results[0].entry.format == "csv"
+
+    def test_search_ranked(self):
+        cat = self._loaded_catalog([
+            _entry(state="TX", official=False),
+            _entry(state="TX", official=True),
+        ])
+        results = cat.search(state="TX")
+        assert results[0].score > results[1].score
+        assert results[0].entry.official
+
+    def test_search_limit(self):
+        entries = [_entry(state="TX", year=str(2000 + i)) for i in range(20)]
+        cat = self._loaded_catalog(entries)
+        results = cat.search(state="TX", limit=5)
+        assert len(results) == 5
+
+    def test_search_empty(self):
+        cat = self._loaded_catalog([_entry(state="TX")])
+        results = cat.search(state="CA")
+        assert len(results) == 0
+
+    def test_search_query(self):
+        cat = self._loaded_catalog([
+            _entry(title="Texas Congressional Districts 2022"),
+            _entry(title="Ohio Block Data 2020"),
+        ])
+        results = cat.search(query="Texas Congressional")
+        assert len(results) >= 1
+        assert "Texas" in results[0].entry.title
+
+    def test_search_no_filters_returns_empty(self):
+        cat = self._loaded_catalog([_entry()])
+        results = cat.search()
+        assert len(results) == 0
+
+
+class TestCoverageMatrix:
+    def _loaded_catalog(self, entries):
+        p = DictRDHCatalogProvider(entries)
+        cat = RDHCatalog(provider=p)
+        cat.load()
+        return cat
+
+    def test_basic(self):
+        cat = self._loaded_catalog([
+            _entry(state="TX", year="2020", dtype="pl94171", fmt="csv"),
+            _entry(state="TX", year="2020", dtype="pl94171", fmt="shp"),
+            _entry(state="CA", year="2020", dtype="cvap", fmt="csv"),
+        ])
+        matrix = cat.coverage_matrix()
+        assert len(matrix) == 2
+
+        tx_cell = next(c for c in matrix if c.state == "TX")
+        assert tx_cell.count == 2
+        assert "csv" in tx_cell.formats
+        assert "shp" in tx_cell.formats
+
+    def test_filter_by_type(self):
+        cat = self._loaded_catalog([
+            _entry(dtype="pl94171"),
+            _entry(dtype="cvap"),
+        ])
+        matrix = cat.coverage_matrix(dataset_type="pl94171")
+        assert len(matrix) == 1
+        assert matrix[0].dataset_type == "pl94171"
+
+    def test_empty(self):
+        cat = self._loaded_catalog([])
+        assert cat.coverage_matrix() == []
+
+    def test_sorted(self):
+        cat = self._loaded_catalog([
+            _entry(state="TX", year="2022"),
+            _entry(state="CA", year="2020"),
+        ])
+        matrix = cat.coverage_matrix()
+        states = [c.state for c in matrix]
+        assert states == sorted(states)
+
+
+class TestCatalogHelpers:
+    def _loaded_catalog(self, entries):
+        p = DictRDHCatalogProvider(entries)
+        cat = RDHCatalog(provider=p)
+        cat.load()
+        return cat
+
+    def test_states(self):
+        cat = self._loaded_catalog([_entry(state="TX"), _entry(state="CA")])
+        assert cat.states() == ["CA", "TX"]
+
+    def test_years(self):
+        cat = self._loaded_catalog([_entry(year="2020"), _entry(year="2022")])
+        assert cat.years() == ["2020", "2022"]
+
+    def test_dataset_types(self):
+        cat = self._loaded_catalog([_entry(dtype="pl94171"), _entry(dtype="cvap")])
+        assert cat.dataset_types() == ["cvap", "pl94171"]
+
+    def test_for_state(self):
+        cat = self._loaded_catalog([
+            _entry(state="TX"),
+            _entry(state="CA"),
+            _entry(state="TX", year="2022"),
+        ])
+        assert len(cat.for_state("TX")) == 2
+        assert len(cat.for_state("ca")) == 1
+
+
+class TestCatalogCache:
+    def test_save_and_load(self, tmp_path):
+        p = DictRDHCatalogProvider([
+            _entry(state="TX"),
+            _entry(state="CA", official=True),
+        ])
+        cat = RDHCatalog(provider=p, cache_dir=tmp_path)
+        cat.load()
+
+        cat2 = RDHCatalog(cache_dir=tmp_path)
+        count = cat2.load()
+        assert count == 2
+        assert cat2.is_loaded
+        assert cat2.entry_count == 2
+
+    def test_cache_expired(self, tmp_path):
+        p = DictRDHCatalogProvider([_entry()])
+        cat = RDHCatalog(provider=p, cache_dir=tmp_path, cache_ttl=1)
+        cat.load()
+
+        cache_file = tmp_path / "rdh_catalog.json"
+        data = json.loads(cache_file.read_text())
+        data["cached_at"] = time.time() - 100
+        cache_file.write_text(json.dumps(data))
+
+        cat2 = RDHCatalog(provider=p, cache_dir=tmp_path, cache_ttl=1)
+        count = cat2.load()
+        assert count == 1
+
+    def test_cache_corrupt(self, tmp_path):
+        cache_file = tmp_path / "rdh_catalog.json"
+        cache_file.write_text("not valid json")
+
+        p = DictRDHCatalogProvider([_entry()])
+        cat = RDHCatalog(provider=p, cache_dir=tmp_path)
+        count = cat.load()
+        assert count == 1
+
+    def test_no_cache_dir(self):
+        p = DictRDHCatalogProvider([_entry()])
+        cat = RDHCatalog(provider=p)
+        cat.load()
+        assert cat.entry_count == 1
+
+    def test_force_bypasses_cache(self, tmp_path):
+        p1 = DictRDHCatalogProvider([_entry()])
+        cat1 = RDHCatalog(provider=p1, cache_dir=tmp_path)
+        cat1.load()
+
+        p2 = DictRDHCatalogProvider([_entry(), _entry(state="CA")])
+        cat2 = RDHCatalog(provider=p2, cache_dir=tmp_path)
+        count = cat2.load(force=True)
+        assert count == 2


### PR DESCRIPTION
## Summary
- `RDHCatalog` class pre-indexing available RDH datasets by state, year, chamber, dataset type, and format
- `search()` with relevance scoring (state 10pts, year/chamber/type 5pts each, official 2pts, title match 3pts)
- `coverage_matrix()` for state × year × type availability grid
- JSON file cache with configurable TTL (default 30 days), expiry, and corruption recovery
- Provider-based architecture (`RDHCatalogProvider` ABC + `DictRDHCatalogProvider`)
- Chamber inference from dataset titles (congress, state_senate, state_house, SLDU/SLDL)
- Helper methods: `states()`, `years()`, `dataset_types()`, `for_state()`
- 49 tests