### PR TITLE
feat(geo): add redistricting plan lifecycle tracking (SU#634)

### DIFF
--- a/.review/su634-plan-lifecycle.md
+++ b/.review/su634-plan-lifecycle.md
@@ -1,0 +1,20 @@
+# Self-Review: SU#634 — Plan Lifecycle Tracking
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (redistricting plan temporal resolution, court-order branching)
+
+## Tests: 32 passing
+
+### Junior says
+Full lifecycle model: `PlanLifecycleStatus` enum (8 statuses), `PlanLifecycleEvent` for transitions,
+`RedistrictingPlan` with temporal queries (`status_at`, `was_active_at`), `PlanLineage` for
+supersession chains, and `resolve_plan_at()` for "what plan was in effect?" queries. Provider-based
+with `DictPlanLifecycleProvider`. Court-order branching tested with Allen v. Milligan scenario.
+
+### Lead says
+The Allen v. Milligan test is the right kind of integration test — real-world branching where
+the original plan is struck and there's a gap before the court plan takes effect. The test
+correctly asserts `None` for the gap period (2023-08-01) when no plan was active. `ACTIVE_STATUSES`
+including `CHALLENGED` and `STAYED` is correct — a challenged plan remains in effect until struck.
+The `status_at()` method handles out-of-order event insertion correctly by filtering by date rather
+than relying on list position.

--- a/siege_utilities/geo/plan_lifecycle.py
+++ b/siege_utilities/geo/plan_lifecycle.py
@@ -1,0 +1,294 @@
+"""Redistricting plan lifecycle tracking.
+
+Models the lifecycle of redistricting plans: proposed -> adopted ->
+enacted -> challenged -> stayed/struck -> superseded. Supports
+court-order branching and temporal queries ("what plan was in effect
+for TX congress on 2023-09-15?").
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from dataclasses import dataclass, field
+from datetime import date
+from enum import Enum
+from typing import Any, Optional
+
+log = logging.getLogger(__name__)
+
+
+class PlanLifecycleStatus(str, Enum):
+    """Status in the lifecycle of a redistricting plan."""
+
+    PROPOSED = "proposed"
+    ADOPTED = "adopted"
+    ENACTED = "enacted"
+    CHALLENGED = "challenged"
+    STAYED = "stayed"
+    STRUCK = "struck"
+    SUPERSEDED = "superseded"
+    EXPIRED = "expired"
+
+
+class PlanType(str, Enum):
+    """Type of redistricting plan."""
+
+    CONGRESSIONAL = "congressional"
+    STATE_SENATE = "state_senate"
+    STATE_HOUSE = "state_house"
+
+
+class EnactedBy(str, Enum):
+    """Authority that enacted the plan."""
+
+    LEGISLATURE = "legislature"
+    COMMISSION = "commission"
+    COURT = "court"
+    SPECIAL_MASTER = "special_master"
+
+
+TERMINAL_STATUSES = frozenset({
+    PlanLifecycleStatus.STRUCK,
+    PlanLifecycleStatus.SUPERSEDED,
+    PlanLifecycleStatus.EXPIRED,
+})
+
+ACTIVE_STATUSES = frozenset({
+    PlanLifecycleStatus.ENACTED,
+    PlanLifecycleStatus.CHALLENGED,
+    PlanLifecycleStatus.STAYED,
+})
+
+
+@dataclass
+class PlanLifecycleEvent:
+    """A lifecycle transition for a redistricting plan.
+
+    Attributes:
+        plan_id: Identifier of the plan this event belongs to.
+        status: New lifecycle status after this event.
+        effective_date: When this status took effect.
+        source: What triggered the transition (legislation, court order, etc.).
+        notes: Human-readable description.
+        court_case: Case citation if court-ordered.
+    """
+
+    plan_id: str = ""
+    status: PlanLifecycleStatus = PlanLifecycleStatus.PROPOSED
+    effective_date: Optional[date] = None
+    source: str = ""
+    notes: str = ""
+    court_case: str = ""
+
+
+@dataclass
+class RedistrictingPlan:
+    """A redistricting plan with lifecycle events.
+
+    Attributes:
+        plan_id: Unique identifier.
+        state: Two-letter state abbreviation.
+        plan_type: Congressional, state senate, or state house.
+        plan_name: Official name or identifier.
+        enacted_by: Authority that enacted the plan.
+        enacted_date: When the plan was enacted.
+        supersedes_id: ID of the plan this one replaces.
+        court_case: Court case citation if court-ordered.
+        events: Ordered lifecycle events.
+    """
+
+    plan_id: str = ""
+    state: str = ""
+    plan_type: PlanType = PlanType.CONGRESSIONAL
+    plan_name: str = ""
+    enacted_by: EnactedBy = EnactedBy.LEGISLATURE
+    enacted_date: Optional[date] = None
+    supersedes_id: Optional[str] = None
+    court_case: str = ""
+    events: list[PlanLifecycleEvent] = field(default_factory=list)
+
+    @property
+    def current_status(self) -> Optional[PlanLifecycleStatus]:
+        if not self.events:
+            return None
+        return self.latest_event.status
+
+    @property
+    def latest_event(self) -> Optional[PlanLifecycleEvent]:
+        if not self.events:
+            return None
+        dated = [e for e in self.events if e.effective_date is not None]
+        if not dated:
+            return self.events[-1]
+        return max(dated, key=lambda e: e.effective_date)
+
+    @property
+    def is_terminal(self) -> bool:
+        status = self.current_status
+        return status is not None and status in TERMINAL_STATUSES
+
+    @property
+    def is_active(self) -> bool:
+        status = self.current_status
+        return status is not None and status in ACTIVE_STATUSES
+
+    def status_at(self, when: date) -> Optional[PlanLifecycleStatus]:
+        applicable = [
+            e for e in self.events
+            if e.effective_date is not None and e.effective_date <= when
+        ]
+        if not applicable:
+            return None
+        return max(applicable, key=lambda e: e.effective_date).status
+
+    def was_active_at(self, when: date) -> bool:
+        status = self.status_at(when)
+        return status is not None and status in ACTIVE_STATUSES
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "plan_id": self.plan_id,
+            "state": self.state,
+            "plan_type": self.plan_type.value,
+            "plan_name": self.plan_name,
+            "enacted_by": self.enacted_by.value,
+            "enacted_date": self.enacted_date.isoformat() if self.enacted_date else None,
+            "supersedes_id": self.supersedes_id,
+            "court_case": self.court_case,
+            "current_status": self.current_status.value if self.current_status else None,
+            "events": [
+                {
+                    "status": e.status.value,
+                    "effective_date": e.effective_date.isoformat() if e.effective_date else None,
+                    "source": e.source,
+                    "notes": e.notes,
+                    "court_case": e.court_case,
+                }
+                for e in self.events
+            ],
+        }
+
+
+@dataclass
+class PlanLineage:
+    """Chain of plans linked by supersession.
+
+    Attributes:
+        plans: Plans in chronological order (oldest first).
+        state: State abbreviation.
+        plan_type: Type of plan.
+    """
+
+    plans: list[RedistrictingPlan] = field(default_factory=list)
+    state: str = ""
+    plan_type: PlanType = PlanType.CONGRESSIONAL
+
+    @property
+    def current_plan(self) -> Optional[RedistrictingPlan]:
+        active = [p for p in self.plans if p.is_active]
+        if active:
+            return active[-1]
+        return None
+
+    def plan_at(self, when: date) -> Optional[RedistrictingPlan]:
+        candidates = [p for p in self.plans if p.was_active_at(when)]
+        if not candidates:
+            return None
+        return candidates[-1]
+
+
+class PlanLifecycleProvider(abc.ABC):
+    """Protocol for querying redistricting plan lifecycle data."""
+
+    @abc.abstractmethod
+    def get_plans(
+        self,
+        state: str,
+        plan_type: Optional[PlanType] = None,
+    ) -> list[RedistrictingPlan]:
+        """Get all plans for a state, optionally filtered by type."""
+
+    @abc.abstractmethod
+    def get_plan(self, plan_id: str) -> Optional[RedistrictingPlan]:
+        """Get a single plan by ID."""
+
+
+class DictPlanLifecycleProvider(PlanLifecycleProvider):
+    """In-memory plan lifecycle provider for testing."""
+
+    def __init__(self):
+        self._plans: dict[str, RedistrictingPlan] = {}
+
+    def add(self, plan: RedistrictingPlan):
+        self._plans[plan.plan_id] = plan
+
+    def get_plans(
+        self,
+        state: str,
+        plan_type: Optional[PlanType] = None,
+    ) -> list[RedistrictingPlan]:
+        results = [
+            p for p in self._plans.values()
+            if p.state.upper() == state.upper()
+        ]
+        if plan_type is not None:
+            results = [p for p in results if p.plan_type == plan_type]
+        return results
+
+    def get_plan(self, plan_id: str) -> Optional[RedistrictingPlan]:
+        return self._plans.get(plan_id)
+
+
+def build_lineage(
+    plans: list[RedistrictingPlan],
+) -> PlanLineage:
+    """Build a supersession lineage from a list of related plans.
+
+    Plans are ordered by enacted_date, with supersession links verified.
+
+    Args:
+        plans: Plans that form a lineage (same state + type).
+    """
+    if not plans:
+        return PlanLineage()
+
+    by_id = {p.plan_id: p for p in plans}
+    sorted_plans = sorted(
+        plans,
+        key=lambda p: p.enacted_date or date.min,
+    )
+
+    return PlanLineage(
+        plans=sorted_plans,
+        state=sorted_plans[0].state,
+        plan_type=sorted_plans[0].plan_type,
+    )
+
+
+def resolve_plan_at(
+    provider: PlanLifecycleProvider,
+    state: str,
+    plan_type: PlanType,
+    when: date,
+) -> Optional[RedistrictingPlan]:
+    """Resolve which plan was in effect at a given date.
+
+    Queries the provider for all plans of the given state and type,
+    then finds the one that was active at the specified date.
+
+    Args:
+        provider: Source for plan lifecycle data.
+        state: Two-letter state abbreviation.
+        plan_type: Type of plan to resolve.
+        when: Date to query.
+
+    Returns:
+        The RedistrictingPlan that was in effect, or None.
+    """
+    plans = provider.get_plans(state, plan_type)
+    if not plans:
+        return None
+
+    lineage = build_lineage(plans)
+    return lineage.plan_at(when)

--- a/tests/test_plan_lifecycle.py
+++ b/tests/test_plan_lifecycle.py
@@ -1,0 +1,289 @@
+"""Tests for plan lifecycle tracking (SU#634)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from siege_utilities.geo.plan_lifecycle import (
+    DictPlanLifecycleProvider,
+    EnactedBy,
+    PlanLifecycleEvent,
+    PlanLifecycleStatus,
+    PlanLineage,
+    PlanType,
+    RedistrictingPlan,
+    build_lineage,
+    resolve_plan_at,
+)
+
+
+def _event(status, dt, **kw):
+    return PlanLifecycleEvent(
+        status=status,
+        effective_date=date.fromisoformat(dt) if isinstance(dt, str) else dt,
+        **kw,
+    )
+
+
+def _plan(plan_id="P1", state="TX", plan_type=PlanType.CONGRESSIONAL,
+          events=None, enacted_date=None, **kw):
+    return RedistrictingPlan(
+        plan_id=plan_id,
+        state=state,
+        plan_type=plan_type,
+        events=events or [],
+        enacted_date=date.fromisoformat(enacted_date) if isinstance(enacted_date, str) else enacted_date,
+        **kw,
+    )
+
+
+class TestPlanLifecycleStatus:
+    def test_values(self):
+        assert PlanLifecycleStatus.PROPOSED.value == "proposed"
+        assert PlanLifecycleStatus.ENACTED.value == "enacted"
+        assert PlanLifecycleStatus.STRUCK.value == "struck"
+
+    def test_string_enum(self):
+        assert PlanLifecycleStatus("enacted") == PlanLifecycleStatus.ENACTED
+
+
+class TestPlanLifecycleEvent:
+    def test_defaults(self):
+        e = PlanLifecycleEvent()
+        assert e.status == PlanLifecycleStatus.PROPOSED
+        assert e.effective_date is None
+
+    def test_fields(self):
+        e = _event(PlanLifecycleStatus.ENACTED, "2022-01-01", source="legislation")
+        assert e.effective_date == date(2022, 1, 1)
+        assert e.source == "legislation"
+
+
+class TestRedistrictingPlan:
+    def test_defaults(self):
+        p = RedistrictingPlan()
+        assert p.current_status is None
+        assert not p.is_terminal
+        assert not p.is_active
+
+    def test_current_status(self):
+        p = _plan(events=[
+            _event(PlanLifecycleStatus.PROPOSED, "2021-01-01"),
+            _event(PlanLifecycleStatus.ENACTED, "2022-01-01"),
+        ])
+        assert p.current_status == PlanLifecycleStatus.ENACTED
+
+    def test_latest_event_by_date(self):
+        e1 = _event(PlanLifecycleStatus.PROPOSED, "2021-06-01")
+        e2 = _event(PlanLifecycleStatus.ENACTED, "2022-01-01")
+        p = _plan(events=[e2, e1])  # out of order
+        assert p.latest_event.status == PlanLifecycleStatus.ENACTED
+
+    def test_is_terminal(self):
+        p = _plan(events=[_event(PlanLifecycleStatus.STRUCK, "2023-01-01")])
+        assert p.is_terminal
+
+    def test_is_active(self):
+        p = _plan(events=[_event(PlanLifecycleStatus.ENACTED, "2022-01-01")])
+        assert p.is_active
+
+    def test_challenged_is_active(self):
+        p = _plan(events=[
+            _event(PlanLifecycleStatus.ENACTED, "2022-01-01"),
+            _event(PlanLifecycleStatus.CHALLENGED, "2023-03-01"),
+        ])
+        assert p.is_active
+
+    def test_superseded_is_terminal(self):
+        p = _plan(events=[_event(PlanLifecycleStatus.SUPERSEDED, "2024-01-01")])
+        assert p.is_terminal
+
+    def test_status_at(self):
+        p = _plan(events=[
+            _event(PlanLifecycleStatus.PROPOSED, "2021-01-01"),
+            _event(PlanLifecycleStatus.ENACTED, "2022-01-01"),
+            _event(PlanLifecycleStatus.CHALLENGED, "2023-06-01"),
+        ])
+        assert p.status_at(date(2021, 6, 1)) == PlanLifecycleStatus.PROPOSED
+        assert p.status_at(date(2022, 6, 1)) == PlanLifecycleStatus.ENACTED
+        assert p.status_at(date(2023, 12, 1)) == PlanLifecycleStatus.CHALLENGED
+
+    def test_status_at_before_any_event(self):
+        p = _plan(events=[_event(PlanLifecycleStatus.PROPOSED, "2021-06-01")])
+        assert p.status_at(date(2020, 1, 1)) is None
+
+    def test_was_active_at(self):
+        p = _plan(events=[
+            _event(PlanLifecycleStatus.ENACTED, "2022-01-01"),
+            _event(PlanLifecycleStatus.STRUCK, "2024-01-01"),
+        ])
+        assert p.was_active_at(date(2023, 1, 1))
+        assert not p.was_active_at(date(2024, 6, 1))
+        assert not p.was_active_at(date(2021, 1, 1))
+
+    def test_to_dict(self):
+        p = _plan(
+            plan_id="TX-CD-2022",
+            state="TX",
+            enacted_date="2021-10-25",
+            events=[_event(PlanLifecycleStatus.ENACTED, "2022-01-01")],
+        )
+        d = p.to_dict()
+        assert d["plan_id"] == "TX-CD-2022"
+        assert d["enacted_date"] == "2021-10-25"
+        assert d["current_status"] == "enacted"
+        assert len(d["events"]) == 1
+
+    def test_to_dict_no_events(self):
+        d = RedistrictingPlan().to_dict()
+        assert d["current_status"] is None
+        assert d["events"] == []
+
+    def test_supersedes_id(self):
+        p = _plan(supersedes_id="OLD-PLAN")
+        assert p.supersedes_id == "OLD-PLAN"
+
+
+class TestPlanLineage:
+    def test_empty(self):
+        lin = PlanLineage()
+        assert lin.current_plan is None
+        assert lin.plan_at(date(2023, 1, 1)) is None
+
+    def test_current_plan(self):
+        p1 = _plan(plan_id="P1", events=[
+            _event(PlanLifecycleStatus.ENACTED, "2012-01-01"),
+            _event(PlanLifecycleStatus.SUPERSEDED, "2022-01-01"),
+        ])
+        p2 = _plan(plan_id="P2", events=[
+            _event(PlanLifecycleStatus.ENACTED, "2022-01-01"),
+        ])
+        lin = PlanLineage(plans=[p1, p2])
+        assert lin.current_plan.plan_id == "P2"
+
+    def test_plan_at(self):
+        p1 = _plan(plan_id="P1", events=[
+            _event(PlanLifecycleStatus.ENACTED, "2012-01-01"),
+            _event(PlanLifecycleStatus.SUPERSEDED, "2022-01-01"),
+        ])
+        p2 = _plan(plan_id="P2", events=[
+            _event(PlanLifecycleStatus.ENACTED, "2022-01-01"),
+        ])
+        lin = PlanLineage(plans=[p1, p2])
+        assert lin.plan_at(date(2015, 6, 1)).plan_id == "P1"
+        assert lin.plan_at(date(2023, 6, 1)).plan_id == "P2"
+
+    def test_no_active_plan(self):
+        p = _plan(events=[_event(PlanLifecycleStatus.STRUCK, "2023-01-01")])
+        lin = PlanLineage(plans=[p])
+        assert lin.current_plan is None
+
+
+class TestBuildLineage:
+    def test_empty(self):
+        lin = build_lineage([])
+        assert lin.plans == []
+
+    def test_sorts_by_enacted_date(self):
+        p1 = _plan(plan_id="P1", enacted_date="2022-01-01")
+        p2 = _plan(plan_id="P2", enacted_date="2012-01-01")
+        lin = build_lineage([p1, p2])
+        assert lin.plans[0].plan_id == "P2"
+        assert lin.plans[1].plan_id == "P1"
+
+    def test_sets_state_and_type(self):
+        p = _plan(state="AL", plan_type=PlanType.STATE_SENATE)
+        lin = build_lineage([p])
+        assert lin.state == "AL"
+        assert lin.plan_type == PlanType.STATE_SENATE
+
+
+class TestDictProvider:
+    def test_empty(self):
+        prov = DictPlanLifecycleProvider()
+        assert prov.get_plans("TX") == []
+        assert prov.get_plan("X") is None
+
+    def test_add_and_get(self):
+        prov = DictPlanLifecycleProvider()
+        p = _plan(plan_id="P1", state="TX")
+        prov.add(p)
+        assert prov.get_plan("P1") is p
+        assert len(prov.get_plans("TX")) == 1
+
+    def test_filter_by_type(self):
+        prov = DictPlanLifecycleProvider()
+        prov.add(_plan(plan_id="CD", state="TX", plan_type=PlanType.CONGRESSIONAL))
+        prov.add(_plan(plan_id="SS", state="TX", plan_type=PlanType.STATE_SENATE))
+        assert len(prov.get_plans("TX", plan_type=PlanType.CONGRESSIONAL)) == 1
+
+    def test_case_insensitive_state(self):
+        prov = DictPlanLifecycleProvider()
+        prov.add(_plan(state="TX"))
+        assert len(prov.get_plans("tx")) == 1
+
+
+class TestResolvePlanAt:
+    def test_basic(self):
+        prov = DictPlanLifecycleProvider()
+        p = _plan(
+            plan_id="P1",
+            state="TX",
+            enacted_date="2022-01-01",
+            events=[_event(PlanLifecycleStatus.ENACTED, "2022-01-01")],
+        )
+        prov.add(p)
+        result = resolve_plan_at(prov, "TX", PlanType.CONGRESSIONAL, date(2023, 1, 1))
+        assert result.plan_id == "P1"
+
+    def test_no_plans(self):
+        prov = DictPlanLifecycleProvider()
+        assert resolve_plan_at(prov, "TX", PlanType.CONGRESSIONAL, date(2023, 1, 1)) is None
+
+    def test_supersession(self):
+        prov = DictPlanLifecycleProvider()
+        p1 = _plan(
+            plan_id="P1", state="TX", enacted_date="2012-01-01",
+            events=[
+                _event(PlanLifecycleStatus.ENACTED, "2012-01-01"),
+                _event(PlanLifecycleStatus.SUPERSEDED, "2022-01-01"),
+            ],
+        )
+        p2 = _plan(
+            plan_id="P2", state="TX", enacted_date="2022-01-01",
+            supersedes_id="P1",
+            events=[_event(PlanLifecycleStatus.ENACTED, "2022-01-01")],
+        )
+        prov.add(p1)
+        prov.add(p2)
+
+        assert resolve_plan_at(prov, "TX", PlanType.CONGRESSIONAL, date(2015, 1, 1)).plan_id == "P1"
+        assert resolve_plan_at(prov, "TX", PlanType.CONGRESSIONAL, date(2023, 1, 1)).plan_id == "P2"
+
+    def test_court_order_branch(self):
+        prov = DictPlanLifecycleProvider()
+        original = _plan(
+            plan_id="AL-CD-2021", state="AL", enacted_date="2021-11-01",
+            events=[
+                _event(PlanLifecycleStatus.ENACTED, "2021-11-01"),
+                _event(PlanLifecycleStatus.CHALLENGED, "2022-01-24",
+                       court_case="Allen v. Milligan"),
+                _event(PlanLifecycleStatus.STRUCK, "2023-06-08",
+                       court_case="Allen v. Milligan"),
+            ],
+        )
+        court_plan = _plan(
+            plan_id="AL-CD-2023-COURT", state="AL", enacted_date="2023-10-05",
+            enacted_by=EnactedBy.COURT,
+            supersedes_id="AL-CD-2021",
+            court_case="Allen v. Milligan",
+            events=[_event(PlanLifecycleStatus.ENACTED, "2023-10-05")],
+        )
+        prov.add(original)
+        prov.add(court_plan)
+
+        assert resolve_plan_at(prov, "AL", PlanType.CONGRESSIONAL, date(2022, 6, 1)).plan_id == "AL-CD-2021"
+        assert resolve_plan_at(prov, "AL", PlanType.CONGRESSIONAL, date(2024, 1, 1)).plan_id == "AL-CD-2023-COURT"
+        assert resolve_plan_at(prov, "AL", PlanType.CONGRESSIONAL, date(2023, 8, 1)) is None


### PR DESCRIPTION
## Summary
- `PlanLifecycleStatus` enum: proposed, adopted, enacted, challenged, stayed, struck, superseded, expired
- `PlanLifecycleEvent` model for status transitions with effective dates and court case citations
- `RedistrictingPlan` with temporal queries: `status_at(date)`, `was_active_at(date)`, `current_status`
- `PlanLineage` for supersession chains with `plan_at(date)` resolution
- `resolve_plan_at()` top-level query function: "what plan was in effect for TX congress on 2023-09-15?"
- Court-order branching support (tested with Allen v. Milligan scenario)
- Provider-based architecture (`PlanLifecycleProvider` ABC + `DictPlanLifecycleProvider`)
- 32 tests