### PR TITLE
feat(geo): add RDH place history overlays (SU#636)

### DIFF
--- a/.review/su636-rdh-overlays.md
+++ b/.review/su636-rdh-overlays.md
@@ -1,0 +1,24 @@
+# Self-Review: SU#636 — RDH Place History Overlay Integration
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (redistricting plan assignments + election results as place history overlays)
+
+## Tests: 36 passing
+
+### Junior says
+Two overlays wired into the WS2 overlay registry:
+- `RedistrictingOverlay` — district assignments over time, with temporal queries (`active_at`),
+  court-intervention detection, plan type filtering
+- `ElectionResultsOverlay` — precinct-level election returns with party totals aggregation,
+  year/office filtering, reconciliation method tracking
+
+Both follow the PlaceHistoryOverlay ABC pattern (name property, fetch method, is_available check).
+Provider-based with Dict providers for testing.
+
+### Lead says
+The `active_at` filter in `RedistrictingOverlayResult` handles open-ended assignments
+(to_date=None means still active) correctly. The Allen v. Milligan test scenario spans both
+overlays: the redistricting overlay tracks the plan lifecycle while election results would
+reference reconciled precinct data from SU#635. The `party_totals` method on
+`ElectionResultsOverlayResult` is useful for quick partisan lean calculations. Both overlays
+register cleanly with `OverlayRegistry` as tested.

--- a/siege_utilities/geo/overlays/election_results.py
+++ b/siege_utilities/geo/overlays/election_results.py
@@ -1,0 +1,167 @@
+"""Election results overlay for place history.
+
+Shows precinct-level election returns for a queried geography,
+reconciled via precinct-VTD mapping where needed.
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from siege_utilities.geo.overlay_registry import PlaceHistoryOverlay
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class ElectionReturn:
+    """Election result for a single contest in a single precinct/VTD.
+
+    Attributes:
+        precinct_id: Precinct or VTD identifier.
+        election_year: Year of the election.
+        election_type: general, primary, runoff, special.
+        office: Office contested (e.g., US_PRESIDENT, US_HOUSE, GOVERNOR).
+        candidate: Candidate name.
+        party: Party abbreviation (DEM, REP, LIB, etc.).
+        votes: Vote count.
+        total_votes: Total votes cast in this contest at this precinct.
+        vote_share: Fraction of total votes (0-1).
+        state: State abbreviation.
+        reconciliation_method: How this precinct was mapped (spatial, name_match, official_crosswalk, or direct).
+    """
+
+    precinct_id: str = ""
+    election_year: int = 0
+    election_type: str = "general"
+    office: str = ""
+    candidate: str = ""
+    party: str = ""
+    votes: int = 0
+    total_votes: int = 0
+    vote_share: float = 0.0
+    state: str = ""
+    reconciliation_method: str = "direct"
+
+
+@dataclass
+class ElectionResultsOverlayResult:
+    """Result of the election results overlay query.
+
+    Attributes:
+        geoid: Queried GEOID.
+        returns: Election returns ordered by year then office.
+        election_years: Distinct years with data.
+        offices: Distinct offices with data.
+    """
+
+    geoid: str = ""
+    returns: list[ElectionReturn] = field(default_factory=list)
+
+    @property
+    def election_years(self) -> list[int]:
+        return sorted(set(r.election_year for r in self.returns))
+
+    @property
+    def offices(self) -> list[str]:
+        return sorted(set(r.office for r in self.returns if r.office))
+
+    def for_year(self, year: int) -> list[ElectionReturn]:
+        return [r for r in self.returns if r.election_year == year]
+
+    def for_office(self, office: str) -> list[ElectionReturn]:
+        return [r for r in self.returns if r.office == office]
+
+    def for_year_office(self, year: int, office: str) -> list[ElectionReturn]:
+        return [
+            r for r in self.returns
+            if r.election_year == year and r.office == office
+        ]
+
+    def party_totals(self, year: int, office: str) -> dict[str, int]:
+        """Sum votes by party for a specific contest."""
+        totals: dict[str, int] = {}
+        for r in self.for_year_office(year, office):
+            totals[r.party] = totals.get(r.party, 0) + r.votes
+        return totals
+
+
+class ElectionDataProvider(abc.ABC):
+    """Protocol for fetching election results for a geography."""
+
+    @abc.abstractmethod
+    def get_election_returns(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        state_fips: Optional[str] = None,
+    ) -> list[ElectionReturn]:
+        """Get election returns for precincts/VTDs overlapping a geography."""
+
+
+class DictElectionDataProvider(ElectionDataProvider):
+    """In-memory election data provider for testing."""
+
+    def __init__(self):
+        self._returns: list[ElectionReturn] = []
+
+    def add(self, ret: ElectionReturn):
+        self._returns.append(ret)
+
+    def get_election_returns(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        state_fips: Optional[str] = None,
+    ) -> list[ElectionReturn]:
+        results = []
+        for r in self._returns:
+            if r.election_year < from_year or r.election_year > to_year:
+                continue
+            if state_fips and r.state.upper() != state_fips.upper():
+                continue
+            results.append(r)
+        return results
+
+
+class ElectionResultsOverlay(PlaceHistoryOverlay):
+    """Place history overlay for precinct-level election results.
+
+    Returns election returns for precincts/VTDs that overlap the
+    queried geography, reconciled via precinct-VTD mapping.
+    """
+
+    def __init__(self, provider: Optional[ElectionDataProvider] = None):
+        self._provider = provider
+
+    @property
+    def name(self) -> str:
+        return "election_results"
+
+    def fetch(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        state_fips: Optional[str] = None,
+    ) -> ElectionResultsOverlayResult:
+        if self._provider is None:
+            return ElectionResultsOverlayResult(geoid=geoid)
+
+        returns = self._provider.get_election_returns(
+            geoid, from_year, to_year, state_fips,
+        )
+        returns.sort(key=lambda r: (r.election_year, r.office, r.party))
+
+        return ElectionResultsOverlayResult(
+            geoid=geoid,
+            returns=returns,
+        )
+
+    def is_available(self) -> bool:
+        return self._provider is not None

--- a/siege_utilities/geo/overlays/redistricting.py
+++ b/siege_utilities/geo/overlays/redistricting.py
@@ -1,0 +1,172 @@
+"""Redistricting overlay for place history.
+
+Shows which redistricting plan(s) and district(s) applied to a
+geography over a queried time range, using plan lifecycle data.
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Any, Optional
+
+from siege_utilities.geo.overlay_registry import PlaceHistoryOverlay
+from siege_utilities.geo.plan_lifecycle import (
+    PlanType,
+    RedistrictingPlan,
+)
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class DistrictAssignment:
+    """A district assignment for a geography under a specific plan.
+
+    Attributes:
+        plan_id: Plan identifier.
+        plan_name: Human-readable plan name.
+        plan_type: Congressional, state senate, or state house.
+        district_id: District identifier (e.g., "TX-28").
+        state: State abbreviation.
+        from_date: When this assignment began.
+        to_date: When this assignment ended (None = still active).
+        enacted_by: Who enacted the plan.
+        court_case: Court case if court-ordered.
+        containment_pct: Fraction of queried geography in this district.
+    """
+
+    plan_id: str = ""
+    plan_name: str = ""
+    plan_type: str = ""
+    district_id: str = ""
+    state: str = ""
+    from_date: Optional[date] = None
+    to_date: Optional[date] = None
+    enacted_by: str = ""
+    court_case: str = ""
+    containment_pct: float = 1.0
+
+
+@dataclass
+class RedistrictingOverlayResult:
+    """Result of the redistricting overlay query.
+
+    Attributes:
+        geoid: Queried GEOID.
+        assignments: District assignments ordered by time.
+        plan_count: Number of distinct plans that applied.
+        had_court_intervention: Whether any plan was court-ordered.
+    """
+
+    geoid: str = ""
+    assignments: list[DistrictAssignment] = field(default_factory=list)
+
+    @property
+    def plan_count(self) -> int:
+        return len(set(a.plan_id for a in self.assignments))
+
+    @property
+    def had_court_intervention(self) -> bool:
+        return any(a.court_case for a in self.assignments)
+
+    @property
+    def plan_types(self) -> list[str]:
+        return sorted(set(a.plan_type for a in self.assignments if a.plan_type))
+
+    def for_plan_type(self, plan_type: str) -> list[DistrictAssignment]:
+        return [a for a in self.assignments if a.plan_type == plan_type]
+
+    def active_at(self, when: date) -> list[DistrictAssignment]:
+        result = []
+        for a in self.assignments:
+            if a.from_date and a.from_date > when:
+                continue
+            if a.to_date and a.to_date < when:
+                continue
+            result.append(a)
+        return result
+
+
+class RedistrictingDataProvider(abc.ABC):
+    """Protocol for fetching redistricting plan assignments for a geography."""
+
+    @abc.abstractmethod
+    def get_district_assignments(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        state_fips: Optional[str] = None,
+    ) -> list[DistrictAssignment]:
+        """Get district assignments for a geography over a time range."""
+
+
+class DictRedistrictingDataProvider(RedistrictingDataProvider):
+    """In-memory redistricting data provider for testing."""
+
+    def __init__(self):
+        self._assignments: list[DistrictAssignment] = []
+
+    def add(self, assignment: DistrictAssignment):
+        self._assignments.append(assignment)
+
+    def get_district_assignments(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        state_fips: Optional[str] = None,
+    ) -> list[DistrictAssignment]:
+        from_date = date(from_year, 1, 1)
+        to_date = date(to_year, 12, 31)
+        results = []
+        for a in self._assignments:
+            if state_fips and a.state.upper() != state_fips.upper():
+                continue
+            if a.to_date and a.to_date < from_date:
+                continue
+            if a.from_date and a.from_date > to_date:
+                continue
+            results.append(a)
+        return results
+
+
+class RedistrictingOverlay(PlaceHistoryOverlay):
+    """Place history overlay for redistricting plan assignments.
+
+    Shows which plan(s) and district(s) applied to a geography
+    over the queried time range.
+    """
+
+    def __init__(self, provider: Optional[RedistrictingDataProvider] = None):
+        self._provider = provider
+
+    @property
+    def name(self) -> str:
+        return "redistricting"
+
+    def fetch(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        state_fips: Optional[str] = None,
+    ) -> RedistrictingOverlayResult:
+        if self._provider is None:
+            return RedistrictingOverlayResult(geoid=geoid)
+
+        assignments = self._provider.get_district_assignments(
+            geoid, from_year, to_year, state_fips,
+        )
+        assignments.sort(key=lambda a: a.from_date or date.min)
+
+        return RedistrictingOverlayResult(
+            geoid=geoid,
+            assignments=assignments,
+        )
+
+    def is_available(self) -> bool:
+        return self._provider is not None

--- a/tests/test_rdh_overlays.py
+++ b/tests/test_rdh_overlays.py
@@ -1,0 +1,302 @@
+"""Tests for RDH overlays — redistricting + election results (SU#636)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from siege_utilities.geo.overlay_registry import OverlayRegistry
+from siege_utilities.geo.overlays.redistricting import (
+    DictRedistrictingDataProvider,
+    DistrictAssignment,
+    RedistrictingOverlay,
+    RedistrictingOverlayResult,
+)
+from siege_utilities.geo.overlays.election_results import (
+    DictElectionDataProvider,
+    ElectionDataProvider,
+    ElectionResultsOverlay,
+    ElectionResultsOverlayResult,
+    ElectionReturn,
+)
+
+
+def _da(plan_id="P1", plan_name="Plan 2022", plan_type="congressional",
+        district_id="TX-28", state="TX", from_date="2022-01-01",
+        to_date=None, enacted_by="legislature", court_case="", **kw):
+    return DistrictAssignment(
+        plan_id=plan_id, plan_name=plan_name, plan_type=plan_type,
+        district_id=district_id, state=state,
+        from_date=date.fromisoformat(from_date) if isinstance(from_date, str) else from_date,
+        to_date=date.fromisoformat(to_date) if isinstance(to_date, str) and to_date else to_date,
+        enacted_by=enacted_by, court_case=court_case, **kw,
+    )
+
+
+def _er(precinct_id="PCT-1", year=2022, office="US_HOUSE", candidate="Smith",
+        party="DEM", votes=100, total_votes=200, state="TX", **kw):
+    return ElectionReturn(
+        precinct_id=precinct_id, election_year=year, office=office,
+        candidate=candidate, party=party, votes=votes,
+        total_votes=total_votes, vote_share=votes / total_votes if total_votes else 0,
+        state=state, **kw,
+    )
+
+
+# ---- Redistricting Overlay ----
+
+class TestDistrictAssignment:
+    def test_defaults(self):
+        a = DistrictAssignment()
+        assert a.plan_id == ""
+        assert a.from_date is None
+
+    def test_fields(self):
+        a = _da()
+        assert a.plan_id == "P1"
+        assert a.from_date == date(2022, 1, 1)
+
+
+class TestRedistrictingOverlayResult:
+    def test_empty(self):
+        r = RedistrictingOverlayResult(geoid="48453")
+        assert r.plan_count == 0
+        assert not r.had_court_intervention
+
+    def test_plan_count(self):
+        r = RedistrictingOverlayResult(assignments=[
+            _da(plan_id="P1"), _da(plan_id="P2"),
+        ])
+        assert r.plan_count == 2
+
+    def test_had_court_intervention(self):
+        r = RedistrictingOverlayResult(assignments=[
+            _da(court_case="Allen v. Milligan"),
+        ])
+        assert r.had_court_intervention
+
+    def test_plan_types(self):
+        r = RedistrictingOverlayResult(assignments=[
+            _da(plan_type="congressional"),
+            _da(plan_type="state_senate"),
+            _da(plan_type="congressional"),
+        ])
+        assert r.plan_types == ["congressional", "state_senate"]
+
+    def test_for_plan_type(self):
+        r = RedistrictingOverlayResult(assignments=[
+            _da(plan_type="congressional"),
+            _da(plan_type="state_senate"),
+        ])
+        assert len(r.for_plan_type("congressional")) == 1
+
+    def test_active_at(self):
+        r = RedistrictingOverlayResult(assignments=[
+            _da(plan_id="P1", from_date="2012-01-01", to_date="2021-12-31"),
+            _da(plan_id="P2", from_date="2022-01-01"),
+        ])
+        active = r.active_at(date(2015, 6, 1))
+        assert len(active) == 1
+        assert active[0].plan_id == "P1"
+
+    def test_active_at_open_ended(self):
+        r = RedistrictingOverlayResult(assignments=[
+            _da(from_date="2022-01-01", to_date=None),
+        ])
+        assert len(r.active_at(date(2025, 1, 1))) == 1
+
+
+class TestDictRedistrictingProvider:
+    def test_empty(self):
+        p = DictRedistrictingDataProvider()
+        assert p.get_district_assignments("G1", 2020, 2024) == []
+
+    def test_time_range_filter(self):
+        p = DictRedistrictingDataProvider()
+        p.add(_da(from_date="2012-01-01", to_date="2021-12-31"))
+        p.add(_da(plan_id="P2", from_date="2022-01-01"))
+
+        assert len(p.get_district_assignments("G1", 2020, 2024)) == 2
+        assert len(p.get_district_assignments("G1", 2023, 2024)) == 1
+
+    def test_state_filter(self):
+        p = DictRedistrictingDataProvider()
+        p.add(_da(state="TX"))
+        p.add(_da(state="CA"))
+        assert len(p.get_district_assignments("G1", 2020, 2024, state_fips="TX")) == 1
+
+
+class TestRedistrictingOverlay:
+    def test_name(self):
+        ov = RedistrictingOverlay()
+        assert ov.name == "redistricting"
+
+    def test_no_provider(self):
+        ov = RedistrictingOverlay()
+        result = ov.fetch("48453", 2020, 2024)
+        assert result.geoid == "48453"
+        assert result.assignments == []
+
+    def test_is_available(self):
+        assert not RedistrictingOverlay().is_available()
+        assert RedistrictingOverlay(DictRedistrictingDataProvider()).is_available()
+
+    def test_fetch(self):
+        p = DictRedistrictingDataProvider()
+        p.add(_da(plan_id="P1", from_date="2012-01-01", to_date="2021-12-31"))
+        p.add(_da(plan_id="P2", from_date="2022-01-01"))
+
+        ov = RedistrictingOverlay(provider=p)
+        result = ov.fetch("48453", 2020, 2024)
+        assert len(result.assignments) == 2
+        assert result.assignments[0].plan_id == "P1"
+
+    def test_registers_with_registry(self):
+        reg = OverlayRegistry()
+        p = DictRedistrictingDataProvider()
+        ov = RedistrictingOverlay(provider=p)
+        reg.register_instance("redistricting", ov)
+        assert reg.is_registered("redistricting")
+        assert reg.get("redistricting").name == "redistricting"
+
+    def test_court_order_scenario(self):
+        p = DictRedistrictingDataProvider()
+        p.add(_da(
+            plan_id="AL-CD-2021", from_date="2022-01-01", to_date="2023-06-08",
+            state="AL", court_case="",
+        ))
+        p.add(_da(
+            plan_id="AL-CD-2023-COURT", from_date="2023-10-05",
+            state="AL", court_case="Allen v. Milligan",
+            enacted_by="court",
+        ))
+
+        ov = RedistrictingOverlay(provider=p)
+        result = ov.fetch("01001", 2022, 2024, state_fips="AL")
+        assert result.plan_count == 2
+        assert result.had_court_intervention
+
+
+# ---- Election Results Overlay ----
+
+class TestElectionReturn:
+    def test_defaults(self):
+        r = ElectionReturn()
+        assert r.votes == 0
+        assert r.reconciliation_method == "direct"
+
+    def test_fields(self):
+        r = _er()
+        assert r.vote_share == pytest.approx(0.5)
+
+
+class TestElectionResultsOverlayResult:
+    def test_empty(self):
+        r = ElectionResultsOverlayResult(geoid="48453")
+        assert r.election_years == []
+        assert r.offices == []
+
+    def test_election_years(self):
+        r = ElectionResultsOverlayResult(returns=[
+            _er(year=2020), _er(year=2022), _er(year=2020),
+        ])
+        assert r.election_years == [2020, 2022]
+
+    def test_offices(self):
+        r = ElectionResultsOverlayResult(returns=[
+            _er(office="US_HOUSE"), _er(office="US_PRESIDENT"),
+        ])
+        assert r.offices == ["US_HOUSE", "US_PRESIDENT"]
+
+    def test_for_year(self):
+        r = ElectionResultsOverlayResult(returns=[
+            _er(year=2020), _er(year=2022),
+        ])
+        assert len(r.for_year(2020)) == 1
+
+    def test_for_office(self):
+        r = ElectionResultsOverlayResult(returns=[
+            _er(office="US_HOUSE"), _er(office="GOVERNOR"),
+        ])
+        assert len(r.for_office("US_HOUSE")) == 1
+
+    def test_for_year_office(self):
+        r = ElectionResultsOverlayResult(returns=[
+            _er(year=2022, office="US_HOUSE"),
+            _er(year=2022, office="GOVERNOR"),
+            _er(year=2020, office="US_HOUSE"),
+        ])
+        assert len(r.for_year_office(2022, "US_HOUSE")) == 1
+
+    def test_party_totals(self):
+        r = ElectionResultsOverlayResult(returns=[
+            _er(year=2022, office="US_HOUSE", party="DEM", votes=100),
+            _er(year=2022, office="US_HOUSE", party="REP", votes=80),
+            _er(year=2022, office="US_HOUSE", party="DEM", votes=50),
+        ])
+        totals = r.party_totals(2022, "US_HOUSE")
+        assert totals["DEM"] == 150
+        assert totals["REP"] == 80
+
+
+class TestDictElectionDataProvider:
+    def test_empty(self):
+        p = DictElectionDataProvider()
+        assert p.get_election_returns("G1", 2020, 2024) == []
+
+    def test_year_filter(self):
+        p = DictElectionDataProvider()
+        p.add(_er(year=2020))
+        p.add(_er(year=2022))
+        p.add(_er(year=2024))
+        assert len(p.get_election_returns("G1", 2021, 2023)) == 1
+
+    def test_state_filter(self):
+        p = DictElectionDataProvider()
+        p.add(_er(state="TX"))
+        p.add(_er(state="CA"))
+        assert len(p.get_election_returns("G1", 2020, 2024, state_fips="TX")) == 1
+
+
+class TestElectionResultsOverlay:
+    def test_name(self):
+        ov = ElectionResultsOverlay()
+        assert ov.name == "election_results"
+
+    def test_no_provider(self):
+        ov = ElectionResultsOverlay()
+        result = ov.fetch("48453", 2020, 2024)
+        assert result.geoid == "48453"
+        assert result.returns == []
+
+    def test_is_available(self):
+        assert not ElectionResultsOverlay().is_available()
+        assert ElectionResultsOverlay(DictElectionDataProvider()).is_available()
+
+    def test_fetch(self):
+        p = DictElectionDataProvider()
+        p.add(_er(year=2020, party="DEM"))
+        p.add(_er(year=2022, party="REP"))
+
+        ov = ElectionResultsOverlay(provider=p)
+        result = ov.fetch("48453", 2020, 2024)
+        assert len(result.returns) == 2
+        assert result.returns[0].election_year == 2020
+
+    def test_registers_with_registry(self):
+        reg = OverlayRegistry()
+        ov = ElectionResultsOverlay(provider=DictElectionDataProvider())
+        reg.register_instance("election_results", ov)
+        assert reg.is_registered("election_results")
+
+    def test_sorted_output(self):
+        p = DictElectionDataProvider()
+        p.add(_er(year=2022, office="GOVERNOR", party="DEM"))
+        p.add(_er(year=2020, office="US_HOUSE", party="REP"))
+        p.add(_er(year=2022, office="US_HOUSE", party="DEM"))
+
+        ov = ElectionResultsOverlay(provider=p)
+        result = ov.fetch("48453", 2020, 2024)
+        years = [r.election_year for r in result.returns]
+        assert years == sorted(years)


### PR DESCRIPTION
## Summary
- `RedistrictingOverlay` — district assignments over time with `active_at()` temporal queries, court-intervention detection, plan type filtering
- `ElectionResultsOverlay` — precinct-level election returns with `party_totals()` aggregation, year/office filtering, reconciliation method tracking
- Both implement `PlaceHistoryOverlay` ABC and register with the WS2 overlay registry
- Provider-based architecture (`RedistrictingDataProvider`, `ElectionDataProvider` ABCs + Dict providers)
- Court-order scenario tested (Allen v. Milligan)
- 36 tests