### PR TITLE
fix(geo): correct urbanicity field mapping and add missing housing_vacant (SU#632)

### DIFF
--- a/siege_utilities/geo/codification_summary.py
+++ b/siege_utilities/geo/codification_summary.py
@@ -82,12 +82,14 @@ class AreaPortrait:
                 "pct_asian": self.demographics.pct_asian,
                 "pct_voting_age": self.demographics.pct_voting_age,
                 "pct_housing_occupied": self.demographics.pct_housing_occupied,
+                "pct_housing_vacant": self.demographics.pct_housing_vacant,
             }
         if self.urbanicity:
             d["urbanicity"] = {
                 "dominant_category": self.urbanicity.dominant_category,
                 "dominant_locale": self.urbanicity.dominant_locale,
-                "distribution": self.urbanicity.category_distribution,
+                "distribution": self.urbanicity.distribution,
+                "category_distribution": self.urbanicity.category_distribution,
             }
         if self.recency:
             d["recency"] = {

--- a/tests/test_codification_summary.py
+++ b/tests/test_codification_summary.py
@@ -168,12 +168,14 @@ class TestToDict:
         assert d["demographics"]["total_block_population"] == 5000
         assert d["demographics"]["pct_asian"] == 0.05
         assert d["demographics"]["pct_housing_occupied"] == 0.90
+        assert d["demographics"]["pct_housing_vacant"] == 0.10
 
     def test_urbanicity_section(self):
         p = AreaPortrait(urbanicity=_urbanicity())
         d = p.to_dict()
         assert d["urbanicity"]["dominant_locale"] == "11"
-        assert d["urbanicity"]["distribution"] == {"city": 0.7, "suburb": 0.3}
+        assert d["urbanicity"]["distribution"] == {"11": 0.7, "21": 0.3}
+        assert d["urbanicity"]["category_distribution"] == {"city": 0.7, "suburb": 0.3}
 
     def test_recency_section(self):
         p = AreaPortrait(recency=_recency())


### PR DESCRIPTION
## Summary

- `to_dict()` mapped `category_distribution` to the `"distribution"` key — locale-code data was inaccessible, category data was mislabeled. Fix adds both fields with correct key names.
- `pct_housing_vacant` exists on `DemographicSignature` (line 77) but was omitted from the demographics section of `to_dict()`. Added.
- Test `test_urbanicity_section` previously verified the buggy mapping. Corrected to assert locale-code distribution under `"distribution"` and category distribution under `"category_distribution"`.
- Test `test_demographics_section` now checks `pct_housing_vacant`.

## Investigation

Verified `UrbanicityDistribution` fields at `codification_urbanicity.py:36-51` (both `distribution` and `category_distribution` exist as separate fields). Verified `DemographicSignature` fields at `codification_demographics.py:50-77` (`pct_housing_vacant` is line 77).

## Test plan

- [x] `test_urbanicity_section` asserts both distribution fields with correct locale-code vs category values
- [x] `test_demographics_section` asserts `pct_housing_vacant == 0.10`
- [x] All 20 tests pass