### PR TITLE
fix(geo): Unicode normalization and official crosswalk exclusivity (SU#635)

### DIFF
--- a/siege_utilities/geo/precinct_vtd.py
+++ b/siege_utilities/geo/precinct_vtd.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import abc
 import logging
 import re
+import unicodedata
 from dataclasses import dataclass, field
 from difflib import SequenceMatcher
 from enum import Enum
@@ -229,7 +230,9 @@ _NORMALIZE_RE = re.compile(r"[^a-z0-9\s]")
 
 
 def _normalize_name(name: str) -> str:
-    return _NORMALIZE_RE.sub("", name.lower()).strip()
+    decomposed = unicodedata.normalize("NFKD", name.lower())
+    ascii_text = decomposed.encode("ascii", "ignore").decode("ascii")
+    return _NORMALIZE_RE.sub("", ascii_text).strip()
 
 
 def _name_similarity(a: str, b: str) -> float:
@@ -317,21 +320,26 @@ def _merge_mappings(
 ) -> list[PrecinctVTDMapping]:
     """Merge mappings from all methods, preferring official > spatial > name."""
     by_precinct: dict[str, dict[str, PrecinctVTDMapping]] = {}
+    official_precincts: set[str] = set()
 
     for m in official:
+        official_precincts.add(m.precinct_id)
         by_precinct.setdefault(m.precinct_id, {})[m.vtd_geoid] = m
 
     for m in spatial:
+        if m.precinct_id in official_precincts:
+            continue
         bucket = by_precinct.setdefault(m.precinct_id, {})
         if m.vtd_geoid not in bucket:
             bucket[m.vtd_geoid] = m
         else:
             existing = bucket[m.vtd_geoid]
-            if existing.method != ReconciliationMethod.OFFICIAL_CROSSWALK:
-                if m.confidence > existing.confidence:
-                    bucket[m.vtd_geoid] = m
+            if m.confidence > existing.confidence:
+                bucket[m.vtd_geoid] = m
 
     for m in names:
+        if m.precinct_id in official_precincts:
+            continue
         bucket = by_precinct.setdefault(m.precinct_id, {})
         if m.vtd_geoid not in bucket:
             bucket[m.vtd_geoid] = m

--- a/tests/test_precinct_vtd.py
+++ b/tests/test_precinct_vtd.py
@@ -44,6 +44,12 @@ class TestNormalizeName:
     def test_strips_punctuation(self):
         assert _normalize_name("Dist. #5 (North)") == "dist 5 north"
 
+    def test_accented_characters(self):
+        assert _normalize_name("Cañón") == "canon"
+        assert _normalize_name("Précinct") == "precinct"
+        assert _normalize_name("Müller") == "muller"
+        assert _normalize_name("Señor García") == "senor garcia"
+
     def test_empty(self):
         assert _normalize_name("") == ""
 
@@ -267,9 +273,21 @@ class TestPrecinctVTDReconciler:
 
         rec = PrecinctVTDReconciler(spatial_provider=sp, official_crosswalk=xw)
         result = rec.reconcile(["P1"])
-        official = [m for m in result.mappings if m.method == ReconciliationMethod.OFFICIAL_CROSSWALK]
-        assert len(official) == 1
-        assert official[0].vtd_geoid == "V_RIGHT"
+        assert len(result.mappings) == 1
+        assert result.mappings[0].vtd_geoid == "V_RIGHT"
+        assert result.mappings[0].method == ReconciliationMethod.OFFICIAL_CROSSWALK
+
+    def test_official_excludes_name_match(self):
+        np = DictNameMatchProvider()
+        np.add_precinct("P1", "Ward 1")
+        np.add_vtd("V_WRONG", "Ward 1")
+
+        xw = [OfficialCrosswalkEntry(precinct_id="P1", vtd_geoid="V_RIGHT")]
+
+        rec = PrecinctVTDReconciler(name_provider=np, official_crosswalk=xw)
+        result = rec.reconcile(["P1"])
+        assert len(result.mappings) == 1
+        assert result.mappings[0].vtd_geoid == "V_RIGHT"
 
     def test_combined_boost(self):
         sp = DictSpatialOverlapProvider()


### PR DESCRIPTION
## Summary

Two HIGH-severity fixes in precinct-VTD reconciliation:

1. **Unicode normalization** — `_normalize_name` regex `[^a-z0-9\s]` stripped accented characters (ñ→nothing, é→nothing) instead of normalizing them. Fix applies `unicodedata.normalize('NFKD')` before ASCII filtering so accented characters decompose to base letters. Affects TX, NM, LA, PR precinct name matching.

2. **Official crosswalk exclusivity** — `_merge_mappings` keyed by `(precinct_id, vtd_geoid)` pairs, allowing official P1→V_RIGHT and spatial P1→V_WRONG to coexist. Fix gives official crosswalk exclusive per-precinct authority: when a precinct has any official entry, spatial and name mappings for that precinct are skipped.

## Investigation

- Verified `_NORMALIZE_RE` at `precinct_vtd.py:228` — regex `[^a-z0-9\s]` has no Unicode awareness
- Verified `_merge_mappings` keying at `precinct_vtd.py:319-337` — nested dict keys by vtd_geoid within precinct, not per-precinct exclusively
- Verified `test_official_overrides_spatial` at `test_precinct_vtd.py:262-272` — only checks official IS present, never checks spatial conflict IS absent

## Test plan

- [x] `test_accented_characters`: Cañón→canon, Précinct→precinct, Müller→muller, Señor García→senor garcia
- [x] `test_official_overrides_spatial` strengthened: asserts `len(result.mappings) == 1` (spatial V_WRONG is absent)
- [x] `test_official_excludes_name_match` added: official V_RIGHT excludes name-matched V_WRONG
- [x] All 42 tests pass