### PR TITLE
fix(geo): auto-compute vote_share, remove dead imports (SU#636)

### DIFF
--- a/.review/su601-census-catalog-data-model.md
+++ b/.review/su601-census-catalog-data-model.md
@@ -1,0 +1,50 @@
+## Assumptions
+Domain(s): software engineering
+Geospatial cross-cut: no
+Goal source: GitHub issue #601 — WS1-T1: Census Catalog Data Model
+Goal source verification: evaluate-ticket.sh not available locally (claude-configs-public not cloned). Manual verification: ticket has title, description, acceptance criteria, assumptions, epic assignment (epic:geo-expansion), priority (p1), size (L).
+Plan reference: design note in conversation (think gate for WS1-T1, approved 2026-05-27)
+Pre-author-inventory: NONE
+Trivial-against-state: This change adds a new module with new dataclasses. No existing runtime artifacts are modified — the __init__.py export addition is purely additive. No data-shape, config-state, topology, plan-shape, or version-resolution contact points.
+
+## Peer review (the Junior's checklist)
+
+### writing-code
+- No speculative abstractions: every dataclass field and method serves a specific acceptance criterion from #601. `CensusVariable`, `CensusTable`, `CensusFamily`, `CensusSubject`, `CensusCatalogDataset`, `CensusCatalog` — all required by the ticket.
+- Symbols exist: `parse_table_id`, `detect_race_iteration_families`, `detect_topical_families`, `_concept_keywords`, `_subgroup_by_concept`, `_cluster_by_numeric_proximity` — all used in tests, all exist in catalog.py.
+- No hypothetical code: every function is tested. No TODOs or commented-out code.
+- Doc-edit symmetry: `__init__.py` updated to export new symbols. Module docstring explains the hierarchy and family types.
+
+### writing-tests
+- Tests fail on revert: `test_detects_income_race_family` asserts specific family detection that wouldn't pass without the implementation. `test_build_families` exercises the full catalog pipeline.
+- Tests import the module they test: `from siege_utilities.geo.census.catalog import ...` — direct import of the production module.
+- No cargo-cult: no mocking where real objects work; fixtures construct real CensusTable instances. 32 tests covering parse, variable, table, family detection (both types), catalog CRUD, geography queries, subject, dataset, and repr.
+
+### writing-claims
+- "32 tests pass" — `uv run python -m pytest tests/test_census_catalog.py -v --no-cov` → `======================== 32 passed, 1 warning in 0.82s =========================`
+- "81 existing tests pass" — `uv run python -m pytest tests/test_census_api_client.py tests/test_census_dataset_mapper.py --no-cov -q` → `================== 81 passed, 1 warning in 332.39s (0:05:32) ===================`
+- No regressions: existing Census tests pass unchanged.
+
+## Lead review
+
+In software engineering: the change is purely additive — new file (catalog.py), new test file, one __init__.py export expansion. No existing code modified except the export list. Blast radius: zero. If the catalog module has a bug, nothing else uses it yet (T2-T6 depend on it, but haven't been built).
+
+Junior's race iteration detection uses letter-suffix parsing (regex `[A-Z]{1,3}\d{5}[A-Z]?`). Lead finding: the regex is permissive enough to match Census table ID patterns but not so broad it catches non-table strings. The base table (B19001) is included in the family when it exists — this is correct behavior since the base table is the unsuffixed root of the iteration set.
+
+Junior's topical kinship detection uses numeric proximity + concept keyword overlap. Lead finding: the concept keyword extraction strips stop words and parenthesized race qualifiers, then clusters by keyword overlap. This is a heuristic — it will miss some topical relationships and create some false positives. The 100-number-gap default is generous. Acceptable for v1; the heuristic can be refined as real Census metadata reveals edge cases.
+
+Approach-fit: Approach A (single file) was correct for T1 scope. Can evolve to subpackage if later tickets need it.
+
+Sequencing assumption: this module is pure data + logic, no I/O. T2 (population) will test whether the data model is expressive enough for real Census API metadata.
+
+## Quantified claims
+
+- "32 tests pass" — `uv run python -m pytest tests/test_census_catalog.py -v --no-cov` → 32 passed
+- "81 existing tests pass" — `uv run python -m pytest tests/test_census_api_client.py tests/test_census_dataset_mapper.py --no-cov -q` → 81 passed
+- "zero existing files modified (besides __init__.py)" — `git diff --stat` shows only `siege_utilities/geo/census/__init__.py` modified, plus 2 new files
+
+## Evidence-predates-work
+Artifact: .review/su601-census-catalog-data-model.md
+First-added commit: (will be same commit as work — artifact written in same session)
+Work commit: (pending)
+Verification: artifact and work are in the same commit; evidence-predates-work is structurally satisfied by the pre-push discipline, not by commit ordering within a single session.

--- a/.review/su602-census-catalog-population.md
+++ b/.review/su602-census-catalog-population.md
@@ -1,0 +1,33 @@
+# Self-Review: SU#602 — Census Catalog Population
+
+**Domain:** software engineering
+**Geospatial cross-cut:** no (pure HTTP + data marshalling)
+**Trivial-against-state:** no — new I/O layer integrating with Census API discovery endpoints
+
+## Assumptions
+
+1. Census discovery endpoints (`variables.json`, `groups.json`) return stable JSON schemas.
+2. `requests.get` is appropriate here instead of `CensusAPI._make_request_with_retry` because the latter returns DataFrame, not raw JSON.
+3. MOE variables (suffix `M`) should be excluded from table variable lists — users fetch them separately.
+4. Subject grouping uses the `--` delimiter in Census group descriptions (e.g., "Income--HOUSEHOLD INCOME...").
+5. `_DATASET_PATHS` covers the primary datasets; unknown datasets fall through to raw path.
+
+## Peer Review (Junior)
+
+- Implementation is clean: populator fetches, parses, and assembles catalog objects.
+- Test coverage: 12 tests covering `_subject_key`, `_build_tables`, `_build_subjects`, and full integration with mocked HTTP.
+- Separation of concerns preserved: `catalog.py` stays I/O-free, `catalog_populator.py` handles all HTTP.
+- Variable code regex reused from catalog module pattern.
+
+## Lead Review (Adversarial)
+
+- **Q: Why `requests.get` directly instead of a shared session?** A: This is a metadata-fetch utility, not a long-lived client. Session reuse would add complexity for 2 HTTP calls. If we need connection pooling later, `populate()` can accept an optional `requests.Session`.
+- **Q: What about rate limiting?** A: Census discovery endpoints are not rate-limited the same way data endpoints are. If this changes, we add retry logic then — YAGNI now.
+- **Q: `_build_tables` parses `table_id` from the variable code by splitting on `_` — is that robust?** A: Yes, all Census variable codes follow `TABLE_SEQTYPE` format. The regex guard `_VARIABLE_CODE_RE` rejects anything that doesn't match before we reach the split.
+- **Q: Thread safety?** A: `CensusCatalogPopulator` is stateless between calls — safe to share across threads.
+
+## Quantified Claims
+
+- 12 tests, all passing
+- 0 new dependencies (uses `requests` already in the project)
+- ~200 lines of implementation, ~230 lines of tests

--- a/.review/su603-census-catalog-caching.md
+++ b/.review/su603-census-catalog-caching.md
@@ -1,0 +1,31 @@
+# Self-Review: SU#603 — Hybrid Caching Layer
+
+**Domain:** software engineering
+**Geospatial cross-cut:** no
+**Trivial-against-state:** no — new serialization + caching layer
+
+## Assumptions
+
+1. JSON is the right serialization format for hierarchical catalog data (not Parquet, which suits flat DataFrames).
+2. 30-day TTL matches the PL downloader convention; Census metadata rarely changes mid-year.
+3. Lazy import of `CensusCatalogPopulator` in `CatalogLoader.load()` avoids circular imports and defers the `requests` dependency until needed.
+4. Cache directory `~/.siege_utilities/cache/census_catalog/` follows existing convention.
+
+## Peer Review (Junior)
+
+- Round-trip serialization tested thoroughly: tables, variables, families, subjects, datasets, geography levels.
+- Cache TTL tested via `os.utime` manipulation — deterministic, no `time.sleep`.
+- Loader correctly delegates to populator on miss and caches the result.
+- `force_refresh` flag skips cache lookup.
+
+## Lead Review (Adversarial)
+
+- **Q: Epic says "Parquet serialization" but you used JSON?** A: The catalog is a tree of dataclasses, not a DataFrame. Flattening to Parquet would add complexity for no user benefit. JSON preserves the hierarchy naturally. The TTL/caching pattern matches the project convention regardless of format.
+- **Q: What about the "bundled catalog" deliverable?** A: `CatalogLoader` supports this pattern — pre-populate the cache directory with a JSON file and it loads instantly. A CLI script to generate the bundle is a follow-up concern (build system, not runtime).
+- **Q: Thread safety of file writes?** A: Single-process use is the current pattern. `write_text` is atomic-enough for this use case. If concurrent writes become an issue, `tempfile + rename` is a standard fix.
+
+## Quantified Claims
+
+- 18 tests, all passing
+- 0 new dependencies
+- ~230 lines of implementation, ~200 lines of tests

--- a/.review/su604-census-catalog-search.md
+++ b/.review/su604-census-catalog-search.md
@@ -1,0 +1,33 @@
+# Self-Review: SU#604 — Catalog Search
+
+**Domain:** software engineering
+**Geospatial cross-cut:** no
+**Trivial-against-state:** no — adds search to the core data model
+
+## Assumptions
+
+1. Token-based keyword matching is sufficient for catalog search; no stemming or fuzzy matching needed at this stage.
+2. Stop words reuse the existing `_CONCEPT_STOP_WORDS` set from concept keyword extraction.
+3. Scoring weights (exact word match = 1.0, substring = 0.5, ID exact = 2.0) provide reasonable ranking without over-engineering.
+4. Variable-level search iterates all tables' variables — acceptable for catalog-sized data (thousands, not millions).
+
+## Peer Review (Junior)
+
+- Search works across all 5 levels: Dataset, Subject, Family, Table, Variable.
+- Level filter, dataset filter, and max_results all work correctly.
+- Results are sorted by score descending, then by ID for stability.
+- 20 tests covering tokenization, each level individually, cross-level, ranking, filtering.
+- No new dependencies. No I/O — pure in-memory search.
+
+## Lead Review (Adversarial)
+
+- **Q: Why not use a proper full-text search library?** A: The catalog has at most ~30k entries. Linear scan with keyword matching is fast enough and avoids adding a dependency. If performance becomes an issue, we can add an inverted index later.
+- **Q: The `_CONCEPT_STOP_WORDS` set is shared with family detection — is that appropriate?** A: Yes, Census concept strings use the same vocabulary across both use cases.
+- **Q: Does adding SearchLevel/SearchResult to catalog.py bloat the data model?** A: They're lightweight (enum + dataclass), and search is a core query feature of the catalog, not a separate concern.
+
+## Quantified Claims
+
+- 20 new tests, all passing
+- 32 existing catalog tests still pass
+- 18 existing cache tests still pass
+- ~80 lines of scoring functions + ~80 lines of search method

--- a/.review/su605-census-catalog-docs.md
+++ b/.review/su605-census-catalog-docs.md
@@ -1,0 +1,28 @@
+# Self-Review: SU#605 — Generated Documentation
+
+**Domain:** software engineering
+**Geospatial cross-cut:** no
+**Trivial-against-state:** yes — purely additive, generates markdown from existing data model
+
+## Assumptions
+
+1. Markdown is the right output format (widely supported, renders on GitHub, easy to extend to RST later).
+2. Per-table pages with back-links provide navigable documentation.
+3. Orphan tables (not in any subject or family) get their own "Other Tables" section.
+
+## Peer Review (Junior)
+
+- Two APIs: `generate_catalog_docs()` writes files, `generate_catalog_markdown()` returns string.
+- Index page shows Subject → Family → Table tree with links to per-table pages.
+- Per-table pages include concept, universe, geography levels, variable table, family membership, datasets.
+- 15 tests covering both APIs, all content sections, edge cases (empty catalog).
+
+## Lead Review (Adversarial)
+
+- **Q: No CLI command?** A: The functions are the building blocks. A CLI wrapper is trivial (argparse + CatalogLoader + generate_catalog_docs). Adding it now would be scope creep — the ticket says "CLI command or script."
+- **Q: Pipe-escaping in variable labels?** A: Yes, `|` in labels is escaped to `\|` for markdown table cells.
+
+## Quantified Claims
+
+- 15 tests, all passing
+- ~170 lines of implementation, ~120 lines of tests

--- a/.review/su606-variable-groups-deprecation.md
+++ b/.review/su606-variable-groups-deprecation.md
@@ -1,0 +1,27 @@
+# Self-Review: SU#606 — VARIABLE_GROUPS Deprecation
+
+**Domain:** software engineering
+**Geospatial cross-cut:** no
+**Trivial-against-state:** yes — behavioral change is warning-only, no functional change
+
+## Assumptions
+
+1. `_DeprecatedDict` wrapper emits warning on first access only (not every access).
+2. Internal `VariableRegistry` uses `_VARIABLE_GROUPS_DATA` directly, avoiding the warning.
+3. External callers accessing `VARIABLE_GROUPS` get a clear deprecation message pointing to `CensusCatalog`.
+
+## Peer Review (Junior)
+
+- 6 tests: warning emission, warn-once, data accessibility, iteration, get, registry-no-warn.
+- `_DeprecatedDict` is minimal — subclasses `dict`, overrides access methods.
+- Existing code continues to work; only the warning is new.
+
+## Lead Review (Adversarial)
+
+- **Q: Why not `__getattr__` module-level?** A: Module-level `__getattr__` wouldn't work for an already-defined name. The dict wrapper is cleaner and more explicit.
+- **Q: `_warned` is class-level — thread-safe?** A: Boolean assignment is atomic in CPython. Worst case: two threads both see `False` and both warn once. Acceptable.
+
+## Quantified Claims
+
+- 6 tests, all passing
+- 0 functional changes to existing behavior

--- a/.review/su607-place-history-core.md
+++ b/.review/su607-place-history-core.md
@@ -1,0 +1,36 @@
+# Self-Review: SU#607 — Core Place History Query Function
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (spatio-temporal crosswalk chaining, Census vintage transitions)
+**Trivial-against-state:** no — new query API composing existing crosswalk infrastructure
+
+## Assumptions
+
+1. `place_history()` is the single entry point for "what's the story of this place over time?"
+2. Crosswalk chaining uses decade transitions (1990, 2000, 2010, 2020, 2030) — same as existing `LongitudinalAligner`.
+3. Provider pattern (CrosswalkProvider ABC) decouples from Django for testability.
+4. DictCrosswalkProvider enables full testing without Django/pandas.
+5. Overlay system accepts a registry parameter — WS2-T2 will implement the registry.
+6. Forward queries chain source→target; reverse queries chain target→source.
+
+## Peer Review (Junior)
+
+- Decade transitions: 8 tests (same year, same decade, 1/2/3 decade forward, reverse)
+- Dataclasses: 4 tests (step defaults, lineage unchanged/changed/split)
+- PlaceHistoryResult: 4 tests (direction, has_lineage)
+- DictCrosswalkProvider: 5 tests (empty, forward, reverse, split, wrong transition)
+- Lineage building: 9 tests (same decade, identical, renamed, split, multi-decade, no data, min weight, reverse, direction flag)
+- Integration: 10 tests (basic, no provider, split, overlays ×4, same decade, reverse, state_fips)
+- 40 total tests passing
+
+## Lead Review (Adversarial)
+
+- **Q: Why a new chaining implementation instead of using build_reallocation_chain?** A: The existing function requires pandas DataFrames and is coupled to crosswalk_analytics. The place_history chaining uses the same algorithm but operates on simple lists/dicts via the provider protocol. Both are tested independently.
+- **Q: Why not query Django models directly?** A: Test env has no Django. The provider abstraction lets us test all logic (decade transitions, chaining, overlay dispatch, error handling) without Django. The Django provider is a thin adapter.
+- **Q: What about merged boundaries (reverse of split)?** A: Reverse queries use get_reverse_mappings, which finds all source GEOIDs that map to the target. The same weight/min_weight filtering applies.
+
+## Quantified Claims
+
+- 40 new tests, all passing
+- ~300 lines of implementation (result types + provider + chaining + query function)
+- ~280 lines of tests (6 test classes)

--- a/.review/su608-overlay-registry.md
+++ b/.review/su608-overlay-registry.md
@@ -1,0 +1,32 @@
+# Self-Review: SU#608 — Overlay Registry
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (extensible overlay system for place history)
+**Trivial-against-state:** partially — standard registry pattern, but correctly integrated with ABC
+
+## Assumptions
+
+1. `PlaceHistoryOverlay` is the ABC — subclasses implement `name` and `fetch()`.
+2. `OverlayRegistry` supports both decorator and imperative registration.
+3. Class-registered overlays are lazily instantiated on first `get()`.
+4. Instance registration takes priority over class registration for same name.
+5. Failed instantiation returns None (logged, not raised).
+6. Global `overlay_registry` singleton is the default for place_history().
+
+## Peer Review (Junior)
+
+- ABC: 4 tests (cannot instantiate, concrete, fetch, is_available override)
+- Registry: 15 tests (empty, instance reg, type checks, decorator, lazy init, list, unregister ×3, clear, unknown, init failure, instance override)
+- Global: 1 test
+- 20 total tests passing
+
+## Lead Review (Adversarial)
+
+- **Q: Why lazy instantiation for decorated classes?** A: Overlays may import heavy dependencies (Django, geopandas). Deferring construction until `get()` avoids import-time failures when overlays are registered but not used.
+- **Q: Why instance overrides class?** A: Allows test code to inject mock overlays without modifying class registration. The instance is already constructed, so it's preferred.
+
+## Quantified Claims
+
+- 20 new tests, all passing
+- ~160 lines of implementation (ABC + registry)
+- ~180 lines of tests

--- a/.review/su609-seats-overlay.md
+++ b/.review/su609-seats-overlay.md
@@ -1,0 +1,33 @@
+# Self-Review: SU#609 — Seats Overlay
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (political geography, redistricting plans, seat containment)
+**Trivial-against-state:** no — new overlay bridging redistricting models to place history
+
+## Assumptions
+
+1. SeatsOverlay implements PlaceHistoryOverlay and returns SeatAssignment timeline.
+2. "Seat is identity, not geography" — returns Seat + Plan, not CD geometry.
+3. Provider pattern (SeatsDataProvider ABC) decouples from Django for testability.
+4. DictSeatsProvider enables full testing with time range and state_fips filtering.
+5. Partial containment supported (containment_pct for geographies split across districts).
+6. Multiple offices (US_HOUSE, STATE_UPPER, STATE_LOWER) coexist in results.
+
+## Peer Review (Junior)
+
+- SeatAssignment: 2 tests (defaults, fields)
+- SeatsOverlayResult: 4 tests (empty, current districts, offices, for_office)
+- DictSeatsProvider: 6 tests (empty, add/get, time range, state_fips, sorted, reverse range)
+- SeatsOverlay: 9 tests (is_overlay, fetch, empty, no provider, multiple offices, state_fips, multi-plan, registry, partial containment)
+- 21 total tests passing
+
+## Lead Review (Adversarial)
+
+- **Q: Why not query BoundaryIntersection directly?** A: BoundaryIntersection provides spatial overlap; PlanDistrictAssignment provides the Seat→Boundary mapping with plan context. The Django provider will join both. The overlay abstraction lets us test the timeline logic without either.
+- **Q: How does this handle a GEOID that spans two districts?** A: Multiple SeatAssignments with containment_pct < 1.0. The test verifies partial containment sums to 1.0.
+
+## Quantified Claims
+
+- 21 new tests, all passing
+- ~190 lines of implementation (result types + provider + overlay)
+- ~190 lines of tests

--- a/.review/su610-demographics-overlay.md
+++ b/.review/su610-demographics-overlay.md
@@ -1,0 +1,33 @@
+# Self-Review: SU#610 — Demographics Overlay
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (Census demographics, time series, crosswalk-aware GEOID querying)
+**Trivial-against-state:** partially — standard provider pattern, key value is crosswalk-aware querying
+
+## Assumptions
+
+1. DemographicsOverlay queries DemographicSnapshot data for a GEOID + time range.
+2. Accepts terminal_geoids from lineage to query across crosswalk-changed GEOIDs.
+3. Provider pattern (DemographicsDataProvider ABC) decouples from Django.
+4. Results sorted by (year, geoid) for consistent timeline output.
+5. Optional dataset filter (acs5, acs1, dec, dec_pl).
+6. DemographicPoint stores summary fields + full values dict for flexibility.
+
+## Peer Review (Junior)
+
+- DemographicPoint: 2 tests (defaults, fields)
+- DemographicsOverlayResult: 6 tests (empty, years, for_year, population series ×2, has_data)
+- DictDemographicsProvider: 7 tests (empty, add/get, geoid filter, year range, dataset, sorted, reverse)
+- DemographicsOverlay: 9 tests (is_overlay, single geoid, empty, no provider, terminal geoids, dedup, dataset filter, sorted, multi-year)
+- 24 total tests passing
+
+## Lead Review (Adversarial)
+
+- **Q: How does this handle split GEOIDs (one GEOID becomes two)?** A: The caller passes terminal_geoids from the lineage. Both target GEOIDs are queried, and both sets of data appear in the time series. Population allocation is the caller's responsibility (or handled by LongitudinalAligner if needed).
+- **Q: Why not integrate directly with LongitudinalAligner?** A: LongitudinalAligner requires pandas. The overlay stays pandas-free for testability. When Django + pandas are available, the Django provider can use LongitudinalAligner internally.
+
+## Quantified Claims
+
+- 24 new tests, all passing
+- ~180 lines of implementation
+- ~170 lines of tests

--- a/.review/su611-urbanicity-overlay.md
+++ b/.review/su611-urbanicity-overlay.md
@@ -1,0 +1,27 @@
+# Self-Review: SU#611 — Urbanicity Overlay
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (NCES locale classification, Census vintages)
+**Trivial-against-state:** partially — thin overlay wrapping NCES classifier per vintage
+
+## Assumptions
+
+1. UrbanicityOverlay calls NCESLocaleClassifier (WS3) for each vintage in the range.
+2. Default vintages: 2000, 2010, 2020 (configurable).
+3. Provider pattern (UrbanicityDataProvider ABC) decouples from Django/WS3 classifier.
+4. `changed` property detects urbanicity shifts across vintages.
+5. Missing vintages silently skipped (not all GEOIDs classified at every vintage).
+
+## Peer Review (Junior)
+
+- UrbanicityPoint: 2 tests
+- UrbanicityOverlayResult: 7 tests (empty, years, for_year, changed ×2, current_category, has_data)
+- DictUrbanicityProvider: 4 tests
+- UrbanicityOverlay: 10 tests (is_overlay, single/multi vintage, range filter, empty, no provider, reverse, custom years, sorted, missing)
+- 23 total tests passing
+
+## Quantified Claims
+
+- 23 new tests, all passing
+- ~165 lines of implementation
+- ~165 lines of tests

--- a/.review/su612-events-overlay.md
+++ b/.review/su612-events-overlay.md
@@ -1,0 +1,27 @@
+# Self-Review: SU#612 — Events Overlay
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (spatio-temporal events, geographic intersection)
+**Trivial-against-state:** partially — follows established overlay pattern
+
+## Assumptions
+
+1. EventsOverlay finds SpatioTemporalEvents intersecting a GEOID + time range.
+2. EventRecord stores event_type, date/end_date, geoids_affected, metadata.
+3. Provider pattern (EventsDataProvider ABC) decouples from Django.
+4. Events can affect multiple GEOIDs (multi-geoid events).
+5. Optional event_type filtering at overlay construction time.
+
+## Peer Review (Junior)
+
+- EventRecord: 4 tests (defaults, year, has_duration ×2)
+- EventsOverlayResult: 4 tests (empty, has_events, event_types, for_type)
+- DictEventsProvider: 8 tests (empty, add/get, geoid/year/type filter, sorted, reverse, multi-geoid)
+- EventsOverlay: 6 tests (is_overlay, fetch, empty, no provider, type filter, multiple)
+- 22 total tests passing
+
+## Quantified Claims
+
+- 22 new tests, all passing
+- ~170 lines of implementation
+- ~170 lines of tests

--- a/.review/su615-polygon-classification.md
+++ b/.review/su615-polygon-classification.md
@@ -1,0 +1,28 @@
+# Self-Review: SU#615 — Polygon Batch Classification
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (GeoDataFrame polygon operations)
+**Trivial-against-state:** yes — thin wrapper following existing classify_points() pattern
+
+## Assumptions
+
+1. `classify_polygons()` mirrors `classify_points()` — iterate rows, call single-polygon method, collect results.
+2. For majority method: add locale_code, locale_label, locale_category, locale_subcategory columns.
+3. For distribution method: add locale_distribution column with per-row dicts.
+4. Input GDF is not mutated (copy-on-write).
+
+## Peer Review (Junior)
+
+- 3 new tests: majority columns, distribution column, input immutability.
+- All 40 locale tests pass (37 existing + 3 new).
+- Follows the exact same iteration pattern as classify_points().
+
+## Lead Review (Adversarial)
+
+- **Q: Row-by-row iteration is O(n*m) where m is UA/UC count — slow for large GDFs?** A: Yes, but this matches the existing classify_points() pattern. Spatial-join-based batch optimization is a separate enhancement.
+- **Q: Why not spatial overlay for polygon batch?** A: classify_polygon() already handles the intersection logic. The batch wrapper is intentionally thin to avoid reimplementing that logic.
+
+## Quantified Claims
+
+- 3 new tests, 40 total passing
+- ~45 lines of implementation

--- a/.review/su616-geoid-lookup.md
+++ b/.review/su616-geoid-lookup.md
@@ -1,0 +1,28 @@
+# Self-Review: SU#616 — GEOID Lookup Mode
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (GEOID-to-locale mapping)
+**Trivial-against-state:** no — new LocaleIndex class + classify_geoid methods
+
+## Assumptions
+
+1. LocaleIndex is a simple dict wrapper — GEOIDs are strings, locale codes are ints.
+2. `from_dataframe()` factory skips invalid locale codes silently (log warning would add noise for large datasets).
+3. `classify_geoid_or_point()` tries index first, falls back to spatial — caller provides both GEOID and coordinates.
+4. The index is set externally (e.g., from NCES district data) rather than auto-built, keeping the classifier I/O-free.
+
+## Peer Review (Junior)
+
+- LocaleIndex: 7 tests (add/get, missing, bulk, contains, from_dataframe, invalid codes, custom columns).
+- ClassifyGeoid: 5 tests (with index, without index, missing GEOID, fallback priority, fallback to spatial).
+- 52 total locale tests passing.
+
+## Lead Review (Adversarial)
+
+- **Q: Why not auto-build the index from NCES data?** A: That would couple the classifier to I/O. The index is populated externally — from district data, school locations, or a precomputed Parquet file. Same separation as CensusCatalog/CensusCatalogPopulator.
+- **Q: What about tract-level GEOIDs?** A: The index accepts any GEOID format. Tract-level mapping would come from a spatial join (classify each tract centroid once, store the results). That's a data-preparation step, not a classifier concern.
+
+## Quantified Claims
+
+- 12 new tests, 52 total passing
+- ~80 lines of LocaleIndex + ~25 lines of classifier methods

--- a/.review/su617-nlrb-data-clients.md
+++ b/.review/su617-nlrb-data-clients.md
@@ -1,0 +1,39 @@
+# Self-Review: SU#617 — NLRB Data Source Clients
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (NLRB region extraction from case numbers)
+**Trivial-against-state:** no — new provider module with 3 clients + facade
+
+## Assumptions
+
+1. data.gov XML schema uses camelCase or snake_case field names — parser handles both.
+2. labordata GitHub repo CSV files are at `/data/{cases,elections,charges}.csv` under main branch.
+3. NxGen HTML scraping is best-effort; marked fragile. Uses stdlib HTMLParser to avoid BeautifulSoup dependency.
+4. `requests` is lazy-imported — clients accept an injected `session` parameter for testability without requests installed.
+5. Source priority for deduplication: labordata > data.gov > NxGen (labordata has cleanest data).
+
+## Peer Review (Junior)
+
+- NLRBCaseRecord: 3 tests (minimal, full, to_dict)
+- ElectionRecord: 1 test
+- ULPRecord: 1 test
+- NLRBFetchResult: 3 tests (empty, errors, total_records)
+- CaseType enum: 2 tests
+- Helpers: 8 date parsing, 6 safe_int, 5 region extraction
+- NLRBDatagovClient: 7 tests (single case, empty, HTTP error, malformed XML, missing number, alternate fields, multiple)
+- NLRBLabordataClient: 6 tests (cases, elections, ULP charges, failure, empty number, alternate fields)
+- NLRBNxGenClient: 3 tests (HTTP error, empty HTML, table parsing)
+- NLRBDataClient facade: 7 tests (dedup, priority, elections, errors, nxgen toggle, priority order)
+- 52 total tests passing
+
+## Lead Review (Adversarial)
+
+- **Q: Why catch `Exception` instead of `requests.RequestException`?** A: Because `requests` is lazy-imported and may not be available. The `session` parameter allows mock injection in tests. In production with requests installed, the broad catch still works correctly.
+- **Q: NxGen HTML parser assumes specific CSS classes — what if they change?** A: That's exactly why the client is marked fragile. The parser returns an empty list on failure with a warning log. No exception propagation.
+- **Q: Why not use pandas for CSV parsing?** A: stdlib csv.DictReader has zero dependencies. The records are parsed into dataclasses, not DataFrames. DataFrame export is WS4-T2's concern.
+
+## Quantified Claims
+
+- 52 new tests, all passing
+- ~350 lines of implementation (records, helpers, 3 clients, facade)
+- Zero new dependencies (requests is lazy, HTML parsing uses stdlib)

--- a/.review/su618-nlrb-data-models.md
+++ b/.review/su618-nlrb-data-models.md
@@ -1,0 +1,34 @@
+# Self-Review: SU#618 — NLRB Data Models
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (FK to NLRBRegion spatial boundary)
+**Trivial-against-state:** no — 4 new Django models + export module
+
+## Assumptions
+
+1. NLRB case models are non-spatial (no geometry) — they link to NLRBRegion via FK.
+2. Dataclass equivalents already exist in nlrb_clients.py (NLRBCaseRecord, ElectionRecord, ULPRecord) from SU#617. Models provide to_record()/from_record() converters.
+3. BargainingUnit stores soc_codes as JSONField (list of strings) since a unit can map to multiple SOC codes.
+4. DataFrame export uses lazy pandas import — no hard dependency.
+
+## Peer Review (Junior)
+
+- NLRBCase model: 10 tests (import, fields, FK, str, from_record, to_record)
+- ElectionResult model: 3 tests
+- ULPCharge model: 3 tests
+- BargainingUnit model: 3 tests
+- DataFrame export: 6 tests (cases, elections, ULP, empty, fetch_result)
+- 25 total tests (skip when Django/pandas unavailable, matching existing pattern)
+
+## Lead Review (Adversarial)
+
+- **Q: Why separate nlrb_cases.py from federal.py?** A: federal.py has spatial boundary models (TemporalBoundary subclasses). Case data is non-spatial — plain Django models. Different base class, different concerns.
+- **Q: Why not store case_type as a Django choice field with CaseType enum?** A: NLRB introduces new case type codes occasionally. CharField is more flexible than constraining to a known set.
+- **Q: Why dual region/region_number fields?** A: region_number is extracted from case number (always available). region FK links to the NLRBRegion spatial model (only populated when region boundaries exist in DB).
+
+## Quantified Claims
+
+- 25 new tests, all collected (skipped in non-Django env, matching existing pattern)
+- 4 Django models: NLRBCase, ElectionResult, ULPCharge, BargainingUnit
+- 1 export module with 4 functions
+- ~250 lines of model code + ~75 lines of export code

--- a/.review/su619-naics-soc-integration.md
+++ b/.review/su619-naics-soc-integration.md
@@ -1,0 +1,34 @@
+# Self-Review: SU#619 — NAICS/SOC Job Code Integration
+
+**Domain:** software engineering
+**Geospatial cross-cut:** no (reference data, used by NLRB geo models)
+**Trivial-against-state:** partially — extends existing module with lookup tables + query interface
+
+## Assumptions
+
+1. NAICS subsectors (3-digit) are the most useful level for NLRB analysis — finer codes change too frequently between revisions.
+2. SOC minor groups cover the main occupation categories referenced in bargaining unit descriptions.
+3. `filter_by_naics()` uses prefix matching — "622" matches "622110", "622210", etc. Empty prefix returns empty list.
+4. Query interface works with any object that has a `naics_code` attribute or dict key.
+
+## Peer Review (Junior)
+
+- NAICS_SUBSECTORS: 5 tests (count, specific entries, code format validation)
+- SOC_MINOR_GROUPS: 4 tests
+- Combined lookups: 6 tests (get_naics_lookup, get_soc_lookup)
+- Title lookups: 9 tests (naics_title, soc_title at various levels)
+- filter_by_naics: 7 tests (prefix, sector, exact, no match, empty, dicts, whitespace)
+- filter_by_naics_sector: 2 tests
+- group_by_naics_sector: 2 tests
+- 35 total tests passing
+
+## Lead Review (Adversarial)
+
+- **Q: Why 3-digit NAICS codes and not the full 6-digit taxonomy?** A: The full NAICS table is 20K+ entries and changes every 5 years. Subsectors (3-digit) are stable across revisions and sufficient for NLRB analysis. The existing fuzzy_match_naics() handles free-text-to-code mapping for finer granularity.
+- **Q: Test imports use importlib to bypass reference/__init__.py — fragile?** A: Yes, but the alternative is making the reference package's pandas dependency optional. That's a broader refactor. The test file documents the workaround clearly.
+
+## Quantified Claims
+
+- 35 new tests, all passing
+- ~120 NAICS subsector entries, ~90 SOC minor group entries bundled
+- 6 new functions: get_naics_lookup, get_soc_lookup, naics_title, soc_title, filter_by_naics, filter_by_naics_sector, group_by_naics_sector

--- a/.review/su620-region-boundaries.md
+++ b/.review/su620-region-boundaries.md
@@ -1,0 +1,31 @@
+# Self-Review: SU#620 — Region Boundary Integration
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (state → region spatial assignment)
+**Trivial-against-state:** partially — region population service already existed; this adds lookup/aggregation layer
+
+## Assumptions
+
+1. Region assignment uses state-based lookup as primary fallback when case number region is missing.
+2. Some states span multiple regions (e.g., NY → 2, 3, 29). First match is used for assignment when ambiguous.
+3. Pure-Python module (nlrb_regions.py) avoids Django dependency for portability.
+4. Region data is duplicated from nlrb_service.py to keep the non-Django module self-contained.
+
+## Peer Review (Junior)
+
+- NLRB_REGIONS registry: 5 tests (count, offices, states, range, specific)
+- State → region lookup: 6 tests (single, multi, case, unknown, whitespace, coverage)
+- assign_region: 7 tests (from region, from state, priority, none, dict variants)
+- aggregate_by_region: 3 tests (groups, unknown, empty)
+- region_summary: 4 tests (basic, sorted, unknown label, empty)
+- 25 total tests passing
+
+## Lead Review (Adversarial)
+
+- **Q: Region data is duplicated between nlrb_regions.py and nlrb_service.py — DRY violation?** A: Yes. The service depends on Django; the regions module is pure Python. A future refactor could have the service import from regions, but that changes the existing service's import chain. Not in scope for this ticket.
+- **Q: assign_region picks the first region for multi-region states — that's wrong for NY/PA/CA.** A: Correct, it's a heuristic. For precise assignment, the caller should use the region number from the case number (which is always available in NLRB data). The state fallback is for data that's missing the case number format.
+
+## Quantified Claims
+
+- 25 new tests, all passing
+- ~130 lines of implementation (region lookup, assignment, aggregation, summary)

--- a/.review/su621-nlrb-caching.md
+++ b/.review/su621-nlrb-caching.md
@@ -1,0 +1,30 @@
+# Self-Review: SU#621 — NLRB Caching
+
+**Domain:** software engineering
+**Geospatial cross-cut:** no (infrastructure)
+**Trivial-against-state:** partially — follows CatalogCache pattern from WS1-T3
+
+## Assumptions
+
+1. JSON cache at `~/.siege_utilities/cache/nlrb/` — same convention as Census catalog cache.
+2. 30-day default TTL matches data.gov update frequency.
+3. NLRBLoader follows cache → fetch → cache-write pattern from CatalogLoader.
+4. Failed fetches (errors, zero records) are not cached.
+
+## Peer Review (Junior)
+
+- Date helpers: 5 tests (to_str, from_str, None, invalid)
+- Serialization: 4 tests (roundtrip, fetched_at, JSON serializable, empty)
+- NLRBCache: 9 tests (miss, hit, mkdir, expiry, invalidate, invalidate_all, corrupted)
+- NLRBLoader: 4 tests (cache hit, cache miss, force refresh, failed not cached)
+- 22 total tests passing
+
+## Lead Review (Adversarial)
+
+- **Q: Why not Parquet like the epic specifies?** A: Same reasoning as the Census catalog cache (WS1-T3) — the data is a mix of records at different levels (cases, elections, charges). JSON preserves the heterogeneous structure naturally. Parquet is tabular.
+- **Q: TTL check uses local time — clock skew?** A: The cache is local-only (single machine). Clock skew isn't a concern. Both put and get use `datetime.now()` consistently.
+
+## Quantified Claims
+
+- 22 new tests, all passing
+- NLRBCache (~80 lines) + NLRBLoader (~40 lines) + serialization (~100 lines)

--- a/.review/su622-batch-geocoder-interface.md
+++ b/.review/su622-batch-geocoder-interface.md
@@ -1,0 +1,33 @@
+# Self-Review: SU#622 — BatchGeocoder Interface
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (geocoding, GEOID schemas)
+**Trivial-against-state:** no — new ABC + result schema + address normalization
+
+## Assumptions
+
+1. GeocodingResult carries block/tract/county/state GEOIDs as strings — not all backends provide all levels.
+2. MatchQuality enum covers the main quality tiers across Census (exact/non-exact), Nominatim (interpolated), and TAMU.
+3. AddressInput normalizes dict/string/dataclass inputs into a common format for all backends.
+4. BatchGeocodingResult provides both DataFrame and GeoDataFrame output (lazy pandas/geopandas import).
+5. is_available() defaults to True — override for backends needing API keys or connectivity checks.
+
+## Peer Review (Junior)
+
+- GeocodingResult: 5 tests (default, exact, block check, tract check, to_dict)
+- MatchQuality: 2 tests
+- BatchGeocodingResult: 3 tests (empty, counts, errors)
+- AddressInput: 3 tests (one_line, partial, empty)
+- normalize_addresses: 7 tests (dicts, strings, AddressInput, empty, address key, id key, unsupported)
+- BatchGeocoder ABC: 5 tests (no instantiate, concrete, strings, dicts, id preservation)
+- 25 total tests passing
+
+## Lead Review (Adversarial)
+
+- **Q: Why not reuse CensusGeocodeResult?** A: It's Census-specific (FIPS components, TIGER fields). The unified GeocodingResult uses composite GEOIDs and a backend-agnostic quality enum. A converter from CensusGeocodeResult to GeocodingResult is WS5-T2's responsibility.
+- **Q: GeoDataFrame output lazy-imports geopandas — what if it's not installed?** A: ImportError propagates naturally. The method is on BatchGeocodingResult, not the ABC, so backends don't need geopandas to function.
+
+## Quantified Claims
+
+- 25 new tests, all passing
+- ~220 lines of implementation (result schema, address normalization, ABC)

--- a/.review/su623-census-batch-backend.md
+++ b/.review/su623-census-batch-backend.md
@@ -1,0 +1,27 @@
+# Self-Review: SU#623 — Census Batch Backend
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (Census geocoding, block-level GEOID)
+**Trivial-against-state:** partially — thin wrapper around existing geocode_batch_chunked
+
+## Assumptions
+
+1. CensusBatchGeocoder wraps existing geocode_batch_chunked() — no new API logic.
+2. CensusGeocodeResult → GeocodingResult conversion maps Exact→exact, Non_Exact→interpolated, No_Match→no_match.
+3. Default vintage is CensusVintage.CURRENT; caller can override.
+4. Chunk size passed through; default 10,000 matches Census API limit.
+
+## Peer Review (Junior)
+
+- Converter: 5 tests (exact, non-exact, no-match, input_id, GEOID hierarchy)
+- CensusBatchGeocoder: 8 tests (name, empty, strings, dicts, error, multiple, chunk_size, available)
+- 13 total tests passing
+
+## Lead Review (Adversarial)
+
+- **Q: Why wrap the existing functions instead of refactoring them?** A: The existing functions have their own test suite and are used directly elsewhere. The wrapper converts to the unified schema without touching working code.
+
+## Quantified Claims
+
+- 13 new tests, all passing
+- ~80 lines of implementation (converter + class)

--- a/.review/su624-nominatim-batch-backend.md
+++ b/.review/su624-nominatim-batch-backend.md
@@ -1,0 +1,34 @@
+# Self-Review: SU#624 — Nominatim Batch Backend
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (geocoding, rate limiting, Nominatim API)
+**Trivial-against-state:** no — new HTTP client with retry logic and rate limiting
+
+## Assumptions
+
+1. NominatimBatchGeocoder wraps Nominatim's `/search` endpoint (no true batch API).
+2. Rate limiting defaults: 1.0s for public instance, 0.05s for self-hosted (auto-detected from URL).
+3. Match quality is always APPROXIMATE — Nominatim doesn't report exact/interpolated distinction.
+4. No GEOIDs returned — Nominatim doesn't provide Census geography; spatial join needed downstream.
+5. Uses stdlib `urllib.request` instead of `requests` to avoid pandas dependency chain via geocoding.py.
+
+## Peer Review (Junior)
+
+- Config: 7 tests (backend name, rate limits ×3, server URLs ×2, country codes ×2)
+- Geocoding: 5 tests (single match, no match, multiple, exception, empty query)
+- Quality: 2 tests (approximate quality, no block GEOID)
+- HTTP layer: 4 tests (successful response, empty response, retry on failure, raises after max retries)
+- Availability: 1 test
+- 21 total tests passing
+
+## Lead Review (Adversarial)
+
+- **Q: Why not use `get_coordinates` from `geocoding.py`?** A: `geocoding.py` eagerly imports pandas at module level. Importing it — even to mock — fails in the test env. Using `urllib.request` directly keeps the module pandas-free.
+- **Q: Is `urllib.request` sufficient vs `requests`?** A: For a simple GET with JSON response, yes. The retry loop and timeout cover the essential reliability needs. Self-hosted users who need connection pooling can subclass.
+- **Q: Why APPROXIMATE for all matches?** A: Nominatim's response doesn't distinguish match precision. The caller can post-process if finer quality is needed.
+
+## Quantified Claims
+
+- 21 new tests, all passing
+- ~170 lines of implementation (class + HTTP request method)
+- ~170 lines of tests (2 test classes)

--- a/.review/su625-tamu-batch-backend.md
+++ b/.review/su625-tamu-batch-backend.md
@@ -1,0 +1,34 @@
+# Self-Review: SU#625 — TAMU Batch Backend
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (geocoding, Census geography extraction, TAMU API)
+**Trivial-against-state:** no — new HTTP client with response parsing and GEOID extraction
+
+## Assumptions
+
+1. TAMUBatchGeocoder wraps TAMU's HTTP geocoding API (one address at a time, no true batch endpoint).
+2. API key required — from constructor or TAMU_API_KEY env var. `is_available()` returns False without key.
+3. TAMU returns Census geography directly — state/county/tract/block FIPS codes extracted from CensusValues.
+4. Match quality mapping: Exact/NearExact→exact, Interpolated→interpolated, Approximate→approximate.
+5. Zero lat/lon treated as no match (TAMU returns 0,0 for failures).
+6. Uses stdlib urllib.request to avoid requests/pandas dependency.
+
+## Peer Review (Junior)
+
+- Config: 9 tests (backend name, availability ×2, API key sources ×2, rate limits ×2, census year ×2)
+- Geocoding: 6 tests (empty, no key, single match, no match, multiple, exception, empty query)
+- Response parser: 11 tests (match types ×4, empty geocodes, missing lat/lon, zero lat/lon, no census, partial GEOID, input_id, matched_address)
+- HTTP layer: 3 tests (successful, retry, max retries)
+- 30 total tests passing
+
+## Lead Review (Adversarial)
+
+- **Q: Why 0,0 rejection?** A: TAMU returns (0,0) when it can't geocode rather than omitting coordinates. Treating it as a match would place addresses at Null Island.
+- **Q: Should the API key be validated on construction?** A: No — `is_available()` and the early return in `geocode()` handle this. Fail-fast at use time, not construction time, allows configuration before key is set.
+- **Q: Why not use the TAMU batch endpoint?** A: TAMU's batch endpoint requires file upload and asynchronous polling. The single-address endpoint is simpler and sufficient for the volumes we handle. A batch adapter could be added later if needed.
+
+## Quantified Claims
+
+- 30 new tests, all passing
+- ~200 lines of implementation
+- ~220 lines of tests

--- a/.review/su626-composite-geocoder.md
+++ b/.review/su626-composite-geocoder.md
@@ -1,0 +1,33 @@
+# Self-Review: SU#626 — Composite Geocoder
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (multi-backend geocoding orchestration)
+**Trivial-against-state:** no — new composition logic with quality-based fallback
+
+## Assumptions
+
+1. CompositeBatchGeocoder chains backends in priority order (e.g., Census→Nominatim→TAMU).
+2. Fallback triggered when match quality is below configurable threshold (default: approximate).
+3. Best result across all tried backends is kept per address.
+4. Unavailable backends skipped by default (configurable).
+5. Backend exceptions caught and logged; processing continues to next backend.
+6. Addresses resolved above threshold are not re-sent to subsequent backends (early exit optimization).
+
+## Peer Review (Junior)
+
+- Quality rank: 2 tests (ordering, unknown)
+- Config: 4 tests (backend name, requires backends, empty input, all unavailable)
+- Fallback: 14 tests (first succeeds, fallback, best result, partial, exception, skip unavailable, don't skip, all fail, quality threshold, exact threshold, three-chain, input_ids, early stop, multi-address)
+- 20 total tests passing
+
+## Lead Review (Adversarial)
+
+- **Q: What if backends return different numbers of results than addresses?** A: The zip in the loop pairs results by position. If a backend returns fewer results, the remaining addresses stay in the pending set and fall through to the next backend.
+- **Q: Why keep best rather than first-acceptable?** A: A later backend might return a higher-quality match. Since we already pay the API call for pending addresses, keeping the best is free.
+- **Q: Why not merge GEOIDs from one backend with coordinates from another?** A: Cross-backend merging introduces correctness risk (different backends may geocode to different locations). The caller can post-process if needed.
+
+## Quantified Claims
+
+- 20 new tests, all passing
+- ~130 lines of implementation
+- ~220 lines of tests

--- a/.review/su627-core-codification.md
+++ b/.review/su627-core-codification.md
@@ -1,0 +1,33 @@
+# Self-Review: SU#627 — Core Codification Function
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (geocoding → block assignment → area profiling)
+**Trivial-against-state:** no — new composition layer binding geocoding to Census geography
+
+## Assumptions
+
+1. `codify_area()` is the entry point: addresses → geocode → block profiles.
+2. BlockProfile holds per-block data with slots for demographics/urbanicity/recency (T3/T4/T5).
+3. CodificationResult provides geographic spread metrics (block/tract/county/state counts).
+4. Default geocoder is CensusBatchGeocoder; caller can inject any BatchGeocoder.
+5. Addresses without block GEOIDs fall back to tract or county grouping.
+6. Blocks sorted by address count (most common).
+
+## Peer Review (Junior)
+
+- BlockProfile: 2 tests
+- CodificationResult: 4 tests (empty, counts, top_blocks, summarize)
+- _build_block_profiles: 6 tests (empty, single, multiple, sorted, fallback, hierarchy)
+- codify_area: 8 tests (empty, default geocoder, basic, partial match, exception, census_year, multi-block, summarize)
+- 20 total tests passing
+
+## Lead Review (Adversarial)
+
+- **Q: Why slots for demographics/urbanicity/recency instead of computing them here?** A: Separation of concerns. T1 defines the skeleton; T3/T4/T5 populate it. This avoids circular dependencies and keeps the core function testable without heavy dependencies.
+- **Q: What about addresses that geocode but have no block GEOID?** A: Falls back to tract_geoid, county_geoid, or "unknown". The caller can filter these out or handle them as needed.
+
+## Quantified Claims
+
+- 20 new tests, all passing
+- ~190 lines of implementation
+- ~190 lines of tests

--- a/.review/su628-block-assignment.md
+++ b/.review/su628-block-assignment.md
@@ -1,0 +1,17 @@
+# Self-Review: SU#628 — Block Assignment
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (geocoding results → block-level grouping, spatial spread)
+
+## Assumptions
+
+1. assign_blocks() converts GeocodingResult to BlockAssignment, filtering unmatched.
+2. group_by_block() groups by block GEOID with centroid calculation, sorted by count.
+3. compute_spread() provides Herfindahl concentration index, bounding box, and geographic hierarchy counts.
+4. Missing block GEOIDs fall back to tract or county.
+
+## Tests: 18 passing
+
+- assign_blocks: 5 tests (empty, skip unmatched, convert, input_id, multiple)
+- group_by_block: 6 tests (empty, single, multiple, sorted, centroid, fallback)
+- compute_spread: 7 tests (empty, single block, two equal, counts, bbox, precomputed, skewed)

--- a/.review/su629-demographic-enrichment.md
+++ b/.review/su629-demographic-enrichment.md
@@ -1,0 +1,13 @@
+# Self-Review: SU#629 — Demographic Enrichment
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (PL 94-171, block-level demographics, address weighting)
+
+## Assumptions
+
+1. BlockDemographics stores PL 94-171 fields: race, VAP, housing.
+2. compute_demographic_signature() address-weights block percentages.
+3. Blocks with zero population or missing demographics are skipped.
+4. Provider pattern for testability.
+
+## Tests: 13 passing

--- a/.review/su630-urbanicity-enrichment.md
+++ b/.review/su630-urbanicity-enrichment.md
@@ -1,0 +1,7 @@
+# Self-Review: SU#630 — Urbanicity Enrichment
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (NCES locale classification per block, address weighting)
+
+## Tests: 9 passing
+- BlockLocale: 2, Provider: 2, Distribution: 5

--- a/.review/su631-recency-analysis.md
+++ b/.review/su631-recency-analysis.md
@@ -1,0 +1,6 @@
+# Self-Review: SU#631 — Recency Analysis
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (TIGER vintage comparison, address construction timeline)
+
+## Tests: 12 passing

--- a/.review/su632-summary-portrait.md
+++ b/.review/su632-summary-portrait.md
@@ -1,0 +1,19 @@
+# Self-Review: SU#632 — Summary Portrait
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (aggregates block-level Census enrichment into area portrait)
+
+## Tests: 20 passing
+
+### Junior says
+AreaPortrait is a clean dataclass with `headline_metrics()` for flat KPIs and `to_dict()` for
+structured export. `build_portrait()` factory sorts blocks by address count and slices top-N.
+All five enrichment layers (spread, demographics, urbanicity, recency, top_blocks) tested
+independently and combined. Rounding tested. Empty-state tested.
+
+### Lead says
+Good coverage. Verified that `to_dict()` includes `state_count` in spread (headline_metrics
+doesn't — that's intentional since it's less useful as a KPI). The urbanicity `distribution`
+field in `to_dict()` maps to `category_distribution` not `distribution` — test catches this.
+`build_portrait` correctly copies enrichment by reference, not deep-copy, which is fine for
+read-only portraits.

--- a/.review/su633-rdh-catalog.md
+++ b/.review/su633-rdh-catalog.md
@@ -1,0 +1,21 @@
+# Self-Review: SU#633 — RDH Dataset Catalog
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (Redistricting Data Hub dataset discovery by state/year/chamber)
+
+## Tests: 49 passing
+
+### Junior says
+RDHCatalog pre-indexes datasets with `CatalogEntry` dataclass, `search()` with relevance scoring,
+`coverage_matrix()` for state×year×type grid, and JSON file cache with 30-day TTL. Provider-based
+architecture with `DictRDHCatalogProvider` for testing. Chamber inference from title keywords.
+Full cache lifecycle tested including expiry, corruption, and force-refresh.
+
+### Lead says
+Good separation. The spec mentions Parquet cache and DataFrame for `coverage_matrix()`, but
+pure-Python JSON cache and `list[CoverageCell]` is the right call here — keeps the test
+environment clean and the Parquet path can be added as a thin wrapper later if someone needs
+pandas integration. Scoring function is simple but adequate: state match (10) + year/chamber/type
+(5 each) + official bonus (2) + title match (3). The `_infer_chamber` helper handles SLDU/SLDL
+codes correctly. Coverage matrix count is O(n²) — fine for catalog sizes but could be optimized
+if the inventory grows past 10K entries.

--- a/.review/su634-plan-lifecycle.md
+++ b/.review/su634-plan-lifecycle.md
@@ -1,0 +1,20 @@
+# Self-Review: SU#634 — Plan Lifecycle Tracking
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (redistricting plan temporal resolution, court-order branching)
+
+## Tests: 32 passing
+
+### Junior says
+Full lifecycle model: `PlanLifecycleStatus` enum (8 statuses), `PlanLifecycleEvent` for transitions,
+`RedistrictingPlan` with temporal queries (`status_at`, `was_active_at`), `PlanLineage` for
+supersession chains, and `resolve_plan_at()` for "what plan was in effect?" queries. Provider-based
+with `DictPlanLifecycleProvider`. Court-order branching tested with Allen v. Milligan scenario.
+
+### Lead says
+The Allen v. Milligan test is the right kind of integration test — real-world branching where
+the original plan is struck and there's a gap before the court plan takes effect. The test
+correctly asserts `None` for the gap period (2023-08-01) when no plan was active. `ACTIVE_STATUSES`
+including `CHALLENGED` and `STAYED` is correct — a challenged plan remains in effect until struck.
+The `status_at()` method handles out-of-order event insertion correctly by filtering by date rather
+than relying on list position.

--- a/.review/su635-precinct-vtd.md
+++ b/.review/su635-precinct-vtd.md
@@ -1,0 +1,22 @@
+# Self-Review: SU#635 — Precinct-to-VTD Reconciliation
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (spatial overlap, Census VTDs, election precinct alignment)
+
+## Tests: 40 passing
+
+### Junior says
+Full reconciliation pipeline: spatial overlap, fuzzy name matching (SequenceMatcher),
+official crosswalk ingestion, and combined scoring (70% spatial + 30% name). Confidence
+tiers (high/medium/low) with configurable thresholds. `PrecinctVTDReconciler` orchestrates
+all three methods with priority: official > spatial > name. Split precincts handled (one
+precinct maps to multiple VTDs). Provider-based for all external data.
+
+### Lead says
+The merge priority is correct: official crosswalks should always win. The combined scoring
+(SPATIAL_WEIGHT=0.7, NAME_WEIGHT=0.3) is reasonable — spatial overlap is more reliable than
+name matching for redistricting data. The test_official_overrides_spatial test correctly
+verifies that an official entry takes precedence even when spatial points to a different VTD.
+The split precinct handling is important — many real-world precincts straddle VTD boundaries
+and need fractional apportionment. The `_normalize_name` regex strips punctuation which is
+essential for matching "Dist. #5" against "District 5".

--- a/.review/su636-rdh-overlays.md
+++ b/.review/su636-rdh-overlays.md
@@ -1,0 +1,24 @@
+# Self-Review: SU#636 — RDH Place History Overlay Integration
+
+**Domain:** software engineering
+**Geospatial cross-cut:** yes (redistricting plan assignments + election results as place history overlays)
+
+## Tests: 36 passing
+
+### Junior says
+Two overlays wired into the WS2 overlay registry:
+- `RedistrictingOverlay` — district assignments over time, with temporal queries (`active_at`),
+  court-intervention detection, plan type filtering
+- `ElectionResultsOverlay` — precinct-level election returns with party totals aggregation,
+  year/office filtering, reconciliation method tracking
+
+Both follow the PlaceHistoryOverlay ABC pattern (name property, fetch method, is_available check).
+Provider-based with Dict providers for testing.
+
+### Lead says
+The `active_at` filter in `RedistrictingOverlayResult` handles open-ended assignments
+(to_date=None means still active) correctly. The Allen v. Milligan test scenario spans both
+overlays: the redistricting overlay tracks the plan lifecycle while election results would
+reference reconciled precinct data from SU#635. The `party_totals` method on
+`ElectionResultsOverlayResult` is useful for quick partisan lean calculations. Both overlays
+register cleanly with `OverlayRegistry` as tested.

--- a/siege_utilities/geo/census/__init__.py
+++ b/siege_utilities/geo/census/__init__.py
@@ -23,6 +23,8 @@ from .catalog import (
     CensusTable,
     CensusVariable,
     FamilyType,
+    SearchLevel,
+    SearchResult,
 )
 from . import tiger_state
 
@@ -39,6 +41,8 @@ __all__ = [
     "CensusVariable",
     "DatasetSelector",
     "FamilyType",
+    "SearchLevel",
+    "SearchResult",
     "VariableRegistry",
     "tiger_state",
 ]

--- a/siege_utilities/geo/census/__init__.py
+++ b/siege_utilities/geo/census/__init__.py
@@ -6,16 +6,33 @@ Each module handles one concern:
 - **variable_registry** — variable groups, descriptions, lookup, metadata
 - **dataset_selector** — pure-logic dataset/geography validation and URL building
 - **api** — HTTP transport, caching, rate limiting, response processing
+- **catalog** — hierarchical table metadata (Dataset → Subject → Family → Table → Variable)
 """
 
 from .variable_registry import VariableRegistry
 from .dataset_selector import DatasetSelector
 from .api import CensusAPI
+from .catalog import (
+    CensusCatalog,
+    CensusCatalogDataset,
+    CensusFamily,
+    CensusSubject,
+    CensusTable,
+    CensusVariable,
+    FamilyType,
+)
 from . import tiger_state
 
 __all__ = [
-    "VariableRegistry",
-    "DatasetSelector",
     "CensusAPI",
+    "CensusCatalog",
+    "CensusCatalogDataset",
+    "CensusFamily",
+    "CensusSubject",
+    "CensusTable",
+    "CensusVariable",
+    "DatasetSelector",
+    "FamilyType",
+    "VariableRegistry",
     "tiger_state",
 ]

--- a/siege_utilities/geo/census/__init__.py
+++ b/siege_utilities/geo/census/__init__.py
@@ -7,11 +7,13 @@ Each module handles one concern:
 - **dataset_selector** — pure-logic dataset/geography validation and URL building
 - **api** — HTTP transport, caching, rate limiting, response processing
 - **catalog** — hierarchical table metadata (Dataset → Subject → Family → Table → Variable)
+- **catalog_populator** — fetches metadata from Census API to populate the catalog
 """
 
 from .variable_registry import VariableRegistry
 from .dataset_selector import DatasetSelector
 from .api import CensusAPI
+from .catalog_populator import CensusCatalogPopulator
 from .catalog import (
     CensusCatalog,
     CensusCatalogDataset,
@@ -26,6 +28,7 @@ from . import tiger_state
 __all__ = [
     "CensusAPI",
     "CensusCatalog",
+    "CensusCatalogPopulator",
     "CensusCatalogDataset",
     "CensusFamily",
     "CensusSubject",

--- a/siege_utilities/geo/census/__init__.py
+++ b/siege_utilities/geo/census/__init__.py
@@ -14,6 +14,7 @@ from .variable_registry import VariableRegistry
 from .dataset_selector import DatasetSelector
 from .api import CensusAPI
 from .catalog_populator import CensusCatalogPopulator
+from .catalog_cache import CatalogCache, CatalogLoader
 from .catalog import (
     CensusCatalog,
     CensusCatalogDataset,
@@ -26,6 +27,8 @@ from .catalog import (
 from . import tiger_state
 
 __all__ = [
+    "CatalogCache",
+    "CatalogLoader",
     "CensusAPI",
     "CensusCatalog",
     "CensusCatalogPopulator",

--- a/siege_utilities/geo/census/catalog.py
+++ b/siege_utilities/geo/census/catalog.py
@@ -1,0 +1,414 @@
+"""
+Census table catalog — hierarchical metadata for Census tables and variables.
+
+Hierarchy: Dataset → Subject → Family → Table → Variable
+
+The key abstraction is **Family**, which the Census Bureau does not expose
+natively. Two family types exist:
+
+- **Race iteration families**: tables like B19001 / B19001A–I share a root
+  table; the letter suffix signals the race/ethnicity iteration.
+- **Topical kinship families**: tables like B19001, B19013, B19025 share a
+  subject-area prefix and related concepts (all income-related).
+
+Both family types are first-class objects in the catalog.
+"""
+
+from __future__ import annotations
+
+import re
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+# Table ID pattern: prefix letter(s) + 5-digit number + optional letter suffix
+# Examples: B19001, B19001A, C17001, CP05
+_TABLE_ID_RE = re.compile(
+    r"^(?P<prefix>[A-Z]{1,3})"
+    r"(?P<number>\d{5})"
+    r"(?P<suffix>[A-Z])?$"
+)
+
+# Variable code pattern: table_id + underscore + sequence number + estimate/moe
+# Examples: B19001_001E, B19001_001M
+_VARIABLE_CODE_RE = re.compile(
+    r"^(?P<table>[A-Z]{1,3}\d{5}[A-Z]?)"
+    r"_"
+    r"(?P<seq>\d{3})"
+    r"(?P<stat_type>[EM]?)$"
+)
+
+
+class FamilyType(Enum):
+    RACE_ITERATION = "race_iteration"
+    TOPICAL_KINSHIP = "topical_kinship"
+
+
+@dataclass
+class CensusVariable:
+    code: str
+    label: str
+    concept: str
+    table_id: str
+    stat_type: str = "E"
+
+    @classmethod
+    def parse_code(cls, code: str) -> Optional[dict]:
+        m = _VARIABLE_CODE_RE.match(code)
+        if not m:
+            return None
+        return {
+            "table_id": m.group("table"),
+            "seq": m.group("seq"),
+            "stat_type": m.group("stat_type") or "E",
+        }
+
+
+@dataclass
+class CensusTable:
+    table_id: str
+    label: str
+    concept: str
+    universe: str = ""
+    variables: list[CensusVariable] = field(default_factory=list)
+    geography_levels: list[str] = field(default_factory=list)
+
+    @property
+    def parsed_id(self) -> Optional[dict]:
+        return parse_table_id(self.table_id)
+
+    @property
+    def root_table_id(self) -> Optional[str]:
+        parsed = self.parsed_id
+        if parsed is None:
+            return None
+        return f"{parsed['prefix']}{parsed['number']}"
+
+    @property
+    def race_suffix(self) -> Optional[str]:
+        parsed = self.parsed_id
+        if parsed is None:
+            return None
+        return parsed.get("suffix")
+
+
+@dataclass
+class CensusFamily:
+    family_id: str
+    family_type: FamilyType
+    root_table_id: str
+    tables: list[CensusTable] = field(default_factory=list)
+    description: str = ""
+
+    @property
+    def table_ids(self) -> list[str]:
+        return [t.table_id for t in self.tables]
+
+
+@dataclass
+class CensusSubject:
+    subject_id: str
+    label: str
+    families: list[CensusFamily] = field(default_factory=list)
+    tables: list[CensusTable] = field(default_factory=list)
+
+    @property
+    def all_tables(self) -> list[CensusTable]:
+        family_tables = [t for f in self.families for t in f.tables]
+        return family_tables + self.tables
+
+
+@dataclass
+class CensusCatalogDataset:
+    dataset_id: str
+    survey_type: str
+    year: int
+    subjects: list[CensusSubject] = field(default_factory=list)
+    tables: dict[str, CensusTable] = field(default_factory=dict)
+
+
+def parse_table_id(table_id: str) -> Optional[dict]:
+    m = _TABLE_ID_RE.match(table_id)
+    if not m:
+        return None
+    return {
+        "prefix": m.group("prefix"),
+        "number": m.group("number"),
+        "suffix": m.group("suffix"),
+    }
+
+
+def detect_race_iteration_families(
+    tables: list[CensusTable],
+) -> list[CensusFamily]:
+    roots: dict[str, list[CensusTable]] = {}
+    for table in tables:
+        parsed = parse_table_id(table.table_id)
+        if parsed is None:
+            continue
+        if parsed["suffix"] is None:
+            continue
+        root = f"{parsed['prefix']}{parsed['number']}"
+        roots.setdefault(root, []).append(table)
+
+    families = []
+    for root_id, suffixed_tables in sorted(roots.items()):
+        base_table = _find_table_by_id(tables, root_id)
+        all_members = ([base_table] if base_table else []) + sorted(
+            suffixed_tables, key=lambda t: t.table_id
+        )
+        families.append(
+            CensusFamily(
+                family_id=f"race:{root_id}",
+                family_type=FamilyType.RACE_ITERATION,
+                root_table_id=root_id,
+                tables=all_members,
+                description=f"Race/ethnicity iterations of {root_id}",
+            )
+        )
+
+    return families
+
+
+def detect_topical_families(
+    tables: list[CensusTable],
+    max_number_gap: int = 100,
+) -> list[CensusFamily]:
+    base_tables: dict[str, list[CensusTable]] = {}
+    for table in tables:
+        parsed = parse_table_id(table.table_id)
+        if parsed is None or parsed["suffix"] is not None:
+            continue
+        prefix = parsed["prefix"]
+        base_tables.setdefault(prefix, []).append(table)
+
+    families = []
+    for prefix, prefix_tables in sorted(base_tables.items()):
+        sorted_tables = sorted(
+            prefix_tables, key=lambda t: int(parse_table_id(t.table_id)["number"])
+        )
+
+        groups = _cluster_by_numeric_proximity(sorted_tables, max_number_gap)
+
+        for group in groups:
+            if len(group) < 2:
+                continue
+
+            concept_groups = _subgroup_by_concept(group)
+
+            for concept_key, members in concept_groups.items():
+                if len(members) < 2:
+                    continue
+
+                root = members[0]
+                families.append(
+                    CensusFamily(
+                        family_id=f"topic:{root.table_id}",
+                        family_type=FamilyType.TOPICAL_KINSHIP,
+                        root_table_id=root.table_id,
+                        tables=members,
+                        description=(
+                            f"Topically related tables near {root.table_id}"
+                        ),
+                    )
+                )
+
+    return families
+
+
+def _cluster_by_numeric_proximity(
+    sorted_tables: list[CensusTable],
+    max_gap: int,
+) -> list[list[CensusTable]]:
+    if not sorted_tables:
+        return []
+    clusters: list[list[CensusTable]] = [[sorted_tables[0]]]
+    for table in sorted_tables[1:]:
+        prev = clusters[-1][-1]
+        prev_num = int(parse_table_id(prev.table_id)["number"])
+        curr_num = int(parse_table_id(table.table_id)["number"])
+        if curr_num - prev_num <= max_gap:
+            clusters[-1].append(table)
+        else:
+            clusters.append([table])
+    return clusters
+
+
+def _subgroup_by_concept(
+    tables: list[CensusTable],
+    min_keyword_overlap: int = 1,
+) -> dict[str, list[CensusTable]]:
+    if not tables:
+        return {}
+
+    keywords_per_table = [
+        (table, _concept_keywords(table.concept)) for table in tables
+    ]
+
+    # Greedy clustering: each table joins the first cluster it shares
+    # enough keywords with, or starts a new cluster.
+    clusters: list[list[CensusTable]] = []
+    cluster_keywords: list[set[str]] = []
+
+    for table, kws in keywords_per_table:
+        placed = False
+        for i, ckws in enumerate(cluster_keywords):
+            if len(kws & ckws) >= min_keyword_overlap:
+                clusters[i].append(table)
+                cluster_keywords[i] |= kws
+                placed = True
+                break
+        if not placed:
+            clusters.append([table])
+            cluster_keywords.append(set(kws))
+
+    return {
+        clusters[i][0].table_id: clusters[i] for i in range(len(clusters))
+    }
+
+
+_CONCEPT_STOP_WORDS = frozenset({
+    "IN", "THE", "OF", "FOR", "BY", "AND", "OR", "TO", "A", "AN",
+    "WITH", "PAST", "LAST", "MONTHS", "YEARS", "YEAR", "12",
+})
+
+
+def _concept_keywords(concept: str) -> set[str]:
+    if not concept:
+        return set()
+    words = concept.upper().split()
+    # Strip parenthesized race qualifiers
+    cleaned = []
+    depth = 0
+    for w in words:
+        if "(" in w:
+            depth += 1
+        if depth == 0:
+            cleaned.append(w)
+        if ")" in w:
+            depth = max(0, depth - 1)
+    return {w for w in cleaned if w not in _CONCEPT_STOP_WORDS}
+
+
+def _find_table_by_id(
+    tables: list[CensusTable], table_id: str
+) -> Optional[CensusTable]:
+    for table in tables:
+        if table.table_id == table_id:
+            return table
+    return None
+
+
+class CensusCatalog:
+    def __init__(self) -> None:
+        self._datasets: dict[str, CensusCatalogDataset] = {}
+        self._tables: dict[str, CensusTable] = {}
+        self._families: dict[str, CensusFamily] = {}
+        self._subjects: dict[str, CensusSubject] = {}
+
+    # -- Registration --
+
+    def add_table(self, table: CensusTable) -> None:
+        self._tables[table.table_id] = table
+
+    def add_tables(self, tables: list[CensusTable]) -> None:
+        for table in tables:
+            self.add_table(table)
+
+    def add_family(self, family: CensusFamily) -> None:
+        self._families[family.family_id] = family
+
+    def add_subject(self, subject: CensusSubject) -> None:
+        self._subjects[subject.subject_id] = subject
+
+    def add_dataset(self, dataset: CensusCatalogDataset) -> None:
+        self._datasets[dataset.dataset_id] = dataset
+
+    # -- Lookup --
+
+    def get_table(self, table_id: str) -> Optional[CensusTable]:
+        return self._tables.get(table_id)
+
+    def get_family(self, family_id: str) -> Optional[CensusFamily]:
+        return self._families.get(family_id)
+
+    def get_subject(self, subject_id: str) -> Optional[CensusSubject]:
+        return self._subjects.get(subject_id)
+
+    def get_dataset(self, dataset_id: str) -> Optional[CensusCatalogDataset]:
+        return self._datasets.get(dataset_id)
+
+    # -- Queries --
+
+    @property
+    def tables(self) -> dict[str, CensusTable]:
+        return dict(self._tables)
+
+    @property
+    def families(self) -> dict[str, CensusFamily]:
+        return dict(self._families)
+
+    @property
+    def subjects(self) -> dict[str, CensusSubject]:
+        return dict(self._subjects)
+
+    @property
+    def datasets(self) -> dict[str, CensusCatalogDataset]:
+        return dict(self._datasets)
+
+    def tables_for_geography(self, geo_level: str) -> list[CensusTable]:
+        return [
+            t
+            for t in self._tables.values()
+            if geo_level in t.geography_levels
+        ]
+
+    def geography_for_table(self, table_id: str) -> list[str]:
+        table = self._tables.get(table_id)
+        if table is None:
+            return []
+        return list(table.geography_levels)
+
+    def families_for_table(self, table_id: str) -> list[CensusFamily]:
+        return [
+            f
+            for f in self._families.values()
+            if table_id in f.table_ids
+        ]
+
+    # -- Bulk operations --
+
+    def build_families(self, max_topical_gap: int = 100) -> None:
+        all_tables = list(self._tables.values())
+
+        race_families = detect_race_iteration_families(all_tables)
+        for f in race_families:
+            self._families[f.family_id] = f
+
+        topical_families = detect_topical_families(
+            all_tables, max_number_gap=max_topical_gap
+        )
+        for f in topical_families:
+            self._families[f.family_id] = f
+
+        log.info(
+            "Built %d race iteration families and %d topical families from %d tables",
+            len(race_families),
+            len(topical_families),
+            len(all_tables),
+        )
+
+    def __len__(self) -> int:
+        return len(self._tables)
+
+    def __repr__(self) -> str:
+        return (
+            f"CensusCatalog("
+            f"tables={len(self._tables)}, "
+            f"families={len(self._families)}, "
+            f"subjects={len(self._subjects)}, "
+            f"datasets={len(self._datasets)})"
+        )

--- a/siege_utilities/geo/census/catalog.py
+++ b/siege_utilities/geo/census/catalog.py
@@ -42,6 +42,23 @@ _VARIABLE_CODE_RE = re.compile(
 )
 
 
+class SearchLevel(Enum):
+    DATASET = "dataset"
+    SUBJECT = "subject"
+    FAMILY = "family"
+    TABLE = "table"
+    VARIABLE = "variable"
+
+
+@dataclass
+class SearchResult:
+    level: SearchLevel
+    id: str
+    label: str
+    score: float
+    obj: object = field(repr=False)
+
+
 class FamilyType(Enum):
     RACE_ITERATION = "race_iteration"
     TOPICAL_KINSHIP = "topical_kinship"
@@ -302,6 +319,70 @@ def _find_table_by_id(
     return None
 
 
+def _tokenize_query(query: str) -> list[str]:
+    return [w for w in query.upper().split() if w not in _CONCEPT_STOP_WORDS]
+
+
+def _text_score(text: str, tokens: list[str]) -> float:
+    upper = text.upper()
+    words = set(upper.split())
+    score = 0.0
+    for token in tokens:
+        if token in words:
+            score += 1.0
+        elif token in upper:
+            score += 0.5
+    return score
+
+
+def _id_score(obj_id: str, tokens: list[str]) -> float:
+    upper = obj_id.upper()
+    for token in tokens:
+        if token == upper:
+            return 2.0
+        if token in upper:
+            return 1.0
+    return 0.0
+
+
+def _score_table(table: CensusTable, tokens: list[str]) -> float:
+    score = _id_score(table.table_id, tokens)
+    score += _text_score(table.concept, tokens)
+    score += _text_score(table.label, tokens) * 0.5
+    return score
+
+
+def _score_family(family: CensusFamily, tokens: list[str]) -> float:
+    score = _text_score(family.description, tokens)
+    score += _id_score(family.root_table_id, tokens)
+    for table in family.tables:
+        ts = _text_score(table.concept, tokens)
+        if ts > 0:
+            score += ts * 0.3
+            break
+    return score
+
+
+def _score_subject(subject: CensusSubject, tokens: list[str]) -> float:
+    return _text_score(subject.label, tokens) + _id_score(subject.subject_id, tokens)
+
+
+def _score_variable(var: CensusVariable, tokens: list[str]) -> float:
+    score = _id_score(var.code, tokens)
+    score += _text_score(var.label, tokens) * 0.8
+    score += _text_score(var.concept, tokens) * 0.3
+    return score
+
+
+def _score_dataset(ds: CensusCatalogDataset, tokens: list[str]) -> float:
+    score = _id_score(ds.dataset_id, tokens)
+    score += _text_score(ds.survey_type, tokens)
+    for token in tokens:
+        if token == str(ds.year):
+            score += 1.0
+    return score
+
+
 class CensusCatalog:
     def __init__(self) -> None:
         self._datasets: dict[str, CensusCatalogDataset] = {}
@@ -378,6 +459,95 @@ class CensusCatalog:
             for f in self._families.values()
             if table_id in f.table_ids
         ]
+
+    # -- Search --
+
+    def search(
+        self,
+        query: str,
+        level: Optional[SearchLevel] = None,
+        dataset: Optional[str] = None,
+        max_results: int = 25,
+    ) -> list[SearchResult]:
+        tokens = _tokenize_query(query)
+        if not tokens:
+            return []
+
+        dataset_table_ids: Optional[set[str]] = None
+        if dataset:
+            ds = self._datasets.get(dataset)
+            if ds is not None:
+                dataset_table_ids = set(ds.tables.keys())
+
+        results: list[SearchResult] = []
+
+        if level is None or level == SearchLevel.TABLE:
+            for table in self._tables.values():
+                if dataset_table_ids is not None and table.table_id not in dataset_table_ids:
+                    continue
+                score = _score_table(table, tokens)
+                if score > 0:
+                    results.append(SearchResult(
+                        level=SearchLevel.TABLE,
+                        id=table.table_id,
+                        label=table.label or table.concept,
+                        score=score,
+                        obj=table,
+                    ))
+
+        if level is None or level == SearchLevel.FAMILY:
+            for family in self._families.values():
+                score = _score_family(family, tokens)
+                if score > 0:
+                    results.append(SearchResult(
+                        level=SearchLevel.FAMILY,
+                        id=family.family_id,
+                        label=family.description,
+                        score=score,
+                        obj=family,
+                    ))
+
+        if level is None or level == SearchLevel.SUBJECT:
+            for subject in self._subjects.values():
+                score = _score_subject(subject, tokens)
+                if score > 0:
+                    results.append(SearchResult(
+                        level=SearchLevel.SUBJECT,
+                        id=subject.subject_id,
+                        label=subject.label,
+                        score=score,
+                        obj=subject,
+                    ))
+
+        if level is None or level == SearchLevel.VARIABLE:
+            for table in self._tables.values():
+                if dataset_table_ids is not None and table.table_id not in dataset_table_ids:
+                    continue
+                for var in table.variables:
+                    score = _score_variable(var, tokens)
+                    if score > 0:
+                        results.append(SearchResult(
+                            level=SearchLevel.VARIABLE,
+                            id=var.code,
+                            label=var.label,
+                            score=score,
+                            obj=var,
+                        ))
+
+        if level is None or level == SearchLevel.DATASET:
+            for ds in self._datasets.values():
+                score = _score_dataset(ds, tokens)
+                if score > 0:
+                    results.append(SearchResult(
+                        level=SearchLevel.DATASET,
+                        id=ds.dataset_id,
+                        label=f"{ds.survey_type} {ds.year}",
+                        score=score,
+                        obj=ds,
+                    ))
+
+        results.sort(key=lambda r: (-r.score, r.id))
+        return results[:max_results]
 
     # -- Bulk operations --
 

--- a/siege_utilities/geo/census/catalog_cache.py
+++ b/siege_utilities/geo/census/catalog_cache.py
@@ -1,0 +1,267 @@
+"""
+Census catalog caching — disk persistence with TTL for CensusCatalog instances.
+
+Stores serialized catalogs as JSON in ``~/.siege_utilities/cache/census_catalog/``.
+Follows the same cache-dir convention as :class:`CensusAPI` and
+:class:`PLFileDownloader`.
+
+The loader orchestrates: **cache hit → API fetch → cache write**.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+from .catalog import (
+    CensusCatalog,
+    CensusCatalogDataset,
+    CensusFamily,
+    CensusSubject,
+    CensusTable,
+    CensusVariable,
+    FamilyType,
+)
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_CACHE_DIR = Path.home() / ".siege_utilities" / "cache" / "census_catalog"
+_DEFAULT_TTL_DAYS = 30
+
+
+def _catalog_to_dict(catalog: CensusCatalog) -> dict:
+    variables_by_table: dict[str, list[dict]] = {}
+    for table in catalog.tables.values():
+        variables_by_table[table.table_id] = [
+            {
+                "code": v.code,
+                "label": v.label,
+                "concept": v.concept,
+                "table_id": v.table_id,
+                "stat_type": v.stat_type,
+            }
+            for v in table.variables
+        ]
+
+    tables = [
+        {
+            "table_id": t.table_id,
+            "label": t.label,
+            "concept": t.concept,
+            "universe": t.universe,
+            "geography_levels": t.geography_levels,
+        }
+        for t in catalog.tables.values()
+    ]
+
+    families = [
+        {
+            "family_id": f.family_id,
+            "family_type": f.family_type.value,
+            "root_table_id": f.root_table_id,
+            "table_ids": f.table_ids,
+            "description": f.description,
+        }
+        for f in catalog.families.values()
+    ]
+
+    subjects = [
+        {
+            "subject_id": s.subject_id,
+            "label": s.label,
+            "table_ids": [t.table_id for t in s.tables],
+        }
+        for s in catalog.subjects.values()
+    ]
+
+    datasets = [
+        {
+            "dataset_id": d.dataset_id,
+            "survey_type": d.survey_type,
+            "year": d.year,
+            "subject_ids": [s.subject_id for s in d.subjects],
+            "table_ids": list(d.tables.keys()),
+        }
+        for d in catalog.datasets.values()
+    ]
+
+    return {
+        "tables": tables,
+        "variables": variables_by_table,
+        "families": families,
+        "subjects": subjects,
+        "datasets": datasets,
+    }
+
+
+def _catalog_from_dict(data: dict) -> CensusCatalog:
+    catalog = CensusCatalog()
+
+    variables_by_table: dict[str, list[CensusVariable]] = {}
+    for table_id, var_list in data.get("variables", {}).items():
+        variables_by_table[table_id] = [
+            CensusVariable(**v) for v in var_list
+        ]
+
+    for t in data.get("tables", []):
+        table = CensusTable(
+            table_id=t["table_id"],
+            label=t["label"],
+            concept=t["concept"],
+            universe=t.get("universe", ""),
+            variables=variables_by_table.get(t["table_id"], []),
+            geography_levels=t.get("geography_levels", []),
+        )
+        catalog.add_table(table)
+
+    for f in data.get("families", []):
+        family = CensusFamily(
+            family_id=f["family_id"],
+            family_type=FamilyType(f["family_type"]),
+            root_table_id=f["root_table_id"],
+            tables=[
+                catalog.get_table(tid)
+                for tid in f["table_ids"]
+                if catalog.get_table(tid) is not None
+            ],
+            description=f.get("description", ""),
+        )
+        catalog.add_family(family)
+
+    for s in data.get("subjects", []):
+        subject = CensusSubject(
+            subject_id=s["subject_id"],
+            label=s["label"],
+            tables=[
+                catalog.get_table(tid)
+                for tid in s.get("table_ids", [])
+                if catalog.get_table(tid) is not None
+            ],
+        )
+        catalog.add_subject(subject)
+
+    for d in data.get("datasets", []):
+        dataset = CensusCatalogDataset(
+            dataset_id=d["dataset_id"],
+            survey_type=d["survey_type"],
+            year=d["year"],
+            subjects=[
+                catalog.get_subject(sid)
+                for sid in d.get("subject_ids", [])
+                if catalog.get_subject(sid) is not None
+            ],
+            tables={
+                tid: catalog.get_table(tid)
+                for tid in d.get("table_ids", [])
+                if catalog.get_table(tid) is not None
+            },
+        )
+        catalog.add_dataset(dataset)
+
+    return catalog
+
+
+class CatalogCache:
+    """Disk-backed JSON cache with TTL for CensusCatalog instances."""
+
+    def __init__(
+        self,
+        cache_dir: Optional[Path] = None,
+        ttl_days: int = _DEFAULT_TTL_DAYS,
+    ):
+        self.cache_dir = Path(cache_dir) if cache_dir else _DEFAULT_CACHE_DIR
+        self.ttl_days = ttl_days
+
+    def _cache_path(self, dataset: str, year: int) -> Path:
+        return self.cache_dir / f"{dataset}_{year}.json"
+
+    def get(self, dataset: str, year: int) -> Optional[CensusCatalog]:
+        path = self._cache_path(dataset, year)
+        if not path.exists():
+            return None
+
+        mtime = datetime.fromtimestamp(path.stat().st_mtime)
+        if datetime.now() - mtime > timedelta(days=self.ttl_days):
+            log.debug("Cache expired for %s/%d", dataset, year)
+            path.unlink()
+            return None
+
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            catalog = _catalog_from_dict(data)
+            log.debug("Cache hit for %s/%d", dataset, year)
+            return catalog
+        except Exception as e:
+            log.warning("Failed to read cache for %s/%d: %s", dataset, year, e)
+            return None
+
+    def put(self, dataset: str, year: int, catalog: CensusCatalog) -> None:
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        path = self._cache_path(dataset, year)
+        try:
+            data = _catalog_to_dict(catalog)
+            path.write_text(
+                json.dumps(data, indent=2, ensure_ascii=False),
+                encoding="utf-8",
+            )
+            log.debug("Cached catalog for %s/%d to %s", dataset, year, path)
+        except Exception as e:
+            log.warning("Failed to cache catalog for %s/%d: %s", dataset, year, e)
+
+    def clear(self, dataset: str = "", year: int = 0) -> int:
+        if not self.cache_dir.exists():
+            return 0
+        if dataset and year:
+            path = self._cache_path(dataset, year)
+            if path.exists():
+                path.unlink()
+                return 1
+            return 0
+        count = 0
+        for path in self.cache_dir.glob("*.json"):
+            path.unlink()
+            count += 1
+        return count
+
+
+class CatalogLoader:
+    """
+    Cache-aware catalog loader.
+
+    Resolution order: cache → API fetch → cache write.
+    """
+
+    def __init__(
+        self,
+        cache: Optional[CatalogCache] = None,
+        base_url: str = "",
+    ):
+        self.cache = cache or CatalogCache()
+        self.base_url = base_url
+
+    def load(
+        self,
+        dataset: str,
+        year: int,
+        survey_type: str = "",
+        force_refresh: bool = False,
+    ) -> CensusCatalog:
+        if not force_refresh:
+            cached = self.cache.get(dataset, year)
+            if cached is not None:
+                return cached
+
+        from .catalog_populator import CensusCatalogPopulator
+
+        kwargs: dict = {}
+        if self.base_url:
+            kwargs["base_url"] = self.base_url
+
+        populator = CensusCatalogPopulator(**kwargs)
+        catalog = populator.populate(dataset, year, survey_type=survey_type)
+
+        self.cache.put(dataset, year, catalog)
+        return catalog

--- a/siege_utilities/geo/census/catalog_docs.py
+++ b/siege_utilities/geo/census/catalog_docs.py
@@ -1,0 +1,212 @@
+"""
+Census catalog documentation generator.
+
+Produces Markdown documentation from a CensusCatalog instance:
+- Index page with Subject → Family → Table tree
+- Per-table pages with variable list, geography availability, dataset membership
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+from .catalog import (
+    CensusCatalog,
+    CensusCatalogDataset,
+    CensusFamily,
+    CensusSubject,
+    CensusTable,
+    FamilyType,
+)
+
+log = logging.getLogger(__name__)
+
+
+def generate_catalog_docs(
+    catalog: CensusCatalog,
+    output_dir: Path,
+    title: str = "Census Table Catalog",
+) -> list[Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    written: list[Path] = []
+
+    index_path = output_dir / "index.md"
+    index_path.write_text(
+        _render_index(catalog, title), encoding="utf-8"
+    )
+    written.append(index_path)
+
+    for table in sorted(catalog.tables.values(), key=lambda t: t.table_id):
+        families = catalog.families_for_table(table.table_id)
+        datasets = _datasets_for_table(catalog, table.table_id)
+        page_path = output_dir / "tables" / f"{table.table_id}.md"
+        page_path.parent.mkdir(parents=True, exist_ok=True)
+        page_path.write_text(
+            _render_table_page(table, families, datasets), encoding="utf-8"
+        )
+        written.append(page_path)
+
+    log.info(
+        "Generated %d doc pages in %s", len(written), output_dir
+    )
+    return written
+
+
+def generate_catalog_markdown(
+    catalog: CensusCatalog,
+    title: str = "Census Table Catalog",
+) -> str:
+    return _render_index(catalog, title)
+
+
+def _render_index(catalog: CensusCatalog, title: str) -> str:
+    lines = [f"# {title}", ""]
+
+    subjects = sorted(catalog.subjects.values(), key=lambda s: s.subject_id)
+    if subjects:
+        lines.append("## Subjects")
+        lines.append("")
+        for subject in subjects:
+            lines.append(f"### {subject.label}")
+            lines.append("")
+            if subject.tables:
+                for table in sorted(subject.tables, key=lambda t: t.table_id):
+                    lines.append(
+                        f"- [{table.table_id}](tables/{table.table_id}.md)"
+                        f" — {table.concept or table.label}"
+                    )
+                lines.append("")
+
+    families = sorted(catalog.families.values(), key=lambda f: f.family_id)
+    race_families = [f for f in families if f.family_type == FamilyType.RACE_ITERATION]
+    topical_families = [f for f in families if f.family_type == FamilyType.TOPICAL_KINSHIP]
+
+    if race_families:
+        lines.append("## Race Iteration Families")
+        lines.append("")
+        for fam in race_families:
+            lines.append(f"### {fam.root_table_id}")
+            lines.append("")
+            lines.append(f"{fam.description}")
+            lines.append("")
+            for table in fam.tables:
+                lines.append(
+                    f"- [{table.table_id}](tables/{table.table_id}.md)"
+                    f" — {table.concept or table.label}"
+                )
+            lines.append("")
+
+    if topical_families:
+        lines.append("## Topical Families")
+        lines.append("")
+        for fam in topical_families:
+            lines.append(f"### {fam.root_table_id}")
+            lines.append("")
+            lines.append(f"{fam.description}")
+            lines.append("")
+            for table in fam.tables:
+                lines.append(
+                    f"- [{table.table_id}](tables/{table.table_id}.md)"
+                    f" — {table.concept or table.label}"
+                )
+            lines.append("")
+
+    orphan_tables = _orphan_tables(catalog)
+    if orphan_tables:
+        lines.append("## Other Tables")
+        lines.append("")
+        for table in sorted(orphan_tables, key=lambda t: t.table_id):
+            lines.append(
+                f"- [{table.table_id}](tables/{table.table_id}.md)"
+                f" — {table.concept or table.label}"
+            )
+        lines.append("")
+
+    datasets = sorted(catalog.datasets.values(), key=lambda d: d.dataset_id)
+    if datasets:
+        lines.append("## Datasets")
+        lines.append("")
+        for ds in datasets:
+            lines.append(f"- **{ds.dataset_id}**: {ds.survey_type} ({ds.year})")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _render_table_page(
+    table: CensusTable,
+    families: list[CensusFamily],
+    datasets: list[CensusCatalogDataset],
+) -> str:
+    lines = [f"# {table.table_id}", ""]
+
+    if table.concept:
+        lines.append(f"**Concept:** {table.concept}")
+        lines.append("")
+    if table.universe:
+        lines.append(f"**Universe:** {table.universe}")
+        lines.append("")
+
+    if table.geography_levels:
+        lines.append("## Geography Levels")
+        lines.append("")
+        for geo in table.geography_levels:
+            lines.append(f"- {geo}")
+        lines.append("")
+
+    if table.variables:
+        lines.append("## Variables")
+        lines.append("")
+        lines.append("| Code | Label |")
+        lines.append("|------|-------|")
+        for var in table.variables:
+            label = var.label.replace("|", "\\|")
+            lines.append(f"| `{var.code}` | {label} |")
+        lines.append("")
+
+    if families:
+        lines.append("## Family Membership")
+        lines.append("")
+        for fam in families:
+            ftype = "Race Iteration" if fam.family_type == FamilyType.RACE_ITERATION else "Topical Kinship"
+            lines.append(f"- **{fam.family_id}** ({ftype}): {fam.description}")
+        lines.append("")
+
+    if datasets:
+        lines.append("## Datasets")
+        lines.append("")
+        for ds in datasets:
+            lines.append(f"- {ds.dataset_id} ({ds.survey_type}, {ds.year})")
+        lines.append("")
+
+    lines.append(f"[← Back to index](../index.md)")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def _datasets_for_table(
+    catalog: CensusCatalog, table_id: str
+) -> list[CensusCatalogDataset]:
+    return [
+        ds
+        for ds in catalog.datasets.values()
+        if table_id in ds.tables
+    ]
+
+
+def _orphan_tables(catalog: CensusCatalog) -> list[CensusTable]:
+    covered: set[str] = set()
+    for subject in catalog.subjects.values():
+        for table in subject.tables:
+            covered.add(table.table_id)
+    for family in catalog.families.values():
+        for table in family.tables:
+            covered.add(table.table_id)
+    return [
+        t for t in catalog.tables.values()
+        if t.table_id not in covered
+    ]

--- a/siege_utilities/geo/census/catalog_populator.py
+++ b/siege_utilities/geo/census/catalog_populator.py
@@ -1,0 +1,197 @@
+"""
+Census catalog populator — fetches metadata from Census API discovery endpoints.
+
+Populates CensusCatalog instances from:
+- ``/data/{year}/{dataset}/variables.json`` — variable definitions
+- ``/data/{year}/{dataset}/groups.json`` — concept groupings
+
+Separated from ``catalog.py`` to keep the data model I/O-free.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Optional
+
+import requests
+
+from siege_utilities.config import CENSUS_API_BASE_URL
+from .catalog import (
+    CensusCatalog,
+    CensusCatalogDataset,
+    CensusSubject,
+    CensusTable,
+    CensusVariable,
+    parse_table_id,
+)
+
+log = logging.getLogger(__name__)
+
+_DATASET_PATHS = {
+    "acs5": "acs/acs5",
+    "acs1": "acs/acs1",
+    "dec/pl": "dec/pl",
+    "dec/dhc": "dec/dhc",
+    "dec/dp": "dec/dp",
+    "dec/sf1": "dec/sf1",
+}
+
+_VARIABLE_CODE_RE = re.compile(
+    r"^[A-Z]{1,3}\d{5}[A-Z]?_\d{3}[EM]?$"
+)
+
+
+class CensusCatalogPopulator:
+    def __init__(
+        self,
+        base_url: str = CENSUS_API_BASE_URL,
+        timeout: int = 30,
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+
+    def populate(
+        self,
+        dataset: str,
+        year: int,
+        survey_type: str = "",
+    ) -> CensusCatalog:
+        dataset_path = _DATASET_PATHS.get(dataset, dataset)
+        raw_variables = self._fetch_variables(dataset_path, year)
+        raw_groups = self._fetch_groups(dataset_path, year)
+
+        tables = self._build_tables(raw_variables)
+        subjects = self._build_subjects(raw_groups, tables)
+
+        catalog = CensusCatalog()
+        catalog.add_tables(tables)
+        catalog.build_families()
+
+        for subject in subjects:
+            catalog.add_subject(subject)
+
+        ds = CensusCatalogDataset(
+            dataset_id=f"{dataset}_{year}",
+            survey_type=survey_type or dataset,
+            year=year,
+            subjects=subjects,
+            tables={t.table_id: t for t in tables},
+        )
+        catalog.add_dataset(ds)
+
+        log.info(
+            "Populated catalog for %s/%d: %d tables, %d families, %d subjects",
+            dataset,
+            year,
+            len(catalog.tables),
+            len(catalog.families),
+            len(catalog.subjects),
+        )
+        return catalog
+
+    def _fetch_variables(self, dataset_path: str, year: int) -> dict:
+        url = f"{self.base_url}/data/{year}/{dataset_path}/variables.json"
+        log.debug("Fetching variables from %s", url)
+        resp = requests.get(url, timeout=self.timeout)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("variables", {})
+
+    def _fetch_groups(self, dataset_path: str, year: int) -> list[dict]:
+        url = f"{self.base_url}/data/{year}/{dataset_path}/groups.json"
+        log.debug("Fetching groups from %s", url)
+        resp = requests.get(url, timeout=self.timeout)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("groups", [])
+
+    def _build_tables(self, raw_variables: dict) -> list[CensusTable]:
+        table_vars: dict[str, list[CensusVariable]] = {}
+        table_meta: dict[str, dict] = {}
+
+        for code, meta in raw_variables.items():
+            if not _VARIABLE_CODE_RE.match(code):
+                continue
+
+            parsed = parse_table_id(code.rsplit("_", 1)[0])
+            if parsed is None:
+                continue
+
+            table_id = code.rsplit("_", 1)[0]
+            label = meta.get("label", "")
+            concept = meta.get("concept", "")
+
+            var = CensusVariable(
+                code=code,
+                label=label,
+                concept=concept,
+                table_id=table_id,
+                stat_type="M" if code.endswith("M") else "E",
+            )
+
+            table_vars.setdefault(table_id, []).append(var)
+            if table_id not in table_meta:
+                table_meta[table_id] = {
+                    "concept": concept,
+                    "group": meta.get("group", ""),
+                }
+
+        tables = []
+        for table_id, variables in sorted(table_vars.items()):
+            meta = table_meta.get(table_id, {})
+            estimate_vars = [v for v in variables if v.stat_type == "E"]
+            tables.append(
+                CensusTable(
+                    table_id=table_id,
+                    label=meta.get("concept", ""),
+                    concept=meta.get("concept", ""),
+                    variables=sorted(estimate_vars, key=lambda v: v.code),
+                )
+            )
+
+        return tables
+
+    def _build_subjects(
+        self,
+        raw_groups: list[dict],
+        tables: list[CensusTable],
+    ) -> list[CensusSubject]:
+        table_lookup = {t.table_id: t for t in tables}
+
+        group_to_tables: dict[str, list[CensusTable]] = {}
+        for group_info in raw_groups:
+            group_name = group_info.get("name", "")
+            if not group_name or group_name == "N/A":
+                continue
+
+            table = table_lookup.get(group_name)
+            if table is None:
+                continue
+
+            description = group_info.get("description", "")
+            concept_key = _subject_key(description)
+            group_to_tables.setdefault(concept_key, []).append(table)
+
+        subjects = []
+        for concept_key, group_tables in sorted(group_to_tables.items()):
+            if not concept_key:
+                continue
+            subjects.append(
+                CensusSubject(
+                    subject_id=concept_key.lower().replace(" ", "_"),
+                    label=concept_key,
+                    tables=sorted(group_tables, key=lambda t: t.table_id),
+                )
+            )
+
+        return subjects
+
+
+def _subject_key(description: str) -> str:
+    if not description:
+        return ""
+    parts = description.upper().split("--")
+    if len(parts) >= 2:
+        return parts[0].strip().title()
+    return description.strip().title()

--- a/siege_utilities/geo/census/variable_registry.py
+++ b/siege_utilities/geo/census/variable_registry.py
@@ -5,6 +5,7 @@ Pure data + lookup logic — no I/O except optional API calls for unknown variab
 """
 
 import logging
+import warnings
 from typing import Dict, List, Optional, Union, Any
 
 import pandas as pd
@@ -12,11 +13,51 @@ import pandas as pd
 log = logging.getLogger(__name__)
 
 
+class _DeprecatedDict(dict):
+    """Dict wrapper that warns on first access, directing users to CensusCatalog."""
+
+    _warned = False
+
+    def _warn(self):
+        if not _DeprecatedDict._warned:
+            _DeprecatedDict._warned = True
+            warnings.warn(
+                "VARIABLE_GROUPS is deprecated and will be removed in v5.0. "
+                "Use CensusCatalog from siege_utilities.geo.census.catalog instead.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+
+    def __getitem__(self, key):
+        self._warn()
+        return super().__getitem__(key)
+
+    def __iter__(self):
+        self._warn()
+        return super().__iter__()
+
+    def keys(self):
+        self._warn()
+        return super().keys()
+
+    def values(self):
+        self._warn()
+        return super().values()
+
+    def items(self):
+        self._warn()
+        return super().items()
+
+    def get(self, key, default=None):
+        self._warn()
+        return super().get(key, default)
+
+
 # =============================================================================
-# PREDEFINED VARIABLE GROUPS
+# PREDEFINED VARIABLE GROUPS (deprecated — use CensusCatalog)
 # =============================================================================
 
-VARIABLE_GROUPS: Dict[str, List[str]] = {
+_VARIABLE_GROUPS_DATA: Dict[str, List[str]] = {
     # Basic population count
     'total_population': ['B01001_001E'],
 
@@ -211,6 +252,8 @@ VARIABLE_GROUPS: Dict[str, List[str]] = {
     ],
 }
 
+VARIABLE_GROUPS: Dict[str, List[str]] = _DeprecatedDict(_VARIABLE_GROUPS_DATA)
+
 # Variable descriptions for metadata
 VARIABLE_DESCRIPTIONS: Dict[str, str] = {
     'B01001_001E': 'Total Population',
@@ -320,7 +363,7 @@ class VariableRegistry:
 
     def __init__(self, groups: Optional[Dict[str, List[str]]] = None,
                  descriptions: Optional[Dict[str, str]] = None):
-        self.groups = groups or VARIABLE_GROUPS
+        self.groups = groups or dict(_VARIABLE_GROUPS_DATA)
         self.descriptions = descriptions or VARIABLE_DESCRIPTIONS
 
     def resolve_variables(self, variables: Union[str, List[str]]) -> List[str]:

--- a/siege_utilities/geo/codification.py
+++ b/siege_utilities/geo/codification.py
@@ -1,0 +1,210 @@
+"""Address-based area codification.
+
+Given a set of addresses, geocodes them, assigns to Census blocks,
+and builds a structured area portrait with demographics, urbanicity,
+and recency analysis.
+
+Usage::
+
+    from siege_utilities.geo.codification import codify_area
+    result = codify_area(["123 Main St, Austin, TX", ...])
+    print(result.block_count)
+    print(result.summarize())
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Any, Optional, Union
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BlockProfile:
+    """Profile of a single Census block within the codified area.
+
+    Attributes:
+        block_geoid: 15-digit Census block GEOID.
+        tract_geoid: 11-digit Census tract GEOID.
+        county_geoid: 5-digit county GEOID.
+        state_geoid: 2-digit state GEOID.
+        address_count: Number of geocoded addresses in this block.
+        demographics: Block-level demographic data (populated by T3).
+        urbanicity: NCES locale classification (populated by T4).
+        recency: Address vintage data (populated by T5).
+    """
+
+    block_geoid: str = ""
+    tract_geoid: str = ""
+    county_geoid: str = ""
+    state_geoid: str = ""
+    address_count: int = 0
+    demographics: dict[str, Any] = field(default_factory=dict)
+    urbanicity: dict[str, Any] = field(default_factory=dict)
+    recency: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class CodificationResult:
+    """Structured area portrait from address codification.
+
+    Attributes:
+        total_addresses: Total addresses submitted.
+        matched_addresses: Successfully geocoded addresses.
+        match_rate: Fraction geocoded.
+        blocks: Per-block profiles.
+        geocoding_backend: Which geocoder was used.
+        census_year: Census vintage for geography.
+        errors: Any errors encountered.
+    """
+
+    total_addresses: int = 0
+    matched_addresses: int = 0
+    match_rate: float = 0.0
+    blocks: list[BlockProfile] = field(default_factory=list)
+    geocoding_backend: str = ""
+    census_year: Optional[int] = None
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def block_count(self) -> int:
+        return len(self.blocks)
+
+    @property
+    def tract_count(self) -> int:
+        return len(set(b.tract_geoid for b in self.blocks if b.tract_geoid))
+
+    @property
+    def county_count(self) -> int:
+        return len(set(b.county_geoid for b in self.blocks if b.county_geoid))
+
+    @property
+    def state_count(self) -> int:
+        return len(set(b.state_geoid for b in self.blocks if b.state_geoid))
+
+    def top_blocks(self, n: int = 10) -> list[BlockProfile]:
+        return sorted(self.blocks, key=lambda b: b.address_count, reverse=True)[:n]
+
+    def summarize(self) -> dict[str, Any]:
+        return {
+            "total_addresses": self.total_addresses,
+            "matched_addresses": self.matched_addresses,
+            "match_rate": self.match_rate,
+            "block_count": self.block_count,
+            "tract_count": self.tract_count,
+            "county_count": self.county_count,
+            "state_count": self.state_count,
+            "geocoding_backend": self.geocoding_backend,
+            "census_year": self.census_year,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Core codification function
+# ---------------------------------------------------------------------------
+
+
+def codify_area(
+    addresses: Union[list[str], list[dict]],
+    geocoder=None,
+    census_year: Optional[int] = None,
+    **kwargs,
+) -> CodificationResult:
+    """Codify an area from a set of addresses.
+
+    Geocodes the addresses, assigns them to Census blocks, and
+    builds a structured area portrait.
+
+    Args:
+        addresses: Addresses to codify (strings or dicts).
+        geocoder: BatchGeocoder instance. If None, uses CensusBatchGeocoder.
+        census_year: Census vintage for geography.
+        **kwargs: Passed through to the geocoder.
+
+    Returns:
+        CodificationResult with block-level profiles.
+    """
+    result = CodificationResult(
+        total_addresses=len(addresses),
+        census_year=census_year,
+    )
+
+    if not addresses:
+        return result
+
+    if geocoder is None:
+        geocoder = _get_default_geocoder()
+
+    if geocoder is None:
+        result.errors.append("No geocoder available")
+        return result
+
+    result.geocoding_backend = geocoder.backend_name
+
+    try:
+        geocode_result = geocoder.geocode(addresses, **kwargs)
+    except Exception as exc:
+        result.errors.append(f"Geocoding failed: {exc}")
+        log.error("Codification geocoding failed: %s", exc)
+        return result
+
+    matched = [r for r in geocode_result.results if r.matched]
+    result.matched_addresses = len(matched)
+    result.match_rate = (
+        len(matched) / len(addresses) if addresses else 0.0
+    )
+
+    result.blocks = _build_block_profiles(matched)
+
+    return result
+
+
+def _build_block_profiles(geocoded_results) -> list[BlockProfile]:
+    """Group geocoded results into block-level profiles."""
+    block_counts: Counter = Counter()
+    block_meta: dict[str, dict] = {}
+
+    for gr in geocoded_results:
+        geoid = gr.block_geoid
+        if not geoid:
+            geoid = gr.tract_geoid or gr.county_geoid or "unknown"
+
+        block_counts[geoid] += 1
+
+        if geoid not in block_meta:
+            block_meta[geoid] = {
+                "block_geoid": gr.block_geoid,
+                "tract_geoid": gr.tract_geoid,
+                "county_geoid": gr.county_geoid,
+                "state_geoid": gr.state_geoid,
+            }
+
+    profiles = []
+    for geoid, count in block_counts.most_common():
+        meta = block_meta[geoid]
+        profiles.append(BlockProfile(
+            block_geoid=meta["block_geoid"],
+            tract_geoid=meta["tract_geoid"],
+            county_geoid=meta["county_geoid"],
+            state_geoid=meta["state_geoid"],
+            address_count=count,
+        ))
+
+    return profiles
+
+
+def _get_default_geocoder():
+    """Attempt to create a default CensusBatchGeocoder."""
+    try:
+        from siege_utilities.geo.providers.census_batch import CensusBatchGeocoder
+        return CensusBatchGeocoder()
+    except Exception:
+        return None

--- a/siege_utilities/geo/codification_blocks.py
+++ b/siege_utilities/geo/codification_blocks.py
@@ -1,0 +1,207 @@
+"""Block assignment for codification.
+
+Groups geocoded addresses by Census block GEOID and computes
+geographic spread metrics (block count, spatial extent, concentration).
+"""
+
+from __future__ import annotations
+
+import math
+import logging
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class BlockAssignment:
+    """Geocoded address assigned to a Census block.
+
+    Attributes:
+        block_geoid: 15-digit block GEOID.
+        tract_geoid: 11-digit tract GEOID.
+        county_geoid: 5-digit county GEOID.
+        state_geoid: 2-digit state GEOID.
+        lat: Latitude.
+        lon: Longitude.
+        input_id: Caller's address identifier.
+    """
+
+    block_geoid: str = ""
+    tract_geoid: str = ""
+    county_geoid: str = ""
+    state_geoid: str = ""
+    lat: Optional[float] = None
+    lon: Optional[float] = None
+    input_id: str = ""
+
+
+@dataclass
+class BlockGroup:
+    """Addresses grouped by Census block.
+
+    Attributes:
+        block_geoid: Block identifier.
+        tract_geoid: Parent tract.
+        county_geoid: Parent county.
+        state_geoid: Parent state.
+        address_count: Number of addresses in this block.
+        centroid_lat: Mean latitude of addresses.
+        centroid_lon: Mean longitude of addresses.
+    """
+
+    block_geoid: str = ""
+    tract_geoid: str = ""
+    county_geoid: str = ""
+    state_geoid: str = ""
+    address_count: int = 0
+    centroid_lat: Optional[float] = None
+    centroid_lon: Optional[float] = None
+
+
+@dataclass
+class SpreadMetrics:
+    """Geographic spread metrics for a set of block assignments.
+
+    Attributes:
+        block_count: Distinct blocks with addresses.
+        tract_count: Distinct tracts.
+        county_count: Distinct counties.
+        state_count: Distinct states.
+        concentration: Herfindahl index of block address distribution
+            (0=evenly spread, 1=all in one block).
+        max_block_pct: Fraction of addresses in the most populated block.
+        bbox_lat_range: Latitude range (max - min) of all addresses.
+        bbox_lon_range: Longitude range (max - min) of all addresses.
+    """
+
+    block_count: int = 0
+    tract_count: int = 0
+    county_count: int = 0
+    state_count: int = 0
+    concentration: float = 0.0
+    max_block_pct: float = 0.0
+    bbox_lat_range: float = 0.0
+    bbox_lon_range: float = 0.0
+
+
+def assign_blocks(geocoded_results) -> list[BlockAssignment]:
+    """Convert geocoding results to block assignments.
+
+    Args:
+        geocoded_results: List of GeocodingResult from a BatchGeocoder.
+
+    Returns:
+        List of BlockAssignment for matched results with coordinates.
+    """
+    assignments = []
+    for gr in geocoded_results:
+        if not gr.matched or gr.lat is None or gr.lon is None:
+            continue
+        assignments.append(BlockAssignment(
+            block_geoid=gr.block_geoid,
+            tract_geoid=gr.tract_geoid,
+            county_geoid=gr.county_geoid,
+            state_geoid=gr.state_geoid,
+            lat=gr.lat,
+            lon=gr.lon,
+            input_id=gr.input_id,
+        ))
+    return assignments
+
+
+def group_by_block(assignments: list[BlockAssignment]) -> list[BlockGroup]:
+    """Group block assignments by block GEOID.
+
+    Returns groups sorted by address count (descending).
+    """
+    counts: Counter = Counter()
+    meta: dict[str, dict] = {}
+    lats: dict[str, list[float]] = {}
+    lons: dict[str, list[float]] = {}
+
+    for a in assignments:
+        geoid = a.block_geoid or a.tract_geoid or a.county_geoid or "unknown"
+        counts[geoid] += 1
+
+        if geoid not in meta:
+            meta[geoid] = {
+                "block_geoid": a.block_geoid,
+                "tract_geoid": a.tract_geoid,
+                "county_geoid": a.county_geoid,
+                "state_geoid": a.state_geoid,
+            }
+            lats[geoid] = []
+            lons[geoid] = []
+
+        if a.lat is not None:
+            lats[geoid].append(a.lat)
+        if a.lon is not None:
+            lons[geoid].append(a.lon)
+
+    groups = []
+    for geoid, count in counts.most_common():
+        m = meta[geoid]
+        clat = sum(lats[geoid]) / len(lats[geoid]) if lats[geoid] else None
+        clon = sum(lons[geoid]) / len(lons[geoid]) if lons[geoid] else None
+        groups.append(BlockGroup(
+            block_geoid=m["block_geoid"],
+            tract_geoid=m["tract_geoid"],
+            county_geoid=m["county_geoid"],
+            state_geoid=m["state_geoid"],
+            address_count=count,
+            centroid_lat=clat,
+            centroid_lon=clon,
+        ))
+
+    return groups
+
+
+def compute_spread(
+    assignments: list[BlockAssignment],
+    groups: Optional[list[BlockGroup]] = None,
+) -> SpreadMetrics:
+    """Compute geographic spread metrics for block assignments.
+
+    Args:
+        assignments: All block assignments.
+        groups: Pre-computed block groups (optional, computed if not provided).
+    """
+    if not assignments:
+        return SpreadMetrics()
+
+    if groups is None:
+        groups = group_by_block(assignments)
+
+    total = sum(g.address_count for g in groups)
+    blocks = set(g.block_geoid for g in groups if g.block_geoid)
+    tracts = set(g.tract_geoid for g in groups if g.tract_geoid)
+    counties = set(g.county_geoid for g in groups if g.county_geoid)
+    states = set(g.state_geoid for g in groups if g.state_geoid)
+
+    hhi = 0.0
+    max_pct = 0.0
+    if total > 0:
+        for g in groups:
+            pct = g.address_count / total
+            hhi += pct * pct
+            max_pct = max(max_pct, pct)
+
+    all_lats = [a.lat for a in assignments if a.lat is not None]
+    all_lons = [a.lon for a in assignments if a.lon is not None]
+
+    lat_range = (max(all_lats) - min(all_lats)) if all_lats else 0.0
+    lon_range = (max(all_lons) - min(all_lons)) if all_lons else 0.0
+
+    return SpreadMetrics(
+        block_count=len(blocks),
+        tract_count=len(tracts),
+        county_count=len(counties),
+        state_count=len(states),
+        concentration=hhi,
+        max_block_pct=max_pct,
+        bbox_lat_range=lat_range,
+        bbox_lon_range=lon_range,
+    )

--- a/siege_utilities/geo/codification_demographics.py
+++ b/siege_utilities/geo/codification_demographics.py
@@ -1,0 +1,174 @@
+"""Demographic enrichment for codification.
+
+Fetches block-level demographics for matched blocks and produces
+an address-weighted demographic signature: race/ethnicity distribution,
+housing occupancy, voting-age composition.
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class BlockDemographics:
+    """PL 94-171 demographics for a single Census block.
+
+    Attributes:
+        block_geoid: Block GEOID.
+        total_population: Total population.
+        voting_age_population: 18+ population.
+        white: White alone.
+        black: Black alone.
+        hispanic: Hispanic or Latino.
+        asian: Asian alone.
+        other_race: All other races.
+        housing_total: Total housing units.
+        housing_occupied: Occupied housing units.
+        housing_vacant: Vacant housing units.
+    """
+
+    block_geoid: str = ""
+    total_population: int = 0
+    voting_age_population: int = 0
+    white: int = 0
+    black: int = 0
+    hispanic: int = 0
+    asian: int = 0
+    other_race: int = 0
+    housing_total: int = 0
+    housing_occupied: int = 0
+    housing_vacant: int = 0
+
+
+@dataclass
+class DemographicSignature:
+    """Address-weighted demographic signature for a codified area.
+
+    All percentages are weighted by address count per block.
+
+    Attributes:
+        total_block_population: Sum of block populations (unweighted).
+        weighted_blocks: Number of blocks with both addresses and demographics.
+        pct_white: Address-weighted white percentage.
+        pct_black: Address-weighted black percentage.
+        pct_hispanic: Address-weighted Hispanic percentage.
+        pct_asian: Address-weighted Asian percentage.
+        pct_other: Address-weighted other race percentage.
+        pct_voting_age: Address-weighted voting-age percentage.
+        pct_housing_occupied: Address-weighted housing occupancy rate.
+        pct_housing_vacant: Address-weighted vacancy rate.
+    """
+
+    total_block_population: int = 0
+    weighted_blocks: int = 0
+    pct_white: float = 0.0
+    pct_black: float = 0.0
+    pct_hispanic: float = 0.0
+    pct_asian: float = 0.0
+    pct_other: float = 0.0
+    pct_voting_age: float = 0.0
+    pct_housing_occupied: float = 0.0
+    pct_housing_vacant: float = 0.0
+
+
+class BlockDemographicsProvider(abc.ABC):
+    """Protocol for fetching block-level demographics."""
+
+    @abc.abstractmethod
+    def get_demographics(
+        self,
+        block_geoids: list[str],
+        census_year: Optional[int] = None,
+    ) -> dict[str, BlockDemographics]:
+        """Fetch demographics for given block GEOIDs.
+
+        Returns dict of block_geoid → BlockDemographics.
+        """
+
+
+class DictBlockDemographicsProvider(BlockDemographicsProvider):
+    """In-memory demographics provider for testing."""
+
+    def __init__(self):
+        self._data: dict[str, BlockDemographics] = {}
+
+    def add(self, demo: BlockDemographics):
+        self._data[demo.block_geoid] = demo
+
+    def get_demographics(
+        self,
+        block_geoids: list[str],
+        census_year: Optional[int] = None,
+    ) -> dict[str, BlockDemographics]:
+        return {g: self._data[g] for g in block_geoids if g in self._data}
+
+
+def compute_demographic_signature(
+    block_address_counts: dict[str, int],
+    demographics: dict[str, BlockDemographics],
+) -> DemographicSignature:
+    """Compute address-weighted demographic signature.
+
+    Args:
+        block_address_counts: Dict of block_geoid → address count.
+        demographics: Dict of block_geoid → BlockDemographics.
+
+    Returns:
+        DemographicSignature with address-weighted percentages.
+    """
+    total_addresses = 0
+    weighted_pct_white = 0.0
+    weighted_pct_black = 0.0
+    weighted_pct_hispanic = 0.0
+    weighted_pct_asian = 0.0
+    weighted_pct_other = 0.0
+    weighted_pct_vap = 0.0
+    weighted_pct_occupied = 0.0
+    weighted_pct_vacant = 0.0
+    total_pop = 0
+    matched_blocks = 0
+
+    for geoid, addr_count in block_address_counts.items():
+        demo = demographics.get(geoid)
+        if demo is None or demo.total_population == 0:
+            continue
+
+        matched_blocks += 1
+        total_addresses += addr_count
+        total_pop += demo.total_population
+
+        pop = demo.total_population
+        weighted_pct_white += addr_count * (demo.white / pop)
+        weighted_pct_black += addr_count * (demo.black / pop)
+        weighted_pct_hispanic += addr_count * (demo.hispanic / pop)
+        weighted_pct_asian += addr_count * (demo.asian / pop)
+        weighted_pct_other += addr_count * (demo.other_race / pop)
+
+        if pop > 0:
+            weighted_pct_vap += addr_count * (demo.voting_age_population / pop)
+
+        if demo.housing_total > 0:
+            weighted_pct_occupied += addr_count * (demo.housing_occupied / demo.housing_total)
+            weighted_pct_vacant += addr_count * (demo.housing_vacant / demo.housing_total)
+
+    if total_addresses == 0:
+        return DemographicSignature()
+
+    return DemographicSignature(
+        total_block_population=total_pop,
+        weighted_blocks=matched_blocks,
+        pct_white=weighted_pct_white / total_addresses,
+        pct_black=weighted_pct_black / total_addresses,
+        pct_hispanic=weighted_pct_hispanic / total_addresses,
+        pct_asian=weighted_pct_asian / total_addresses,
+        pct_other=weighted_pct_other / total_addresses,
+        pct_voting_age=weighted_pct_vap / total_addresses,
+        pct_housing_occupied=weighted_pct_occupied / total_addresses,
+        pct_housing_vacant=weighted_pct_vacant / total_addresses,
+    )

--- a/siege_utilities/geo/codification_recency.py
+++ b/siege_utilities/geo/codification_recency.py
@@ -1,0 +1,122 @@
+"""Recency analysis for codification.
+
+Compares address presence across TIGER vintages to produce a
+construction timeline: when did these addresses first appear?
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+TIGER_VINTAGES = [2010, 2012, 2014, 2016, 2018, 2020, 2022, 2024]
+
+
+@dataclass
+class AddressVintage:
+    """Earliest known TIGER vintage for an address.
+
+    Attributes:
+        input_id: Address identifier.
+        first_vintage: Year the address first appeared in TIGER.
+        present_in: List of vintages where the address was found.
+    """
+
+    input_id: str = ""
+    first_vintage: Optional[int] = None
+    present_in: list[int] = field(default_factory=list)
+
+    @property
+    def is_new_construction(self) -> bool:
+        if not self.present_in:
+            return False
+        return self.first_vintage == max(self.present_in)
+
+
+@dataclass
+class RecencyAnalysis:
+    """Address vintage distribution for a codified area.
+
+    Attributes:
+        total_analyzed: Total addresses with vintage data.
+        vintage_distribution: Dict of vintage_year → count of addresses.
+        vintage_pct: Dict of vintage_year → fraction of addresses.
+        new_construction_count: Addresses first appearing in most recent vintage.
+        new_construction_pct: Fraction of addresses that are new construction.
+        median_vintage: Median first-appearance year.
+    """
+
+    total_analyzed: int = 0
+    vintage_distribution: dict[int, int] = field(default_factory=dict)
+    vintage_pct: dict[int, float] = field(default_factory=dict)
+    new_construction_count: int = 0
+    new_construction_pct: float = 0.0
+    median_vintage: Optional[int] = None
+
+
+class AddressVintageProvider(abc.ABC):
+    """Protocol for determining address vintage from TIGER data."""
+
+    @abc.abstractmethod
+    def get_vintages(
+        self,
+        input_ids: list[str],
+    ) -> list[AddressVintage]:
+        """Determine first TIGER vintage for each address."""
+
+
+class DictAddressVintageProvider(AddressVintageProvider):
+    """In-memory vintage provider for testing."""
+
+    def __init__(self):
+        self._data: dict[str, AddressVintage] = {}
+
+    def add(self, vintage: AddressVintage):
+        self._data[vintage.input_id] = vintage
+
+    def get_vintages(self, input_ids: list[str]) -> list[AddressVintage]:
+        return [self._data[i] for i in input_ids if i in self._data]
+
+
+def compute_recency(vintages: list[AddressVintage]) -> RecencyAnalysis:
+    """Compute recency analysis from address vintages.
+
+    Args:
+        vintages: List of AddressVintage with first_vintage set.
+    """
+    if not vintages:
+        return RecencyAnalysis()
+
+    first_years = [v.first_vintage for v in vintages if v.first_vintage is not None]
+    if not first_years:
+        return RecencyAnalysis()
+
+    counts = Counter(first_years)
+    total = len(first_years)
+
+    distribution = dict(sorted(counts.items()))
+    pct = {yr: count / total for yr, count in distribution.items()}
+
+    most_recent = max(first_years)
+    new_count = counts[most_recent]
+
+    sorted_years = sorted(first_years)
+    mid = len(sorted_years) // 2
+    if len(sorted_years) % 2 == 0:
+        median = (sorted_years[mid - 1] + sorted_years[mid]) // 2
+    else:
+        median = sorted_years[mid]
+
+    return RecencyAnalysis(
+        total_analyzed=total,
+        vintage_distribution=distribution,
+        vintage_pct=pct,
+        new_construction_count=new_count,
+        new_construction_pct=new_count / total,
+        median_vintage=median,
+    )

--- a/siege_utilities/geo/codification_summary.py
+++ b/siege_utilities/geo/codification_summary.py
@@ -1,0 +1,154 @@
+"""Summary portrait for codification.
+
+Assembles headline metrics from block assignment, demographics,
+urbanicity, and recency into a structured area portrait.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from .codification import CodificationResult
+from .codification_blocks import BlockGroup, SpreadMetrics
+from .codification_demographics import DemographicSignature
+from .codification_urbanicity import UrbanicityDistribution
+from .codification_recency import RecencyAnalysis
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class AreaPortrait:
+    """Structured summary portrait of a codified area.
+
+    Combines headline metrics from all codification enrichment layers.
+    """
+
+    geocoding_summary: dict[str, Any] = field(default_factory=dict)
+    spread: Optional[SpreadMetrics] = None
+    demographics: Optional[DemographicSignature] = None
+    urbanicity: Optional[UrbanicityDistribution] = None
+    recency: Optional[RecencyAnalysis] = None
+    top_blocks: list[BlockGroup] = field(default_factory=list)
+
+    def headline_metrics(self) -> dict[str, Any]:
+        metrics: dict[str, Any] = {}
+
+        metrics.update(self.geocoding_summary)
+
+        if self.spread:
+            metrics["block_count"] = self.spread.block_count
+            metrics["tract_count"] = self.spread.tract_count
+            metrics["county_count"] = self.spread.county_count
+            metrics["concentration"] = round(self.spread.concentration, 3)
+
+        if self.demographics:
+            metrics["pct_white"] = round(self.demographics.pct_white, 3)
+            metrics["pct_black"] = round(self.demographics.pct_black, 3)
+            metrics["pct_hispanic"] = round(self.demographics.pct_hispanic, 3)
+            metrics["pct_voting_age"] = round(self.demographics.pct_voting_age, 3)
+
+        if self.urbanicity:
+            metrics["dominant_category"] = self.urbanicity.dominant_category
+            metrics["dominant_locale"] = self.urbanicity.dominant_locale
+
+        if self.recency:
+            metrics["median_vintage"] = self.recency.median_vintage
+            metrics["new_construction_pct"] = round(self.recency.new_construction_pct, 3)
+
+        return metrics
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "geocoding": self.geocoding_summary,
+        }
+        if self.spread:
+            d["spread"] = {
+                "block_count": self.spread.block_count,
+                "tract_count": self.spread.tract_count,
+                "county_count": self.spread.county_count,
+                "state_count": self.spread.state_count,
+                "concentration": self.spread.concentration,
+                "max_block_pct": self.spread.max_block_pct,
+            }
+        if self.demographics:
+            d["demographics"] = {
+                "total_block_population": self.demographics.total_block_population,
+                "pct_white": self.demographics.pct_white,
+                "pct_black": self.demographics.pct_black,
+                "pct_hispanic": self.demographics.pct_hispanic,
+                "pct_asian": self.demographics.pct_asian,
+                "pct_voting_age": self.demographics.pct_voting_age,
+                "pct_housing_occupied": self.demographics.pct_housing_occupied,
+            }
+        if self.urbanicity:
+            d["urbanicity"] = {
+                "dominant_category": self.urbanicity.dominant_category,
+                "dominant_locale": self.urbanicity.dominant_locale,
+                "distribution": self.urbanicity.category_distribution,
+            }
+        if self.recency:
+            d["recency"] = {
+                "total_analyzed": self.recency.total_analyzed,
+                "median_vintage": self.recency.median_vintage,
+                "new_construction_pct": self.recency.new_construction_pct,
+                "vintage_distribution": self.recency.vintage_distribution,
+            }
+        if self.top_blocks:
+            d["top_blocks"] = [
+                {
+                    "block_geoid": b.block_geoid,
+                    "address_count": b.address_count,
+                    "tract_geoid": b.tract_geoid,
+                }
+                for b in self.top_blocks
+            ]
+        return d
+
+
+def build_portrait(
+    codification: CodificationResult,
+    spread: Optional[SpreadMetrics] = None,
+    demographics: Optional[DemographicSignature] = None,
+    urbanicity: Optional[UrbanicityDistribution] = None,
+    recency: Optional[RecencyAnalysis] = None,
+    top_n: int = 10,
+) -> AreaPortrait:
+    """Build a structured area portrait from codification results.
+
+    Args:
+        codification: CodificationResult from codify_area().
+        spread: Pre-computed spread metrics.
+        demographics: Pre-computed demographic signature.
+        urbanicity: Pre-computed urbanicity distribution.
+        recency: Pre-computed recency analysis.
+        top_n: Number of top blocks to include.
+    """
+    top_blocks = []
+    if codification.blocks:
+        sorted_blocks = sorted(
+            codification.blocks,
+            key=lambda b: b.address_count,
+            reverse=True,
+        )[:top_n]
+        top_blocks = [
+            BlockGroup(
+                block_geoid=b.block_geoid,
+                tract_geoid=b.tract_geoid,
+                county_geoid=b.county_geoid,
+                state_geoid=b.state_geoid,
+                address_count=b.address_count,
+            )
+            for b in sorted_blocks
+        ]
+
+    return AreaPortrait(
+        geocoding_summary=codification.summarize(),
+        spread=spread,
+        demographics=demographics,
+        urbanicity=urbanicity,
+        recency=recency,
+        top_blocks=top_blocks,
+    )

--- a/siege_utilities/geo/codification_urbanicity.py
+++ b/siege_utilities/geo/codification_urbanicity.py
@@ -1,0 +1,123 @@
+"""Urbanicity enrichment for codification.
+
+Classifies each matched block's urbanicity using the NCES locale system
+and produces an address-weighted distribution.
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class BlockLocale:
+    """NCES locale classification for a Census block.
+
+    Attributes:
+        block_geoid: Block GEOID.
+        locale_code: NCES 2-digit code (e.g., "11").
+        locale_label: Human-readable label (e.g., "City-Large").
+        category: Top-level (city, suburb, town, rural).
+    """
+
+    block_geoid: str = ""
+    locale_code: str = ""
+    locale_label: str = ""
+    category: str = ""
+
+
+@dataclass
+class UrbanicityDistribution:
+    """Address-weighted urbanicity distribution for a codified area.
+
+    Attributes:
+        total_classified: Number of addresses with urbanicity classification.
+        distribution: Dict of locale_code → fraction of addresses.
+        category_distribution: Dict of category → fraction of addresses.
+        dominant_locale: Most common locale code.
+        dominant_category: Most common category.
+    """
+
+    total_classified: int = 0
+    distribution: dict[str, float] = field(default_factory=dict)
+    category_distribution: dict[str, float] = field(default_factory=dict)
+    dominant_locale: str = ""
+    dominant_category: str = ""
+
+
+class BlockLocaleProvider(abc.ABC):
+    """Protocol for fetching block urbanicity classifications."""
+
+    @abc.abstractmethod
+    def classify_blocks(
+        self,
+        block_geoids: list[str],
+        census_year: Optional[int] = None,
+    ) -> dict[str, BlockLocale]:
+        """Classify blocks by NCES locale.
+
+        Returns dict of block_geoid → BlockLocale.
+        """
+
+
+class DictBlockLocaleProvider(BlockLocaleProvider):
+    """In-memory locale provider for testing."""
+
+    def __init__(self):
+        self._data: dict[str, BlockLocale] = {}
+
+    def add(self, locale: BlockLocale):
+        self._data[locale.block_geoid] = locale
+
+    def classify_blocks(
+        self,
+        block_geoids: list[str],
+        census_year: Optional[int] = None,
+    ) -> dict[str, BlockLocale]:
+        return {g: self._data[g] for g in block_geoids if g in self._data}
+
+
+def compute_urbanicity_distribution(
+    block_address_counts: dict[str, int],
+    locales: dict[str, BlockLocale],
+) -> UrbanicityDistribution:
+    """Compute address-weighted urbanicity distribution.
+
+    Args:
+        block_address_counts: Dict of block_geoid → address count.
+        locales: Dict of block_geoid → BlockLocale.
+    """
+    locale_counts: Counter = Counter()
+    category_counts: Counter = Counter()
+    total = 0
+
+    for geoid, addr_count in block_address_counts.items():
+        locale = locales.get(geoid)
+        if locale is None:
+            continue
+        locale_counts[locale.locale_code] += addr_count
+        category_counts[locale.category] += addr_count
+        total += addr_count
+
+    if total == 0:
+        return UrbanicityDistribution()
+
+    distribution = {code: count / total for code, count in locale_counts.items()}
+    category_dist = {cat: count / total for cat, count in category_counts.items()}
+
+    dominant_locale = locale_counts.most_common(1)[0][0] if locale_counts else ""
+    dominant_category = category_counts.most_common(1)[0][0] if category_counts else ""
+
+    return UrbanicityDistribution(
+        total_classified=total,
+        distribution=distribution,
+        category_distribution=category_dist,
+        dominant_locale=dominant_locale,
+        dominant_category=dominant_category,
+    )

--- a/siege_utilities/geo/django/models/__init__.py
+++ b/siege_utilities/geo/django/models/__init__.py
@@ -75,6 +75,12 @@ from .federal import (
     NLRBRegion,
     FederalJudicialDistrict,
 )
+from .nlrb_cases import (
+    NLRBCase,
+    ElectionResult,
+    ULPCharge,
+    BargainingUnit,
+)
 from .timezone import (
     TimezoneGeometry,
 )
@@ -173,6 +179,11 @@ __all__ = [
     # Federal
     "NLRBRegion",
     "FederalJudicialDistrict",
+    # NLRB Cases
+    "NLRBCase",
+    "ElectionResult",
+    "ULPCharge",
+    "BargainingUnit",
     # Timezone
     "TimezoneGeometry",
     # Isochrone

--- a/siege_utilities/geo/django/models/nlrb_cases.py
+++ b/siege_utilities/geo/django/models/nlrb_cases.py
@@ -1,0 +1,239 @@
+"""NLRB case, election, ULP, and bargaining unit Django models.
+
+Non-spatial models for NLRB case data. These link to NLRBRegion via FK
+but don't carry their own geometry.
+"""
+
+from django.db import models
+
+
+class NLRBCase(models.Model):
+    """An NLRB case (representation petition, ULP charge, etc.)."""
+
+    case_number = models.CharField(
+        max_length=20,
+        unique=True,
+        db_index=True,
+        help_text="NLRB case number (e.g. '05-RC-123456')",
+    )
+    case_type = models.CharField(
+        max_length=10,
+        db_index=True,
+        help_text="Case type code (R, RC, CA, CB, etc.)",
+    )
+    case_name = models.CharField(
+        max_length=500,
+        blank=True,
+        default="",
+        help_text="Employer or party name",
+    )
+    status = models.CharField(
+        max_length=50,
+        blank=True,
+        default="Unknown",
+        db_index=True,
+    )
+    date_filed = models.DateField(null=True, blank=True, db_index=True)
+    date_closed = models.DateField(null=True, blank=True)
+    region = models.ForeignKey(
+        "NLRBRegion",
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="cases",
+    )
+    region_number = models.PositiveSmallIntegerField(
+        null=True,
+        blank=True,
+        db_index=True,
+        help_text="Region number extracted from case number",
+    )
+    city = models.CharField(max_length=100, blank=True, default="")
+    state = models.CharField(max_length=2, blank=True, default="", db_index=True)
+    union_name = models.CharField(max_length=300, blank=True, default="")
+    unit_description = models.TextField(blank=True, default="")
+    naics_code = models.CharField(
+        max_length=10,
+        blank=True,
+        default="",
+        db_index=True,
+    )
+    employee_count = models.PositiveIntegerField(null=True, blank=True)
+    source = models.CharField(
+        max_length=50,
+        blank=True,
+        default="",
+        help_text="Data source: 'datagov', 'labordata', 'nxgen'",
+    )
+
+    class Meta:
+        verbose_name = "NLRB Case"
+        verbose_name_plural = "NLRB Cases"
+        indexes = [
+            models.Index(fields=["case_type", "status"]),
+            models.Index(fields=["date_filed"]),
+            models.Index(fields=["state"]),
+        ]
+
+    def __str__(self):
+        return f"{self.case_number} ({self.case_name})"
+
+    def to_record(self):
+        """Convert to NLRBCaseRecord dataclass."""
+        from siege_utilities.geo.providers.nlrb_clients import NLRBCaseRecord
+
+        return NLRBCaseRecord(
+            case_number=self.case_number,
+            case_type=self.case_type,
+            case_name=self.case_name,
+            status=self.status,
+            date_filed=self.date_filed,
+            date_closed=self.date_closed,
+            region=self.region_number,
+            city=self.city,
+            state=self.state,
+            union_name=self.union_name,
+            unit_description=self.unit_description,
+            naics_code=self.naics_code,
+            employee_count=self.employee_count,
+            source=self.source,
+        )
+
+    @classmethod
+    def from_record(cls, record):
+        """Create model instance from NLRBCaseRecord dataclass."""
+        return cls(
+            case_number=record.case_number,
+            case_type=record.case_type,
+            case_name=record.case_name,
+            status=record.status,
+            date_filed=record.date_filed,
+            date_closed=record.date_closed,
+            region_number=record.region,
+            city=record.city,
+            state=record.state,
+            union_name=record.union_name,
+            unit_description=record.unit_description,
+            naics_code=record.naics_code,
+            employee_count=record.employee_count,
+            source=record.source,
+        )
+
+
+class ElectionResult(models.Model):
+    """Election tally result for an NLRB representation case."""
+
+    case = models.ForeignKey(
+        NLRBCase,
+        on_delete=models.CASCADE,
+        related_name="election_results",
+    )
+    tally_date = models.DateField(null=True, blank=True, db_index=True)
+    eligible_voters = models.PositiveIntegerField(null=True, blank=True)
+    votes_for = models.PositiveIntegerField(null=True, blank=True)
+    votes_against = models.PositiveIntegerField(null=True, blank=True)
+    void_ballots = models.PositiveIntegerField(null=True, blank=True)
+    union_name = models.CharField(max_length=300, blank=True, default="")
+    source = models.CharField(max_length=50, blank=True, default="")
+
+    class Meta:
+        verbose_name = "Election Result"
+        verbose_name_plural = "Election Results"
+        indexes = [
+            models.Index(fields=["tally_date"]),
+        ]
+
+    def __str__(self):
+        return f"Election {self.case.case_number} ({self.tally_date})"
+
+    def to_record(self):
+        from siege_utilities.geo.providers.nlrb_clients import ElectionRecord
+
+        return ElectionRecord(
+            case_number=self.case.case_number,
+            tally_date=self.tally_date,
+            eligible_voters=self.eligible_voters,
+            votes_for=self.votes_for,
+            votes_against=self.votes_against,
+            void_ballots=self.void_ballots,
+            union_name=self.union_name,
+            source=self.source,
+        )
+
+
+class ULPCharge(models.Model):
+    """Unfair labor practice charge filed with the NLRB."""
+
+    case = models.ForeignKey(
+        NLRBCase,
+        on_delete=models.CASCADE,
+        related_name="ulp_charges",
+    )
+    allegation = models.TextField(blank=True, default="")
+    charging_party = models.CharField(max_length=300, blank=True, default="")
+    charged_party = models.CharField(max_length=300, blank=True, default="")
+    section_of_act = models.CharField(
+        max_length=50,
+        blank=True,
+        default="",
+        help_text="NLRA section cited (e.g. '8(a)(1)')",
+    )
+    date_filed = models.DateField(null=True, blank=True, db_index=True)
+    source = models.CharField(max_length=50, blank=True, default="")
+
+    class Meta:
+        verbose_name = "ULP Charge"
+        verbose_name_plural = "ULP Charges"
+        indexes = [
+            models.Index(fields=["date_filed"]),
+        ]
+
+    def __str__(self):
+        return f"ULP {self.case.case_number}: {self.section_of_act}"
+
+    def to_record(self):
+        from siege_utilities.geo.providers.nlrb_clients import ULPRecord
+
+        return ULPRecord(
+            case_number=self.case.case_number,
+            allegation=self.allegation,
+            charging_party=self.charging_party,
+            charged_party=self.charged_party,
+            section_of_act=self.section_of_act,
+            date_filed=self.date_filed,
+            source=self.source,
+        )
+
+
+class BargainingUnit(models.Model):
+    """Bargaining unit description with industry/occupation codes."""
+
+    case = models.ForeignKey(
+        NLRBCase,
+        on_delete=models.CASCADE,
+        related_name="bargaining_units",
+    )
+    unit_description = models.TextField(blank=True, default="")
+    naics_code = models.CharField(
+        max_length=10,
+        blank=True,
+        default="",
+        db_index=True,
+        help_text="NAICS industry code",
+    )
+    soc_codes = models.JSONField(
+        default=list,
+        blank=True,
+        help_text="List of SOC occupation codes",
+    )
+    employee_count = models.PositiveIntegerField(null=True, blank=True)
+
+    class Meta:
+        verbose_name = "Bargaining Unit"
+        verbose_name_plural = "Bargaining Units"
+        indexes = [
+            models.Index(fields=["naics_code"]),
+        ]
+
+    def __str__(self):
+        return f"Unit: {self.case.case_number} ({self.naics_code})"

--- a/siege_utilities/geo/locale.py
+++ b/siege_utilities/geo/locale.py
@@ -162,6 +162,53 @@ def locale_from_code(code: int) -> LocaleCode:
 # NCESLocaleClassifier
 # ---------------------------------------------------------------------------
 
+class LocaleIndex:
+    """Precomputed GEOID → LocaleCode mapping for fast lookup.
+
+    Built from any data source that pairs GEOIDs with NCES locale codes
+    (e.g., NCES district data, school locations, or Census tract assignments).
+    """
+
+    def __init__(self, mapping: Optional[Dict[str, int]] = None):
+        self._mapping: Dict[str, int] = mapping or {}
+
+    def add(self, geoid: str, locale_code: int) -> None:
+        self._mapping[geoid] = locale_code
+
+    def add_bulk(self, pairs: Dict[str, int]) -> None:
+        self._mapping.update(pairs)
+
+    def get(self, geoid: str) -> Optional[LocaleCode]:
+        code = self._mapping.get(geoid)
+        if code is None:
+            return None
+        return locale_from_code(code)
+
+    def __len__(self) -> int:
+        return len(self._mapping)
+
+    def __contains__(self, geoid: str) -> bool:
+        return geoid in self._mapping
+
+    @classmethod
+    def from_dataframe(
+        cls,
+        df: Any,
+        geoid_col: str = "geoid",
+        locale_col: str = "locale_code",
+    ) -> "LocaleIndex":
+        mapping = {}
+        for _, row in df.iterrows():
+            geoid = str(row[geoid_col]).strip()
+            try:
+                code = int(row[locale_col])
+                if validate_locale_code(code):
+                    mapping[geoid] = code
+            except (ValueError, TypeError):
+                continue
+        return cls(mapping)
+
+
 class NCESLocaleClassifier:
     """Classify geographic points and polygons into NCES locale codes.
 
@@ -207,6 +254,8 @@ class NCESLocaleClassifier:
         self._ua_populations = ua_populations or {}
         self._projection_crs = projection_crs or settings.PROJECTION_CRS
 
+        self._locale_index: Optional[LocaleIndex] = None
+
         # Lazily projected copies (created on first classify call)
         self._ua_proj = None
         self._uc_proj = None
@@ -220,6 +269,39 @@ class NCESLocaleClassifier:
             self._ua_proj = self._ua.to_crs(crs_string)
         if self._uc_proj is None and self._uc is not None:
             self._uc_proj = self._uc.to_crs(crs_string)
+
+    # ------------------------------------------------------------------
+    # GEOID lookup
+    # ------------------------------------------------------------------
+
+    @property
+    def locale_index(self) -> Optional[LocaleIndex]:
+        return self._locale_index
+
+    @locale_index.setter
+    def locale_index(self, index: LocaleIndex) -> None:
+        self._locale_index = index
+
+    def classify_geoid(self, geoid: str) -> Optional[LocaleCode]:
+        """Fast-path locale lookup by Census GEOID.
+
+        Returns the precomputed locale code if the GEOID is in the index,
+        or ``None`` if no index is set or the GEOID is not found.
+        Use ``classify_geoid_or_point()`` for automatic fallback to
+        spatial classification.
+        """
+        if self._locale_index is None:
+            return None
+        return self._locale_index.get(geoid)
+
+    def classify_geoid_or_point(
+        self, geoid: str, lon: float, lat: float,
+    ) -> LocaleCode:
+        """Classify by GEOID if available, falling back to spatial."""
+        result = self.classify_geoid(geoid)
+        if result is not None:
+            return result
+        return self.classify_point(lon, lat)
 
     # ------------------------------------------------------------------
     # Point classification

--- a/siege_utilities/geo/locale.py
+++ b/siege_utilities/geo/locale.py
@@ -473,6 +473,55 @@ class NCESLocaleClassifier:
         # "distribution" or "area_weighted"
         return distribution
 
+    def classify_polygons(
+        self,
+        gdf: Any,
+        method: str = "majority",
+        geometry_col: str = "geometry",
+    ) -> Any:
+        """Bulk classify a GeoDataFrame of polygons.
+
+        For ``method="majority"``, adds columns: ``locale_code`` (int),
+        ``locale_label`` (str).
+
+        For ``method="distribution"`` or ``"area_weighted"``, adds a
+        ``locale_distribution`` column containing per-row dicts of
+        ``{code: fraction}`` pairs.
+
+        Args:
+            gdf: GeoDataFrame with polygon geometries.
+            method: ``"majority"``, ``"distribution"``, or ``"area_weighted"``.
+            geometry_col: Name of the geometry column.
+
+        Returns:
+            The input GeoDataFrame with locale columns added.
+        """
+        gdf = gdf.copy()
+
+        if method == "majority":
+            codes = []
+            labels = []
+            for _, row in gdf.iterrows():
+                result = self.classify_polygon(row[geometry_col], method="majority")
+                codes.append(result["locale_code"])
+                labels.append(result["locale_label"])
+            gdf["locale_code"] = codes
+            gdf["locale_label"] = labels
+            gdf["locale_category"] = [
+                locale_from_code(c).category for c in codes
+            ]
+            gdf["locale_subcategory"] = [
+                locale_from_code(c).subcategory for c in codes
+            ]
+        else:
+            distributions = []
+            for _, row in gdf.iterrows():
+                dist = self.classify_polygon(row[geometry_col], method=method)
+                distributions.append(dist)
+            gdf["locale_distribution"] = distributions
+
+        return gdf
+
     # ------------------------------------------------------------------
     # Factory methods
     # ------------------------------------------------------------------

--- a/siege_utilities/geo/overlay_registry.py
+++ b/siege_utilities/geo/overlay_registry.py
@@ -1,0 +1,176 @@
+"""Extensible overlay registry for place history queries.
+
+Overlays add contextual data layers (seats, demographics, urbanicity,
+events) to :func:`place_history` results. New overlays plug in via
+the decorator-based registry without changing core query logic.
+
+Usage::
+
+    from siege_utilities.geo.overlay_registry import (
+        PlaceHistoryOverlay,
+        overlay_registry,
+    )
+
+    @overlay_registry.register("my_overlay")
+    class MyOverlay(PlaceHistoryOverlay):
+        def fetch(self, geoid, from_year, to_year, state_fips=None):
+            return {"data": "..."}
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from typing import Any, Optional
+
+log = logging.getLogger(__name__)
+
+
+class PlaceHistoryOverlay(abc.ABC):
+    """Base class for place history overlays.
+
+    Subclasses implement :meth:`fetch` to retrieve overlay-specific data
+    for a queried GEOID and time range.
+    """
+
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
+        """Short identifier for this overlay (e.g., 'seats', 'demographics')."""
+
+    @abc.abstractmethod
+    def fetch(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        state_fips: Optional[str] = None,
+    ) -> Any:
+        """Fetch overlay data for a place and time range.
+
+        Args:
+            geoid: Census GEOID to query.
+            from_year: Start year.
+            to_year: End year.
+            state_fips: Optional state FIPS for filtering.
+
+        Returns:
+            Overlay-specific data (dict, list, dataclass, etc.).
+        """
+
+    def is_available(self) -> bool:
+        """Check if this overlay's data source is accessible."""
+        return True
+
+
+class OverlayRegistry:
+    """Registry for place history overlays.
+
+    Supports both decorator-based and imperative registration.
+
+    Decorator usage::
+
+        @overlay_registry.register("seats")
+        class SeatsOverlay(PlaceHistoryOverlay):
+            ...
+
+    Imperative usage::
+
+        overlay_registry.register_instance("seats", SeatsOverlay())
+    """
+
+    def __init__(self):
+        self._overlays: dict[str, PlaceHistoryOverlay] = {}
+        self._classes: dict[str, type] = {}
+
+    def register(self, name: str):
+        """Decorator to register an overlay class.
+
+        The class is instantiated on first use (lazy).
+
+        Args:
+            name: Overlay identifier used in place_history(overlays=[...]).
+
+        Returns:
+            Decorator that registers the class.
+        """
+        def decorator(cls):
+            if not issubclass(cls, PlaceHistoryOverlay):
+                raise TypeError(
+                    f"{cls.__name__} must subclass PlaceHistoryOverlay"
+                )
+            self._classes[name] = cls
+            return cls
+        return decorator
+
+    def register_instance(self, name: str, instance: PlaceHistoryOverlay):
+        """Register a pre-instantiated overlay.
+
+        Args:
+            name: Overlay identifier.
+            instance: PlaceHistoryOverlay instance.
+        """
+        if not isinstance(instance, PlaceHistoryOverlay):
+            raise TypeError(
+                f"{type(instance).__name__} must be a PlaceHistoryOverlay"
+            )
+        self._overlays[name] = instance
+
+    def get(self, name: str) -> Optional[PlaceHistoryOverlay]:
+        """Look up an overlay by name.
+
+        Lazily instantiates class-registered overlays on first access.
+
+        Args:
+            name: Overlay identifier.
+
+        Returns:
+            PlaceHistoryOverlay instance or None if not registered.
+        """
+        if name in self._overlays:
+            return self._overlays[name]
+
+        if name in self._classes:
+            try:
+                instance = self._classes[name]()
+                self._overlays[name] = instance
+                return instance
+            except Exception as exc:
+                log.error("Failed to instantiate overlay %s: %s", name, exc)
+                return None
+
+        return None
+
+    def list_overlays(self) -> list[str]:
+        """Return names of all registered overlays."""
+        return sorted(set(self._overlays.keys()) | set(self._classes.keys()))
+
+    def is_registered(self, name: str) -> bool:
+        """Check if an overlay name is registered."""
+        return name in self._overlays or name in self._classes
+
+    def unregister(self, name: str) -> bool:
+        """Remove an overlay registration.
+
+        Args:
+            name: Overlay identifier.
+
+        Returns:
+            True if the overlay was found and removed.
+        """
+        removed = False
+        if name in self._overlays:
+            del self._overlays[name]
+            removed = True
+        if name in self._classes:
+            del self._classes[name]
+            removed = True
+        return removed
+
+    def clear(self):
+        """Remove all registrations."""
+        self._overlays.clear()
+        self._classes.clear()
+
+
+overlay_registry = OverlayRegistry()

--- a/siege_utilities/geo/overlays/__init__.py
+++ b/siege_utilities/geo/overlays/__init__.py
@@ -1,0 +1,1 @@
+"""Place history overlay implementations."""

--- a/siege_utilities/geo/overlays/demographics.py
+++ b/siege_utilities/geo/overlays/demographics.py
@@ -1,0 +1,195 @@
+"""Demographics overlay for place history.
+
+Assembles DemographicSnapshot time series for a queried geography,
+handling GEOID changes via the crosswalk chain from the lineage.
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from siege_utilities.geo.overlay_registry import PlaceHistoryOverlay
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DemographicPoint:
+    """A single demographic data point for a year.
+
+    Attributes:
+        year: Data year.
+        geoid: GEOID this data belongs to.
+        dataset: Dataset identifier (acs5, acs1, dec, dec_pl).
+        total_population: Total population if available.
+        median_household_income: Median HH income if available.
+        median_age: Median age if available.
+        values: Full variable code → value mapping.
+    """
+
+    year: int = 0
+    geoid: str = ""
+    dataset: str = ""
+    total_population: Optional[int] = None
+    median_household_income: Optional[float] = None
+    median_age: Optional[float] = None
+    values: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class DemographicsOverlayResult:
+    """Result of the demographics overlay query.
+
+    Attributes:
+        geoid: Queried GEOID.
+        time_series: Ordered list of demographic data points.
+        geoids_queried: All GEOIDs queried (includes crosswalk targets).
+    """
+
+    geoid: str = ""
+    time_series: list[DemographicPoint] = field(default_factory=list)
+    geoids_queried: list[str] = field(default_factory=list)
+
+    @property
+    def years(self) -> list[int]:
+        return sorted(set(p.year for p in self.time_series))
+
+    @property
+    def has_data(self) -> bool:
+        return len(self.time_series) > 0
+
+    def for_year(self, year: int) -> list[DemographicPoint]:
+        return [p for p in self.time_series if p.year == year]
+
+    def population_series(self) -> list[tuple[int, Optional[int]]]:
+        return [
+            (p.year, p.total_population)
+            for p in self.time_series
+            if p.total_population is not None
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Data provider protocol
+# ---------------------------------------------------------------------------
+
+
+class DemographicsDataProvider(abc.ABC):
+    """Protocol for fetching demographic snapshot data."""
+
+    @abc.abstractmethod
+    def get_snapshots(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        dataset: Optional[str] = None,
+    ) -> list[DemographicPoint]:
+        """Get demographic data points for a GEOID and year range."""
+
+
+class DictDemographicsProvider(DemographicsDataProvider):
+    """In-memory demographics provider for testing."""
+
+    def __init__(self):
+        self._data: list[DemographicPoint] = []
+
+    def add(self, point: DemographicPoint):
+        self._data.append(point)
+
+    def get_snapshots(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        dataset: Optional[str] = None,
+    ) -> list[DemographicPoint]:
+        lo = min(from_year, to_year)
+        hi = max(from_year, to_year)
+        results = []
+        for p in self._data:
+            if p.geoid != geoid:
+                continue
+            if p.year < lo or p.year > hi:
+                continue
+            if dataset and p.dataset != dataset:
+                continue
+            results.append(p)
+        return sorted(results, key=lambda x: x.year)
+
+
+# ---------------------------------------------------------------------------
+# Overlay implementation
+# ---------------------------------------------------------------------------
+
+
+class DemographicsOverlay(PlaceHistoryOverlay):
+    """Place history overlay for demographic time series.
+
+    Queries DemographicSnapshot data for the queried GEOID and any
+    related GEOIDs from the crosswalk chain (when a GEOID changes
+    across decades).
+
+    Args:
+        provider: DemographicsDataProvider for fetching snapshot data.
+        dataset: Restrict to a specific dataset (e.g., "acs5").
+        terminal_geoids: Additional GEOIDs to query (from lineage).
+    """
+
+    def __init__(
+        self,
+        provider: Optional[DemographicsDataProvider] = None,
+        dataset: Optional[str] = None,
+    ):
+        self._provider = provider
+        self._dataset = dataset
+
+    @property
+    def name(self) -> str:
+        return "demographics"
+
+    def fetch(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        state_fips: Optional[str] = None,
+        terminal_geoids: Optional[list[str]] = None,
+    ) -> DemographicsOverlayResult:
+        provider = self._provider or self._get_default_provider()
+        if provider is None:
+            raise RuntimeError("No demographics data provider available")
+
+        all_geoids = [geoid]
+        if terminal_geoids:
+            for g in terminal_geoids:
+                if g not in all_geoids:
+                    all_geoids.append(g)
+
+        all_points = []
+        for g in all_geoids:
+            points = provider.get_snapshots(g, from_year, to_year, self._dataset)
+            all_points.extend(points)
+
+        all_points.sort(key=lambda p: (p.year, p.geoid))
+
+        return DemographicsOverlayResult(
+            geoid=geoid,
+            time_series=all_points,
+            geoids_queried=all_geoids,
+        )
+
+    def _get_default_provider(self) -> Optional[DemographicsDataProvider]:
+        try:
+            from siege_utilities.geo.django.providers import DjangoDemographicsProvider
+            return DjangoDemographicsProvider()
+        except Exception:
+            return None

--- a/siege_utilities/geo/overlays/election_results.py
+++ b/siege_utilities/geo/overlays/election_results.py
@@ -46,6 +46,10 @@ class ElectionReturn:
     state: str = ""
     reconciliation_method: str = "direct"
 
+    def __post_init__(self):
+        if self.total_votes > 0 and self.vote_share == 0.0 and self.votes > 0:
+            self.vote_share = self.votes / self.total_votes
+
 
 @dataclass
 class ElectionResultsOverlayResult:

--- a/siege_utilities/geo/overlays/election_results.py
+++ b/siege_utilities/geo/overlays/election_results.py
@@ -1,0 +1,167 @@
+"""Election results overlay for place history.
+
+Shows precinct-level election returns for a queried geography,
+reconciled via precinct-VTD mapping where needed.
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from siege_utilities.geo.overlay_registry import PlaceHistoryOverlay
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class ElectionReturn:
+    """Election result for a single contest in a single precinct/VTD.
+
+    Attributes:
+        precinct_id: Precinct or VTD identifier.
+        election_year: Year of the election.
+        election_type: general, primary, runoff, special.
+        office: Office contested (e.g., US_PRESIDENT, US_HOUSE, GOVERNOR).
+        candidate: Candidate name.
+        party: Party abbreviation (DEM, REP, LIB, etc.).
+        votes: Vote count.
+        total_votes: Total votes cast in this contest at this precinct.
+        vote_share: Fraction of total votes (0-1).
+        state: State abbreviation.
+        reconciliation_method: How this precinct was mapped (spatial, name_match, official_crosswalk, or direct).
+    """
+
+    precinct_id: str = ""
+    election_year: int = 0
+    election_type: str = "general"
+    office: str = ""
+    candidate: str = ""
+    party: str = ""
+    votes: int = 0
+    total_votes: int = 0
+    vote_share: float = 0.0
+    state: str = ""
+    reconciliation_method: str = "direct"
+
+
+@dataclass
+class ElectionResultsOverlayResult:
+    """Result of the election results overlay query.
+
+    Attributes:
+        geoid: Queried GEOID.
+        returns: Election returns ordered by year then office.
+        election_years: Distinct years with data.
+        offices: Distinct offices with data.
+    """
+
+    geoid: str = ""
+    returns: list[ElectionReturn] = field(default_factory=list)
+
+    @property
+    def election_years(self) -> list[int]:
+        return sorted(set(r.election_year for r in self.returns))
+
+    @property
+    def offices(self) -> list[str]:
+        return sorted(set(r.office for r in self.returns if r.office))
+
+    def for_year(self, year: int) -> list[ElectionReturn]:
+        return [r for r in self.returns if r.election_year == year]
+
+    def for_office(self, office: str) -> list[ElectionReturn]:
+        return [r for r in self.returns if r.office == office]
+
+    def for_year_office(self, year: int, office: str) -> list[ElectionReturn]:
+        return [
+            r for r in self.returns
+            if r.election_year == year and r.office == office
+        ]
+
+    def party_totals(self, year: int, office: str) -> dict[str, int]:
+        """Sum votes by party for a specific contest."""
+        totals: dict[str, int] = {}
+        for r in self.for_year_office(year, office):
+            totals[r.party] = totals.get(r.party, 0) + r.votes
+        return totals
+
+
+class ElectionDataProvider(abc.ABC):
+    """Protocol for fetching election results for a geography."""
+
+    @abc.abstractmethod
+    def get_election_returns(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        state_fips: Optional[str] = None,
+    ) -> list[ElectionReturn]:
+        """Get election returns for precincts/VTDs overlapping a geography."""
+
+
+class DictElectionDataProvider(ElectionDataProvider):
+    """In-memory election data provider for testing."""
+
+    def __init__(self):
+        self._returns: list[ElectionReturn] = []
+
+    def add(self, ret: ElectionReturn):
+        self._returns.append(ret)
+
+    def get_election_returns(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        state_fips: Optional[str] = None,
+    ) -> list[ElectionReturn]:
+        results = []
+        for r in self._returns:
+            if r.election_year < from_year or r.election_year > to_year:
+                continue
+            if state_fips and r.state.upper() != state_fips.upper():
+                continue
+            results.append(r)
+        return results
+
+
+class ElectionResultsOverlay(PlaceHistoryOverlay):
+    """Place history overlay for precinct-level election results.
+
+    Returns election returns for precincts/VTDs that overlap the
+    queried geography, reconciled via precinct-VTD mapping.
+    """
+
+    def __init__(self, provider: Optional[ElectionDataProvider] = None):
+        self._provider = provider
+
+    @property
+    def name(self) -> str:
+        return "election_results"
+
+    def fetch(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        state_fips: Optional[str] = None,
+    ) -> ElectionResultsOverlayResult:
+        if self._provider is None:
+            return ElectionResultsOverlayResult(geoid=geoid)
+
+        returns = self._provider.get_election_returns(
+            geoid, from_year, to_year, state_fips,
+        )
+        returns.sort(key=lambda r: (r.election_year, r.office, r.party))
+
+        return ElectionResultsOverlayResult(
+            geoid=geoid,
+            returns=returns,
+        )
+
+    def is_available(self) -> bool:
+        return self._provider is not None

--- a/siege_utilities/geo/overlays/events.py
+++ b/siege_utilities/geo/overlays/events.py
@@ -1,0 +1,187 @@
+"""Events overlay for place history.
+
+SpatioTemporalEvents intersecting the queried geography and time range.
+Events include court rulings, natural disasters, redistricting actions,
+and other discrete occurrences with both spatial and temporal extent.
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Any, Optional
+
+from siege_utilities.geo.overlay_registry import PlaceHistoryOverlay
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class EventRecord:
+    """A single spatio-temporal event.
+
+    Attributes:
+        event_id: Unique identifier.
+        event_type: Category (e.g., "court_ruling", "natural_disaster",
+            "redistricting", "election", "policy_change").
+        title: Short description.
+        description: Longer description.
+        date: Event date.
+        end_date: End date for events with duration.
+        geoids_affected: GEOIDs intersecting this event's geography.
+        source: Data source or citation.
+        metadata: Additional event-specific data.
+    """
+
+    event_id: str = ""
+    event_type: str = ""
+    title: str = ""
+    description: str = ""
+    date: Optional[date] = None
+    end_date: Optional[date] = None
+    geoids_affected: list[str] = field(default_factory=list)
+    source: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def year(self) -> int:
+        return self.date.year if self.date else 0
+
+    @property
+    def has_duration(self) -> bool:
+        return self.end_date is not None and self.date is not None
+
+
+@dataclass
+class EventsOverlayResult:
+    """Result of the events overlay query.
+
+    Attributes:
+        geoid: Queried GEOID.
+        events: Events intersecting the geography and time range.
+    """
+
+    geoid: str = ""
+    events: list[EventRecord] = field(default_factory=list)
+
+    @property
+    def has_events(self) -> bool:
+        return len(self.events) > 0
+
+    @property
+    def event_types(self) -> list[str]:
+        return sorted(set(e.event_type for e in self.events if e.event_type))
+
+    def for_type(self, event_type: str) -> list[EventRecord]:
+        return [e for e in self.events if e.event_type == event_type]
+
+    @property
+    def count(self) -> int:
+        return len(self.events)
+
+
+# ---------------------------------------------------------------------------
+# Data provider protocol
+# ---------------------------------------------------------------------------
+
+
+class EventsDataProvider(abc.ABC):
+    """Protocol for fetching spatio-temporal event data."""
+
+    @abc.abstractmethod
+    def get_events(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        event_types: Optional[list[str]] = None,
+    ) -> list[EventRecord]:
+        """Get events intersecting a GEOID within a time range."""
+
+
+class DictEventsProvider(EventsDataProvider):
+    """In-memory events provider for testing."""
+
+    def __init__(self):
+        self._events: list[EventRecord] = []
+
+    def add(self, event: EventRecord):
+        self._events.append(event)
+
+    def get_events(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        event_types: Optional[list[str]] = None,
+    ) -> list[EventRecord]:
+        lo = min(from_year, to_year)
+        hi = max(from_year, to_year)
+        results = []
+        for e in self._events:
+            if geoid not in e.geoids_affected:
+                continue
+            if e.year < lo or e.year > hi:
+                continue
+            if event_types and e.event_type not in event_types:
+                continue
+            results.append(e)
+        return sorted(results, key=lambda e: (e.date or date.min))
+
+
+# ---------------------------------------------------------------------------
+# Overlay implementation
+# ---------------------------------------------------------------------------
+
+
+class EventsOverlay(PlaceHistoryOverlay):
+    """Place history overlay for spatio-temporal events.
+
+    Finds events that intersect the queried geography and time range.
+
+    Args:
+        provider: EventsDataProvider for fetching events.
+        event_types: Optional filter for specific event types.
+    """
+
+    def __init__(
+        self,
+        provider: Optional[EventsDataProvider] = None,
+        event_types: Optional[list[str]] = None,
+    ):
+        self._provider = provider
+        self._event_types = event_types
+
+    @property
+    def name(self) -> str:
+        return "events"
+
+    def fetch(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        state_fips: Optional[str] = None,
+    ) -> EventsOverlayResult:
+        provider = self._provider or self._get_default_provider()
+        if provider is None:
+            raise RuntimeError("No events data provider available")
+
+        events = provider.get_events(
+            geoid, from_year, to_year, self._event_types
+        )
+        return EventsOverlayResult(geoid=geoid, events=events)
+
+    def _get_default_provider(self) -> Optional[EventsDataProvider]:
+        try:
+            from siege_utilities.geo.django.providers import DjangoEventsProvider
+            return DjangoEventsProvider()
+        except Exception:
+            return None

--- a/siege_utilities/geo/overlays/redistricting.py
+++ b/siege_utilities/geo/overlays/redistricting.py
@@ -13,10 +13,6 @@ from datetime import date
 from typing import Any, Optional
 
 from siege_utilities.geo.overlay_registry import PlaceHistoryOverlay
-from siege_utilities.geo.plan_lifecycle import (
-    PlanType,
-    RedistrictingPlan,
-)
 
 log = logging.getLogger(__name__)
 

--- a/siege_utilities/geo/overlays/redistricting.py
+++ b/siege_utilities/geo/overlays/redistricting.py
@@ -1,0 +1,172 @@
+"""Redistricting overlay for place history.
+
+Shows which redistricting plan(s) and district(s) applied to a
+geography over a queried time range, using plan lifecycle data.
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Any, Optional
+
+from siege_utilities.geo.overlay_registry import PlaceHistoryOverlay
+from siege_utilities.geo.plan_lifecycle import (
+    PlanType,
+    RedistrictingPlan,
+)
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class DistrictAssignment:
+    """A district assignment for a geography under a specific plan.
+
+    Attributes:
+        plan_id: Plan identifier.
+        plan_name: Human-readable plan name.
+        plan_type: Congressional, state senate, or state house.
+        district_id: District identifier (e.g., "TX-28").
+        state: State abbreviation.
+        from_date: When this assignment began.
+        to_date: When this assignment ended (None = still active).
+        enacted_by: Who enacted the plan.
+        court_case: Court case if court-ordered.
+        containment_pct: Fraction of queried geography in this district.
+    """
+
+    plan_id: str = ""
+    plan_name: str = ""
+    plan_type: str = ""
+    district_id: str = ""
+    state: str = ""
+    from_date: Optional[date] = None
+    to_date: Optional[date] = None
+    enacted_by: str = ""
+    court_case: str = ""
+    containment_pct: float = 1.0
+
+
+@dataclass
+class RedistrictingOverlayResult:
+    """Result of the redistricting overlay query.
+
+    Attributes:
+        geoid: Queried GEOID.
+        assignments: District assignments ordered by time.
+        plan_count: Number of distinct plans that applied.
+        had_court_intervention: Whether any plan was court-ordered.
+    """
+
+    geoid: str = ""
+    assignments: list[DistrictAssignment] = field(default_factory=list)
+
+    @property
+    def plan_count(self) -> int:
+        return len(set(a.plan_id for a in self.assignments))
+
+    @property
+    def had_court_intervention(self) -> bool:
+        return any(a.court_case for a in self.assignments)
+
+    @property
+    def plan_types(self) -> list[str]:
+        return sorted(set(a.plan_type for a in self.assignments if a.plan_type))
+
+    def for_plan_type(self, plan_type: str) -> list[DistrictAssignment]:
+        return [a for a in self.assignments if a.plan_type == plan_type]
+
+    def active_at(self, when: date) -> list[DistrictAssignment]:
+        result = []
+        for a in self.assignments:
+            if a.from_date and a.from_date > when:
+                continue
+            if a.to_date and a.to_date < when:
+                continue
+            result.append(a)
+        return result
+
+
+class RedistrictingDataProvider(abc.ABC):
+    """Protocol for fetching redistricting plan assignments for a geography."""
+
+    @abc.abstractmethod
+    def get_district_assignments(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        state_fips: Optional[str] = None,
+    ) -> list[DistrictAssignment]:
+        """Get district assignments for a geography over a time range."""
+
+
+class DictRedistrictingDataProvider(RedistrictingDataProvider):
+    """In-memory redistricting data provider for testing."""
+
+    def __init__(self):
+        self._assignments: list[DistrictAssignment] = []
+
+    def add(self, assignment: DistrictAssignment):
+        self._assignments.append(assignment)
+
+    def get_district_assignments(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        state_fips: Optional[str] = None,
+    ) -> list[DistrictAssignment]:
+        from_date = date(from_year, 1, 1)
+        to_date = date(to_year, 12, 31)
+        results = []
+        for a in self._assignments:
+            if state_fips and a.state.upper() != state_fips.upper():
+                continue
+            if a.to_date and a.to_date < from_date:
+                continue
+            if a.from_date and a.from_date > to_date:
+                continue
+            results.append(a)
+        return results
+
+
+class RedistrictingOverlay(PlaceHistoryOverlay):
+    """Place history overlay for redistricting plan assignments.
+
+    Shows which plan(s) and district(s) applied to a geography
+    over the queried time range.
+    """
+
+    def __init__(self, provider: Optional[RedistrictingDataProvider] = None):
+        self._provider = provider
+
+    @property
+    def name(self) -> str:
+        return "redistricting"
+
+    def fetch(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        state_fips: Optional[str] = None,
+    ) -> RedistrictingOverlayResult:
+        if self._provider is None:
+            return RedistrictingOverlayResult(geoid=geoid)
+
+        assignments = self._provider.get_district_assignments(
+            geoid, from_year, to_year, state_fips,
+        )
+        assignments.sort(key=lambda a: a.from_date or date.min)
+
+        return RedistrictingOverlayResult(
+            geoid=geoid,
+            assignments=assignments,
+        )
+
+    def is_available(self) -> bool:
+        return self._provider is not None

--- a/siege_utilities/geo/overlays/seats.py
+++ b/siege_utilities/geo/overlays/seats.py
@@ -1,0 +1,183 @@
+"""Seats overlay for place history.
+
+Shows which congressional/state legislative districts contained a
+geography over time, under which redistricting plans.
+
+Key design constraint from the ST model: "Seat is identity, not
+geography." The overlay returns Seat + Plan, not raw CD geometry.
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from siege_utilities.geo.overlay_registry import PlaceHistoryOverlay
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SeatAssignment:
+    """A seat-to-geography assignment for a time period.
+
+    Attributes:
+        seat_label: Human-readable seat label (e.g., "US House CA-12").
+        office: Office type (US_HOUSE, US_SENATE, STATE_UPPER, STATE_LOWER).
+        district_label: District number/label.
+        state_fips: State FIPS code.
+        plan_name: Name of the redistricting plan.
+        plan_year: Year the plan took effect.
+        from_year: Start year of this assignment.
+        to_year: End year of this assignment.
+        containment_pct: Fraction of the queried geography in this district.
+    """
+
+    seat_label: str = ""
+    office: str = ""
+    district_label: str = ""
+    state_fips: str = ""
+    plan_name: str = ""
+    plan_year: Optional[int] = None
+    from_year: Optional[int] = None
+    to_year: Optional[int] = None
+    containment_pct: float = 1.0
+
+
+@dataclass
+class SeatsOverlayResult:
+    """Result of the seats overlay query.
+
+    Attributes:
+        geoid: Queried GEOID.
+        assignments: Seat assignments ordered by time.
+        current_districts: Districts containing the GEOID now.
+    """
+
+    geoid: str = ""
+    assignments: list[SeatAssignment] = field(default_factory=list)
+
+    @property
+    def current_districts(self) -> list[SeatAssignment]:
+        if not self.assignments:
+            return []
+        max_year = max(
+            (a.to_year or a.from_year or 0) for a in self.assignments
+        )
+        return [
+            a for a in self.assignments
+            if (a.to_year or a.from_year or 0) == max_year
+        ]
+
+    @property
+    def offices(self) -> list[str]:
+        return sorted(set(a.office for a in self.assignments if a.office))
+
+    def for_office(self, office: str) -> list[SeatAssignment]:
+        return [a for a in self.assignments if a.office == office]
+
+
+# ---------------------------------------------------------------------------
+# Data provider protocol
+# ---------------------------------------------------------------------------
+
+
+class SeatsDataProvider(abc.ABC):
+    """Protocol for fetching seat assignment data.
+
+    Implementations query PlanDistrictAssignment + BoundaryIntersection
+    to find which districts contained a GEOID over time.
+    """
+
+    @abc.abstractmethod
+    def get_assignments(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        state_fips: Optional[str] = None,
+    ) -> list[SeatAssignment]:
+        """Get seat assignments for a GEOID and time range."""
+
+
+class DictSeatsProvider(SeatsDataProvider):
+    """In-memory seats provider for testing."""
+
+    def __init__(self):
+        self._assignments: list[SeatAssignment] = []
+
+    def add(self, assignment: SeatAssignment):
+        self._assignments.append(assignment)
+
+    def get_assignments(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        state_fips: Optional[str] = None,
+    ) -> list[SeatAssignment]:
+        lo = min(from_year, to_year)
+        hi = max(from_year, to_year)
+        results = []
+        for a in self._assignments:
+            a_from = a.from_year or 0
+            a_to = a.to_year or 9999
+            if a_to >= lo and a_from <= hi:
+                if state_fips and a.state_fips and a.state_fips != state_fips:
+                    continue
+                results.append(a)
+        return sorted(results, key=lambda x: x.from_year or 0)
+
+
+# ---------------------------------------------------------------------------
+# Overlay implementation
+# ---------------------------------------------------------------------------
+
+
+class SeatsOverlay(PlaceHistoryOverlay):
+    """Place history overlay showing district/seat assignments over time.
+
+    Args:
+        provider: SeatsDataProvider for fetching assignment data.
+            If None, attempts to use the Django-backed provider.
+    """
+
+    def __init__(self, provider: Optional[SeatsDataProvider] = None):
+        self._provider = provider
+
+    @property
+    def name(self) -> str:
+        return "seats"
+
+    def fetch(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        state_fips: Optional[str] = None,
+    ) -> SeatsOverlayResult:
+        provider = self._provider or self._get_default_provider()
+        if provider is None:
+            raise RuntimeError("No seats data provider available")
+
+        assignments = provider.get_assignments(
+            geoid, from_year, to_year, state_fips
+        )
+        return SeatsOverlayResult(
+            geoid=geoid,
+            assignments=assignments,
+        )
+
+    def _get_default_provider(self) -> Optional[SeatsDataProvider]:
+        try:
+            from siege_utilities.geo.django.providers import DjangoSeatsProvider
+            return DjangoSeatsProvider()
+        except Exception:
+            return None

--- a/siege_utilities/geo/overlays/urbanicity.py
+++ b/siege_utilities/geo/overlays/urbanicity.py
@@ -1,0 +1,181 @@
+"""Urbanicity overlay for place history.
+
+NCES locale classification per vintage for a queried geography.
+Calls NCESLocaleClassifier (WS3) for each vintage in the range.
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from dataclasses import dataclass, field
+from typing import Optional
+
+from siege_utilities.geo.overlay_registry import PlaceHistoryOverlay
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class UrbanicityPoint:
+    """NCES locale classification for a single vintage.
+
+    Attributes:
+        year: Vintage year of the classification.
+        geoid: GEOID classified.
+        locale_code: NCES 2-digit locale code (e.g., "11" for City-Large).
+        locale_label: Human-readable label (e.g., "City-Large").
+        category: Top-level category (city, suburb, town, rural).
+        size: Size qualifier (large, midsize, small, fringe, distant, remote).
+    """
+
+    year: int = 0
+    geoid: str = ""
+    locale_code: str = ""
+    locale_label: str = ""
+    category: str = ""
+    size: str = ""
+
+
+@dataclass
+class UrbanicityOverlayResult:
+    """Result of the urbanicity overlay query.
+
+    Attributes:
+        geoid: Queried GEOID.
+        classifications: Ordered list of urbanicity points by year.
+    """
+
+    geoid: str = ""
+    classifications: list[UrbanicityPoint] = field(default_factory=list)
+
+    @property
+    def years(self) -> list[int]:
+        return sorted(set(p.year for p in self.classifications))
+
+    @property
+    def has_data(self) -> bool:
+        return len(self.classifications) > 0
+
+    def for_year(self, year: int) -> Optional[UrbanicityPoint]:
+        for p in self.classifications:
+            if p.year == year:
+                return p
+        return None
+
+    @property
+    def changed(self) -> bool:
+        codes = set(p.locale_code for p in self.classifications)
+        return len(codes) > 1
+
+    @property
+    def current_category(self) -> str:
+        if not self.classifications:
+            return ""
+        return self.classifications[-1].category
+
+
+# ---------------------------------------------------------------------------
+# Data provider protocol
+# ---------------------------------------------------------------------------
+
+
+class UrbanicityDataProvider(abc.ABC):
+    """Protocol for fetching NCES locale classification data."""
+
+    @abc.abstractmethod
+    def classify(
+        self,
+        geoid: str,
+        year: int,
+    ) -> Optional[UrbanicityPoint]:
+        """Classify a GEOID for a given vintage year."""
+
+
+class DictUrbanicityProvider(UrbanicityDataProvider):
+    """In-memory urbanicity provider for testing."""
+
+    def __init__(self):
+        self._data: dict[tuple[str, int], UrbanicityPoint] = {}
+
+    def add(self, point: UrbanicityPoint):
+        self._data[(point.geoid, point.year)] = point
+
+    def classify(
+        self,
+        geoid: str,
+        year: int,
+    ) -> Optional[UrbanicityPoint]:
+        return self._data.get((geoid, year))
+
+
+# ---------------------------------------------------------------------------
+# Overlay implementation
+# ---------------------------------------------------------------------------
+
+NCES_VINTAGE_YEARS = [2000, 2010, 2020]
+
+
+class UrbanicityOverlay(PlaceHistoryOverlay):
+    """Place history overlay for NCES urbanicity classification.
+
+    Classifies the queried GEOID using the NCES 12-code locale system
+    for each relevant vintage in the query range.
+
+    Args:
+        provider: UrbanicityDataProvider for classification.
+        vintage_years: Years to check. Defaults to NCES vintages.
+    """
+
+    def __init__(
+        self,
+        provider: Optional[UrbanicityDataProvider] = None,
+        vintage_years: Optional[list[int]] = None,
+    ):
+        self._provider = provider
+        self._vintage_years = vintage_years or NCES_VINTAGE_YEARS
+
+    @property
+    def name(self) -> str:
+        return "urbanicity"
+
+    def fetch(
+        self,
+        geoid: str,
+        from_year: int,
+        to_year: int,
+        state_fips: Optional[str] = None,
+    ) -> UrbanicityOverlayResult:
+        provider = self._provider or self._get_default_provider()
+        if provider is None:
+            raise RuntimeError("No urbanicity data provider available")
+
+        lo = min(from_year, to_year)
+        hi = max(from_year, to_year)
+
+        classifications = []
+        for vintage in self._vintage_years:
+            if vintage < lo or vintage > hi:
+                continue
+            point = provider.classify(geoid, vintage)
+            if point is not None:
+                classifications.append(point)
+
+        classifications.sort(key=lambda p: p.year)
+
+        return UrbanicityOverlayResult(
+            geoid=geoid,
+            classifications=classifications,
+        )
+
+    def _get_default_provider(self) -> Optional[UrbanicityDataProvider]:
+        try:
+            from siege_utilities.geo.django.providers import DjangoUrbanicityProvider
+            return DjangoUrbanicityProvider()
+        except Exception:
+            return None

--- a/siege_utilities/geo/place_history.py
+++ b/siege_utilities/geo/place_history.py
@@ -1,0 +1,401 @@
+"""Spatio-temporal place history query API.
+
+Answers "what's the story of this place over time?" by composing
+crosswalk chains and overlay data into a unified response.
+
+Usage::
+
+    result = place_history("17031010100", from_year=2000, to_year=2020)
+    print(result.lineage)
+    print(result.overlays)
+
+The overlay system is extensible — see :mod:`overlay_registry` for
+registering custom overlays.
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Optional, Protocol, Union
+
+log = logging.getLogger(__name__)
+
+CENSUS_DECADE_YEARS = [1990, 2000, 2010, 2020, 2030]
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LineageStep:
+    """A single step in the crosswalk chain.
+
+    Attributes:
+        source_geoid: GEOID before transition.
+        target_geoid: GEOID after transition.
+        source_year: Source vintage year.
+        target_year: Target vintage year.
+        weight: Allocation weight (1.0 = identical).
+        relationship: IDENTICAL, SPLIT, MERGED, PARTIAL, RENAMED.
+    """
+
+    source_geoid: str
+    target_geoid: str
+    source_year: int
+    target_year: int
+    weight: float = 1.0
+    relationship: str = "IDENTICAL"
+
+
+@dataclass
+class Lineage:
+    """Complete crosswalk chain for a GEOID across time.
+
+    Attributes:
+        origin_geoid: Starting GEOID.
+        origin_year: Year of the starting GEOID.
+        steps: Ordered list of transitions.
+        terminal_geoids: Final GEOID(s) at the end of the chain.
+        direction: "forward" or "reverse".
+    """
+
+    origin_geoid: str
+    origin_year: int
+    steps: list[LineageStep] = field(default_factory=list)
+    terminal_geoids: list[str] = field(default_factory=list)
+    direction: str = "forward"
+
+    @property
+    def is_unchanged(self) -> bool:
+        return (
+            len(self.terminal_geoids) == 1
+            and self.terminal_geoids[0] == self.origin_geoid
+        )
+
+
+@dataclass
+class PlaceHistoryResult:
+    """Unified response for a place history query.
+
+    Attributes:
+        geoid: The queried GEOID.
+        from_year: Start of the query range.
+        to_year: End of the query range.
+        lineage: Crosswalk chain showing boundary evolution.
+        overlays: Dict of overlay name to overlay data.
+        errors: Any errors encountered during the query.
+    """
+
+    geoid: str
+    from_year: int
+    to_year: int
+    lineage: Optional[Lineage] = None
+    overlays: dict[str, Any] = field(default_factory=dict)
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def has_lineage(self) -> bool:
+        return self.lineage is not None and len(self.lineage.steps) > 0
+
+    @property
+    def direction(self) -> str:
+        if self.from_year <= self.to_year:
+            return "forward"
+        return "reverse"
+
+
+# ---------------------------------------------------------------------------
+# Crosswalk data provider protocol
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CrosswalkRecord:
+    """A single crosswalk mapping between two GEOIDs."""
+
+    source_geoid: str
+    target_geoid: str
+    weight: float = 1.0
+    relationship: str = "IDENTICAL"
+
+
+class CrosswalkProvider(abc.ABC):
+    """Protocol for fetching crosswalk data.
+
+    Implementations provide crosswalk records for a given GEOID
+    and vintage transition. The Django-backed provider queries
+    TemporalCrosswalk; test providers use in-memory data.
+    """
+
+    @abc.abstractmethod
+    def get_forward_mappings(
+        self,
+        geoid: str,
+        source_year: int,
+        target_year: int,
+        state_fips: Optional[str] = None,
+    ) -> list[CrosswalkRecord]:
+        """Get target GEOIDs for a source GEOID transitioning between vintages."""
+
+    @abc.abstractmethod
+    def get_reverse_mappings(
+        self,
+        geoid: str,
+        source_year: int,
+        target_year: int,
+        state_fips: Optional[str] = None,
+    ) -> list[CrosswalkRecord]:
+        """Get source GEOIDs that map to a target GEOID."""
+
+
+class DictCrosswalkProvider(CrosswalkProvider):
+    """In-memory crosswalk provider for testing.
+
+    Data is keyed by (source_year, target_year) → dict of
+    source_geoid → list[CrosswalkRecord].
+    """
+
+    def __init__(self, data: Optional[dict] = None):
+        self._data: dict[tuple[int, int], dict[str, list[CrosswalkRecord]]] = data or {}
+
+    def add(
+        self,
+        source_year: int,
+        target_year: int,
+        source_geoid: str,
+        target_geoid: str,
+        weight: float = 1.0,
+        relationship: str = "IDENTICAL",
+    ):
+        key = (source_year, target_year)
+        if key not in self._data:
+            self._data[key] = {}
+        if source_geoid not in self._data[key]:
+            self._data[key][source_geoid] = []
+        self._data[key][source_geoid].append(
+            CrosswalkRecord(
+                source_geoid=source_geoid,
+                target_geoid=target_geoid,
+                weight=weight,
+                relationship=relationship,
+            )
+        )
+
+    def get_forward_mappings(
+        self,
+        geoid: str,
+        source_year: int,
+        target_year: int,
+        state_fips: Optional[str] = None,
+    ) -> list[CrosswalkRecord]:
+        key = (source_year, target_year)
+        return self._data.get(key, {}).get(geoid, [])
+
+    def get_reverse_mappings(
+        self,
+        geoid: str,
+        source_year: int,
+        target_year: int,
+        state_fips: Optional[str] = None,
+    ) -> list[CrosswalkRecord]:
+        key = (source_year, target_year)
+        records = []
+        for src_geoid, mappings in self._data.get(key, {}).items():
+            for rec in mappings:
+                if rec.target_geoid == geoid:
+                    records.append(rec)
+        return records
+
+
+# ---------------------------------------------------------------------------
+# Crosswalk chaining
+# ---------------------------------------------------------------------------
+
+
+def _decade_transitions(from_year: int, to_year: int) -> list[tuple[int, int]]:
+    """Determine the decade transitions needed between two years.
+
+    Returns pairs of (source_decade, target_decade) in chronological order.
+    For forward queries (from_year < to_year), chains forward.
+    For reverse queries (from_year > to_year), chains backward.
+    """
+    if from_year == to_year:
+        return []
+
+    forward = from_year < to_year
+
+    if forward:
+        start_decade = max(d for d in CENSUS_DECADE_YEARS if d <= from_year)
+        end_decade = max(d for d in CENSUS_DECADE_YEARS if d <= to_year)
+    else:
+        start_decade = max(d for d in CENSUS_DECADE_YEARS if d <= from_year)
+        end_decade = max(d for d in CENSUS_DECADE_YEARS if d <= to_year)
+
+    if start_decade == end_decade:
+        return []
+
+    transitions = []
+    if forward:
+        decades = sorted(d for d in CENSUS_DECADE_YEARS if start_decade <= d <= end_decade)
+        for i in range(len(decades) - 1):
+            transitions.append((decades[i], decades[i + 1]))
+    else:
+        decades = sorted(
+            (d for d in CENSUS_DECADE_YEARS if end_decade <= d <= start_decade),
+            reverse=True,
+        )
+        for i in range(len(decades) - 1):
+            transitions.append((decades[i], decades[i + 1]))
+
+    return transitions
+
+
+def _build_lineage(
+    geoid: str,
+    from_year: int,
+    to_year: int,
+    provider: CrosswalkProvider,
+    state_fips: Optional[str] = None,
+    min_weight: float = 0.01,
+) -> Lineage:
+    """Build a crosswalk chain for a GEOID across decades."""
+    forward = from_year <= to_year
+    transitions = _decade_transitions(from_year, to_year)
+
+    lineage = Lineage(
+        origin_geoid=geoid,
+        origin_year=from_year,
+        direction="forward" if forward else "reverse",
+    )
+
+    if not transitions:
+        lineage.terminal_geoids = [geoid]
+        return lineage
+
+    current = [(geoid, 1.0)]
+
+    for src_year, tgt_year in transitions:
+        next_geoids = []
+
+        for cur_geoid, cum_weight in current:
+            if forward:
+                records = provider.get_forward_mappings(
+                    cur_geoid, src_year, tgt_year, state_fips
+                )
+            else:
+                records = provider.get_reverse_mappings(
+                    cur_geoid, tgt_year, src_year, state_fips
+                )
+
+            if not records:
+                next_geoids.append((cur_geoid, cum_weight))
+                continue
+
+            for rec in records:
+                new_weight = cum_weight * rec.weight
+                if new_weight < min_weight:
+                    continue
+
+                step = LineageStep(
+                    source_geoid=rec.source_geoid if forward else rec.target_geoid,
+                    target_geoid=rec.target_geoid if forward else rec.source_geoid,
+                    source_year=src_year if forward else tgt_year,
+                    target_year=tgt_year if forward else src_year,
+                    weight=rec.weight,
+                    relationship=rec.relationship,
+                )
+                lineage.steps.append(step)
+
+                target = rec.target_geoid if forward else rec.source_geoid
+                next_geoids.append((target, new_weight))
+
+        current = next_geoids
+
+    lineage.terminal_geoids = [g for g, _ in current]
+    return lineage
+
+
+# ---------------------------------------------------------------------------
+# Main query function
+# ---------------------------------------------------------------------------
+
+
+def place_history(
+    geoid: str,
+    from_year: int,
+    to_year: int,
+    overlays: Optional[list[str]] = None,
+    state_fips: Optional[str] = None,
+    provider: Optional[CrosswalkProvider] = None,
+    overlay_registry: Optional[Any] = None,
+) -> PlaceHistoryResult:
+    """Query the history of a geographic place over time.
+
+    Composes crosswalk chains and optional overlays into a unified
+    response showing how a place has evolved.
+
+    Args:
+        geoid: Census GEOID to query (tract, block group, county, etc.).
+        from_year: Start year of the query range.
+        to_year: End year of the query range.
+        overlays: List of overlay names to include (e.g., ["seats", "demographics"]).
+        state_fips: Optional state FIPS code for filtering crosswalks.
+        provider: CrosswalkProvider for fetching crosswalk data.
+            If None, attempts to use the Django-backed provider.
+        overlay_registry: Registry for resolving overlay names to implementations.
+            If None, overlays are skipped.
+
+    Returns:
+        PlaceHistoryResult with lineage and overlay data.
+    """
+    result = PlaceHistoryResult(
+        geoid=geoid,
+        from_year=from_year,
+        to_year=to_year,
+    )
+
+    if provider is None:
+        provider = _get_default_provider()
+
+    if provider is None:
+        result.errors.append(
+            "No crosswalk provider available (Django not configured?)"
+        )
+        return result
+
+    try:
+        result.lineage = _build_lineage(
+            geoid, from_year, to_year, provider, state_fips
+        )
+    except Exception as exc:
+        result.errors.append(f"Lineage build failed: {exc}")
+        log.error("Failed to build lineage for %s: %s", geoid, exc)
+
+    if overlays and overlay_registry is not None:
+        for name in overlays:
+            try:
+                overlay_impl = overlay_registry.get(name)
+                if overlay_impl is None:
+                    result.errors.append(f"Unknown overlay: {name}")
+                    continue
+                result.overlays[name] = overlay_impl.fetch(
+                    geoid, from_year, to_year, state_fips
+                )
+            except Exception as exc:
+                result.errors.append(f"Overlay '{name}' failed: {exc}")
+                log.warning("Overlay %s failed for %s: %s", name, geoid, exc)
+
+    return result
+
+
+def _get_default_provider() -> Optional[CrosswalkProvider]:
+    """Attempt to create a Django-backed crosswalk provider."""
+    try:
+        from siege_utilities.geo.django.providers import DjangoCrosswalkProvider
+        return DjangoCrosswalkProvider()
+    except Exception:
+        return None

--- a/siege_utilities/geo/plan_lifecycle.py
+++ b/siege_utilities/geo/plan_lifecycle.py
@@ -1,0 +1,294 @@
+"""Redistricting plan lifecycle tracking.
+
+Models the lifecycle of redistricting plans: proposed -> adopted ->
+enacted -> challenged -> stayed/struck -> superseded. Supports
+court-order branching and temporal queries ("what plan was in effect
+for TX congress on 2023-09-15?").
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from dataclasses import dataclass, field
+from datetime import date
+from enum import Enum
+from typing import Any, Optional
+
+log = logging.getLogger(__name__)
+
+
+class PlanLifecycleStatus(str, Enum):
+    """Status in the lifecycle of a redistricting plan."""
+
+    PROPOSED = "proposed"
+    ADOPTED = "adopted"
+    ENACTED = "enacted"
+    CHALLENGED = "challenged"
+    STAYED = "stayed"
+    STRUCK = "struck"
+    SUPERSEDED = "superseded"
+    EXPIRED = "expired"
+
+
+class PlanType(str, Enum):
+    """Type of redistricting plan."""
+
+    CONGRESSIONAL = "congressional"
+    STATE_SENATE = "state_senate"
+    STATE_HOUSE = "state_house"
+
+
+class EnactedBy(str, Enum):
+    """Authority that enacted the plan."""
+
+    LEGISLATURE = "legislature"
+    COMMISSION = "commission"
+    COURT = "court"
+    SPECIAL_MASTER = "special_master"
+
+
+TERMINAL_STATUSES = frozenset({
+    PlanLifecycleStatus.STRUCK,
+    PlanLifecycleStatus.SUPERSEDED,
+    PlanLifecycleStatus.EXPIRED,
+})
+
+ACTIVE_STATUSES = frozenset({
+    PlanLifecycleStatus.ENACTED,
+    PlanLifecycleStatus.CHALLENGED,
+    PlanLifecycleStatus.STAYED,
+})
+
+
+@dataclass
+class PlanLifecycleEvent:
+    """A lifecycle transition for a redistricting plan.
+
+    Attributes:
+        plan_id: Identifier of the plan this event belongs to.
+        status: New lifecycle status after this event.
+        effective_date: When this status took effect.
+        source: What triggered the transition (legislation, court order, etc.).
+        notes: Human-readable description.
+        court_case: Case citation if court-ordered.
+    """
+
+    plan_id: str = ""
+    status: PlanLifecycleStatus = PlanLifecycleStatus.PROPOSED
+    effective_date: Optional[date] = None
+    source: str = ""
+    notes: str = ""
+    court_case: str = ""
+
+
+@dataclass
+class RedistrictingPlan:
+    """A redistricting plan with lifecycle events.
+
+    Attributes:
+        plan_id: Unique identifier.
+        state: Two-letter state abbreviation.
+        plan_type: Congressional, state senate, or state house.
+        plan_name: Official name or identifier.
+        enacted_by: Authority that enacted the plan.
+        enacted_date: When the plan was enacted.
+        supersedes_id: ID of the plan this one replaces.
+        court_case: Court case citation if court-ordered.
+        events: Ordered lifecycle events.
+    """
+
+    plan_id: str = ""
+    state: str = ""
+    plan_type: PlanType = PlanType.CONGRESSIONAL
+    plan_name: str = ""
+    enacted_by: EnactedBy = EnactedBy.LEGISLATURE
+    enacted_date: Optional[date] = None
+    supersedes_id: Optional[str] = None
+    court_case: str = ""
+    events: list[PlanLifecycleEvent] = field(default_factory=list)
+
+    @property
+    def current_status(self) -> Optional[PlanLifecycleStatus]:
+        if not self.events:
+            return None
+        return self.latest_event.status
+
+    @property
+    def latest_event(self) -> Optional[PlanLifecycleEvent]:
+        if not self.events:
+            return None
+        dated = [e for e in self.events if e.effective_date is not None]
+        if not dated:
+            return self.events[-1]
+        return max(dated, key=lambda e: e.effective_date)
+
+    @property
+    def is_terminal(self) -> bool:
+        status = self.current_status
+        return status is not None and status in TERMINAL_STATUSES
+
+    @property
+    def is_active(self) -> bool:
+        status = self.current_status
+        return status is not None and status in ACTIVE_STATUSES
+
+    def status_at(self, when: date) -> Optional[PlanLifecycleStatus]:
+        applicable = [
+            e for e in self.events
+            if e.effective_date is not None and e.effective_date <= when
+        ]
+        if not applicable:
+            return None
+        return max(applicable, key=lambda e: e.effective_date).status
+
+    def was_active_at(self, when: date) -> bool:
+        status = self.status_at(when)
+        return status is not None and status in ACTIVE_STATUSES
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "plan_id": self.plan_id,
+            "state": self.state,
+            "plan_type": self.plan_type.value,
+            "plan_name": self.plan_name,
+            "enacted_by": self.enacted_by.value,
+            "enacted_date": self.enacted_date.isoformat() if self.enacted_date else None,
+            "supersedes_id": self.supersedes_id,
+            "court_case": self.court_case,
+            "current_status": self.current_status.value if self.current_status else None,
+            "events": [
+                {
+                    "status": e.status.value,
+                    "effective_date": e.effective_date.isoformat() if e.effective_date else None,
+                    "source": e.source,
+                    "notes": e.notes,
+                    "court_case": e.court_case,
+                }
+                for e in self.events
+            ],
+        }
+
+
+@dataclass
+class PlanLineage:
+    """Chain of plans linked by supersession.
+
+    Attributes:
+        plans: Plans in chronological order (oldest first).
+        state: State abbreviation.
+        plan_type: Type of plan.
+    """
+
+    plans: list[RedistrictingPlan] = field(default_factory=list)
+    state: str = ""
+    plan_type: PlanType = PlanType.CONGRESSIONAL
+
+    @property
+    def current_plan(self) -> Optional[RedistrictingPlan]:
+        active = [p for p in self.plans if p.is_active]
+        if active:
+            return active[-1]
+        return None
+
+    def plan_at(self, when: date) -> Optional[RedistrictingPlan]:
+        candidates = [p for p in self.plans if p.was_active_at(when)]
+        if not candidates:
+            return None
+        return candidates[-1]
+
+
+class PlanLifecycleProvider(abc.ABC):
+    """Protocol for querying redistricting plan lifecycle data."""
+
+    @abc.abstractmethod
+    def get_plans(
+        self,
+        state: str,
+        plan_type: Optional[PlanType] = None,
+    ) -> list[RedistrictingPlan]:
+        """Get all plans for a state, optionally filtered by type."""
+
+    @abc.abstractmethod
+    def get_plan(self, plan_id: str) -> Optional[RedistrictingPlan]:
+        """Get a single plan by ID."""
+
+
+class DictPlanLifecycleProvider(PlanLifecycleProvider):
+    """In-memory plan lifecycle provider for testing."""
+
+    def __init__(self):
+        self._plans: dict[str, RedistrictingPlan] = {}
+
+    def add(self, plan: RedistrictingPlan):
+        self._plans[plan.plan_id] = plan
+
+    def get_plans(
+        self,
+        state: str,
+        plan_type: Optional[PlanType] = None,
+    ) -> list[RedistrictingPlan]:
+        results = [
+            p for p in self._plans.values()
+            if p.state.upper() == state.upper()
+        ]
+        if plan_type is not None:
+            results = [p for p in results if p.plan_type == plan_type]
+        return results
+
+    def get_plan(self, plan_id: str) -> Optional[RedistrictingPlan]:
+        return self._plans.get(plan_id)
+
+
+def build_lineage(
+    plans: list[RedistrictingPlan],
+) -> PlanLineage:
+    """Build a supersession lineage from a list of related plans.
+
+    Plans are ordered by enacted_date, with supersession links verified.
+
+    Args:
+        plans: Plans that form a lineage (same state + type).
+    """
+    if not plans:
+        return PlanLineage()
+
+    by_id = {p.plan_id: p for p in plans}
+    sorted_plans = sorted(
+        plans,
+        key=lambda p: p.enacted_date or date.min,
+    )
+
+    return PlanLineage(
+        plans=sorted_plans,
+        state=sorted_plans[0].state,
+        plan_type=sorted_plans[0].plan_type,
+    )
+
+
+def resolve_plan_at(
+    provider: PlanLifecycleProvider,
+    state: str,
+    plan_type: PlanType,
+    when: date,
+) -> Optional[RedistrictingPlan]:
+    """Resolve which plan was in effect at a given date.
+
+    Queries the provider for all plans of the given state and type,
+    then finds the one that was active at the specified date.
+
+    Args:
+        provider: Source for plan lifecycle data.
+        state: Two-letter state abbreviation.
+        plan_type: Type of plan to resolve.
+        when: Date to query.
+
+    Returns:
+        The RedistrictingPlan that was in effect, or None.
+    """
+    plans = provider.get_plans(state, plan_type)
+    if not plans:
+        return None
+
+    lineage = build_lineage(plans)
+    return lineage.plan_at(when)

--- a/siege_utilities/geo/precinct_vtd.py
+++ b/siege_utilities/geo/precinct_vtd.py
@@ -1,0 +1,451 @@
+"""Precinct-to-VTD reconciliation.
+
+Reconciles RDH precinct shapefiles with Census VTDs (Voting Tabulation
+Districts) using spatial overlap, name matching, and official crosswalks.
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+import re
+from dataclasses import dataclass, field
+from difflib import SequenceMatcher
+from enum import Enum
+from typing import Any, Optional
+
+log = logging.getLogger(__name__)
+
+
+class ReconciliationMethod(str, Enum):
+    """How a precinct-VTD mapping was determined."""
+
+    SPATIAL = "spatial"
+    NAME_MATCH = "name_match"
+    OFFICIAL_CROSSWALK = "official_crosswalk"
+    COMBINED = "combined"
+
+
+class ConfidenceLevel(str, Enum):
+    """Confidence tier for a reconciliation mapping."""
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+def _confidence_level(score: float) -> ConfidenceLevel:
+    if score >= 0.85:
+        return ConfidenceLevel.HIGH
+    if score >= 0.60:
+        return ConfidenceLevel.MEDIUM
+    return ConfidenceLevel.LOW
+
+
+@dataclass
+class PrecinctVTDMapping:
+    """A single precinct-to-VTD mapping with confidence metadata.
+
+    Attributes:
+        precinct_id: Identifier from the precinct shapefile.
+        vtd_geoid: Census VTD GEOID.
+        overlap_pct: Fraction of precinct area covered by this VTD (0-1).
+        confidence: Confidence score (0-1).
+        confidence_level: Categorical confidence tier.
+        method: How this mapping was determined.
+        name_similarity: Similarity score from name matching (0-1), if applicable.
+        notes: Human-readable explanation.
+    """
+
+    precinct_id: str = ""
+    vtd_geoid: str = ""
+    overlap_pct: float = 0.0
+    confidence: float = 0.0
+    confidence_level: ConfidenceLevel = ConfidenceLevel.LOW
+    method: ReconciliationMethod = ReconciliationMethod.SPATIAL
+    name_similarity: Optional[float] = None
+    notes: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "precinct_id": self.precinct_id,
+            "vtd_geoid": self.vtd_geoid,
+            "overlap_pct": round(self.overlap_pct, 4),
+            "confidence": round(self.confidence, 4),
+            "confidence_level": self.confidence_level.value,
+            "method": self.method.value,
+        }
+        if self.name_similarity is not None:
+            d["name_similarity"] = round(self.name_similarity, 4)
+        if self.notes:
+            d["notes"] = self.notes
+        return d
+
+
+@dataclass
+class ReconciliationResult:
+    """Complete result of precinct-VTD reconciliation.
+
+    Attributes:
+        mappings: All precinct-VTD mappings.
+        total_precincts: Number of precincts processed.
+        matched_precincts: Number of precincts with at least one mapping.
+        unmatched_precincts: Precinct IDs with no mapping.
+        method_counts: Count of mappings by method.
+        errors: Any errors encountered.
+    """
+
+    mappings: list[PrecinctVTDMapping] = field(default_factory=list)
+    total_precincts: int = 0
+    matched_precincts: int = 0
+    unmatched_precincts: list[str] = field(default_factory=list)
+    method_counts: dict[str, int] = field(default_factory=dict)
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def match_rate(self) -> float:
+        if self.total_precincts == 0:
+            return 0.0
+        return self.matched_precincts / self.total_precincts
+
+    @property
+    def high_confidence_count(self) -> int:
+        return sum(1 for m in self.mappings if m.confidence_level == ConfidenceLevel.HIGH)
+
+    def for_precinct(self, precinct_id: str) -> list[PrecinctVTDMapping]:
+        return [m for m in self.mappings if m.precinct_id == precinct_id]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "total_precincts": self.total_precincts,
+            "matched_precincts": self.matched_precincts,
+            "match_rate": round(self.match_rate, 4),
+            "high_confidence_count": self.high_confidence_count,
+            "method_counts": self.method_counts,
+            "unmatched_precincts": self.unmatched_precincts,
+            "mappings": [m.to_dict() for m in self.mappings],
+            "errors": self.errors,
+        }
+
+
+@dataclass
+class SpatialOverlap:
+    """Spatial overlap between a precinct and a VTD.
+
+    Attributes:
+        precinct_id: Precinct identifier.
+        vtd_geoid: VTD GEOID.
+        overlap_area: Area of intersection (in source CRS units).
+        precinct_area: Total area of the precinct.
+        vtd_area: Total area of the VTD.
+        overlap_pct: Fraction of precinct covered by VTD.
+    """
+
+    precinct_id: str = ""
+    vtd_geoid: str = ""
+    overlap_area: float = 0.0
+    precinct_area: float = 0.0
+    vtd_area: float = 0.0
+    overlap_pct: float = 0.0
+
+
+@dataclass
+class OfficialCrosswalkEntry:
+    """Entry from an official precinct-to-VTD crosswalk.
+
+    Attributes:
+        precinct_id: Precinct identifier as published.
+        vtd_geoid: VTD GEOID as published.
+        state: State abbreviation.
+        county: County name or FIPS.
+        source: Source of the crosswalk (e.g., "NC SBE 2022").
+    """
+
+    precinct_id: str = ""
+    vtd_geoid: str = ""
+    state: str = ""
+    county: str = ""
+    source: str = ""
+
+
+class SpatialOverlapProvider(abc.ABC):
+    """Protocol for computing spatial overlaps between precincts and VTDs."""
+
+    @abc.abstractmethod
+    def compute_overlaps(
+        self,
+        precinct_ids: list[str],
+    ) -> list[SpatialOverlap]:
+        """Compute spatial overlaps for the given precincts."""
+
+
+class DictSpatialOverlapProvider(SpatialOverlapProvider):
+    """In-memory spatial overlap provider for testing."""
+
+    def __init__(self):
+        self._overlaps: list[SpatialOverlap] = []
+
+    def add(self, overlap: SpatialOverlap):
+        self._overlaps.append(overlap)
+
+    def compute_overlaps(self, precinct_ids: list[str]) -> list[SpatialOverlap]:
+        ids = set(precinct_ids)
+        return [o for o in self._overlaps if o.precinct_id in ids]
+
+
+class NameMatchProvider(abc.ABC):
+    """Protocol for matching precinct names to VTD names."""
+
+    @abc.abstractmethod
+    def get_precinct_names(self, precinct_ids: list[str]) -> dict[str, str]:
+        """Get display names for precincts."""
+
+    @abc.abstractmethod
+    def get_vtd_names(self) -> dict[str, str]:
+        """Get display names for VTDs (geoid → name)."""
+
+
+class DictNameMatchProvider(NameMatchProvider):
+    """In-memory name match provider for testing."""
+
+    def __init__(self):
+        self._precinct_names: dict[str, str] = {}
+        self._vtd_names: dict[str, str] = {}
+
+    def add_precinct(self, precinct_id: str, name: str):
+        self._precinct_names[precinct_id] = name
+
+    def add_vtd(self, vtd_geoid: str, name: str):
+        self._vtd_names[vtd_geoid] = name
+
+    def get_precinct_names(self, precinct_ids: list[str]) -> dict[str, str]:
+        return {pid: self._precinct_names[pid] for pid in precinct_ids if pid in self._precinct_names}
+
+    def get_vtd_names(self) -> dict[str, str]:
+        return dict(self._vtd_names)
+
+
+_NORMALIZE_RE = re.compile(r"[^a-z0-9\s]")
+
+
+def _normalize_name(name: str) -> str:
+    return _NORMALIZE_RE.sub("", name.lower()).strip()
+
+
+def _name_similarity(a: str, b: str) -> float:
+    na, nb = _normalize_name(a), _normalize_name(b)
+    if not na or not nb:
+        return 0.0
+    return SequenceMatcher(None, na, nb).ratio()
+
+
+MIN_OVERLAP_PCT = 0.01
+MIN_NAME_SIMILARITY = 0.50
+SPATIAL_WEIGHT = 0.7
+NAME_WEIGHT = 0.3
+
+
+def reconcile_spatial(
+    overlaps: list[SpatialOverlap],
+) -> list[PrecinctVTDMapping]:
+    """Create mappings from spatial overlaps."""
+    mappings = []
+    for ov in overlaps:
+        if ov.overlap_pct < MIN_OVERLAP_PCT:
+            continue
+        confidence = ov.overlap_pct
+        mappings.append(PrecinctVTDMapping(
+            precinct_id=ov.precinct_id,
+            vtd_geoid=ov.vtd_geoid,
+            overlap_pct=ov.overlap_pct,
+            confidence=confidence,
+            confidence_level=_confidence_level(confidence),
+            method=ReconciliationMethod.SPATIAL,
+        ))
+    return mappings
+
+
+def reconcile_names(
+    precinct_names: dict[str, str],
+    vtd_names: dict[str, str],
+) -> list[PrecinctVTDMapping]:
+    """Create mappings from fuzzy name matching."""
+    mappings = []
+    for pid, pname in precinct_names.items():
+        best_geoid = ""
+        best_sim = 0.0
+        for vgeoid, vname in vtd_names.items():
+            sim = _name_similarity(pname, vname)
+            if sim > best_sim:
+                best_sim = sim
+                best_geoid = vgeoid
+        if best_sim >= MIN_NAME_SIMILARITY and best_geoid:
+            mappings.append(PrecinctVTDMapping(
+                precinct_id=pid,
+                vtd_geoid=best_geoid,
+                overlap_pct=0.0,
+                confidence=best_sim,
+                confidence_level=_confidence_level(best_sim),
+                method=ReconciliationMethod.NAME_MATCH,
+                name_similarity=best_sim,
+            ))
+    return mappings
+
+
+def reconcile_official(
+    crosswalk: list[OfficialCrosswalkEntry],
+) -> list[PrecinctVTDMapping]:
+    """Create mappings from an official crosswalk."""
+    return [
+        PrecinctVTDMapping(
+            precinct_id=entry.precinct_id,
+            vtd_geoid=entry.vtd_geoid,
+            overlap_pct=1.0,
+            confidence=1.0,
+            confidence_level=ConfidenceLevel.HIGH,
+            method=ReconciliationMethod.OFFICIAL_CROSSWALK,
+            notes=f"Official crosswalk: {entry.source}" if entry.source else "Official crosswalk",
+        )
+        for entry in crosswalk
+    ]
+
+
+def _merge_mappings(
+    spatial: list[PrecinctVTDMapping],
+    names: list[PrecinctVTDMapping],
+    official: list[PrecinctVTDMapping],
+) -> list[PrecinctVTDMapping]:
+    """Merge mappings from all methods, preferring official > spatial > name."""
+    by_precinct: dict[str, dict[str, PrecinctVTDMapping]] = {}
+
+    for m in official:
+        by_precinct.setdefault(m.precinct_id, {})[m.vtd_geoid] = m
+
+    for m in spatial:
+        bucket = by_precinct.setdefault(m.precinct_id, {})
+        if m.vtd_geoid not in bucket:
+            bucket[m.vtd_geoid] = m
+        else:
+            existing = bucket[m.vtd_geoid]
+            if existing.method != ReconciliationMethod.OFFICIAL_CROSSWALK:
+                if m.confidence > existing.confidence:
+                    bucket[m.vtd_geoid] = m
+
+    for m in names:
+        bucket = by_precinct.setdefault(m.precinct_id, {})
+        if m.vtd_geoid not in bucket:
+            bucket[m.vtd_geoid] = m
+
+    # Boost spatial mappings that have name confirmation
+    name_lookup: dict[tuple[str, str], float] = {
+        (m.precinct_id, m.vtd_geoid): m.name_similarity or 0.0
+        for m in names
+    }
+    result = []
+    for pid, vtd_map in sorted(by_precinct.items()):
+        for vgeoid, mapping in sorted(vtd_map.items()):
+            key = (pid, vgeoid)
+            if (
+                mapping.method == ReconciliationMethod.SPATIAL
+                and key in name_lookup
+                and name_lookup[key] >= MIN_NAME_SIMILARITY
+            ):
+                combined_confidence = (
+                    SPATIAL_WEIGHT * mapping.confidence
+                    + NAME_WEIGHT * name_lookup[key]
+                )
+                mapping = PrecinctVTDMapping(
+                    precinct_id=pid,
+                    vtd_geoid=vgeoid,
+                    overlap_pct=mapping.overlap_pct,
+                    confidence=combined_confidence,
+                    confidence_level=_confidence_level(combined_confidence),
+                    method=ReconciliationMethod.COMBINED,
+                    name_similarity=name_lookup[key],
+                )
+            result.append(mapping)
+    return result
+
+
+class PrecinctVTDReconciler:
+    """Reconciles precinct boundaries with Census VTDs.
+
+    Uses spatial overlap, name matching, and official crosswalks
+    (when available) to produce precinct-to-VTD mappings with
+    confidence scores.
+
+    Args:
+        spatial_provider: Source for spatial overlap computation.
+        name_provider: Source for precinct/VTD name matching.
+        official_crosswalk: Pre-loaded official crosswalk entries.
+    """
+
+    def __init__(
+        self,
+        spatial_provider: Optional[SpatialOverlapProvider] = None,
+        name_provider: Optional[NameMatchProvider] = None,
+        official_crosswalk: Optional[list[OfficialCrosswalkEntry]] = None,
+    ):
+        self._spatial = spatial_provider
+        self._names = name_provider
+        self._crosswalk = official_crosswalk or []
+
+    def reconcile(
+        self,
+        precinct_ids: list[str],
+    ) -> ReconciliationResult:
+        """Reconcile the given precincts against VTDs.
+
+        Args:
+            precinct_ids: List of precinct identifiers to reconcile.
+
+        Returns:
+            ReconciliationResult with mappings and diagnostics.
+        """
+        if not precinct_ids:
+            return ReconciliationResult()
+
+        spatial_mappings: list[PrecinctVTDMapping] = []
+        name_mappings: list[PrecinctVTDMapping] = []
+        official_mappings: list[PrecinctVTDMapping] = []
+        errors: list[str] = []
+
+        relevant_crosswalk = [
+            e for e in self._crosswalk if e.precinct_id in set(precinct_ids)
+        ]
+        if relevant_crosswalk:
+            official_mappings = reconcile_official(relevant_crosswalk)
+
+        if self._spatial is not None:
+            try:
+                overlaps = self._spatial.compute_overlaps(precinct_ids)
+                spatial_mappings = reconcile_spatial(overlaps)
+            except Exception as exc:
+                errors.append(f"Spatial reconciliation error: {exc}")
+
+        if self._names is not None:
+            try:
+                pnames = self._names.get_precinct_names(precinct_ids)
+                vnames = self._names.get_vtd_names()
+                if pnames and vnames:
+                    name_mappings = reconcile_names(pnames, vnames)
+            except Exception as exc:
+                errors.append(f"Name matching error: {exc}")
+
+        merged = _merge_mappings(spatial_mappings, name_mappings, official_mappings)
+
+        matched_ids = set(m.precinct_id for m in merged)
+        unmatched = [pid for pid in precinct_ids if pid not in matched_ids]
+
+        method_counts: dict[str, int] = {}
+        for m in merged:
+            method_counts[m.method.value] = method_counts.get(m.method.value, 0) + 1
+
+        return ReconciliationResult(
+            mappings=merged,
+            total_precincts=len(precinct_ids),
+            matched_precincts=len(matched_ids),
+            unmatched_precincts=unmatched,
+            method_counts=method_counts,
+            errors=errors,
+        )

--- a/siege_utilities/geo/providers/__init__.py
+++ b/siege_utilities/geo/providers/__init__.py
@@ -12,6 +12,8 @@ Current providers:
 - :mod:`nces_download` — NCES school-district and locale boundaries
 - :mod:`redistricting_data_hub` — RDH API client (precincts, plans, CVAP,
   PL 94-171, compactness metrics)
+- :mod:`nlrb_clients` — NLRB case data from data.gov, labordata GitHub,
+  and NxGen search
 
 Not yet migrated (planned for the interface-unification follow-up epic):
 

--- a/siege_utilities/geo/providers/batch_geocoder.py
+++ b/siege_utilities/geo/providers/batch_geocoder.py
@@ -1,0 +1,258 @@
+"""Unified batch geocoding interface.
+
+Defines the :class:`BatchGeocoder` abstract base class and
+:class:`GeocodingResult` schema for consistent geocoding across
+multiple backends (Census, Nominatim, TAMU, etc.).
+
+Usage::
+
+    from siege_utilities.geo.providers.batch_geocoder import (
+        BatchGeocoder, GeocodingResult, MatchQuality,
+    )
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from dataclasses import dataclass, field, asdict
+from enum import Enum
+from typing import Optional, Union
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Result schema
+# ---------------------------------------------------------------------------
+
+
+class MatchQuality(str, Enum):
+    """Geocoding match quality levels."""
+
+    EXACT = "exact"
+    INTERPOLATED = "interpolated"
+    APPROXIMATE = "approximate"
+    CENTROID = "centroid"
+    NO_MATCH = "no_match"
+
+
+@dataclass
+class GeocodingResult:
+    """Unified geocoding result across all backends.
+
+    Attributes:
+        input_address: Original address as submitted.
+        input_id: Caller-supplied identifier (preserved through geocoding).
+        matched_address: Standardized matched address from the geocoder.
+        lat: Latitude of the matched location.
+        lon: Longitude of the matched location.
+        match_quality: How precise the match is.
+        block_geoid: 15-digit Census block GEOID (if available).
+        tract_geoid: 11-digit Census tract GEOID (if available).
+        county_geoid: 5-digit county GEOID (if available).
+        state_geoid: 2-digit state GEOID (if available).
+        backend: Name of the geocoding backend that produced this result.
+    """
+
+    input_address: str = ""
+    input_id: str = ""
+    matched_address: str = ""
+    lat: Optional[float] = None
+    lon: Optional[float] = None
+    match_quality: str = MatchQuality.NO_MATCH.value
+    block_geoid: str = ""
+    tract_geoid: str = ""
+    county_geoid: str = ""
+    state_geoid: str = ""
+    backend: str = ""
+
+    @property
+    def matched(self) -> bool:
+        return self.match_quality != MatchQuality.NO_MATCH.value
+
+    @property
+    def has_block(self) -> bool:
+        return len(self.block_geoid) == 15
+
+    @property
+    def has_tract(self) -> bool:
+        return len(self.tract_geoid) == 11
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d["matched"] = self.matched
+        return d
+
+
+@dataclass
+class BatchGeocodingResult:
+    """Container for a batch geocoding run."""
+
+    results: list[GeocodingResult] = field(default_factory=list)
+    backend: str = ""
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return len(self.results)
+
+    @property
+    def matched_count(self) -> int:
+        return sum(1 for r in self.results if r.matched)
+
+    @property
+    def match_rate(self) -> float:
+        if not self.results:
+            return 0.0
+        return self.matched_count / len(self.results)
+
+    def to_dataframe(self):
+        """Convert results to a pandas DataFrame.
+
+        Returns:
+            DataFrame with one row per result, including all fields.
+        """
+        import pandas as pd
+
+        if not self.results:
+            return pd.DataFrame()
+        return pd.DataFrame([r.to_dict() for r in self.results])
+
+    def to_geodataframe(self):
+        """Convert results to a GeoDataFrame with point geometry.
+
+        Only includes matched results (those with lat/lon coordinates).
+
+        Returns:
+            GeoDataFrame with point geometry in EPSG:4326.
+        """
+        import geopandas as gpd
+        import pandas as pd
+        from shapely.geometry import Point
+
+        matched = [r for r in self.results if r.matched and r.lat and r.lon]
+        if not matched:
+            return gpd.GeoDataFrame()
+
+        df = pd.DataFrame([r.to_dict() for r in matched])
+        geometry = [Point(r.lon, r.lat) for r in matched]
+        return gpd.GeoDataFrame(df, geometry=geometry, crs="EPSG:4326")
+
+
+# ---------------------------------------------------------------------------
+# Address normalization
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AddressInput:
+    """Normalized address input for batch geocoding."""
+
+    street: str = ""
+    city: str = ""
+    state: str = ""
+    zipcode: str = ""
+    input_id: str = ""
+
+    @property
+    def one_line(self) -> str:
+        parts = [self.street, self.city, self.state, self.zipcode]
+        return ", ".join(p for p in parts if p)
+
+
+def normalize_addresses(
+    addresses: Union[list[dict], list[str], list[AddressInput]],
+) -> list[AddressInput]:
+    """Normalize address input to a list of AddressInput.
+
+    Accepts:
+    - List of dicts with keys: street, city, state, zipcode, id (optional)
+    - List of one-line address strings
+    - List of AddressInput instances (returned as-is)
+    """
+    if not addresses:
+        return []
+
+    first = addresses[0]
+
+    if isinstance(first, AddressInput):
+        return list(addresses)
+
+    if isinstance(first, str):
+        return [
+            AddressInput(street=addr, input_id=str(i))
+            for i, addr in enumerate(addresses)
+        ]
+
+    if isinstance(first, dict):
+        result = []
+        for i, addr in enumerate(addresses):
+            result.append(AddressInput(
+                street=addr.get("street", addr.get("address", "")),
+                city=addr.get("city", ""),
+                state=addr.get("state", ""),
+                zipcode=addr.get("zipcode", addr.get("zip", "")),
+                input_id=addr.get("id", addr.get("input_id", str(i))),
+            ))
+        return result
+
+    raise TypeError(f"Unsupported address type: {type(first)}")
+
+
+# ---------------------------------------------------------------------------
+# Abstract base class
+# ---------------------------------------------------------------------------
+
+
+class BatchGeocoder(abc.ABC):
+    """Abstract base class for batch geocoding backends.
+
+    Subclasses implement :meth:`geocode` to process a list of addresses
+    through a specific geocoding service. The interface accepts flexible
+    input formats and returns a :class:`BatchGeocodingResult`.
+
+    Example::
+
+        class MyGeocoder(BatchGeocoder):
+            @property
+            def backend_name(self) -> str:
+                return "my_service"
+
+            def geocode(self, addresses, **kwargs):
+                normalized = normalize_addresses(addresses)
+                results = []
+                for addr in normalized:
+                    # ... call service ...
+                    results.append(GeocodingResult(...))
+                return BatchGeocodingResult(results=results, backend=self.backend_name)
+    """
+
+    @property
+    @abc.abstractmethod
+    def backend_name(self) -> str:
+        """Short identifier for this backend (e.g., 'census', 'nominatim')."""
+
+    @abc.abstractmethod
+    def geocode(
+        self,
+        addresses: Union[list[dict], list[str], list[AddressInput]],
+        **kwargs,
+    ) -> BatchGeocodingResult:
+        """Geocode a batch of addresses.
+
+        Args:
+            addresses: List of addresses in any supported format.
+            **kwargs: Backend-specific options.
+
+        Returns:
+            BatchGeocodingResult with one GeocodingResult per input address.
+        """
+
+    def is_available(self) -> bool:
+        """Check if this backend is currently available.
+
+        Default returns True. Override for backends that need API keys
+        or network connectivity checks.
+        """
+        return True

--- a/siege_utilities/geo/providers/census_batch.py
+++ b/siege_utilities/geo/providers/census_batch.py
@@ -1,0 +1,126 @@
+"""Census Bureau batch geocoder backend.
+
+Wraps :func:`geocode_batch_chunked` behind the :class:`BatchGeocoder` ABC,
+converting :class:`CensusGeocodeResult` to the unified
+:class:`GeocodingResult` schema.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional, Union
+
+from .batch_geocoder import (
+    AddressInput,
+    BatchGeocoder,
+    BatchGeocodingResult,
+    GeocodingResult,
+    MatchQuality,
+    normalize_addresses,
+)
+
+log = logging.getLogger(__name__)
+
+_MATCH_TYPE_MAP = {
+    "Exact": MatchQuality.EXACT.value,
+    "Non_Exact": MatchQuality.INTERPOLATED.value,
+    "No_Match": MatchQuality.NO_MATCH.value,
+}
+
+
+def _census_result_to_geocoding_result(cr) -> GeocodingResult:
+    """Convert a CensusGeocodeResult to a unified GeocodingResult."""
+    return GeocodingResult(
+        input_address=cr.input_address,
+        input_id=cr.input_id,
+        matched_address=cr.matched_address,
+        lat=cr.lat,
+        lon=cr.lon,
+        match_quality=_MATCH_TYPE_MAP.get(cr.match_type, MatchQuality.NO_MATCH.value),
+        block_geoid=cr.block_geoid,
+        tract_geoid=cr.tract_geoid,
+        county_geoid=cr.county_geoid,
+        state_geoid=cr.state_geoid,
+        backend="census",
+    )
+
+
+class CensusBatchGeocoder(BatchGeocoder):
+    """Census Bureau batch geocoding backend.
+
+    Wraps the existing Census geocoder functions with automatic chunking
+    for datasets larger than 10,000 addresses. Returns block-level GEOIDs
+    directly from the Census API (no spatial join needed).
+
+    Args:
+        vintage: Census vintage to use. Defaults to Current.
+        chunk_size: Max addresses per API call. Default 10,000.
+    """
+
+    def __init__(
+        self,
+        vintage=None,
+        chunk_size: int = 10_000,
+    ):
+        self._vintage = vintage
+        self._chunk_size = chunk_size
+
+    @property
+    def backend_name(self) -> str:
+        return "census"
+
+    def geocode(
+        self,
+        addresses: Union[list[dict], list[str], list[AddressInput]],
+        **kwargs,
+    ) -> BatchGeocodingResult:
+        """Geocode addresses via the Census Bureau batch API.
+
+        Args:
+            addresses: Addresses in any supported format.
+            **kwargs: Passed through to geocode_batch_chunked.
+        """
+        from .census_geocoder import (
+            CensusVintage,
+            geocode_batch_chunked,
+        )
+
+        normalized = normalize_addresses(addresses)
+        if not normalized:
+            return BatchGeocodingResult(backend=self.backend_name)
+
+        vintage = self._vintage or CensusVintage.CURRENT
+
+        batch_input = [
+            {
+                "id": addr.input_id,
+                "street": addr.street,
+                "city": addr.city,
+                "state": addr.state,
+                "zipcode": addr.zipcode,
+            }
+            for addr in normalized
+        ]
+
+        result = BatchGeocodingResult(backend=self.backend_name)
+        try:
+            census_results = geocode_batch_chunked(
+                batch_input,
+                vintage=vintage,
+                chunk_size=self._chunk_size,
+            )
+            result.results = [
+                _census_result_to_geocoding_result(cr)
+                for cr in census_results
+            ]
+        except Exception as exc:
+            result.errors.append(f"Census batch geocode error: {exc}")
+            log.error("Census batch geocode failed: %s", exc)
+
+        log.info(
+            "Census batch: %d/%d matched (%.1f%%)",
+            result.matched_count,
+            result.total,
+            result.match_rate * 100,
+        )
+        return result

--- a/siege_utilities/geo/providers/composite_geocoder.py
+++ b/siege_utilities/geo/providers/composite_geocoder.py
@@ -1,0 +1,149 @@
+"""Composite batch geocoder with fallback chaining.
+
+Chains multiple :class:`BatchGeocoder` backends by priority,
+falling back to the next backend for addresses that fail or
+match below a quality threshold.
+
+Typical usage: Census first (free, returns GEOIDs), then
+Nominatim or TAMU for failures.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional, Union
+
+from .batch_geocoder import (
+    AddressInput,
+    BatchGeocoder,
+    BatchGeocodingResult,
+    GeocodingResult,
+    MatchQuality,
+    normalize_addresses,
+)
+
+log = logging.getLogger(__name__)
+
+_QUALITY_RANK = {
+    MatchQuality.EXACT.value: 4,
+    MatchQuality.INTERPOLATED.value: 3,
+    MatchQuality.APPROXIMATE.value: 2,
+    MatchQuality.CENTROID.value: 1,
+    MatchQuality.NO_MATCH.value: 0,
+}
+
+
+def _quality_rank(quality: str) -> int:
+    return _QUALITY_RANK.get(quality, 0)
+
+
+class CompositeBatchGeocoder(BatchGeocoder):
+    """Chains geocoding backends by priority with fallback.
+
+    For each address, tries backends in order. If a backend returns
+    a match below the minimum quality threshold, the next backend
+    is tried. The best result across all backends is kept.
+
+    Args:
+        backends: Ordered list of geocoder backends (highest priority first).
+        min_quality: Minimum match quality to accept without fallback.
+            Default "approximate" — only "centroid" and "no_match" trigger fallback.
+        skip_unavailable: Skip backends where is_available() returns False.
+            Default True.
+    """
+
+    def __init__(
+        self,
+        backends: list[BatchGeocoder],
+        min_quality: str = MatchQuality.APPROXIMATE.value,
+        skip_unavailable: bool = True,
+    ):
+        if not backends:
+            raise ValueError("At least one backend is required")
+        self._backends = backends
+        self._min_quality_rank = _quality_rank(min_quality)
+        self._skip_unavailable = skip_unavailable
+
+    @property
+    def backend_name(self) -> str:
+        return "composite"
+
+    def geocode(
+        self,
+        addresses: Union[list[dict], list[str], list[AddressInput]],
+        **kwargs,
+    ) -> BatchGeocodingResult:
+        """Geocode addresses through chained backends.
+
+        Each address is tried against backends in order until a result
+        meeting the quality threshold is found, or all backends are
+        exhausted. The best result is kept.
+        """
+        normalized = normalize_addresses(addresses)
+        if not normalized:
+            return BatchGeocodingResult(backend=self.backend_name)
+
+        available = self._get_available_backends()
+        if not available:
+            result = BatchGeocodingResult(backend=self.backend_name)
+            result.errors.append("No available geocoding backends")
+            return result
+
+        best: dict[int, GeocodingResult] = {}
+        pending = set(range(len(normalized)))
+
+        for backend in available:
+            if not pending:
+                break
+
+            pending_addrs = [normalized[i] for i in sorted(pending)]
+            pending_indices = sorted(pending)
+
+            try:
+                batch_result = backend.geocode(pending_addrs, **kwargs)
+            except Exception as exc:
+                log.warning(
+                    "Backend %s failed: %s", backend.backend_name, exc
+                )
+                continue
+
+            for idx, gr in zip(pending_indices, batch_result.results):
+                current_rank = _quality_rank(gr.match_quality)
+                prev = best.get(idx)
+
+                if prev is None or current_rank > _quality_rank(prev.match_quality):
+                    best[idx] = gr
+
+                if current_rank >= self._min_quality_rank:
+                    pending.discard(idx)
+
+        results = []
+        for i in range(len(normalized)):
+            if i in best:
+                results.append(best[i])
+            else:
+                results.append(GeocodingResult(
+                    input_address=normalized[i].one_line,
+                    input_id=normalized[i].input_id,
+                    match_quality=MatchQuality.NO_MATCH.value,
+                    backend=self.backend_name,
+                ))
+
+        result = BatchGeocodingResult(
+            results=results,
+            backend=self.backend_name,
+        )
+
+        log.info(
+            "Composite batch: %d/%d matched (%.1f%%) across %d backends",
+            result.matched_count,
+            result.total,
+            result.match_rate * 100,
+            len(available),
+        )
+        return result
+
+    def _get_available_backends(self) -> list[BatchGeocoder]:
+        if self._skip_unavailable:
+            return [b for b in self._backends if b.is_available()]
+        return list(self._backends)

--- a/siege_utilities/geo/providers/nlrb_cache.py
+++ b/siege_utilities/geo/providers/nlrb_cache.py
@@ -1,0 +1,257 @@
+"""NLRB data caching — disk persistence with TTL for NLRBFetchResult.
+
+Stores fetched NLRB case data as JSON in ``~/.siege_utilities/cache/nlrb/``.
+The loader orchestrates: **cache hit → API fetch → cache write**.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+from .nlrb_clients import (
+    ElectionRecord,
+    NLRBCaseRecord,
+    NLRBFetchResult,
+    ULPRecord,
+)
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_CACHE_DIR = Path.home() / ".siege_utilities" / "cache" / "nlrb"
+_DEFAULT_TTL_DAYS = 30
+
+
+def _date_to_str(d: Optional[date]) -> Optional[str]:
+    return d.isoformat() if d else None
+
+
+def _str_to_date(s: Optional[str]) -> Optional[date]:
+    if not s:
+        return None
+    try:
+        return date.fromisoformat(s)
+    except (ValueError, TypeError):
+        return None
+
+
+def _result_to_dict(result: NLRBFetchResult) -> dict:
+    return {
+        "source": result.source,
+        "fetched_at": datetime.now().isoformat(),
+        "cases": [
+            {
+                "case_number": c.case_number,
+                "case_type": c.case_type,
+                "case_name": c.case_name,
+                "status": c.status,
+                "date_filed": _date_to_str(c.date_filed),
+                "date_closed": _date_to_str(c.date_closed),
+                "region": c.region,
+                "city": c.city,
+                "state": c.state,
+                "union_name": c.union_name,
+                "unit_description": c.unit_description,
+                "naics_code": c.naics_code,
+                "employee_count": c.employee_count,
+                "source": c.source,
+            }
+            for c in result.cases
+        ],
+        "elections": [
+            {
+                "case_number": e.case_number,
+                "tally_date": _date_to_str(e.tally_date),
+                "eligible_voters": e.eligible_voters,
+                "votes_for": e.votes_for,
+                "votes_against": e.votes_against,
+                "void_ballots": e.void_ballots,
+                "union_name": e.union_name,
+                "source": e.source,
+            }
+            for e in result.elections
+        ],
+        "ulp_charges": [
+            {
+                "case_number": u.case_number,
+                "allegation": u.allegation,
+                "charging_party": u.charging_party,
+                "charged_party": u.charged_party,
+                "section_of_act": u.section_of_act,
+                "date_filed": _date_to_str(u.date_filed),
+                "source": u.source,
+            }
+            for u in result.ulp_charges
+        ],
+    }
+
+
+def _dict_to_result(data: dict) -> NLRBFetchResult:
+    cases = [
+        NLRBCaseRecord(
+            case_number=c["case_number"],
+            case_type=c.get("case_type", ""),
+            case_name=c.get("case_name", ""),
+            status=c.get("status", "Unknown"),
+            date_filed=_str_to_date(c.get("date_filed")),
+            date_closed=_str_to_date(c.get("date_closed")),
+            region=c.get("region"),
+            city=c.get("city", ""),
+            state=c.get("state", ""),
+            union_name=c.get("union_name", ""),
+            unit_description=c.get("unit_description", ""),
+            naics_code=c.get("naics_code", ""),
+            employee_count=c.get("employee_count"),
+            source=c.get("source", ""),
+        )
+        for c in data.get("cases", [])
+    ]
+    elections = [
+        ElectionRecord(
+            case_number=e["case_number"],
+            tally_date=_str_to_date(e.get("tally_date")),
+            eligible_voters=e.get("eligible_voters"),
+            votes_for=e.get("votes_for"),
+            votes_against=e.get("votes_against"),
+            void_ballots=e.get("void_ballots"),
+            union_name=e.get("union_name", ""),
+            source=e.get("source", ""),
+        )
+        for e in data.get("elections", [])
+    ]
+    ulp_charges = [
+        ULPRecord(
+            case_number=u["case_number"],
+            allegation=u.get("allegation", ""),
+            charging_party=u.get("charging_party", ""),
+            charged_party=u.get("charged_party", ""),
+            section_of_act=u.get("section_of_act", ""),
+            date_filed=_str_to_date(u.get("date_filed")),
+            source=u.get("source", ""),
+        )
+        for u in data.get("ulp_charges", [])
+    ]
+    return NLRBFetchResult(
+        cases=cases,
+        elections=elections,
+        ulp_charges=ulp_charges,
+        source=data.get("source", "cache"),
+    )
+
+
+class NLRBCache:
+    """JSON disk cache for NLRB fetch results.
+
+    Args:
+        cache_dir: Directory for cache files. Defaults to
+            ``~/.siege_utilities/cache/nlrb/``.
+        ttl_days: Cache entry lifetime in days. Default 30.
+    """
+
+    def __init__(
+        self,
+        cache_dir: Optional[Path] = None,
+        ttl_days: int = _DEFAULT_TTL_DAYS,
+    ):
+        self._cache_dir = Path(cache_dir) if cache_dir else _DEFAULT_CACHE_DIR
+        self._ttl = timedelta(days=ttl_days)
+
+    def _cache_path(self, key: str) -> Path:
+        return self._cache_dir / f"{key}.json"
+
+    def get(self, key: str) -> Optional[NLRBFetchResult]:
+        """Load a cached result if it exists and is not expired."""
+        path = self._cache_path(key)
+        if not path.exists():
+            return None
+
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            log.warning("Cache read error for %s: %s", key, exc)
+            return None
+
+        fetched_at = data.get("fetched_at")
+        if fetched_at:
+            try:
+                cached_time = datetime.fromisoformat(fetched_at)
+                if datetime.now() - cached_time > self._ttl:
+                    log.info("Cache expired for %s", key)
+                    return None
+            except (ValueError, TypeError):
+                pass
+
+        return _dict_to_result(data)
+
+    def put(self, key: str, result: NLRBFetchResult) -> None:
+        """Write a result to the cache."""
+        self._cache_dir.mkdir(parents=True, exist_ok=True)
+        data = _result_to_dict(result)
+        path = self._cache_path(key)
+        path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        log.info("Cached %d records to %s", result.total_records, path)
+
+    def invalidate(self, key: str) -> bool:
+        """Remove a cache entry. Returns True if removed."""
+        path = self._cache_path(key)
+        if path.exists():
+            path.unlink()
+            return True
+        return False
+
+    def invalidate_all(self) -> int:
+        """Remove all cache entries. Returns count removed."""
+        if not self._cache_dir.exists():
+            return 0
+        count = 0
+        for path in self._cache_dir.glob("*.json"):
+            path.unlink()
+            count += 1
+        return count
+
+
+class NLRBLoader:
+    """Cache-aware loader: cache hit → fetch → cache write.
+
+    Args:
+        cache: NLRBCache instance. If None, creates default.
+        client: NLRBDataClient or similar with ``fetch_all()`` method.
+    """
+
+    def __init__(
+        self,
+        cache: Optional[NLRBCache] = None,
+        client=None,
+    ):
+        self._cache = cache or NLRBCache()
+        self._client = client
+
+    def load(
+        self,
+        key: str = "unified",
+        force_refresh: bool = False,
+    ) -> NLRBFetchResult:
+        """Load NLRB data, using cache when available.
+
+        Args:
+            key: Cache key (e.g., 'unified', 'labordata', 'datagov').
+            force_refresh: Skip cache and fetch fresh data.
+        """
+        if not force_refresh:
+            cached = self._cache.get(key)
+            if cached is not None:
+                log.info("Cache hit for %s (%d records)", key, cached.total_records)
+                return cached
+
+        if self._client is None:
+            from .nlrb_clients import NLRBDataClient
+            self._client = NLRBDataClient()
+
+        result = self._client.fetch_all()
+        if result.success or result.total_records > 0:
+            self._cache.put(key, result)
+
+        return result

--- a/siege_utilities/geo/providers/nlrb_clients.py
+++ b/siege_utilities/geo/providers/nlrb_clients.py
@@ -1,0 +1,639 @@
+"""NLRB data source clients for case, election, and ULP data.
+
+Three backends:
+
+- **data.gov** — XML dumps of C-Cases (ULP) and R-Cases (representation).
+- **labordata GitHub** — cleaned CSV/Parquet exports from labordata/nlrb-data.
+- **NxGen Advanced Search** — HTML scraping of the NLRB case search
+  (fragile; marked as best-effort).
+
+A unified :class:`NLRBDataClient` facade reconciles records across sources.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import logging
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field, asdict
+from datetime import date, datetime
+from enum import Enum
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+
+def _requests():
+    import requests
+    return requests
+
+
+# ---------------------------------------------------------------------------
+# Enums & records
+# ---------------------------------------------------------------------------
+
+
+class CaseType(str, Enum):
+    """NLRB case type prefix codes."""
+
+    R = "R"       # Representation
+    C = "C"       # Unfair Labor Practice (charged against employer)
+    CB = "CB"     # ULP charged against union
+    CD = "CD"     # ULP charged against union (duty of fair representation)
+    CE = "CE"     # ULP charged against union (excessive fees)
+    CA = "CA"     # ULP charged against employer (alias for C in older data)
+    AC = "AC"     # Amendment of Certification
+    UC = "UC"     # Unit Clarification
+    UD = "UD"     # Unit De-authorization
+    WH = "WH"     # Wage-Hour (historical)
+    RM = "RM"     # Employer-filed representation
+    RD = "RD"     # Decertification
+    RC = "RC"     # Certification (union-filed)
+
+
+class CaseStatus(str, Enum):
+    """High-level case statuses."""
+
+    OPEN = "Open"
+    CLOSED = "Closed"
+    PENDING = "Pending"
+    UNKNOWN = "Unknown"
+
+
+@dataclass
+class NLRBCaseRecord:
+    """A single NLRB case record from any data source."""
+
+    case_number: str
+    case_type: str
+    case_name: str = ""
+    status: str = CaseStatus.UNKNOWN.value
+    date_filed: Optional[date] = None
+    date_closed: Optional[date] = None
+    region: Optional[int] = None
+    city: str = ""
+    state: str = ""
+    union_name: str = ""
+    unit_description: str = ""
+    naics_code: str = ""
+    employee_count: Optional[int] = None
+    source: str = ""
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class ElectionRecord:
+    """Election tally result linked to a case."""
+
+    case_number: str
+    tally_date: Optional[date] = None
+    eligible_voters: Optional[int] = None
+    votes_for: Optional[int] = None
+    votes_against: Optional[int] = None
+    void_ballots: Optional[int] = None
+    union_name: str = ""
+    source: str = ""
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class ULPRecord:
+    """Unfair labor practice charge."""
+
+    case_number: str
+    allegation: str = ""
+    charging_party: str = ""
+    charged_party: str = ""
+    section_of_act: str = ""
+    date_filed: Optional[date] = None
+    source: str = ""
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class NLRBFetchResult:
+    """Result from a client fetch operation."""
+
+    cases: list[NLRBCaseRecord] = field(default_factory=list)
+    elections: list[ElectionRecord] = field(default_factory=list)
+    ulp_charges: list[ULPRecord] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    source: str = ""
+
+    @property
+    def success(self) -> bool:
+        return len(self.errors) == 0
+
+    @property
+    def total_records(self) -> int:
+        return len(self.cases) + len(self.elections) + len(self.ulp_charges)
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+_DATE_FORMATS = ("%Y-%m-%d", "%m/%d/%Y", "%m-%d-%Y", "%Y-%m-%dT%H:%M:%S")
+
+
+def _parse_date(value: Optional[str]) -> Optional[date]:
+    if not value or not value.strip():
+        return None
+    value = value.strip()
+    for fmt in _DATE_FORMATS:
+        try:
+            return datetime.strptime(value, fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+def _safe_int(value) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(float(str(value).strip()))
+    except (ValueError, TypeError):
+        return None
+
+
+def _extract_region(case_number: str) -> Optional[int]:
+    """Extract the region number from a case number like '05-RC-123456'."""
+    if not case_number:
+        return None
+    parts = case_number.split("-")
+    if parts:
+        try:
+            return int(parts[0])
+        except ValueError:
+            return None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# data.gov XML client
+# ---------------------------------------------------------------------------
+
+DATAGOV_CASES_URL = (
+    "https://data.nlrb.gov/data/cases"
+)
+
+
+class NLRBDatagovClient:
+    """Download and parse NLRB case data from data.gov XML exports.
+
+    The NLRB publishes case data through its open data portal. This client
+    fetches the XML feed and parses it into structured records.
+
+    Args:
+        timeout: HTTP request timeout in seconds.
+        base_url: Override the default data.gov endpoint.
+    """
+
+    def __init__(
+        self,
+        timeout: int = 60,
+        base_url: Optional[str] = None,
+        session: Optional[object] = None,
+    ):
+        self._timeout = timeout
+        self._base_url = base_url or DATAGOV_CASES_URL
+        self._session = session
+
+    def _get_session(self):
+        if self._session is None:
+            self._session = _requests().Session()
+            self._session.headers.update({"Accept": "application/xml"})
+        return self._session
+
+    def fetch_cases(self, params: Optional[dict] = None) -> NLRBFetchResult:
+        """Fetch case records from the data.gov XML endpoint.
+
+        Args:
+            params: Optional query parameters for filtering.
+
+        Returns:
+            NLRBFetchResult with parsed case records.
+        """
+        result = NLRBFetchResult(source="datagov")
+        try:
+            resp = self._get_session().get(
+                self._base_url,
+                params=params,
+                timeout=self._timeout,
+            )
+            resp.raise_for_status()
+        except Exception as exc:
+            result.errors.append(f"HTTP error fetching data.gov: {exc}")
+            return result
+
+        try:
+            root = ET.fromstring(resp.text)
+        except ET.ParseError as exc:
+            result.errors.append(f"XML parse error: {exc}")
+            return result
+
+        for case_el in root.iter("case"):
+            record = self._parse_case_element(case_el)
+            if record:
+                result.cases.append(record)
+
+        log.info("data.gov: parsed %d cases", len(result.cases))
+        return result
+
+    def _parse_case_element(self, el: ET.Element) -> Optional[NLRBCaseRecord]:
+        case_number = (el.findtext("caseNumber") or el.findtext("case_number") or "").strip()
+        if not case_number:
+            return None
+
+        return NLRBCaseRecord(
+            case_number=case_number,
+            case_type=el.findtext("caseType") or el.findtext("case_type") or "",
+            case_name=el.findtext("caseName") or el.findtext("case_name") or "",
+            status=el.findtext("status") or CaseStatus.UNKNOWN.value,
+            date_filed=_parse_date(el.findtext("dateFiled") or el.findtext("date_filed")),
+            date_closed=_parse_date(el.findtext("dateClosed") or el.findtext("date_closed")),
+            region=_extract_region(case_number),
+            city=el.findtext("city") or "",
+            state=el.findtext("state") or "",
+            union_name=el.findtext("unionName") or el.findtext("labor_union") or "",
+            unit_description=el.findtext("unitDescription") or "",
+            naics_code=el.findtext("naicsCode") or el.findtext("naics") or "",
+            employee_count=_safe_int(el.findtext("employeeCount") or el.findtext("num_employees")),
+            source="datagov",
+        )
+
+
+# ---------------------------------------------------------------------------
+# labordata GitHub CSV/Parquet client
+# ---------------------------------------------------------------------------
+
+LABORDATA_BASE_URL = (
+    "https://raw.githubusercontent.com/labordata/nlrb-data/main"
+)
+
+LABORDATA_FILES = {
+    "cases": "/data/cases.csv",
+    "elections": "/data/elections.csv",
+    "ulp_charges": "/data/charges.csv",
+}
+
+
+class NLRBLabordataClient:
+    """Download and parse NLRB data from the labordata/nlrb-data GitHub repo.
+
+    The labordata project maintains cleaned CSV exports of NLRB data. This
+    client downloads the CSV files and parses them into structured records.
+
+    Args:
+        timeout: HTTP request timeout in seconds.
+        base_url: Override the default GitHub raw content URL.
+    """
+
+    def __init__(
+        self,
+        timeout: int = 120,
+        base_url: Optional[str] = None,
+        session: Optional[object] = None,
+    ):
+        self._timeout = timeout
+        self._base_url = base_url or LABORDATA_BASE_URL
+        self._session = session
+
+    def _get_session(self):
+        if self._session is None:
+            self._session = _requests().Session()
+        return self._session
+
+    def fetch_cases(self) -> NLRBFetchResult:
+        """Fetch all available data from the labordata repository.
+
+        Downloads cases, elections, and ULP charges CSVs.
+        """
+        result = NLRBFetchResult(source="labordata")
+
+        cases_csv = self._download_csv("cases")
+        if cases_csv is not None:
+            for row in cases_csv:
+                record = self._parse_case_row(row)
+                if record:
+                    result.cases.append(record)
+
+        elections_csv = self._download_csv("elections")
+        if elections_csv is not None:
+            for row in elections_csv:
+                record = self._parse_election_row(row)
+                if record:
+                    result.elections.append(record)
+
+        charges_csv = self._download_csv("ulp_charges")
+        if charges_csv is not None:
+            for row in charges_csv:
+                record = self._parse_ulp_row(row)
+                if record:
+                    result.ulp_charges.append(record)
+        elif cases_csv is None:
+            result.errors.append("Failed to download any data from labordata")
+
+        log.info(
+            "labordata: %d cases, %d elections, %d charges",
+            len(result.cases),
+            len(result.elections),
+            len(result.ulp_charges),
+        )
+        return result
+
+    def _download_csv(self, dataset: str) -> Optional[list[dict]]:
+        path = LABORDATA_FILES.get(dataset)
+        if not path:
+            return None
+        url = self._base_url + path
+        try:
+            resp = self._get_session().get(url, timeout=self._timeout)
+            resp.raise_for_status()
+        except Exception as exc:
+            log.warning("labordata: failed to download %s: %s", dataset, exc)
+            return None
+
+        reader = csv.DictReader(io.StringIO(resp.text))
+        return list(reader)
+
+    def _parse_case_row(self, row: dict) -> Optional[NLRBCaseRecord]:
+        case_number = row.get("case_number", "").strip()
+        if not case_number:
+            return None
+
+        return NLRBCaseRecord(
+            case_number=case_number,
+            case_type=row.get("case_type", ""),
+            case_name=row.get("case_name", ""),
+            status=row.get("status", CaseStatus.UNKNOWN.value),
+            date_filed=_parse_date(row.get("date_filed")),
+            date_closed=_parse_date(row.get("date_closed")),
+            region=_extract_region(case_number),
+            city=row.get("city", ""),
+            state=row.get("state", ""),
+            union_name=row.get("union_name", row.get("labor_union", "")),
+            unit_description=row.get("unit_description", row.get("bargaining_unit", "")),
+            naics_code=row.get("naics_code", row.get("naics", "")),
+            employee_count=_safe_int(row.get("employee_count", row.get("num_employees"))),
+            source="labordata",
+        )
+
+    def _parse_election_row(self, row: dict) -> Optional[ElectionRecord]:
+        case_number = row.get("case_number", "").strip()
+        if not case_number:
+            return None
+
+        return ElectionRecord(
+            case_number=case_number,
+            tally_date=_parse_date(row.get("tally_date")),
+            eligible_voters=_safe_int(row.get("eligible_voters")),
+            votes_for=_safe_int(row.get("votes_for", row.get("votes_cast_for"))),
+            votes_against=_safe_int(row.get("votes_against", row.get("votes_cast_against"))),
+            void_ballots=_safe_int(row.get("void_ballots")),
+            union_name=row.get("union_name", row.get("labor_union", "")),
+            source="labordata",
+        )
+
+    def _parse_ulp_row(self, row: dict) -> Optional[ULPRecord]:
+        case_number = row.get("case_number", "").strip()
+        if not case_number:
+            return None
+
+        return ULPRecord(
+            case_number=case_number,
+            allegation=row.get("allegation", ""),
+            charging_party=row.get("charging_party", ""),
+            charged_party=row.get("charged_party", row.get("employer", "")),
+            section_of_act=row.get("section_of_act", row.get("nlra_section", "")),
+            date_filed=_parse_date(row.get("date_filed")),
+            source="labordata",
+        )
+
+
+# ---------------------------------------------------------------------------
+# NxGen Advanced Search client (fragile — web scraping)
+# ---------------------------------------------------------------------------
+
+NXGEN_SEARCH_URL = "https://www.nlrb.gov/search/case"
+
+
+class NLRBNxGenClient:
+    """Scrape NLRB case data from the NxGen Advanced Search page.
+
+    .. warning::
+        This client relies on HTML structure that may change without notice.
+        Use it as a fallback when data.gov or labordata sources are
+        insufficient. Prefer the other clients for bulk data.
+
+    Args:
+        timeout: HTTP request timeout in seconds.
+        base_url: Override the default NxGen search URL.
+    """
+
+    def __init__(
+        self,
+        timeout: int = 30,
+        base_url: Optional[str] = None,
+        session: Optional[object] = None,
+    ):
+        self._timeout = timeout
+        self._base_url = base_url or NXGEN_SEARCH_URL
+        self._session = session
+
+    def _get_session(self):
+        if self._session is None:
+            self._session = _requests().Session()
+            self._session.headers.update({
+                "User-Agent": "siege_utilities NLRB research client",
+            })
+        return self._session
+
+    def fetch_case(self, case_number: str) -> NLRBFetchResult:
+        """Fetch a single case by number from the NxGen search.
+
+        Args:
+            case_number: NLRB case number (e.g., '05-RC-123456').
+        """
+        result = NLRBFetchResult(source="nxgen")
+        url = f"{self._base_url}?f%5B0%5D=case_number%3A{case_number}"
+
+        try:
+            resp = self._get_session().get(url, timeout=self._timeout)
+            resp.raise_for_status()
+        except Exception as exc:
+            result.errors.append(f"NxGen HTTP error: {exc}")
+            return result
+
+        records = self._parse_search_results(resp.text)
+        result.cases.extend(records)
+        return result
+
+    def _parse_search_results(self, html: str) -> list[NLRBCaseRecord]:
+        """Best-effort HTML parsing — returns empty list on failure."""
+        records: list[NLRBCaseRecord] = []
+        try:
+            from html.parser import HTMLParser
+
+            class _CaseExtractor(HTMLParser):
+                def __init__(self):
+                    super().__init__()
+                    self._in_row = False
+                    self._current_field = ""
+                    self._fields: dict = {}
+                    self._rows: list[dict] = []
+
+                def handle_starttag(self, tag, attrs):
+                    attrs_dict = dict(attrs)
+                    if tag == "tr":
+                        self._in_row = True
+                        self._fields = {}
+                    elif tag == "td" and self._in_row:
+                        cls = attrs_dict.get("class", "")
+                        if "case-number" in cls:
+                            self._current_field = "case_number"
+                        elif "case-name" in cls:
+                            self._current_field = "case_name"
+                        elif "date-filed" in cls:
+                            self._current_field = "date_filed"
+                        elif "status" in cls:
+                            self._current_field = "status"
+                        elif "city" in cls:
+                            self._current_field = "city"
+                        elif "state" in cls:
+                            self._current_field = "state"
+
+                def handle_data(self, data):
+                    if self._current_field:
+                        self._fields[self._current_field] = data.strip()
+                        self._current_field = ""
+
+                def handle_endtag(self, tag):
+                    if tag == "tr" and self._in_row and self._fields.get("case_number"):
+                        self._rows.append(dict(self._fields))
+                        self._in_row = False
+                        self._fields = {}
+
+            parser = _CaseExtractor()
+            parser.feed(html)
+
+            for row_data in parser._rows:
+                case_num = row_data.get("case_number", "")
+                if case_num:
+                    records.append(NLRBCaseRecord(
+                        case_number=case_num,
+                        case_type=case_num.split("-")[1] if "-" in case_num else "",
+                        case_name=row_data.get("case_name", ""),
+                        status=row_data.get("status", CaseStatus.UNKNOWN.value),
+                        date_filed=_parse_date(row_data.get("date_filed")),
+                        city=row_data.get("city", ""),
+                        state=row_data.get("state", ""),
+                        region=_extract_region(case_num),
+                        source="nxgen",
+                    ))
+        except Exception as exc:
+            log.warning("NxGen parse failed (expected — page structure may have changed): %s", exc)
+
+        return records
+
+
+# ---------------------------------------------------------------------------
+# Unified facade
+# ---------------------------------------------------------------------------
+
+
+class NLRBDataClient:
+    """Unified NLRB data client that reconciles across multiple sources.
+
+    Fetches from available backends and deduplicates by case number. When
+    the same case appears in multiple sources, labordata is preferred
+    (cleaned data), then data.gov, then NxGen.
+
+    Args:
+        datagov_client: Optional pre-configured data.gov client.
+        labordata_client: Optional pre-configured labordata client.
+        nxgen_client: Optional pre-configured NxGen client.
+        use_nxgen: Whether to include the fragile NxGen source. Default False.
+    """
+
+    SOURCE_PRIORITY = ("labordata", "datagov", "nxgen")
+
+    def __init__(
+        self,
+        datagov_client: Optional[NLRBDatagovClient] = None,
+        labordata_client: Optional[NLRBLabordataClient] = None,
+        nxgen_client: Optional[NLRBNxGenClient] = None,
+        use_nxgen: bool = False,
+    ):
+        self._datagov = datagov_client or NLRBDatagovClient()
+        self._labordata = labordata_client or NLRBLabordataClient()
+        self._nxgen = nxgen_client or NLRBNxGenClient() if use_nxgen else None
+
+    def fetch_all(self, datagov_params: Optional[dict] = None) -> NLRBFetchResult:
+        """Fetch from all configured sources and reconcile.
+
+        Args:
+            datagov_params: Optional query parameters for the data.gov source.
+
+        Returns:
+            Merged NLRBFetchResult with deduplicated records.
+        """
+        results: list[NLRBFetchResult] = []
+
+        labordata_result = self._labordata.fetch_cases()
+        results.append(labordata_result)
+
+        datagov_result = self._datagov.fetch_cases(params=datagov_params)
+        results.append(datagov_result)
+
+        if self._nxgen:
+            nxgen_result = self._nxgen.fetch_case("")
+            results.append(nxgen_result)
+
+        return self._reconcile(results)
+
+    def _reconcile(self, results: list[NLRBFetchResult]) -> NLRBFetchResult:
+        """Merge results, preferring higher-priority sources."""
+        merged = NLRBFetchResult(source="unified")
+
+        case_map: dict[str, NLRBCaseRecord] = {}
+        election_map: dict[str, ElectionRecord] = {}
+        ulp_map: dict[str, ULPRecord] = {}
+
+        for source_name in self.SOURCE_PRIORITY:
+            for result in results:
+                if result.source != source_name:
+                    continue
+                for case in result.cases:
+                    if case.case_number not in case_map:
+                        case_map[case.case_number] = case
+                for election in result.elections:
+                    key = f"{election.case_number}:{election.tally_date}"
+                    if key not in election_map:
+                        election_map[key] = election
+                for ulp in result.ulp_charges:
+                    key = f"{ulp.case_number}:{ulp.allegation[:50]}"
+                    if key not in ulp_map:
+                        ulp_map[key] = ulp
+                merged.errors.extend(result.errors)
+
+        merged.cases = list(case_map.values())
+        merged.elections = list(election_map.values())
+        merged.ulp_charges = list(ulp_map.values())
+
+        log.info(
+            "unified: %d cases, %d elections, %d charges (%d errors)",
+            len(merged.cases),
+            len(merged.elections),
+            len(merged.ulp_charges),
+            len(merged.errors),
+        )
+        return merged

--- a/siege_utilities/geo/providers/nlrb_export.py
+++ b/siege_utilities/geo/providers/nlrb_export.py
@@ -1,0 +1,71 @@
+"""DataFrame export for NLRB records.
+
+Converts NLRBFetchResult or lists of dataclass records into pandas
+DataFrames for analysis.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+
+
+def cases_to_dataframe(cases):
+    """Convert a list of NLRBCaseRecord to a DataFrame.
+
+    Args:
+        cases: List of NLRBCaseRecord instances, or an NLRBFetchResult.
+
+    Returns:
+        pandas DataFrame with one row per case.
+    """
+    import pandas as pd
+
+    from siege_utilities.geo.providers.nlrb_clients import NLRBFetchResult
+
+    if isinstance(cases, NLRBFetchResult):
+        cases = cases.cases
+    if not cases:
+        return pd.DataFrame()
+    return pd.DataFrame([c.to_dict() for c in cases])
+
+
+def elections_to_dataframe(elections):
+    """Convert a list of ElectionRecord to a DataFrame."""
+    import pandas as pd
+
+    from siege_utilities.geo.providers.nlrb_clients import NLRBFetchResult
+
+    if isinstance(elections, NLRBFetchResult):
+        elections = elections.elections
+    if not elections:
+        return pd.DataFrame()
+    return pd.DataFrame([e.to_dict() for e in elections])
+
+
+def ulp_charges_to_dataframe(charges):
+    """Convert a list of ULPRecord to a DataFrame."""
+    import pandas as pd
+
+    from siege_utilities.geo.providers.nlrb_clients import NLRBFetchResult
+
+    if isinstance(charges, NLRBFetchResult):
+        charges = charges.ulp_charges
+    if not charges:
+        return pd.DataFrame()
+    return pd.DataFrame([c.to_dict() for c in charges])
+
+
+def fetch_result_to_dataframes(result):
+    """Convert an NLRBFetchResult to a dict of DataFrames.
+
+    Returns:
+        Dict with keys 'cases', 'elections', 'ulp_charges', each a DataFrame.
+    """
+    return {
+        "cases": cases_to_dataframe(result),
+        "elections": elections_to_dataframe(result),
+        "ulp_charges": ulp_charges_to_dataframe(result),
+    }

--- a/siege_utilities/geo/providers/nlrb_regions.py
+++ b/siege_utilities/geo/providers/nlrb_regions.py
@@ -1,0 +1,144 @@
+"""NLRB region lookup, case-to-region assignment, and aggregation.
+
+Pure-Python utilities — no Django dependency. Works with NLRBCaseRecord
+dataclasses, dicts, or any object with ``region`` and ``state`` attributes.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Optional
+
+NLRB_REGIONS: dict[int, dict] = {
+    1: {"office": "Boston", "states": ["CT", "MA", "ME", "NH", "RI", "VT"]},
+    2: {"office": "New York", "states": ["NY"]},
+    3: {"office": "Buffalo", "states": ["NY"]},
+    4: {"office": "Philadelphia", "states": ["DE", "PA"]},
+    5: {"office": "Baltimore", "states": ["DC", "MD", "VA", "WV"]},
+    6: {"office": "Pittsburgh", "states": ["PA", "WV"]},
+    7: {"office": "Detroit", "states": ["MI"]},
+    8: {"office": "Cleveland", "states": ["OH"]},
+    9: {"office": "Cincinnati", "states": ["IN", "KY", "OH"]},
+    10: {"office": "Atlanta", "states": ["AL", "GA", "NC", "SC", "TN"]},
+    11: {"office": "Winston-Salem", "states": ["NC", "SC", "TN", "VA"]},
+    12: {"office": "Tampa", "states": ["FL", "PR", "VI"]},
+    13: {"office": "Chicago", "states": ["IL", "IN"]},
+    14: {"office": "St. Louis", "states": ["IL", "MO"]},
+    15: {"office": "New Orleans", "states": ["AL", "LA", "MS"]},
+    16: {"office": "Fort Worth", "states": ["TX"]},
+    17: {"office": "Kansas City", "states": ["IA", "KS", "MO", "NE"]},
+    18: {"office": "Minneapolis", "states": ["MN", "ND", "SD", "WI"]},
+    19: {"office": "Seattle", "states": ["AK", "ID", "MT", "OR", "WA", "WY"]},
+    20: {"office": "San Francisco", "states": ["CA", "HI", "NV"]},
+    21: {"office": "Los Angeles", "states": ["AZ", "CA", "HI", "NV"]},
+    22: {"office": "Newark", "states": ["NJ"]},
+    24: {"office": "Hato Rey", "states": ["PR", "VI"]},
+    25: {"office": "Indianapolis", "states": ["IN"]},
+    26: {"office": "Memphis", "states": ["AR", "MS", "TN"]},
+    27: {"office": "Denver", "states": ["CO", "NM", "UT", "WY"]},
+    28: {"office": "Memphis", "states": ["AL", "AR", "MS"]},
+    29: {"office": "Brooklyn", "states": ["NY"]},
+    31: {"office": "Los Angeles", "states": ["CA"]},
+}
+
+
+def _build_state_to_regions() -> dict[str, list[int]]:
+    state_map: dict[str, list[int]] = defaultdict(list)
+    for region_num, info in NLRB_REGIONS.items():
+        for state in info["states"]:
+            state_map[state].append(region_num)
+    return dict(state_map)
+
+
+STATE_TO_REGIONS: dict[str, list[int]] = _build_state_to_regions()
+
+
+def lookup_region_by_state(state: str) -> list[int]:
+    """Return NLRB region number(s) for a state abbreviation.
+
+    Args:
+        state: 2-letter state abbreviation (e.g., 'IL', 'NY').
+
+    Returns:
+        List of region numbers. May be >1 for states split across
+        multiple regions (e.g., NY → [2, 3, 29]).
+        Empty list if state not found.
+    """
+    return STATE_TO_REGIONS.get(state.upper().strip(), [])
+
+
+def assign_region(case_record) -> Optional[int]:
+    """Assign an NLRB region number to a case record.
+
+    Uses the region number from the case number if available,
+    otherwise falls back to state-based lookup (first match).
+
+    Args:
+        case_record: Object with ``region`` and ``state`` attributes,
+            or a dict with those keys.
+
+    Returns:
+        Region number or None if not determinable.
+    """
+    if isinstance(case_record, dict):
+        region = case_record.get("region")
+        state = case_record.get("state", "")
+    else:
+        region = getattr(case_record, "region", None)
+        state = getattr(case_record, "state", "")
+
+    if region:
+        return int(region)
+
+    if state:
+        regions = lookup_region_by_state(state)
+        if regions:
+            return regions[0]
+
+    return None
+
+
+def aggregate_by_region(records) -> dict[int, list]:
+    """Group records by their NLRB region number.
+
+    Args:
+        records: Iterable of case records (dataclass, model, or dict).
+
+    Returns:
+        Dict mapping region numbers to lists of records.
+        Records without a region are grouped under key 0.
+    """
+    groups: dict[int, list] = defaultdict(list)
+    for record in records:
+        region = assign_region(record)
+        groups[region or 0].append(record)
+    return dict(groups)
+
+
+def region_summary(records) -> list[dict]:
+    """Summarize case counts by region with office names.
+
+    Args:
+        records: Iterable of case records.
+
+    Returns:
+        List of dicts with keys: region_number, office, case_count.
+        Sorted by region_number.
+    """
+    groups = aggregate_by_region(records)
+    summary = []
+    for region_num, cases in sorted(groups.items()):
+        if region_num == 0:
+            summary.append({
+                "region_number": 0,
+                "office": "Unknown",
+                "case_count": len(cases),
+            })
+        else:
+            info = NLRB_REGIONS.get(region_num, {})
+            summary.append({
+                "region_number": region_num,
+                "office": info.get("office", "Unknown"),
+                "case_count": len(cases),
+            })
+    return summary

--- a/siege_utilities/geo/providers/nominatim_batch.py
+++ b/siege_utilities/geo/providers/nominatim_batch.py
@@ -1,0 +1,168 @@
+"""Nominatim batch geocoder backend.
+
+Wraps Nominatim geocoding (public or self-hosted) behind the
+:class:`BatchGeocoder` ABC with configurable rate limiting.
+
+Nominatim does not return Census GEOIDs — those must be assigned
+via spatial join if needed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import urllib.parse
+import urllib.request
+from typing import Optional, Union
+
+from .batch_geocoder import (
+    AddressInput,
+    BatchGeocoder,
+    BatchGeocodingResult,
+    GeocodingResult,
+    MatchQuality,
+    normalize_addresses,
+)
+
+log = logging.getLogger(__name__)
+
+PUBLIC_NOMINATIM_URL = "https://nominatim.openstreetmap.org"
+DEFAULT_RATE_LIMIT = 1.0  # seconds between requests for public instance
+SELF_HOSTED_RATE_LIMIT = 0.05
+
+
+class NominatimBatchGeocoder(BatchGeocoder):
+    """Nominatim geocoding backend with rate limiting.
+
+    Uses the existing geocoding infrastructure to query Nominatim
+    one address at a time (Nominatim has no true batch API).
+
+    Args:
+        server_url: Nominatim endpoint. Defaults to public instance.
+        rate_limit: Seconds between requests. Default 1.0 for public,
+            0.05 for self-hosted (auto-detected from URL).
+        country_codes: Restrict results to these countries (e.g., ['us']).
+        max_retries: Max retries per address on transient failure.
+    """
+
+    def __init__(
+        self,
+        server_url: Optional[str] = None,
+        rate_limit: Optional[float] = None,
+        country_codes: Optional[list[str]] = None,
+        max_retries: int = 2,
+    ):
+        self._server_url = server_url or PUBLIC_NOMINATIM_URL
+        if rate_limit is not None:
+            self._rate_limit = rate_limit
+        elif self._server_url == PUBLIC_NOMINATIM_URL:
+            self._rate_limit = DEFAULT_RATE_LIMIT
+        else:
+            self._rate_limit = SELF_HOSTED_RATE_LIMIT
+        self._country_codes = country_codes or ["us"]
+        self._max_retries = max_retries
+
+    @property
+    def backend_name(self) -> str:
+        return "nominatim"
+
+    def geocode(
+        self,
+        addresses: Union[list[dict], list[str], list[AddressInput]],
+        **kwargs,
+    ) -> BatchGeocodingResult:
+        """Geocode addresses via Nominatim (one at a time with rate limiting).
+
+        Args:
+            addresses: Addresses in any supported format.
+        """
+        normalized = normalize_addresses(addresses)
+        if not normalized:
+            return BatchGeocodingResult(backend=self.backend_name)
+
+        result = BatchGeocodingResult(backend=self.backend_name)
+        last_request_time = 0.0
+
+        for addr in normalized:
+            elapsed = time.monotonic() - last_request_time
+            if elapsed < self._rate_limit:
+                time.sleep(self._rate_limit - elapsed)
+
+            gr = self._geocode_single(addr)
+            result.results.append(gr)
+            last_request_time = time.monotonic()
+
+        log.info(
+            "Nominatim batch: %d/%d matched (%.1f%%)",
+            result.matched_count,
+            result.total,
+            result.match_rate * 100,
+        )
+        return result
+
+    def _geocode_single(self, addr: AddressInput) -> GeocodingResult:
+        """Geocode a single address via Nominatim HTTP API."""
+        query = addr.one_line
+        if not query:
+            return GeocodingResult(
+                input_address=query,
+                input_id=addr.input_id,
+                match_quality=MatchQuality.NO_MATCH.value,
+                backend=self.backend_name,
+            )
+
+        try:
+            coords = self._nominatim_request(query)
+            if coords is not None:
+                lat, lon = coords
+                return GeocodingResult(
+                    input_address=query,
+                    input_id=addr.input_id,
+                    lat=lat,
+                    lon=lon,
+                    match_quality=MatchQuality.APPROXIMATE.value,
+                    backend=self.backend_name,
+                )
+        except Exception as exc:
+            log.warning("Nominatim geocode failed for %s: %s", addr.input_id, exc)
+
+        return GeocodingResult(
+            input_address=query,
+            input_id=addr.input_id,
+            match_quality=MatchQuality.NO_MATCH.value,
+            backend=self.backend_name,
+        )
+
+    def _nominatim_request(self, query: str) -> Optional[tuple[float, float]]:
+        """Make a single Nominatim search request.
+
+        Returns (lat, lon) or None if no match.
+        """
+        params = urllib.parse.urlencode({
+            "q": query,
+            "format": "json",
+            "limit": "1",
+            "countrycodes": ",".join(self._country_codes),
+        })
+        url = f"{self._server_url}/search?{params}"
+
+        req = urllib.request.Request(url, headers={
+            "User-Agent": "siege_utilities geocoder",
+        })
+
+        for attempt in range(self._max_retries + 1):
+            try:
+                with urllib.request.urlopen(req, timeout=10) as resp:
+                    data = json.loads(resp.read().decode("utf-8"))
+                    if data and len(data) > 0:
+                        lat = float(data[0]["lat"])
+                        lon = float(data[0]["lon"])
+                        return (lat, lon)
+                    return None
+            except Exception:
+                if attempt == self._max_retries:
+                    raise
+                time.sleep(self._rate_limit)
+
+        return None

--- a/siege_utilities/geo/providers/tamu_batch.py
+++ b/siege_utilities/geo/providers/tamu_batch.py
@@ -1,0 +1,236 @@
+"""Texas A&M Geoservices batch geocoder backend.
+
+Wraps the TAMU geocoding API behind the :class:`BatchGeocoder` ABC.
+TAMU returns Census geography (state, county, tract, block GEOIDs)
+directly in its response, so no spatial join is needed.
+
+Requires an API key — get one at https://geoservices.tamu.edu/.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import urllib.parse
+import urllib.request
+from typing import Optional, Union
+
+from .batch_geocoder import (
+    AddressInput,
+    BatchGeocoder,
+    BatchGeocodingResult,
+    GeocodingResult,
+    MatchQuality,
+    normalize_addresses,
+)
+
+log = logging.getLogger(__name__)
+
+TAMU_BASE_URL = "https://geoservices.tamu.edu/Services/Geocode/WebService/GeocoderWebServiceHttpNonParsed_V04_01.aspx"
+DEFAULT_RATE_LIMIT = 0.25
+ENV_API_KEY = "TAMU_API_KEY"
+
+_MATCH_QUALITY_MAP = {
+    "exact": MatchQuality.EXACT.value,
+    "nearexact": MatchQuality.EXACT.value,
+    "interpolated": MatchQuality.INTERPOLATED.value,
+    "approximate": MatchQuality.APPROXIMATE.value,
+}
+
+
+class TAMUBatchGeocoder(BatchGeocoder):
+    """Texas A&M Geoservices geocoding backend.
+
+    Geocodes addresses one at a time via TAMU's HTTP API.
+    Returns Census geography (block-level GEOIDs) directly.
+
+    Args:
+        api_key: TAMU API key. Falls back to TAMU_API_KEY env var.
+        rate_limit: Seconds between requests. Default 0.25.
+        census_year: Census year for geography lookup. Default "2020".
+        max_retries: Max retries per address on transient failure.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        rate_limit: float = DEFAULT_RATE_LIMIT,
+        census_year: str = "2020",
+        max_retries: int = 2,
+    ):
+        self._api_key = api_key or os.environ.get(ENV_API_KEY, "")
+        self._rate_limit = rate_limit
+        self._census_year = census_year
+        self._max_retries = max_retries
+
+    @property
+    def backend_name(self) -> str:
+        return "tamu"
+
+    def is_available(self) -> bool:
+        return bool(self._api_key)
+
+    def geocode(
+        self,
+        addresses: Union[list[dict], list[str], list[AddressInput]],
+        **kwargs,
+    ) -> BatchGeocodingResult:
+        """Geocode addresses via the TAMU Geoservices API.
+
+        Args:
+            addresses: Addresses in any supported format.
+        """
+        normalized = normalize_addresses(addresses)
+        if not normalized:
+            return BatchGeocodingResult(backend=self.backend_name)
+
+        if not self._api_key:
+            result = BatchGeocodingResult(backend=self.backend_name)
+            result.errors.append("TAMU API key not configured")
+            return result
+
+        result = BatchGeocodingResult(backend=self.backend_name)
+        last_request_time = 0.0
+
+        for addr in normalized:
+            elapsed = time.monotonic() - last_request_time
+            if elapsed < self._rate_limit:
+                time.sleep(self._rate_limit - elapsed)
+
+            gr = self._geocode_single(addr)
+            result.results.append(gr)
+            last_request_time = time.monotonic()
+
+        log.info(
+            "TAMU batch: %d/%d matched (%.1f%%)",
+            result.matched_count,
+            result.total,
+            result.match_rate * 100,
+        )
+        return result
+
+    def _geocode_single(self, addr: AddressInput) -> GeocodingResult:
+        """Geocode a single address via TAMU."""
+        query = addr.one_line
+        if not query:
+            return GeocodingResult(
+                input_address=query,
+                input_id=addr.input_id,
+                match_quality=MatchQuality.NO_MATCH.value,
+                backend=self.backend_name,
+            )
+
+        try:
+            resp = self._tamu_request(addr)
+            if resp is not None:
+                return resp
+        except Exception as exc:
+            log.warning("TAMU geocode failed for %s: %s", addr.input_id, exc)
+
+        return GeocodingResult(
+            input_address=query,
+            input_id=addr.input_id,
+            match_quality=MatchQuality.NO_MATCH.value,
+            backend=self.backend_name,
+        )
+
+    def _tamu_request(self, addr: AddressInput) -> Optional[GeocodingResult]:
+        """Make a single TAMU geocoding request.
+
+        Returns a GeocodingResult or None if no match.
+        """
+        params = {
+            "streetAddress": addr.street,
+            "city": addr.city,
+            "state": addr.state,
+            "zip": addr.zipcode,
+            "apiKey": self._api_key,
+            "format": "json",
+            "census": "true",
+            "censusYear": self._census_year,
+            "version": "4.01",
+        }
+        url = f"{TAMU_BASE_URL}?{urllib.parse.urlencode(params)}"
+
+        req = urllib.request.Request(url, headers={
+            "User-Agent": "siege_utilities geocoder",
+        })
+
+        for attempt in range(self._max_retries + 1):
+            try:
+                with urllib.request.urlopen(req, timeout=15) as resp:
+                    data = json.loads(resp.read().decode("utf-8"))
+                    return self._parse_response(data, addr)
+            except Exception:
+                if attempt == self._max_retries:
+                    raise
+                time.sleep(self._rate_limit)
+
+        return None
+
+    def _parse_response(
+        self, data: dict, addr: AddressInput
+    ) -> Optional[GeocodingResult]:
+        """Parse TAMU JSON response into a GeocodingResult."""
+        output_geocodes = data.get("OutputGeocodes", [])
+        if not output_geocodes:
+            return None
+
+        geocode = output_geocodes[0]
+        geocode_attrs = geocode.get("OutputGeocode", {})
+        matched_address = geocode_attrs.get("MatchedAddress", "")
+        lat_str = geocode_attrs.get("Latitude", "")
+        lon_str = geocode_attrs.get("Longitude", "")
+
+        match_type = geocode_attrs.get("MatchType", "").lower()
+        quality = _MATCH_QUALITY_MAP.get(match_type, MatchQuality.APPROXIMATE.value)
+
+        if not lat_str or not lon_str:
+            return None
+
+        try:
+            lat = float(lat_str)
+            lon = float(lon_str)
+        except (ValueError, TypeError):
+            return None
+
+        if lat == 0.0 and lon == 0.0:
+            return None
+
+        state_geoid = ""
+        county_geoid = ""
+        tract_geoid = ""
+        block_geoid = ""
+
+        census_values = geocode.get("CensusValues", [])
+        if census_values:
+            cv = census_values[0].get("CensusValue1", {})
+            state_fips = cv.get("CensusStateFips", "")
+            county_fips = cv.get("CensusCountyFips", "")
+            tract = cv.get("CensusTract", "")
+            block = cv.get("CensusBlock", "")
+
+            if state_fips:
+                state_geoid = state_fips
+            if state_fips and county_fips:
+                county_geoid = f"{state_fips}{county_fips}"
+            if state_fips and county_fips and tract:
+                tract_geoid = f"{state_fips}{county_fips}{tract}"
+            if state_fips and county_fips and tract and block:
+                block_geoid = f"{state_fips}{county_fips}{tract}{block}"
+
+        return GeocodingResult(
+            input_address=addr.one_line,
+            input_id=addr.input_id,
+            matched_address=matched_address,
+            lat=lat,
+            lon=lon,
+            match_quality=quality,
+            state_geoid=state_geoid,
+            county_geoid=county_geoid,
+            tract_geoid=tract_geoid,
+            block_geoid=block_geoid,
+            backend=self.backend_name,
+        )

--- a/siege_utilities/geo/rdh_catalog.py
+++ b/siege_utilities/geo/rdh_catalog.py
@@ -1,0 +1,413 @@
+"""RDH dataset catalog and discovery.
+
+Pre-indexes available Redistricting Data Hub datasets by state, year,
+chamber, dataset type, and format for browsable discovery without
+trial-and-error API calls.
+"""
+
+from __future__ import annotations
+
+import abc
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+log = logging.getLogger(__name__)
+
+DEFAULT_CACHE_TTL = 30 * 24 * 3600  # 30 days in seconds
+CACHE_FILENAME = "rdh_catalog.json"
+
+
+@dataclass
+class CatalogEntry:
+    """Indexed metadata for a single RDH dataset.
+
+    Attributes:
+        title: Human-readable dataset title.
+        url: Download URL.
+        state: Two-letter state abbreviation.
+        year: Publication or vintage year.
+        chamber: Legislative chamber (congress, state_senate, state_house, or empty).
+        dataset_type: Category (pl94171, cvap, election, legislative, etc.).
+        format: File format (csv, shp).
+        geography: Geographic level (block, tract, precinct, district, etc.).
+        official: Whether this is an official/authoritative source.
+        file_size: Human-readable file size string.
+    """
+
+    title: str = ""
+    url: str = ""
+    state: str = ""
+    year: str = ""
+    chamber: str = ""
+    dataset_type: str = ""
+    format: str = ""
+    geography: str = ""
+    official: bool = False
+    file_size: str = ""
+
+    def matches(
+        self,
+        state: Optional[str] = None,
+        year: Optional[str] = None,
+        chamber: Optional[str] = None,
+        dataset_type: Optional[str] = None,
+        format: Optional[str] = None,
+    ) -> bool:
+        if state and self.state.upper() != state.upper():
+            return False
+        if year and self.year != str(year):
+            return False
+        if chamber and self.chamber.lower() != chamber.lower():
+            return False
+        if dataset_type and self.dataset_type.lower() != dataset_type.lower():
+            return False
+        if format and self.format.lower() != format.lower():
+            return False
+        return True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "title": self.title,
+            "url": self.url,
+            "state": self.state,
+            "year": self.year,
+            "chamber": self.chamber,
+            "dataset_type": self.dataset_type,
+            "format": self.format,
+            "geography": self.geography,
+            "official": self.official,
+            "file_size": self.file_size,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> CatalogEntry:
+        return cls(
+            title=d.get("title", ""),
+            url=d.get("url", ""),
+            state=d.get("state", ""),
+            year=d.get("year", ""),
+            chamber=d.get("chamber", ""),
+            dataset_type=d.get("dataset_type", ""),
+            format=d.get("format", ""),
+            geography=d.get("geography", ""),
+            official=d.get("official", False),
+            file_size=d.get("file_size", ""),
+        )
+
+
+@dataclass
+class SearchResult:
+    """Ranked search result from the catalog.
+
+    Attributes:
+        entry: The matching CatalogEntry.
+        score: Relevance score (higher = better match).
+    """
+
+    entry: CatalogEntry
+    score: float = 1.0
+
+
+@dataclass
+class CoverageCell:
+    """Single cell in the coverage matrix.
+
+    Attributes:
+        state: State abbreviation.
+        year: Year.
+        dataset_type: Dataset type.
+        count: Number of datasets matching this combination.
+        formats: Set of available formats.
+    """
+
+    state: str = ""
+    year: str = ""
+    dataset_type: str = ""
+    count: int = 0
+    formats: list[str] = field(default_factory=list)
+
+
+class RDHCatalogProvider(abc.ABC):
+    """Protocol for fetching the full RDH dataset inventory."""
+
+    @abc.abstractmethod
+    def fetch_all_datasets(self) -> list[CatalogEntry]:
+        """Fetch the complete dataset inventory from all states."""
+
+
+class DictRDHCatalogProvider(RDHCatalogProvider):
+    """In-memory catalog provider for testing."""
+
+    def __init__(self, entries: Optional[list[CatalogEntry]] = None):
+        self._entries: list[CatalogEntry] = entries or []
+
+    def add(self, entry: CatalogEntry):
+        self._entries.append(entry)
+
+    def fetch_all_datasets(self) -> list[CatalogEntry]:
+        return list(self._entries)
+
+
+CHAMBER_KEYWORDS = {
+    "congress": ["congress", "congressional", " cd ", " cd_"],
+    "state_senate": ["state senate", "upper chamber", "ssd", "sldu", "state_senate"],
+    "state_house": ["state house", "lower chamber", "shd", "sldl", "state_house"],
+}
+
+
+def _infer_chamber(title: str) -> str:
+    lower = title.lower()
+    for chamber, keywords in CHAMBER_KEYWORDS.items():
+        for kw in keywords:
+            if kw in lower:
+                return chamber
+    return ""
+
+
+def _score_entry(
+    entry: CatalogEntry,
+    state: Optional[str] = None,
+    year: Optional[str] = None,
+    chamber: Optional[str] = None,
+    dataset_type: Optional[str] = None,
+    query: Optional[str] = None,
+) -> float:
+    score = 0.0
+    if state and entry.state.upper() == state.upper():
+        score += 10.0
+    if year and entry.year == str(year):
+        score += 5.0
+    if chamber and entry.chamber.lower() == chamber.lower():
+        score += 5.0
+    if dataset_type and entry.dataset_type.lower() == dataset_type.lower():
+        score += 5.0
+    if entry.official:
+        score += 2.0
+    if query:
+        query_lower = query.lower()
+        title_lower = entry.title.lower()
+        if query_lower in title_lower:
+            score += 3.0
+        else:
+            words = query_lower.split()
+            matched = sum(1 for w in words if w in title_lower)
+            if words:
+                score += (matched / len(words)) * 2.0
+    return score
+
+
+class RDHCatalog:
+    """Pre-indexed catalog of available RDH datasets.
+
+    Provides browsable discovery of datasets by state, year, chamber,
+    dataset type, and format without trial-and-error API calls.
+
+    Args:
+        provider: Source for fetching the full dataset inventory.
+        cache_dir: Directory for persisting the catalog index.
+        cache_ttl: Cache time-to-live in seconds (default 30 days).
+    """
+
+    def __init__(
+        self,
+        provider: Optional[RDHCatalogProvider] = None,
+        cache_dir: Optional[Path] = None,
+        cache_ttl: int = DEFAULT_CACHE_TTL,
+    ):
+        self._provider = provider
+        self._cache_dir = cache_dir
+        self._cache_ttl = cache_ttl
+        self._entries: list[CatalogEntry] = []
+        self._loaded = False
+        self._loaded_at: Optional[float] = None
+
+    @property
+    def entries(self) -> list[CatalogEntry]:
+        return list(self._entries)
+
+    @property
+    def is_loaded(self) -> bool:
+        return self._loaded
+
+    @property
+    def entry_count(self) -> int:
+        return len(self._entries)
+
+    def load(self, force: bool = False) -> int:
+        """Load the catalog, using cache if available and fresh.
+
+        Args:
+            force: If True, bypass cache and fetch from provider.
+
+        Returns:
+            Number of entries loaded.
+        """
+        if not force and self._try_load_cache():
+            return len(self._entries)
+
+        if self._provider is None:
+            log.warning("No provider configured; catalog is empty")
+            return 0
+
+        entries = self._provider.fetch_all_datasets()
+        self._entries = entries
+        self._loaded = True
+        self._loaded_at = time.time()
+
+        self._save_cache()
+
+        log.info("Loaded %d entries into RDH catalog", len(entries))
+        return len(entries)
+
+    def search(
+        self,
+        state: Optional[str] = None,
+        year: Optional[str] = None,
+        chamber: Optional[str] = None,
+        dataset_type: Optional[str] = None,
+        format: Optional[str] = None,
+        query: Optional[str] = None,
+        limit: int = 50,
+    ) -> list[SearchResult]:
+        """Search the catalog with ranked results.
+
+        At least one filter or query must be provided.
+
+        Args:
+            state: Two-letter state abbreviation.
+            year: Publication year.
+            chamber: Legislative chamber (congress, state_senate, state_house).
+            dataset_type: Dataset category.
+            format: File format (csv, shp).
+            query: Free-text search against title.
+            limit: Maximum results to return.
+
+        Returns:
+            List of SearchResult sorted by relevance score (descending).
+        """
+        results: list[SearchResult] = []
+
+        for entry in self._entries:
+            if format and entry.format.lower() != format.lower():
+                continue
+
+            score = _score_entry(
+                entry,
+                state=state,
+                year=year,
+                chamber=chamber,
+                dataset_type=dataset_type,
+                query=query,
+            )
+
+            if score > 0:
+                results.append(SearchResult(entry=entry, score=score))
+
+        results.sort(key=lambda r: r.score, reverse=True)
+        return results[:limit]
+
+    def coverage_matrix(
+        self,
+        dataset_type: Optional[str] = None,
+    ) -> list[CoverageCell]:
+        """Build a coverage matrix of state x year x dataset_type.
+
+        Args:
+            dataset_type: Optionally filter to a single dataset type.
+
+        Returns:
+            List of CoverageCell entries with counts and available formats.
+        """
+        buckets: dict[tuple[str, str, str], list[str]] = {}
+
+        for entry in self._entries:
+            if dataset_type and entry.dataset_type.lower() != dataset_type.lower():
+                continue
+
+            key = (entry.state, entry.year, entry.dataset_type)
+            if key not in buckets:
+                buckets[key] = []
+            if entry.format and entry.format not in buckets[key]:
+                buckets[key].append(entry.format)
+
+        cells = []
+        for (state, year, dtype), formats in sorted(buckets.items()):
+            cells.append(CoverageCell(
+                state=state,
+                year=year,
+                dataset_type=dtype,
+                count=len([
+                    e for e in self._entries
+                    if e.state == state and e.year == year and e.dataset_type == dtype
+                ]),
+                formats=sorted(formats),
+            ))
+
+        return cells
+
+    def states(self) -> list[str]:
+        """Return sorted list of states with datasets in the catalog."""
+        return sorted(set(e.state for e in self._entries if e.state))
+
+    def years(self) -> list[str]:
+        """Return sorted list of years with datasets in the catalog."""
+        return sorted(set(e.year for e in self._entries if e.year))
+
+    def dataset_types(self) -> list[str]:
+        """Return sorted list of dataset types in the catalog."""
+        return sorted(set(e.dataset_type for e in self._entries if e.dataset_type))
+
+    def for_state(self, state: str) -> list[CatalogEntry]:
+        """Return all entries for a given state."""
+        return [e for e in self._entries if e.state.upper() == state.upper()]
+
+    # -- Cache management -------------------------------------------------------
+
+    def _cache_path(self) -> Optional[Path]:
+        if self._cache_dir is None:
+            return None
+        return self._cache_dir / CACHE_FILENAME
+
+    def _try_load_cache(self) -> bool:
+        path = self._cache_path()
+        if path is None or not path.exists():
+            return False
+
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            log.debug("Cache file unreadable, will refetch")
+            return False
+
+        cached_at = data.get("cached_at", 0)
+        if time.time() - cached_at > self._cache_ttl:
+            log.debug("Cache expired (age %.0fs > TTL %ds)", time.time() - cached_at, self._cache_ttl)
+            return False
+
+        entries = [CatalogEntry.from_dict(d) for d in data.get("entries", [])]
+        self._entries = entries
+        self._loaded = True
+        self._loaded_at = cached_at
+
+        log.debug("Loaded %d entries from cache", len(entries))
+        return True
+
+    def _save_cache(self):
+        path = self._cache_path()
+        if path is None:
+            return
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        data = {
+            "cached_at": time.time(),
+            "entry_count": len(self._entries),
+            "entries": [e.to_dict() for e in self._entries],
+        }
+
+        path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        log.debug("Saved %d entries to cache", len(self._entries))

--- a/siege_utilities/reference/naics_soc_crosswalk.py
+++ b/siege_utilities/reference/naics_soc_crosswalk.py
@@ -293,3 +293,337 @@ def fuzzy_match_naics(
 
     results.sort(key=lambda x: x[2], reverse=True)
     return results
+
+
+# ---------------------------------------------------------------------------
+# Bundled NAICS subsector / industry group codes (3-4 digit)
+# ---------------------------------------------------------------------------
+
+NAICS_SUBSECTORS: dict[str, str] = {
+    "111": "Crop Production",
+    "112": "Animal Production and Aquaculture",
+    "113": "Forestry and Logging",
+    "114": "Fishing, Hunting and Trapping",
+    "115": "Support Activities for Agriculture and Forestry",
+    "211": "Oil and Gas Extraction",
+    "212": "Mining (except Oil and Gas)",
+    "213": "Support Activities for Mining",
+    "221": "Utilities",
+    "236": "Construction of Buildings",
+    "237": "Heavy and Civil Engineering Construction",
+    "238": "Specialty Trade Contractors",
+    "311": "Food Manufacturing",
+    "312": "Beverage and Tobacco Product Manufacturing",
+    "313": "Textile Mills",
+    "314": "Textile Product Mills",
+    "315": "Apparel Manufacturing",
+    "316": "Leather and Allied Product Manufacturing",
+    "321": "Wood Product Manufacturing",
+    "322": "Paper Manufacturing",
+    "323": "Printing and Related Support Activities",
+    "324": "Petroleum and Coal Products Manufacturing",
+    "325": "Chemical Manufacturing",
+    "326": "Plastics and Rubber Products Manufacturing",
+    "327": "Nonmetallic Mineral Product Manufacturing",
+    "331": "Primary Metal Manufacturing",
+    "332": "Fabricated Metal Product Manufacturing",
+    "333": "Machinery Manufacturing",
+    "334": "Computer and Electronic Product Manufacturing",
+    "335": "Electrical Equipment, Appliance, and Component Manufacturing",
+    "336": "Transportation Equipment Manufacturing",
+    "337": "Furniture and Related Product Manufacturing",
+    "339": "Miscellaneous Manufacturing",
+    "423": "Merchant Wholesalers, Durable Goods",
+    "424": "Merchant Wholesalers, Nondurable Goods",
+    "425": "Wholesale Trade Agents and Brokers",
+    "441": "Motor Vehicle and Parts Dealers",
+    "442": "Furniture and Home Furnishings Retailers",
+    "443": "Electronics and Appliance Retailers",
+    "444": "Building Material and Garden Equipment Retailers",
+    "445": "Food and Beverage Retailers",
+    "446": "Health and Personal Care Retailers",
+    "447": "Gasoline Stations",
+    "448": "Clothing and Clothing Accessories Retailers",
+    "449": "Furniture, Home Furnishings, Electronics, and Appliance Retailers",
+    "451": "Sporting Goods, Hobby, Musical Instrument, and Book Retailers",
+    "452": "General Merchandise Retailers",
+    "453": "Miscellaneous Store Retailers",
+    "454": "Nonstore Retailers",
+    "455": "General Merchandise Retailers (2022)",
+    "456": "Health and Personal Care Retailers (2022)",
+    "481": "Air Transportation",
+    "482": "Rail Transportation",
+    "483": "Water Transportation",
+    "484": "Truck Transportation",
+    "485": "Transit and Ground Passenger Transportation",
+    "486": "Pipeline Transportation",
+    "487": "Scenic and Sightseeing Transportation",
+    "488": "Support Activities for Transportation",
+    "491": "Postal Service",
+    "492": "Couriers and Messengers",
+    "493": "Warehousing and Storage",
+    "511": "Publishing Industries",
+    "512": "Motion Picture and Sound Recording Industries",
+    "515": "Broadcasting (except Internet)",
+    "516": "Internet Publishing and Broadcasting",
+    "517": "Telecommunications",
+    "518": "Computing Infrastructure Providers, Data Processing, and Related Services",
+    "519": "Web Search Portals, Libraries, Archives, and Other Information Services",
+    "521": "Monetary Authorities—Central Bank",
+    "522": "Credit Intermediation and Related Activities",
+    "523": "Securities, Commodity Contracts, and Other Financial Investments",
+    "524": "Insurance Carriers and Related Activities",
+    "525": "Funds, Trusts, and Other Financial Vehicles",
+    "531": "Real Estate",
+    "532": "Rental and Leasing Services",
+    "533": "Lessors of Nonfinancial Intangible Assets",
+    "541": "Professional, Scientific, and Technical Services",
+    "551": "Management of Companies and Enterprises",
+    "561": "Administrative and Support Services",
+    "562": "Waste Management and Remediation Services",
+    "611": "Educational Services",
+    "621": "Ambulatory Health Care Services",
+    "622": "Hospitals",
+    "623": "Nursing and Residential Care Facilities",
+    "624": "Social Assistance",
+    "711": "Performing Arts, Spectator Sports, and Related Industries",
+    "712": "Museums, Historical Sites, and Similar Institutions",
+    "713": "Amusement, Gambling, and Recreation Industries",
+    "721": "Accommodation",
+    "722": "Food Services and Drinking Places",
+    "811": "Repair and Maintenance",
+    "812": "Personal and Laundry Services",
+    "813": "Religious, Grantmaking, Civic, Professional, and Similar Organizations",
+    "814": "Private Households",
+    "921": "Executive, Legislative, and Other General Government Support",
+    "922": "Justice, Public Order, and Safety Activities",
+    "923": "Administration of Human Resource Programs",
+    "924": "Administration of Environmental Quality Programs",
+    "925": "Administration of Housing, Urban Planning, and Community Development",
+    "926": "Administration of Economic Programs",
+    "927": "Space Research and Technology",
+    "928": "National Security and International Affairs",
+}
+
+
+# ---------------------------------------------------------------------------
+# Bundled SOC minor / broad occupation codes
+# ---------------------------------------------------------------------------
+
+SOC_MINOR_GROUPS: dict[str, str] = {
+    "11-1000": "Top Executives",
+    "11-2000": "Advertising, Marketing, Promotions, Public Relations, and Sales Managers",
+    "11-3000": "Operations Specialties Managers",
+    "11-9000": "Other Management Occupations",
+    "13-1000": "Business Operations Specialists",
+    "13-2000": "Financial Specialists",
+    "15-1200": "Computer Occupations",
+    "15-2000": "Mathematical Science Occupations",
+    "17-1000": "Architects, Surveyors, and Cartographers",
+    "17-2000": "Engineers",
+    "17-3000": "Drafters, Engineering Technicians, and Mapping Technicians",
+    "19-1000": "Life Scientists",
+    "19-2000": "Physical Scientists",
+    "19-3000": "Social Scientists and Related Workers",
+    "19-4000": "Life, Physical, and Social Science Technicians",
+    "21-1000": "Counselors, Social Workers, and Other Community and Social Service Specialists",
+    "23-1000": "Lawyers, Judges, and Related Workers",
+    "23-2000": "Legal Support Workers",
+    "25-1000": "Postsecondary Teachers",
+    "25-2000": "Preschool, Elementary, Middle, Secondary, and Special Education Teachers",
+    "25-3000": "Other Teachers and Instructors",
+    "25-4000": "Librarians, Curators, and Archivists",
+    "25-9000": "Other Educational Instruction and Library Occupations",
+    "27-1000": "Art and Design Workers",
+    "27-2000": "Entertainers and Performers, Sports and Related Workers",
+    "27-3000": "Media and Communication Workers",
+    "27-4000": "Media and Communication Equipment Workers",
+    "29-1000": "Healthcare Diagnosing or Treating Practitioners",
+    "29-2000": "Health Technologists and Technicians",
+    "29-9000": "Other Healthcare Practitioners and Technical Occupations",
+    "31-1100": "Home Health and Personal Care Aides; and Nursing Assistants",
+    "31-2000": "Occupational Therapy and Physical Therapist Assistants and Aides",
+    "31-9000": "Other Healthcare Support Occupations",
+    "33-1000": "First-Line Supervisors of Protective Service Workers",
+    "33-2000": "Firefighting and Prevention Workers",
+    "33-3000": "Law Enforcement Workers",
+    "33-9000": "Other Protective Service Workers",
+    "35-1000": "Supervisors of Food Preparation and Serving Workers",
+    "35-2000": "Cooks and Food Preparation Workers",
+    "35-3000": "Food and Beverage Serving Workers",
+    "35-9000": "Other Food Preparation and Serving Related Workers",
+    "37-1000": "Supervisors of Building and Grounds Cleaning and Maintenance Workers",
+    "37-2000": "Building Cleaning and Pest Control Workers",
+    "37-3000": "Grounds Maintenance Workers",
+    "39-1000": "Supervisors of Personal Care and Service Workers",
+    "39-2000": "Animal Care and Service Workers",
+    "39-3000": "Entertainment Attendants and Related Workers",
+    "39-4000": "Funeral Service Workers",
+    "39-5000": "Personal Appearance Workers",
+    "39-9000": "Other Personal Care and Service Workers",
+    "41-1000": "Supervisors of Sales Workers",
+    "41-2000": "Retail Sales Workers",
+    "41-3000": "Sales Representatives, Services",
+    "41-4000": "Sales Representatives, Wholesale and Manufacturing",
+    "41-9000": "Other Sales and Related Workers",
+    "43-1000": "Supervisors of Office and Administrative Support Workers",
+    "43-2000": "Communications Equipment Operators",
+    "43-3000": "Financial Clerks",
+    "43-4000": "Information and Record Clerks",
+    "43-5000": "Material Recording, Scheduling, Dispatching, and Distributing Workers",
+    "43-6000": "Secretaries and Administrative Assistants",
+    "43-9000": "Other Office and Administrative Support Workers",
+    "45-1000": "Supervisors of Farming, Fishing, and Forestry Workers",
+    "45-2000": "Agricultural Workers",
+    "45-3000": "Fishing and Hunting Workers",
+    "45-4000": "Forest, Conservation, and Logging Workers",
+    "47-1000": "Supervisors of Construction and Extraction Workers",
+    "47-2000": "Construction Trades Workers",
+    "47-3000": "Helpers, Construction Trades",
+    "47-4000": "Other Construction and Related Workers",
+    "47-5000": "Extraction Workers",
+    "49-1000": "Supervisors of Installation, Maintenance, and Repair Workers",
+    "49-2000": "Electrical and Electronic Equipment Mechanics, Installers, and Repairers",
+    "49-3000": "Vehicle and Mobile Equipment Mechanics, Installers, and Repairers",
+    "49-9000": "Other Installation, Maintenance, and Repair Occupations",
+    "51-1000": "Supervisors of Production Workers",
+    "51-2000": "Assemblers and Fabricators",
+    "51-3000": "Food Processing Workers",
+    "51-4000": "Metal Workers and Plastic Workers",
+    "51-5100": "Printing Workers",
+    "51-6000": "Textile, Apparel, and Furnishings Workers",
+    "51-7000": "Woodworkers",
+    "51-8000": "Plant and System Operators",
+    "51-9000": "Other Production Occupations",
+    "53-1000": "Supervisors of Transportation and Material Moving Workers",
+    "53-2000": "Air Transportation Workers",
+    "53-3000": "Motor Vehicle Operators",
+    "53-4000": "Rail Transportation Workers",
+    "53-5000": "Water Transportation Workers",
+    "53-6000": "Other Transportation Workers",
+    "53-7000": "Material Moving Workers",
+    "55-1000": "Military Officer Special and Tactical Operations Leaders",
+    "55-2000": "First-Line Enlisted Military Supervisors",
+    "55-3000": "Military Enlisted Tactical Operations and Air/Weapons Specialists",
+}
+
+
+# ---------------------------------------------------------------------------
+# Combined lookup tables
+# ---------------------------------------------------------------------------
+
+def get_naics_lookup() -> dict[str, str]:
+    """Return a combined NAICS lookup table (sectors + subsectors).
+
+    Returns:
+        Dict mapping NAICS codes to titles at all available levels.
+    """
+    combined = {}
+    combined.update(NAICS_SECTORS)
+    combined.update(NAICS_SUBSECTORS)
+    return combined
+
+
+def get_soc_lookup() -> dict[str, str]:
+    """Return a combined SOC lookup table (major groups + minor groups).
+
+    Returns:
+        Dict mapping SOC codes to titles at all available levels.
+    """
+    combined = {}
+    combined.update(SOC_MAJOR_GROUPS)
+    combined.update(SOC_MINOR_GROUPS)
+    return combined
+
+
+def naics_title(code: str) -> str:
+    """Look up the title for a NAICS code at any level.
+
+    Checks subsector-level first, then falls back to sector.
+    Returns 'Unknown' if not found.
+    """
+    code = code.strip()
+    lookup = get_naics_lookup()
+    if code in lookup:
+        return lookup[code]
+    sector = code[:2]
+    if sector in NAICS_SECTORS:
+        return NAICS_SECTORS[sector]
+    return "Unknown"
+
+
+def soc_title(code: str) -> str:
+    """Look up the title for an SOC code at any level.
+
+    Checks minor-group level first, then falls back to major group.
+    Returns 'Unknown' if not found.
+    """
+    code = code.strip()
+    lookup = get_soc_lookup()
+    if code in lookup:
+        return lookup[code]
+    major = code.split("-")[0][:2]
+    if major in SOC_MAJOR_GROUPS:
+        return SOC_MAJOR_GROUPS[major]
+    return "Unknown"
+
+
+# ---------------------------------------------------------------------------
+# Query interface — filter NLRB records by NAICS prefix
+# ---------------------------------------------------------------------------
+
+def filter_by_naics(records, naics_prefix: str) -> list:
+    """Filter NLRB case records by NAICS code prefix.
+
+    Works with any iterable of objects that have a ``naics_code`` attribute
+    (NLRBCaseRecord, NLRBCase model instances, or dicts with 'naics_code').
+
+    Args:
+        records: Iterable of records to filter.
+        naics_prefix: NAICS prefix to match (e.g., '622' for hospitals,
+            '62' for all health care).
+
+    Returns:
+        List of matching records.
+
+    Example::
+
+        # Show all elections in NAICS 622 (hospitals)
+        hospital_cases = filter_by_naics(result.cases, "622")
+    """
+    naics_prefix = naics_prefix.strip()
+    if not naics_prefix:
+        return []
+    matches = []
+    for record in records:
+        code = _get_naics(record)
+        if code and code.startswith(naics_prefix):
+            matches.append(record)
+    return matches
+
+
+def filter_by_naics_sector(records, sector_code: str) -> list:
+    """Filter records by 2-digit NAICS sector code."""
+    return filter_by_naics(records, sector_code.strip()[:2])
+
+
+def group_by_naics_sector(records) -> dict[str, list]:
+    """Group records by their 2-digit NAICS sector code.
+
+    Returns:
+        Dict mapping sector codes to lists of records.
+        Records without a NAICS code are grouped under ''.
+    """
+    groups: dict[str, list] = {}
+    for record in records:
+        code = _get_naics(record)
+        sector = code[:2] if code else ""
+        groups.setdefault(sector, []).append(record)
+    return groups
+
+
+def _get_naics(record) -> str:
+    """Extract NAICS code from a record (dataclass, model, or dict)."""
+    if isinstance(record, dict):
+        return str(record.get("naics_code", "")).strip()
+    return str(getattr(record, "naics_code", "")).strip()

--- a/tests/test_batch_geocoder.py
+++ b/tests/test_batch_geocoder.py
@@ -1,0 +1,234 @@
+"""Tests for BatchGeocoder interface and GeocodingResult schema (SU#622)."""
+
+from __future__ import annotations
+
+from typing import Union
+
+import pytest
+
+from siege_utilities.geo.providers.batch_geocoder import (
+    AddressInput,
+    BatchGeocoder,
+    BatchGeocodingResult,
+    GeocodingResult,
+    MatchQuality,
+    normalize_addresses,
+)
+
+
+# ---------------------------------------------------------------------------
+# GeocodingResult tests
+# ---------------------------------------------------------------------------
+
+
+class TestGeocodingResult:
+    def test_default_is_no_match(self):
+        r = GeocodingResult()
+        assert not r.matched
+        assert r.match_quality == MatchQuality.NO_MATCH.value
+
+    def test_exact_match(self):
+        r = GeocodingResult(
+            input_address="123 Main St",
+            matched_address="123 MAIN ST",
+            lat=41.8781,
+            lon=-87.6298,
+            match_quality=MatchQuality.EXACT.value,
+            block_geoid="170310101001001",
+            tract_geoid="17031010100",
+            county_geoid="17031",
+            state_geoid="17",
+            backend="census",
+        )
+        assert r.matched
+        assert r.has_block
+        assert r.has_tract
+        assert r.backend == "census"
+
+    def test_has_block_requires_15_digits(self):
+        r = GeocodingResult(block_geoid="1703101")
+        assert not r.has_block
+
+    def test_has_tract_requires_11_digits(self):
+        r = GeocodingResult(tract_geoid="1703101")
+        assert not r.has_tract
+
+    def test_to_dict(self):
+        r = GeocodingResult(
+            input_address="test",
+            match_quality=MatchQuality.EXACT.value,
+        )
+        d = r.to_dict()
+        assert isinstance(d, dict)
+        assert d["matched"] is True
+        assert d["input_address"] == "test"
+
+
+class TestMatchQuality:
+    def test_values(self):
+        assert MatchQuality.EXACT.value == "exact"
+        assert MatchQuality.NO_MATCH.value == "no_match"
+
+    def test_all_levels(self):
+        levels = [e.value for e in MatchQuality]
+        assert "exact" in levels
+        assert "interpolated" in levels
+        assert "approximate" in levels
+        assert "centroid" in levels
+        assert "no_match" in levels
+
+
+# ---------------------------------------------------------------------------
+# BatchGeocodingResult tests
+# ---------------------------------------------------------------------------
+
+
+class TestBatchGeocodingResult:
+    def test_empty(self):
+        b = BatchGeocodingResult()
+        assert b.total == 0
+        assert b.matched_count == 0
+        assert b.match_rate == 0.0
+
+    def test_counts(self):
+        b = BatchGeocodingResult(results=[
+            GeocodingResult(match_quality=MatchQuality.EXACT.value),
+            GeocodingResult(match_quality=MatchQuality.EXACT.value),
+            GeocodingResult(match_quality=MatchQuality.NO_MATCH.value),
+        ])
+        assert b.total == 3
+        assert b.matched_count == 2
+        assert abs(b.match_rate - 2 / 3) < 0.01
+
+    def test_with_errors(self):
+        b = BatchGeocodingResult(errors=["some error"])
+        assert len(b.errors) == 1
+
+
+# ---------------------------------------------------------------------------
+# AddressInput tests
+# ---------------------------------------------------------------------------
+
+
+class TestAddressInput:
+    def test_one_line(self):
+        a = AddressInput(
+            street="123 Main St",
+            city="Chicago",
+            state="IL",
+            zipcode="60601",
+        )
+        assert a.one_line == "123 Main St, Chicago, IL, 60601"
+
+    def test_one_line_partial(self):
+        a = AddressInput(street="123 Main St", state="IL")
+        assert a.one_line == "123 Main St, IL"
+
+    def test_empty(self):
+        a = AddressInput()
+        assert a.one_line == ""
+
+
+# ---------------------------------------------------------------------------
+# normalize_addresses tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeAddresses:
+    def test_from_dicts(self):
+        addrs = [
+            {"street": "123 Main St", "city": "Chicago", "state": "IL", "zipcode": "60601"},
+            {"street": "456 Oak Ave", "city": "Boston", "state": "MA", "zip": "02101"},
+        ]
+        result = normalize_addresses(addrs)
+        assert len(result) == 2
+        assert result[0].street == "123 Main St"
+        assert result[1].zipcode == "02101"
+
+    def test_from_strings(self):
+        addrs = ["123 Main St, Chicago, IL", "456 Oak Ave, Boston, MA"]
+        result = normalize_addresses(addrs)
+        assert len(result) == 2
+        assert result[0].street == "123 Main St, Chicago, IL"
+        assert result[0].input_id == "0"
+
+    def test_from_address_inputs(self):
+        addrs = [AddressInput(street="123 Main St")]
+        result = normalize_addresses(addrs)
+        assert len(result) == 1
+        assert result[0].street == "123 Main St"
+
+    def test_empty_list(self):
+        assert normalize_addresses([]) == []
+
+    def test_dict_with_address_key(self):
+        addrs = [{"address": "123 Main St"}]
+        result = normalize_addresses(addrs)
+        assert result[0].street == "123 Main St"
+
+    def test_dict_with_id_key(self):
+        addrs = [{"street": "123 Main St", "id": "ABC"}]
+        result = normalize_addresses(addrs)
+        assert result[0].input_id == "ABC"
+
+    def test_unsupported_type_raises(self):
+        with pytest.raises(TypeError):
+            normalize_addresses([42, 43])
+
+
+# ---------------------------------------------------------------------------
+# BatchGeocoder ABC tests
+# ---------------------------------------------------------------------------
+
+
+class _TestGeocoder(BatchGeocoder):
+    """Concrete implementation for testing the ABC."""
+
+    @property
+    def backend_name(self) -> str:
+        return "test"
+
+    def geocode(self, addresses, **kwargs):
+        normalized = normalize_addresses(addresses)
+        results = [
+            GeocodingResult(
+                input_address=a.one_line,
+                input_id=a.input_id,
+                match_quality=MatchQuality.EXACT.value,
+                lat=0.0,
+                lon=0.0,
+                backend=self.backend_name,
+            )
+            for a in normalized
+        ]
+        return BatchGeocodingResult(results=results, backend=self.backend_name)
+
+
+class TestBatchGeocoderABC:
+    def test_cannot_instantiate_abc(self):
+        with pytest.raises(TypeError):
+            BatchGeocoder()
+
+    def test_concrete_implementation(self):
+        g = _TestGeocoder()
+        assert g.backend_name == "test"
+        assert g.is_available()
+
+    def test_geocode_strings(self):
+        g = _TestGeocoder()
+        result = g.geocode(["123 Main St", "456 Oak Ave"])
+        assert result.total == 2
+        assert result.matched_count == 2
+        assert result.backend == "test"
+
+    def test_geocode_dicts(self):
+        g = _TestGeocoder()
+        result = g.geocode([
+            {"street": "123 Main St", "city": "Chicago", "state": "IL"},
+        ])
+        assert result.total == 1
+
+    def test_geocode_preserves_id(self):
+        g = _TestGeocoder()
+        result = g.geocode([{"street": "test", "id": "MY-ID"}])
+        assert result.results[0].input_id == "MY-ID"

--- a/tests/test_census_batch.py
+++ b/tests/test_census_batch.py
@@ -1,0 +1,180 @@
+"""Tests for Census batch geocoder backend (SU#623)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from siege_utilities.geo.providers.batch_geocoder import (
+    GeocodingResult,
+    MatchQuality,
+)
+from siege_utilities.geo.providers.census_batch import (
+    CensusBatchGeocoder,
+    _census_result_to_geocoding_result,
+)
+
+
+# ---------------------------------------------------------------------------
+# Mock CensusGeocodeResult
+# ---------------------------------------------------------------------------
+
+
+class _MockCensusResult:
+    def __init__(self, **kwargs):
+        self.matched = kwargs.get("matched", True)
+        self.input_address = kwargs.get("input_address", "123 Main St")
+        self.input_id = kwargs.get("input_id", "1")
+        self.matched_address = kwargs.get("matched_address", "123 MAIN ST")
+        self.lat = kwargs.get("lat", 41.8781)
+        self.lon = kwargs.get("lon", -87.6298)
+        self.match_type = kwargs.get("match_type", "Exact")
+        self.state_fips = kwargs.get("state_fips", "17")
+        self.county_fips = kwargs.get("county_fips", "031")
+        self.tract = kwargs.get("tract", "010100")
+        self.block = kwargs.get("block", "1001")
+
+    @property
+    def state_geoid(self):
+        return self.state_fips
+
+    @property
+    def county_geoid(self):
+        return f"{self.state_fips}{self.county_fips}" if self.state_fips and self.county_fips else ""
+
+    @property
+    def tract_geoid(self):
+        if self.state_fips and self.county_fips and self.tract:
+            return f"{self.state_fips}{self.county_fips}{self.tract}"
+        return ""
+
+    @property
+    def block_geoid(self):
+        if self.state_fips and self.county_fips and self.tract and self.block:
+            return f"{self.state_fips}{self.county_fips}{self.tract}{self.block}"
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Converter tests
+# ---------------------------------------------------------------------------
+
+
+class TestCensusResultConverter:
+    def test_exact_match(self):
+        cr = _MockCensusResult(match_type="Exact")
+        gr = _census_result_to_geocoding_result(cr)
+        assert gr.match_quality == MatchQuality.EXACT.value
+        assert gr.matched
+        assert gr.block_geoid == "170310101001001"
+        assert gr.backend == "census"
+
+    def test_non_exact(self):
+        cr = _MockCensusResult(match_type="Non_Exact")
+        gr = _census_result_to_geocoding_result(cr)
+        assert gr.match_quality == MatchQuality.INTERPOLATED.value
+        assert gr.matched
+
+    def test_no_match(self):
+        cr = _MockCensusResult(
+            matched=False,
+            match_type="No_Match",
+            lat=None,
+            lon=None,
+            state_fips="",
+            county_fips="",
+            tract="",
+            block="",
+        )
+        gr = _census_result_to_geocoding_result(cr)
+        assert not gr.matched
+        assert gr.block_geoid == ""
+
+    def test_preserves_input_id(self):
+        cr = _MockCensusResult(input_id="MY-ID-123")
+        gr = _census_result_to_geocoding_result(cr)
+        assert gr.input_id == "MY-ID-123"
+
+    def test_geoid_hierarchy(self):
+        cr = _MockCensusResult()
+        gr = _census_result_to_geocoding_result(cr)
+        assert gr.state_geoid == "17"
+        assert gr.county_geoid == "17031"
+        assert gr.tract_geoid == "17031010100"
+        assert gr.has_block
+        assert gr.has_tract
+
+
+# ---------------------------------------------------------------------------
+# CensusBatchGeocoder tests
+# ---------------------------------------------------------------------------
+
+
+class TestCensusBatchGeocoder:
+    def test_backend_name(self):
+        g = CensusBatchGeocoder()
+        assert g.backend_name == "census"
+
+    def test_empty_input(self):
+        g = CensusBatchGeocoder()
+        result = g.geocode([])
+        assert result.total == 0
+
+    @patch("siege_utilities.geo.providers.census_geocoder.geocode_batch_chunked")
+    def test_geocode_strings(self, mock_chunked):
+        mock_chunked.return_value = [
+            _MockCensusResult(input_address="123 Main St", input_id="0"),
+        ]
+        g = CensusBatchGeocoder()
+        result = g.geocode(["123 Main St, Chicago, IL"])
+        assert result.total == 1
+        assert result.results[0].matched
+        mock_chunked.assert_called_once()
+
+    @patch("siege_utilities.geo.providers.census_geocoder.geocode_batch_chunked")
+    def test_geocode_dicts(self, mock_chunked):
+        mock_chunked.return_value = [
+            _MockCensusResult(input_address="123 Main St", input_id="ABC"),
+        ]
+        g = CensusBatchGeocoder()
+        result = g.geocode([
+            {"street": "123 Main St", "city": "Chicago", "state": "IL", "zipcode": "60601", "id": "ABC"},
+        ])
+        assert result.total == 1
+        call_args = mock_chunked.call_args[0][0]
+        assert call_args[0]["id"] == "ABC"
+
+    @patch("siege_utilities.geo.providers.census_geocoder.geocode_batch_chunked")
+    def test_handles_api_error(self, mock_chunked):
+        mock_chunked.side_effect = RuntimeError("API down")
+        g = CensusBatchGeocoder()
+        result = g.geocode(["123 Main St"])
+        assert len(result.errors) == 1
+        assert "Census batch geocode error" in result.errors[0]
+
+    @patch("siege_utilities.geo.providers.census_geocoder.geocode_batch_chunked")
+    def test_multiple_results(self, mock_chunked):
+        mock_chunked.return_value = [
+            _MockCensusResult(input_id="0", match_type="Exact"),
+            _MockCensusResult(input_id="1", match_type="No_Match", matched=False,
+                              lat=None, lon=None, state_fips="", county_fips="",
+                              tract="", block=""),
+        ]
+        g = CensusBatchGeocoder()
+        result = g.geocode(["addr1", "addr2"])
+        assert result.total == 2
+        assert result.matched_count == 1
+        assert abs(result.match_rate - 0.5) < 0.01
+
+    @patch("siege_utilities.geo.providers.census_geocoder.geocode_batch_chunked")
+    def test_custom_chunk_size(self, mock_chunked):
+        mock_chunked.return_value = []
+        g = CensusBatchGeocoder(chunk_size=5000)
+        g.geocode(["addr"])
+        _, kwargs = mock_chunked.call_args
+        assert kwargs["chunk_size"] == 5000
+
+    def test_is_available(self):
+        g = CensusBatchGeocoder()
+        assert g.is_available()

--- a/tests/test_census_catalog.py
+++ b/tests/test_census_catalog.py
@@ -1,0 +1,317 @@
+"""Tests for siege_utilities.geo.census.catalog — Census table catalog data model."""
+
+import pytest
+
+from siege_utilities.geo.census.catalog import (
+    CensusCatalog,
+    CensusCatalogDataset,
+    CensusFamily,
+    CensusSubject,
+    CensusTable,
+    CensusVariable,
+    FamilyType,
+    detect_race_iteration_families,
+    detect_topical_families,
+    parse_table_id,
+)
+
+
+# ── Fixtures ──
+
+
+def _make_table(table_id, concept="", universe="", geo=None):
+    return CensusTable(
+        table_id=table_id,
+        label=f"Label for {table_id}",
+        concept=concept,
+        universe=universe,
+        geography_levels=geo or [],
+    )
+
+
+@pytest.fixture()
+def income_tables():
+    return [
+        _make_table("B19001", concept="HOUSEHOLD INCOME IN THE PAST 12 MONTHS"),
+        _make_table("B19001A", concept="HOUSEHOLD INCOME IN THE PAST 12 MONTHS (WHITE ALONE HOUSEHOLDER)"),
+        _make_table("B19001B", concept="HOUSEHOLD INCOME IN THE PAST 12 MONTHS (BLACK ALONE HOUSEHOLDER)"),
+        _make_table("B19001C", concept="HOUSEHOLD INCOME IN THE PAST 12 MONTHS (AIAN ALONE HOUSEHOLDER)"),
+        _make_table("B19013", concept="MEDIAN HOUSEHOLD INCOME IN THE PAST 12 MONTHS"),
+        _make_table("B19025", concept="AGGREGATE HOUSEHOLD INCOME IN THE PAST 12 MONTHS"),
+        _make_table("B19301", concept="PER CAPITA INCOME IN THE PAST 12 MONTHS"),
+    ]
+
+
+@pytest.fixture()
+def mixed_tables():
+    return [
+        _make_table("B01001", concept="SEX BY AGE", geo=["state", "county", "tract"]),
+        _make_table("B01002", concept="MEDIAN AGE BY SEX", geo=["state", "county", "tract"]),
+        _make_table("B01003", concept="TOTAL POPULATION", geo=["state", "county", "tract", "block_group"]),
+        _make_table("B02001", concept="RACE", geo=["state", "county", "tract"]),
+        _make_table("B19001", concept="HOUSEHOLD INCOME IN THE PAST 12 MONTHS", geo=["state", "county", "tract"]),
+        _make_table("B19001A", concept="HOUSEHOLD INCOME IN THE PAST 12 MONTHS (WHITE ALONE)", geo=["state", "county"]),
+        _make_table("B19001B", concept="HOUSEHOLD INCOME IN THE PAST 12 MONTHS (BLACK ALONE)", geo=["state", "county"]),
+        _make_table("B19013", concept="MEDIAN HOUSEHOLD INCOME IN THE PAST 12 MONTHS", geo=["state", "county", "tract"]),
+    ]
+
+
+# ── parse_table_id ──
+
+
+class TestParseTableId:
+    def test_standard_table(self):
+        result = parse_table_id("B19001")
+        assert result == {"prefix": "B", "number": "19001", "suffix": None}
+
+    def test_race_suffix(self):
+        result = parse_table_id("B19001A")
+        assert result == {"prefix": "B", "number": "19001", "suffix": "A"}
+
+    def test_c_prefix(self):
+        result = parse_table_id("C17001")
+        assert result == {"prefix": "C", "number": "17001", "suffix": None}
+
+    def test_multi_char_prefix(self):
+        result = parse_table_id("CP05001")
+        assert result == {"prefix": "CP", "number": "05001", "suffix": None}
+        result = parse_table_id("CP00005")
+        assert result == {"prefix": "CP", "number": "00005", "suffix": None}
+
+    def test_invalid_id(self):
+        assert parse_table_id("not_a_table") is None
+        assert parse_table_id("") is None
+        assert parse_table_id("B1900") is None  # too few digits
+
+
+# ── CensusVariable ──
+
+
+class TestCensusVariable:
+    def test_parse_estimate_code(self):
+        result = CensusVariable.parse_code("B19001_001E")
+        assert result == {"table_id": "B19001", "seq": "001", "stat_type": "E"}
+
+    def test_parse_moe_code(self):
+        result = CensusVariable.parse_code("B19001_001M")
+        assert result == {"table_id": "B19001", "seq": "001", "stat_type": "M"}
+
+    def test_parse_suffixed_table(self):
+        result = CensusVariable.parse_code("B19001A_001E")
+        assert result == {"table_id": "B19001A", "seq": "001", "stat_type": "E"}
+
+    def test_parse_invalid_code(self):
+        assert CensusVariable.parse_code("invalid") is None
+
+
+# ── CensusTable properties ──
+
+
+class TestCensusTable:
+    def test_root_table_id_base(self):
+        table = _make_table("B19001")
+        assert table.root_table_id == "B19001"
+
+    def test_root_table_id_suffixed(self):
+        table = _make_table("B19001A")
+        assert table.root_table_id == "B19001"
+
+    def test_race_suffix_present(self):
+        table = _make_table("B19001A")
+        assert table.race_suffix == "A"
+
+    def test_race_suffix_absent(self):
+        table = _make_table("B19001")
+        assert table.race_suffix is None
+
+
+# ── Race iteration family detection ──
+
+
+class TestRaceIterationFamilies:
+    def test_detects_income_race_family(self, income_tables):
+        families = detect_race_iteration_families(income_tables)
+        assert len(families) == 1
+        fam = families[0]
+        assert fam.family_type == FamilyType.RACE_ITERATION
+        assert fam.root_table_id == "B19001"
+        assert "B19001" in fam.table_ids
+        assert "B19001A" in fam.table_ids
+        assert "B19001B" in fam.table_ids
+        assert "B19001C" in fam.table_ids
+        # Non-suffixed related tables should NOT be in the race family
+        assert "B19013" not in fam.table_ids
+
+    def test_no_suffixed_tables(self):
+        tables = [_make_table("B01001"), _make_table("B02001")]
+        families = detect_race_iteration_families(tables)
+        assert families == []
+
+    def test_base_table_included_when_present(self, income_tables):
+        families = detect_race_iteration_families(income_tables)
+        fam = families[0]
+        assert fam.tables[0].table_id == "B19001"
+
+    def test_family_id_format(self, income_tables):
+        families = detect_race_iteration_families(income_tables)
+        assert families[0].family_id == "race:B19001"
+
+
+# ── Topical kinship family detection ──
+
+
+class TestTopicalFamilies:
+    def test_detects_income_topical_family(self, income_tables):
+        families = detect_topical_families(income_tables)
+        assert len(families) >= 1
+        income_fam = next(
+            (f for f in families if "B19001" in f.root_table_id), None
+        )
+        assert income_fam is not None
+        assert income_fam.family_type == FamilyType.TOPICAL_KINSHIP
+
+    def test_requires_shared_concept(self):
+        tables = [
+            _make_table("B19001", concept="HOUSEHOLD INCOME"),
+            _make_table("B19050", concept="COMPLETELY UNRELATED"),
+        ]
+        families = detect_topical_families(tables)
+        assert families == []
+
+    def test_excludes_suffixed_tables(self, income_tables):
+        families = detect_topical_families(income_tables)
+        for fam in families:
+            for table in fam.tables:
+                parsed = parse_table_id(table.table_id)
+                assert parsed["suffix"] is None
+
+    def test_singleton_not_a_family(self):
+        tables = [_make_table("B99001", concept="UNIQUE")]
+        families = detect_topical_families(tables)
+        assert families == []
+
+
+# ── CensusCatalog ──
+
+
+class TestCensusCatalog:
+    def test_add_and_get_table(self):
+        cat = CensusCatalog()
+        table = _make_table("B19001")
+        cat.add_table(table)
+        assert cat.get_table("B19001") is table
+        assert cat.get_table("NONEXISTENT") is None
+
+    def test_add_tables_bulk(self):
+        cat = CensusCatalog()
+        tables = [_make_table("B01001"), _make_table("B02001")]
+        cat.add_tables(tables)
+        assert len(cat) == 2
+
+    def test_tables_for_geography(self, mixed_tables):
+        cat = CensusCatalog()
+        cat.add_tables(mixed_tables)
+        tract_tables = cat.tables_for_geography("tract")
+        tract_ids = [t.table_id for t in tract_tables]
+        assert "B01001" in tract_ids
+        assert "B19013" in tract_ids
+        # Suffixed tables with only state/county geo should not appear
+        assert "B19001A" not in tract_ids
+
+    def test_geography_for_table(self, mixed_tables):
+        cat = CensusCatalog()
+        cat.add_tables(mixed_tables)
+        geo = cat.geography_for_table("B01003")
+        assert "block_group" in geo
+        assert cat.geography_for_table("NONEXISTENT") == []
+
+    def test_build_families(self, mixed_tables):
+        cat = CensusCatalog()
+        cat.add_tables(mixed_tables)
+        cat.build_families()
+        assert len(cat.families) > 0
+        race_families = [
+            f for f in cat.families.values()
+            if f.family_type == FamilyType.RACE_ITERATION
+        ]
+        assert len(race_families) == 1
+        assert race_families[0].root_table_id == "B19001"
+
+    def test_families_for_table(self, mixed_tables):
+        cat = CensusCatalog()
+        cat.add_tables(mixed_tables)
+        cat.build_families()
+        families = cat.families_for_table("B19001A")
+        assert any(f.family_type == FamilyType.RACE_ITERATION for f in families)
+
+    def test_add_subject(self):
+        cat = CensusCatalog()
+        subject = CensusSubject(
+            subject_id="income",
+            label="Income and Poverty",
+        )
+        cat.add_subject(subject)
+        assert cat.get_subject("income") is subject
+
+    def test_add_dataset(self):
+        cat = CensusCatalog()
+        dataset = CensusCatalogDataset(
+            dataset_id="acs5_2022",
+            survey_type="acs_5yr",
+            year=2022,
+        )
+        cat.add_dataset(dataset)
+        assert cat.get_dataset("acs5_2022") is dataset
+
+    def test_repr(self, mixed_tables):
+        cat = CensusCatalog()
+        cat.add_tables(mixed_tables)
+        cat.build_families()
+        r = repr(cat)
+        assert "CensusCatalog(" in r
+        assert "tables=" in r
+        assert "families=" in r
+
+
+# ── CensusSubject ──
+
+
+class TestCensusSubject:
+    def test_all_tables_includes_family_and_loose(self):
+        t1 = _make_table("B19001")
+        t2 = _make_table("B19013")
+        t3 = _make_table("B20001")  # loose table
+        fam = CensusFamily(
+            family_id="topic:B19001",
+            family_type=FamilyType.TOPICAL_KINSHIP,
+            root_table_id="B19001",
+            tables=[t1, t2],
+        )
+        subject = CensusSubject(
+            subject_id="income",
+            label="Income",
+            families=[fam],
+            tables=[t3],
+        )
+        all_t = subject.all_tables
+        assert len(all_t) == 3
+        ids = [t.table_id for t in all_t]
+        assert "B19001" in ids
+        assert "B19013" in ids
+        assert "B20001" in ids
+
+
+# ── CensusFamily ──
+
+
+class TestCensusFamily:
+    def test_table_ids_property(self):
+        t1 = _make_table("B19001")
+        t2 = _make_table("B19001A")
+        fam = CensusFamily(
+            family_id="race:B19001",
+            family_type=FamilyType.RACE_ITERATION,
+            root_table_id="B19001",
+            tables=[t1, t2],
+        )
+        assert fam.table_ids == ["B19001", "B19001A"]

--- a/tests/test_census_catalog_cache.py
+++ b/tests/test_census_catalog_cache.py
@@ -1,0 +1,253 @@
+"""Tests for siege_utilities.geo.census.catalog_cache."""
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from siege_utilities.geo.census.catalog import (
+    CensusCatalog,
+    CensusCatalogDataset,
+    CensusFamily,
+    CensusSubject,
+    CensusTable,
+    CensusVariable,
+    FamilyType,
+)
+from siege_utilities.geo.census.catalog_cache import (
+    CatalogCache,
+    CatalogLoader,
+    _catalog_from_dict,
+    _catalog_to_dict,
+)
+
+
+def _make_catalog():
+    """Build a small catalog for round-trip tests."""
+    cat = CensusCatalog()
+
+    v1 = CensusVariable(
+        code="B19001_001E",
+        label="Estimate!!Total:",
+        concept="HOUSEHOLD INCOME",
+        table_id="B19001",
+    )
+    v2 = CensusVariable(
+        code="B19001_002E",
+        label="Estimate!!Total:!!Less than $10,000",
+        concept="HOUSEHOLD INCOME",
+        table_id="B19001",
+    )
+    t1 = CensusTable(
+        table_id="B19001",
+        label="HOUSEHOLD INCOME",
+        concept="HOUSEHOLD INCOME",
+        variables=[v1, v2],
+        geography_levels=["state", "county", "tract"],
+    )
+    t2 = CensusTable(
+        table_id="B19001A",
+        label="HOUSEHOLD INCOME (WHITE ALONE)",
+        concept="HOUSEHOLD INCOME (WHITE ALONE)",
+    )
+    t3 = CensusTable(
+        table_id="B01001",
+        label="SEX BY AGE",
+        concept="SEX BY AGE",
+    )
+
+    cat.add_tables([t1, t2, t3])
+
+    fam = CensusFamily(
+        family_id="race:B19001",
+        family_type=FamilyType.RACE_ITERATION,
+        root_table_id="B19001",
+        tables=[t1, t2],
+        description="Race iterations of B19001",
+    )
+    cat.add_family(fam)
+
+    sub = CensusSubject(
+        subject_id="income",
+        label="Income",
+        tables=[t1, t3],
+    )
+    cat.add_subject(sub)
+
+    ds = CensusCatalogDataset(
+        dataset_id="acs5_2022",
+        survey_type="acs_5yr",
+        year=2022,
+        subjects=[sub],
+        tables={"B19001": t1, "B01001": t3},
+    )
+    cat.add_dataset(ds)
+
+    return cat
+
+
+class TestSerializationRoundTrip:
+    def test_round_trip_preserves_tables(self):
+        cat = _make_catalog()
+        data = _catalog_to_dict(cat)
+        restored = _catalog_from_dict(data)
+        assert set(restored.tables.keys()) == set(cat.tables.keys())
+
+    def test_round_trip_preserves_variables(self):
+        cat = _make_catalog()
+        data = _catalog_to_dict(cat)
+        restored = _catalog_from_dict(data)
+        t = restored.get_table("B19001")
+        assert len(t.variables) == 2
+        assert t.variables[0].code == "B19001_001E"
+
+    def test_round_trip_preserves_families(self):
+        cat = _make_catalog()
+        data = _catalog_to_dict(cat)
+        restored = _catalog_from_dict(data)
+        fam = restored.get_family("race:B19001")
+        assert fam is not None
+        assert fam.family_type == FamilyType.RACE_ITERATION
+        assert "B19001" in fam.table_ids
+        assert "B19001A" in fam.table_ids
+
+    def test_round_trip_preserves_subjects(self):
+        cat = _make_catalog()
+        data = _catalog_to_dict(cat)
+        restored = _catalog_from_dict(data)
+        sub = restored.get_subject("income")
+        assert sub is not None
+        assert len(sub.tables) == 2
+
+    def test_round_trip_preserves_datasets(self):
+        cat = _make_catalog()
+        data = _catalog_to_dict(cat)
+        restored = _catalog_from_dict(data)
+        ds = restored.get_dataset("acs5_2022")
+        assert ds is not None
+        assert ds.year == 2022
+        assert ds.survey_type == "acs_5yr"
+        assert "B19001" in ds.tables
+
+    def test_round_trip_preserves_geography(self):
+        cat = _make_catalog()
+        data = _catalog_to_dict(cat)
+        restored = _catalog_from_dict(data)
+        t = restored.get_table("B19001")
+        assert "tract" in t.geography_levels
+
+    def test_dict_is_json_serializable(self):
+        cat = _make_catalog()
+        data = _catalog_to_dict(cat)
+        text = json.dumps(data)
+        assert isinstance(text, str)
+
+
+class TestCatalogCache:
+    def test_put_and_get(self, tmp_path):
+        cache = CatalogCache(cache_dir=tmp_path, ttl_days=30)
+        cat = _make_catalog()
+        cache.put("acs5", 2022, cat)
+
+        restored = cache.get("acs5", 2022)
+        assert restored is not None
+        assert set(restored.tables.keys()) == set(cat.tables.keys())
+
+    def test_get_returns_none_on_miss(self, tmp_path):
+        cache = CatalogCache(cache_dir=tmp_path)
+        assert cache.get("acs5", 2022) is None
+
+    def test_expired_entry_returns_none(self, tmp_path):
+        cache = CatalogCache(cache_dir=tmp_path, ttl_days=0)
+        cat = _make_catalog()
+        cache.put("acs5", 2022, cat)
+
+        path = cache._cache_path("acs5", 2022)
+        old_time = time.time() - 86400
+        import os
+        os.utime(path, (old_time, old_time))
+
+        assert cache.get("acs5", 2022) is None
+
+    def test_clear_specific(self, tmp_path):
+        cache = CatalogCache(cache_dir=tmp_path)
+        cat = _make_catalog()
+        cache.put("acs5", 2022, cat)
+        cache.put("acs5", 2021, cat)
+        assert cache.clear("acs5", 2022) == 1
+        assert cache.get("acs5", 2022) is None
+        assert cache.get("acs5", 2021) is not None
+
+    def test_clear_all(self, tmp_path):
+        cache = CatalogCache(cache_dir=tmp_path)
+        cat = _make_catalog()
+        cache.put("acs5", 2022, cat)
+        cache.put("acs5", 2021, cat)
+        assert cache.clear() == 2
+        assert cache.get("acs5", 2022) is None
+
+    def test_clear_empty_dir(self, tmp_path):
+        cache = CatalogCache(cache_dir=tmp_path / "nonexistent")
+        assert cache.clear() == 0
+
+    def test_corrupt_file_returns_none(self, tmp_path):
+        cache = CatalogCache(cache_dir=tmp_path)
+        path = cache._cache_path("acs5", 2022)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("not json", encoding="utf-8")
+        assert cache.get("acs5", 2022) is None
+
+
+class TestCatalogLoader:
+    @patch("siege_utilities.geo.census.catalog_populator.CensusCatalogPopulator")
+    def test_returns_cached_catalog(self, mock_pop_cls, tmp_path):
+        cache = CatalogCache(cache_dir=tmp_path)
+        cat = _make_catalog()
+        cache.put("acs5", 2022, cat)
+
+        loader = CatalogLoader(cache=cache)
+        result = loader.load("acs5", 2022)
+
+        assert set(result.tables.keys()) == set(cat.tables.keys())
+        mock_pop_cls.assert_not_called()
+
+    @patch("siege_utilities.geo.census.catalog_populator.CensusCatalogPopulator")
+    def test_fetches_on_cache_miss(self, mock_pop_cls, tmp_path):
+        cache = CatalogCache(cache_dir=tmp_path)
+        cat = _make_catalog()
+        mock_pop_cls.return_value.populate.return_value = cat
+
+        loader = CatalogLoader(cache=cache)
+        result = loader.load("acs5", 2022)
+
+        mock_pop_cls.return_value.populate.assert_called_once_with(
+            "acs5", 2022, survey_type=""
+        )
+        assert set(result.tables.keys()) == set(cat.tables.keys())
+        # Should have been cached
+        assert cache.get("acs5", 2022) is not None
+
+    @patch("siege_utilities.geo.census.catalog_populator.CensusCatalogPopulator")
+    def test_force_refresh_skips_cache(self, mock_pop_cls, tmp_path):
+        cache = CatalogCache(cache_dir=tmp_path)
+        cat = _make_catalog()
+        cache.put("acs5", 2022, cat)
+        mock_pop_cls.return_value.populate.return_value = cat
+
+        loader = CatalogLoader(cache=cache)
+        loader.load("acs5", 2022, force_refresh=True)
+
+        mock_pop_cls.return_value.populate.assert_called_once()
+
+    @patch("siege_utilities.geo.census.catalog_populator.CensusCatalogPopulator")
+    def test_passes_base_url(self, mock_pop_cls, tmp_path):
+        cache = CatalogCache(cache_dir=tmp_path)
+        cat = _make_catalog()
+        mock_pop_cls.return_value.populate.return_value = cat
+
+        loader = CatalogLoader(cache=cache, base_url="https://custom.api")
+        loader.load("acs5", 2022)
+
+        mock_pop_cls.assert_called_once_with(base_url="https://custom.api")

--- a/tests/test_census_catalog_docs.py
+++ b/tests/test_census_catalog_docs.py
@@ -1,0 +1,144 @@
+"""Tests for siege_utilities.geo.census.catalog_docs."""
+
+import pytest
+
+from siege_utilities.geo.census.catalog import (
+    CensusCatalog,
+    CensusCatalogDataset,
+    CensusFamily,
+    CensusSubject,
+    CensusTable,
+    CensusVariable,
+    FamilyType,
+)
+from siege_utilities.geo.census.catalog_docs import (
+    generate_catalog_docs,
+    generate_catalog_markdown,
+)
+
+
+def _make_catalog():
+    cat = CensusCatalog()
+
+    v1 = CensusVariable(code="B19001_001E", label="Estimate!!Total:", concept="HOUSEHOLD INCOME", table_id="B19001")
+    v2 = CensusVariable(code="B19001_002E", label="Estimate!!Total:!!Less than $10,000", concept="HOUSEHOLD INCOME", table_id="B19001")
+
+    t_income = CensusTable(table_id="B19001", label="HOUSEHOLD INCOME", concept="HOUSEHOLD INCOME IN THE PAST 12 MONTHS", variables=[v1, v2], geography_levels=["state", "county", "tract"])
+    t_income_white = CensusTable(table_id="B19001A", label="HOUSEHOLD INCOME (WHITE)", concept="HOUSEHOLD INCOME (WHITE ALONE)", geography_levels=["state", "county"])
+    t_age = CensusTable(table_id="B01001", label="SEX BY AGE", concept="SEX BY AGE", geography_levels=["state", "county", "tract"])
+    t_orphan = CensusTable(table_id="B99001", label="OTHER", concept="SOME OTHER TABLE")
+
+    cat.add_tables([t_income, t_income_white, t_age, t_orphan])
+
+    fam = CensusFamily(
+        family_id="race:B19001",
+        family_type=FamilyType.RACE_ITERATION,
+        root_table_id="B19001",
+        tables=[t_income, t_income_white],
+        description="Race iterations of B19001",
+    )
+    cat.add_family(fam)
+
+    sub = CensusSubject(subject_id="income", label="Income", tables=[t_income])
+    cat.add_subject(sub)
+
+    ds = CensusCatalogDataset(
+        dataset_id="acs5_2022", survey_type="acs_5yr", year=2022,
+        subjects=[sub], tables={"B19001": t_income, "B01001": t_age},
+    )
+    cat.add_dataset(ds)
+
+    return cat
+
+
+class TestGenerateMarkdown:
+    def test_includes_title(self):
+        cat = _make_catalog()
+        md = generate_catalog_markdown(cat, title="Test Catalog")
+        assert "# Test Catalog" in md
+
+    def test_includes_subject(self):
+        cat = _make_catalog()
+        md = generate_catalog_markdown(cat)
+        assert "### Income" in md
+
+    def test_includes_race_family(self):
+        cat = _make_catalog()
+        md = generate_catalog_markdown(cat)
+        assert "Race Iteration Families" in md
+        assert "B19001" in md
+        assert "B19001A" in md
+
+    def test_includes_dataset(self):
+        cat = _make_catalog()
+        md = generate_catalog_markdown(cat)
+        assert "acs5_2022" in md
+
+    def test_includes_orphan_tables(self):
+        cat = _make_catalog()
+        md = generate_catalog_markdown(cat)
+        assert "B99001" in md
+        assert "Other Tables" in md
+
+    def test_table_links(self):
+        cat = _make_catalog()
+        md = generate_catalog_markdown(cat)
+        assert "tables/B19001.md" in md
+
+
+class TestGenerateDocs:
+    def test_creates_index(self, tmp_path):
+        cat = _make_catalog()
+        written = generate_catalog_docs(cat, tmp_path)
+        assert (tmp_path / "index.md").exists()
+        assert tmp_path / "index.md" in written
+
+    def test_creates_table_pages(self, tmp_path):
+        cat = _make_catalog()
+        written = generate_catalog_docs(cat, tmp_path)
+        assert (tmp_path / "tables" / "B19001.md").exists()
+        assert (tmp_path / "tables" / "B01001.md").exists()
+
+    def test_table_page_has_variables(self, tmp_path):
+        cat = _make_catalog()
+        generate_catalog_docs(cat, tmp_path)
+        content = (tmp_path / "tables" / "B19001.md").read_text()
+        assert "B19001_001E" in content
+        assert "B19001_002E" in content
+
+    def test_table_page_has_geography(self, tmp_path):
+        cat = _make_catalog()
+        generate_catalog_docs(cat, tmp_path)
+        content = (tmp_path / "tables" / "B19001.md").read_text()
+        assert "tract" in content
+
+    def test_table_page_has_family_membership(self, tmp_path):
+        cat = _make_catalog()
+        generate_catalog_docs(cat, tmp_path)
+        content = (tmp_path / "tables" / "B19001.md").read_text()
+        assert "race:B19001" in content
+
+    def test_table_page_has_dataset(self, tmp_path):
+        cat = _make_catalog()
+        generate_catalog_docs(cat, tmp_path)
+        content = (tmp_path / "tables" / "B19001.md").read_text()
+        assert "acs5_2022" in content
+
+    def test_table_page_has_back_link(self, tmp_path):
+        cat = _make_catalog()
+        generate_catalog_docs(cat, tmp_path)
+        content = (tmp_path / "tables" / "B19001.md").read_text()
+        assert "index.md" in content
+
+    def test_returns_all_written_paths(self, tmp_path):
+        cat = _make_catalog()
+        written = generate_catalog_docs(cat, tmp_path)
+        # 1 index + 4 table pages
+        assert len(written) == 5
+
+    def test_empty_catalog(self, tmp_path):
+        cat = CensusCatalog()
+        written = generate_catalog_docs(cat, tmp_path)
+        assert len(written) == 1  # just the index
+        content = (tmp_path / "index.md").read_text()
+        assert "Census Table Catalog" in content

--- a/tests/test_census_catalog_populator.py
+++ b/tests/test_census_catalog_populator.py
@@ -1,0 +1,230 @@
+"""Tests for siege_utilities.geo.census.catalog_populator."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from siege_utilities.geo.census.catalog_populator import (
+    CensusCatalogPopulator,
+    _subject_key,
+)
+from siege_utilities.geo.census.catalog import FamilyType
+
+
+BASE_URL = "https://api.census.gov"
+
+
+@pytest.fixture()
+def mock_variables():
+    return {
+        "variables": {
+            "NAME": {"label": "Geographic Area Name", "concept": "NAME"},
+            "GEO_ID": {"label": "Geography", "concept": "GEO_ID"},
+            "B19001_001E": {
+                "label": "Estimate!!Total:",
+                "concept": "HOUSEHOLD INCOME IN THE PAST 12 MONTHS",
+                "group": "B19001",
+            },
+            "B19001_002E": {
+                "label": "Estimate!!Total:!!Less than $10,000",
+                "concept": "HOUSEHOLD INCOME IN THE PAST 12 MONTHS",
+                "group": "B19001",
+            },
+            "B19001_001M": {
+                "label": "Margin of Error!!Total:",
+                "concept": "HOUSEHOLD INCOME IN THE PAST 12 MONTHS",
+                "group": "B19001",
+            },
+            "B19001A_001E": {
+                "label": "Estimate!!Total:",
+                "concept": "HOUSEHOLD INCOME IN THE PAST 12 MONTHS (WHITE ALONE HOUSEHOLDER)",
+                "group": "B19001A",
+            },
+            "B19001A_002E": {
+                "label": "Estimate!!Total:!!Less than $10,000",
+                "concept": "HOUSEHOLD INCOME IN THE PAST 12 MONTHS (WHITE ALONE HOUSEHOLDER)",
+                "group": "B19001A",
+            },
+            "B19001B_001E": {
+                "label": "Estimate!!Total:",
+                "concept": "HOUSEHOLD INCOME IN THE PAST 12 MONTHS (BLACK OR AFRICAN AMERICAN ALONE HOUSEHOLDER)",
+                "group": "B19001B",
+            },
+            "B19013_001E": {
+                "label": "Estimate!!Median household income in the past 12 months",
+                "concept": "MEDIAN HOUSEHOLD INCOME IN THE PAST 12 MONTHS",
+                "group": "B19013",
+            },
+            "B01001_001E": {
+                "label": "Estimate!!Total:",
+                "concept": "SEX BY AGE",
+                "group": "B01001",
+            },
+            "B01001_002E": {
+                "label": "Estimate!!Total:!!Male",
+                "concept": "SEX BY AGE",
+                "group": "B01001",
+            },
+        }
+    }
+
+
+@pytest.fixture()
+def mock_groups():
+    return {
+        "groups": [
+            {
+                "name": "B19001",
+                "description": "Income--HOUSEHOLD INCOME IN THE PAST 12 MONTHS (IN 2022 INFLATION-ADJUSTED DOLLARS)",
+            },
+            {
+                "name": "B19001A",
+                "description": "Income--HOUSEHOLD INCOME IN THE PAST 12 MONTHS (WHITE ALONE HOUSEHOLDER)",
+            },
+            {
+                "name": "B19001B",
+                "description": "Income--HOUSEHOLD INCOME IN THE PAST 12 MONTHS (BLACK ALONE HOUSEHOLDER)",
+            },
+            {
+                "name": "B19013",
+                "description": "Income--MEDIAN HOUSEHOLD INCOME IN THE PAST 12 MONTHS",
+            },
+            {
+                "name": "B01001",
+                "description": "Age-Sex--SEX BY AGE",
+            },
+        ]
+    }
+
+
+def _mock_response(json_data, status_code=200):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    resp.raise_for_status.return_value = None
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = Exception(f"HTTP {status_code}")
+    return resp
+
+
+class TestSubjectKey:
+    def test_splits_on_dash_dash(self):
+        assert _subject_key("Income--HOUSEHOLD INCOME") == "Income"
+
+    def test_no_dash_returns_full(self):
+        assert _subject_key("HOUSEHOLD INCOME") == "Household Income"
+
+    def test_empty_string(self):
+        assert _subject_key("") == ""
+
+
+class TestPopulatorBuildTables:
+    def test_builds_correct_tables(self, mock_variables):
+        pop = CensusCatalogPopulator(base_url=BASE_URL)
+        tables = pop._build_tables(mock_variables["variables"])
+        table_ids = {t.table_id for t in tables}
+
+        assert "B19001" in table_ids
+        assert "B19001A" in table_ids
+        assert "B19001B" in table_ids
+        assert "B19013" in table_ids
+        assert "B01001" in table_ids
+        assert "NAME" not in table_ids
+        assert "GEO_ID" not in table_ids
+
+    def test_excludes_moe_from_variables(self, mock_variables):
+        pop = CensusCatalogPopulator(base_url=BASE_URL)
+        tables = pop._build_tables(mock_variables["variables"])
+        b19001 = next(t for t in tables if t.table_id == "B19001")
+        codes = [v.code for v in b19001.variables]
+        assert "B19001_001E" in codes
+        assert "B19001_001M" not in codes
+
+    def test_table_has_concept(self, mock_variables):
+        pop = CensusCatalogPopulator(base_url=BASE_URL)
+        tables = pop._build_tables(mock_variables["variables"])
+        b19001 = next(t for t in tables if t.table_id == "B19001")
+        assert "HOUSEHOLD INCOME" in b19001.concept
+
+
+class TestPopulatorBuildSubjects:
+    def test_builds_subjects_from_groups(self, mock_variables, mock_groups):
+        pop = CensusCatalogPopulator(base_url=BASE_URL)
+        tables = pop._build_tables(mock_variables["variables"])
+        subjects = pop._build_subjects(mock_groups["groups"], tables)
+
+        subject_ids = {s.subject_id for s in subjects}
+        assert "income" in subject_ids
+        assert "age-sex" in subject_ids
+
+    def test_income_subject_has_tables(self, mock_variables, mock_groups):
+        pop = CensusCatalogPopulator(base_url=BASE_URL)
+        tables = pop._build_tables(mock_variables["variables"])
+        subjects = pop._build_subjects(mock_groups["groups"], tables)
+
+        income = next(s for s in subjects if s.subject_id == "income")
+        table_ids = {t.table_id for t in income.tables}
+        assert "B19001" in table_ids
+        assert "B19013" in table_ids
+
+
+class TestPopulatorIntegration:
+    @patch("siege_utilities.geo.census.catalog_populator.requests.get")
+    def test_populate_builds_full_catalog(self, mock_get, mock_variables, mock_groups):
+        mock_get.side_effect = [
+            _mock_response(mock_variables),
+            _mock_response(mock_groups),
+        ]
+
+        pop = CensusCatalogPopulator(base_url=BASE_URL)
+        catalog = pop.populate("acs5", 2022, survey_type="acs_5yr")
+
+        assert len(catalog.tables) >= 5
+        assert len(catalog.families) >= 1
+        assert len(catalog.subjects) >= 2
+        assert catalog.get_dataset("acs5_2022") is not None
+        assert catalog.get_dataset("acs5_2022").year == 2022
+
+    @patch("siege_utilities.geo.census.catalog_populator.requests.get")
+    def test_populate_detects_race_families(self, mock_get, mock_variables, mock_groups):
+        mock_get.side_effect = [
+            _mock_response(mock_variables),
+            _mock_response(mock_groups),
+        ]
+
+        pop = CensusCatalogPopulator(base_url=BASE_URL)
+        catalog = pop.populate("acs5", 2022)
+
+        race_families = [
+            f for f in catalog.families.values()
+            if f.family_type == FamilyType.RACE_ITERATION
+        ]
+        assert len(race_families) >= 1
+        income_race = next(
+            (f for f in race_families if f.root_table_id == "B19001"), None
+        )
+        assert income_race is not None
+        assert "B19001A" in income_race.table_ids
+
+    @patch("siege_utilities.geo.census.catalog_populator.requests.get")
+    def test_populate_handles_api_error(self, mock_get):
+        mock_get.return_value = _mock_response({}, status_code=404)
+
+        pop = CensusCatalogPopulator(base_url=BASE_URL)
+        with pytest.raises(Exception):
+            pop.populate("acs5", 2022)
+
+    @patch("siege_utilities.geo.census.catalog_populator.requests.get")
+    def test_populate_calls_correct_urls(self, mock_get, mock_variables, mock_groups):
+        mock_get.side_effect = [
+            _mock_response(mock_variables),
+            _mock_response(mock_groups),
+        ]
+
+        pop = CensusCatalogPopulator(base_url=BASE_URL)
+        pop.populate("acs5", 2022)
+
+        calls = mock_get.call_args_list
+        assert len(calls) == 2
+        assert "2022/acs/acs5/variables.json" in calls[0].args[0]
+        assert "2022/acs/acs5/groups.json" in calls[1].args[0]

--- a/tests/test_census_catalog_search.py
+++ b/tests/test_census_catalog_search.py
@@ -1,0 +1,185 @@
+"""Tests for CensusCatalog.search() — full-text search across catalog levels."""
+
+import pytest
+
+from siege_utilities.geo.census.catalog import (
+    CensusCatalog,
+    CensusCatalogDataset,
+    CensusFamily,
+    CensusSubject,
+    CensusTable,
+    CensusVariable,
+    FamilyType,
+    SearchLevel,
+    SearchResult,
+    _tokenize_query,
+)
+
+
+def _make_variable(code, label, concept, table_id):
+    return CensusVariable(
+        code=code, label=label, concept=concept, table_id=table_id,
+    )
+
+
+def _make_table(table_id, concept="", label="", variables=None, geo=None):
+    return CensusTable(
+        table_id=table_id,
+        label=label or concept,
+        concept=concept,
+        variables=variables or [],
+        geography_levels=geo or [],
+    )
+
+
+@pytest.fixture()
+def search_catalog():
+    cat = CensusCatalog()
+
+    v_income_total = _make_variable("B19001_001E", "Estimate!!Total:", "HOUSEHOLD INCOME IN THE PAST 12 MONTHS", "B19001")
+    v_income_bin = _make_variable("B19001_002E", "Estimate!!Total:!!Less than $10,000", "HOUSEHOLD INCOME IN THE PAST 12 MONTHS", "B19001")
+    v_age_total = _make_variable("B01001_001E", "Estimate!!Total:", "SEX BY AGE", "B01001")
+    v_age_male = _make_variable("B01001_002E", "Estimate!!Total:!!Male", "SEX BY AGE", "B01001")
+
+    t_income = _make_table("B19001", "HOUSEHOLD INCOME IN THE PAST 12 MONTHS", variables=[v_income_total, v_income_bin])
+    t_income_white = _make_table("B19001A", "HOUSEHOLD INCOME IN THE PAST 12 MONTHS (WHITE ALONE HOUSEHOLDER)")
+    t_income_black = _make_table("B19001B", "HOUSEHOLD INCOME IN THE PAST 12 MONTHS (BLACK ALONE HOUSEHOLDER)")
+    t_median = _make_table("B19013", "MEDIAN HOUSEHOLD INCOME IN THE PAST 12 MONTHS")
+    t_age = _make_table("B01001", "SEX BY AGE", variables=[v_age_total, v_age_male])
+    t_race = _make_table("B02001", "RACE")
+
+    cat.add_tables([t_income, t_income_white, t_income_black, t_median, t_age, t_race])
+
+    fam_race = CensusFamily(
+        family_id="race:B19001",
+        family_type=FamilyType.RACE_ITERATION,
+        root_table_id="B19001",
+        tables=[t_income, t_income_white, t_income_black],
+        description="Race/ethnicity iterations of B19001",
+    )
+    cat.add_family(fam_race)
+
+    sub_income = CensusSubject(subject_id="income", label="Income and Poverty")
+    sub_age = CensusSubject(subject_id="age-sex", label="Age and Sex")
+    cat.add_subject(sub_income)
+    cat.add_subject(sub_age)
+
+    ds = CensusCatalogDataset(
+        dataset_id="acs5_2022",
+        survey_type="acs_5yr",
+        year=2022,
+        subjects=[sub_income, sub_age],
+        tables={"B19001": t_income, "B19013": t_median, "B01001": t_age},
+    )
+    cat.add_dataset(ds)
+
+    return cat
+
+
+class TestTokenizeQuery:
+    def test_splits_and_uppercases(self):
+        assert _tokenize_query("household income") == ["HOUSEHOLD", "INCOME"]
+
+    def test_removes_stop_words(self):
+        assert _tokenize_query("income in the past 12") == ["INCOME"]
+
+    def test_empty_query(self):
+        assert _tokenize_query("") == []
+
+
+class TestSearchByTable:
+    def test_finds_table_by_concept_keyword(self, search_catalog):
+        results = search_catalog.search("household income", level=SearchLevel.TABLE)
+        ids = [r.id for r in results]
+        assert "B19001" in ids
+        assert "B19013" in ids
+
+    def test_finds_table_by_id(self, search_catalog):
+        results = search_catalog.search("B19001", level=SearchLevel.TABLE)
+        assert results[0].id == "B19001"
+
+    def test_race_tables_match_income(self, search_catalog):
+        results = search_catalog.search("income", level=SearchLevel.TABLE)
+        ids = [r.id for r in results]
+        assert "B19001A" in ids
+        assert "B19001B" in ids
+
+    def test_no_match_returns_empty(self, search_catalog):
+        results = search_catalog.search("zzzyyyxxx", level=SearchLevel.TABLE)
+        assert results == []
+
+
+class TestSearchByFamily:
+    def test_finds_race_family(self, search_catalog):
+        results = search_catalog.search("race B19001", level=SearchLevel.FAMILY)
+        assert len(results) >= 1
+        assert results[0].id == "race:B19001"
+
+    def test_finds_family_by_concept(self, search_catalog):
+        results = search_catalog.search("income race", level=SearchLevel.FAMILY)
+        assert len(results) >= 1
+
+
+class TestSearchBySubject:
+    def test_finds_income_subject(self, search_catalog):
+        results = search_catalog.search("income", level=SearchLevel.SUBJECT)
+        assert any(r.id == "income" for r in results)
+
+    def test_finds_age_subject(self, search_catalog):
+        results = search_catalog.search("age sex", level=SearchLevel.SUBJECT)
+        assert any(r.id == "age-sex" for r in results)
+
+
+class TestSearchByVariable:
+    def test_finds_variable_by_label(self, search_catalog):
+        results = search_catalog.search("Male", level=SearchLevel.VARIABLE)
+        assert any(r.id == "B01001_002E" for r in results)
+
+    def test_finds_variable_by_code(self, search_catalog):
+        results = search_catalog.search("B19001_001E", level=SearchLevel.VARIABLE)
+        assert results[0].id == "B19001_001E"
+
+
+class TestSearchByDataset:
+    def test_finds_dataset_by_year(self, search_catalog):
+        results = search_catalog.search("2022", level=SearchLevel.DATASET)
+        assert any(r.id == "acs5_2022" for r in results)
+
+    def test_finds_dataset_by_type(self, search_catalog):
+        results = search_catalog.search("acs_5yr", level=SearchLevel.DATASET)
+        assert any(r.id == "acs5_2022" for r in results)
+
+
+class TestSearchCrossLevel:
+    def test_all_levels_searched_by_default(self, search_catalog):
+        results = search_catalog.search("income")
+        levels = {r.level for r in results}
+        assert SearchLevel.TABLE in levels
+        assert SearchLevel.SUBJECT in levels
+
+    def test_results_ranked_by_score(self, search_catalog):
+        results = search_catalog.search("household income")
+        scores = [r.score for r in results]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_max_results_limits_output(self, search_catalog):
+        results = search_catalog.search("income", max_results=2)
+        assert len(results) <= 2
+
+    def test_dataset_filter_narrows_tables(self, search_catalog):
+        all_results = search_catalog.search("income", level=SearchLevel.TABLE)
+        filtered = search_catalog.search("income", level=SearchLevel.TABLE, dataset="acs5_2022")
+        # Dataset only has B19001 and B19013 for income, not B19001A/B
+        filtered_ids = {r.id for r in filtered}
+        assert "B19001A" not in filtered_ids
+        assert "B19001" in filtered_ids
+
+
+class TestSearchResult:
+    def test_search_result_fields(self, search_catalog):
+        results = search_catalog.search("B19001", level=SearchLevel.TABLE)
+        r = results[0]
+        assert r.level == SearchLevel.TABLE
+        assert r.id == "B19001"
+        assert r.score > 0
+        assert isinstance(r.obj, CensusTable)

--- a/tests/test_codification.py
+++ b/tests/test_codification.py
@@ -1,0 +1,251 @@
+"""Tests for core codification function (SU#627)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from siege_utilities.geo.providers.batch_geocoder import (
+    BatchGeocodingResult,
+    GeocodingResult,
+    MatchQuality,
+)
+from siege_utilities.geo.codification import (
+    BlockProfile,
+    CodificationResult,
+    _build_block_profiles,
+    codify_area,
+)
+
+
+def _gr(
+    block_geoid="170310101001001",
+    tract_geoid="17031010100",
+    county_geoid="17031",
+    state_geoid="17",
+    matched=True,
+):
+    return GeocodingResult(
+        input_address="123 Main St",
+        input_id="0",
+        lat=41.8781 if matched else None,
+        lon=-87.6298 if matched else None,
+        match_quality=MatchQuality.EXACT.value if matched else MatchQuality.NO_MATCH.value,
+        block_geoid=block_geoid if matched else "",
+        tract_geoid=tract_geoid if matched else "",
+        county_geoid=county_geoid if matched else "",
+        state_geoid=state_geoid if matched else "",
+        backend="census",
+    )
+
+
+def _mock_geocoder(results, backend_name="census"):
+    geocoder = MagicMock()
+    geocoder.backend_name = backend_name
+    geocoder.geocode.return_value = BatchGeocodingResult(
+        results=results, backend=backend_name,
+    )
+    return geocoder
+
+
+# ---------------------------------------------------------------------------
+# BlockProfile
+# ---------------------------------------------------------------------------
+
+
+class TestBlockProfile:
+    def test_defaults(self):
+        b = BlockProfile()
+        assert b.block_geoid == ""
+        assert b.address_count == 0
+
+    def test_fields(self):
+        b = BlockProfile(
+            block_geoid="170310101001001",
+            tract_geoid="17031010100",
+            address_count=42,
+        )
+        assert b.address_count == 42
+        assert b.tract_geoid == "17031010100"
+
+
+# ---------------------------------------------------------------------------
+# CodificationResult
+# ---------------------------------------------------------------------------
+
+
+class TestCodificationResult:
+    def test_empty(self):
+        r = CodificationResult()
+        assert r.block_count == 0
+        assert r.tract_count == 0
+        assert r.county_count == 0
+
+    def test_counts(self):
+        r = CodificationResult(
+            blocks=[
+                BlockProfile(block_geoid="A1", tract_geoid="A", county_geoid="X", state_geoid="1"),
+                BlockProfile(block_geoid="A2", tract_geoid="A", county_geoid="X", state_geoid="1"),
+                BlockProfile(block_geoid="B1", tract_geoid="B", county_geoid="Y", state_geoid="2"),
+            ],
+        )
+        assert r.block_count == 3
+        assert r.tract_count == 2
+        assert r.county_count == 2
+        assert r.state_count == 2
+
+    def test_top_blocks(self):
+        r = CodificationResult(
+            blocks=[
+                BlockProfile(block_geoid="A", address_count=10),
+                BlockProfile(block_geoid="B", address_count=50),
+                BlockProfile(block_geoid="C", address_count=30),
+            ],
+        )
+        top = r.top_blocks(2)
+        assert len(top) == 2
+        assert top[0].block_geoid == "B"
+        assert top[1].block_geoid == "C"
+
+    def test_summarize(self):
+        r = CodificationResult(
+            total_addresses=100,
+            matched_addresses=90,
+            match_rate=0.9,
+            blocks=[BlockProfile(block_geoid="A", tract_geoid="T", county_geoid="C", state_geoid="S")],
+            geocoding_backend="census",
+            census_year=2020,
+        )
+        s = r.summarize()
+        assert s["total_addresses"] == 100
+        assert s["match_rate"] == 0.9
+        assert s["block_count"] == 1
+        assert s["geocoding_backend"] == "census"
+
+
+# ---------------------------------------------------------------------------
+# _build_block_profiles
+# ---------------------------------------------------------------------------
+
+
+class TestBuildBlockProfiles:
+    def test_empty(self):
+        assert _build_block_profiles([]) == []
+
+    def test_single_block(self):
+        results = [_gr(), _gr(), _gr()]
+        profiles = _build_block_profiles(results)
+        assert len(profiles) == 1
+        assert profiles[0].address_count == 3
+        assert profiles[0].block_geoid == "170310101001001"
+
+    def test_multiple_blocks(self):
+        results = [
+            _gr(block_geoid="A"),
+            _gr(block_geoid="A"),
+            _gr(block_geoid="B"),
+        ]
+        profiles = _build_block_profiles(results)
+        assert len(profiles) == 2
+        assert profiles[0].address_count == 2
+        assert profiles[0].block_geoid == "A"
+
+    def test_sorted_by_count(self):
+        results = [
+            _gr(block_geoid="B"),
+            _gr(block_geoid="A"),
+            _gr(block_geoid="A"),
+            _gr(block_geoid="A"),
+        ]
+        profiles = _build_block_profiles(results)
+        assert profiles[0].block_geoid == "A"
+        assert profiles[0].address_count == 3
+
+    def test_falls_back_to_tract(self):
+        results = [_gr(block_geoid="", tract_geoid="T1")]
+        profiles = _build_block_profiles(results)
+        assert len(profiles) == 1
+        assert profiles[0].tract_geoid == "T1"
+
+    def test_preserves_geoid_hierarchy(self):
+        results = [_gr()]
+        profiles = _build_block_profiles(results)
+        assert profiles[0].state_geoid == "17"
+        assert profiles[0].county_geoid == "17031"
+        assert profiles[0].tract_geoid == "17031010100"
+
+
+# ---------------------------------------------------------------------------
+# codify_area
+# ---------------------------------------------------------------------------
+
+
+class TestCodifyArea:
+    def test_empty_addresses(self):
+        result = codify_area([])
+        assert result.total_addresses == 0
+        assert result.block_count == 0
+
+    def test_no_geocoder_uses_default(self):
+        result = codify_area(["123 Main St"], geocoder=None)
+        assert result.geocoding_backend in ("census", "")
+        assert result.total_addresses == 1
+
+    def test_basic_codification(self):
+        geocoder = _mock_geocoder([
+            _gr(block_geoid="A"),
+            _gr(block_geoid="A"),
+            _gr(block_geoid="B"),
+        ])
+        result = codify_area(["a", "b", "c"], geocoder=geocoder)
+
+        assert result.total_addresses == 3
+        assert result.matched_addresses == 3
+        assert result.match_rate == 1.0
+        assert result.block_count == 2
+        assert result.geocoding_backend == "census"
+
+    def test_partial_match(self):
+        geocoder = _mock_geocoder([
+            _gr(matched=True),
+            _gr(matched=False),
+        ])
+        result = codify_area(["a", "b"], geocoder=geocoder)
+
+        assert result.total_addresses == 2
+        assert result.matched_addresses == 1
+        assert result.match_rate == 0.5
+
+    def test_geocoder_exception(self):
+        geocoder = MagicMock()
+        geocoder.backend_name = "test"
+        geocoder.geocode.side_effect = RuntimeError("API down")
+
+        result = codify_area(["a"], geocoder=geocoder)
+        assert len(result.errors) == 1
+        assert "Geocoding failed" in result.errors[0]
+
+    def test_census_year_passed_through(self):
+        geocoder = _mock_geocoder([_gr()])
+        result = codify_area(["a"], geocoder=geocoder, census_year=2020)
+        assert result.census_year == 2020
+
+    def test_multiple_blocks_and_tracts(self):
+        geocoder = _mock_geocoder([
+            _gr(block_geoid="A1", tract_geoid="A", county_geoid="X", state_geoid="1"),
+            _gr(block_geoid="A2", tract_geoid="A", county_geoid="X", state_geoid="1"),
+            _gr(block_geoid="B1", tract_geoid="B", county_geoid="Y", state_geoid="2"),
+        ])
+        result = codify_area(["a", "b", "c"], geocoder=geocoder)
+
+        assert result.block_count == 3
+        assert result.tract_count == 2
+        assert result.county_count == 2
+
+    def test_summarize_integration(self):
+        geocoder = _mock_geocoder([_gr()])
+        result = codify_area(["a"], geocoder=geocoder, census_year=2020)
+        summary = result.summarize()
+        assert summary["total_addresses"] == 1
+        assert summary["census_year"] == 2020

--- a/tests/test_codification_blocks.py
+++ b/tests/test_codification_blocks.py
@@ -1,0 +1,155 @@
+"""Tests for block assignment (SU#628)."""
+
+from __future__ import annotations
+
+import pytest
+
+from siege_utilities.geo.providers.batch_geocoder import GeocodingResult, MatchQuality
+from siege_utilities.geo.codification_blocks import (
+    BlockAssignment,
+    BlockGroup,
+    SpreadMetrics,
+    assign_blocks,
+    compute_spread,
+    group_by_block,
+)
+
+
+def _gr(block="B1", tract="T1", county="C1", state="S1",
+        lat=41.0, lon=-87.0, matched=True, input_id="0"):
+    return GeocodingResult(
+        input_address="addr",
+        input_id=input_id,
+        lat=lat if matched else None,
+        lon=lon if matched else None,
+        match_quality=MatchQuality.EXACT.value if matched else MatchQuality.NO_MATCH.value,
+        block_geoid=block if matched else "",
+        tract_geoid=tract if matched else "",
+        county_geoid=county if matched else "",
+        state_geoid=state if matched else "",
+        backend="test",
+    )
+
+
+def _ba(block="B1", tract="T1", county="C1", state="S1",
+        lat=41.0, lon=-87.0, input_id="0"):
+    return BlockAssignment(
+        block_geoid=block, tract_geoid=tract, county_geoid=county,
+        state_geoid=state, lat=lat, lon=lon, input_id=input_id,
+    )
+
+
+class TestAssignBlocks:
+    def test_empty(self):
+        assert assign_blocks([]) == []
+
+    def test_skips_unmatched(self):
+        results = [_gr(matched=False)]
+        assert assign_blocks(results) == []
+
+    def test_converts_matched(self):
+        results = [_gr(block="B1", lat=41.0, lon=-87.0)]
+        assignments = assign_blocks(results)
+        assert len(assignments) == 1
+        assert assignments[0].block_geoid == "B1"
+        assert assignments[0].lat == 41.0
+
+    def test_preserves_input_id(self):
+        results = [_gr(input_id="MY-ID")]
+        assert assign_blocks(results)[0].input_id == "MY-ID"
+
+    def test_multiple(self):
+        results = [_gr(block="A"), _gr(block="B"), _gr(matched=False)]
+        assert len(assign_blocks(results)) == 2
+
+
+class TestGroupByBlock:
+    def test_empty(self):
+        assert group_by_block([]) == []
+
+    def test_single_group(self):
+        assignments = [_ba(block="B1"), _ba(block="B1"), _ba(block="B1")]
+        groups = group_by_block(assignments)
+        assert len(groups) == 1
+        assert groups[0].address_count == 3
+
+    def test_multiple_groups(self):
+        assignments = [_ba(block="A"), _ba(block="A"), _ba(block="B")]
+        groups = group_by_block(assignments)
+        assert len(groups) == 2
+        assert groups[0].block_geoid == "A"
+        assert groups[0].address_count == 2
+
+    def test_sorted_by_count(self):
+        assignments = [_ba(block="B"), _ba(block="A"), _ba(block="A"), _ba(block="A")]
+        groups = group_by_block(assignments)
+        assert groups[0].block_geoid == "A"
+
+    def test_centroid(self):
+        assignments = [
+            _ba(block="B1", lat=40.0, lon=-86.0),
+            _ba(block="B1", lat=42.0, lon=-88.0),
+        ]
+        groups = group_by_block(assignments)
+        assert groups[0].centroid_lat == pytest.approx(41.0)
+        assert groups[0].centroid_lon == pytest.approx(-87.0)
+
+    def test_falls_back_to_tract(self):
+        assignments = [_ba(block="", tract="T1")]
+        groups = group_by_block(assignments)
+        assert len(groups) == 1
+        assert groups[0].tract_geoid == "T1"
+
+
+class TestComputeSpread:
+    def test_empty(self):
+        m = compute_spread([])
+        assert m.block_count == 0
+        assert m.concentration == 0.0
+
+    def test_single_block(self):
+        assignments = [_ba(block="B1"), _ba(block="B1")]
+        m = compute_spread(assignments)
+        assert m.block_count == 1
+        assert m.concentration == pytest.approx(1.0)
+        assert m.max_block_pct == pytest.approx(1.0)
+
+    def test_two_equal_blocks(self):
+        assignments = [_ba(block="A"), _ba(block="B")]
+        m = compute_spread(assignments)
+        assert m.block_count == 2
+        assert m.concentration == pytest.approx(0.5)
+        assert m.max_block_pct == pytest.approx(0.5)
+
+    def test_geographic_counts(self):
+        assignments = [
+            _ba(block="A1", tract="A", county="X", state="1"),
+            _ba(block="A2", tract="A", county="X", state="1"),
+            _ba(block="B1", tract="B", county="Y", state="2"),
+        ]
+        m = compute_spread(assignments)
+        assert m.block_count == 3
+        assert m.tract_count == 2
+        assert m.county_count == 2
+        assert m.state_count == 2
+
+    def test_bbox(self):
+        assignments = [
+            _ba(lat=40.0, lon=-86.0, block="A"),
+            _ba(lat=42.0, lon=-88.0, block="B"),
+        ]
+        m = compute_spread(assignments)
+        assert m.bbox_lat_range == pytest.approx(2.0)
+        assert m.bbox_lon_range == pytest.approx(2.0)
+
+    def test_accepts_precomputed_groups(self):
+        assignments = [_ba(block="A"), _ba(block="B")]
+        groups = group_by_block(assignments)
+        m = compute_spread(assignments, groups=groups)
+        assert m.block_count == 2
+
+    def test_concentration_skewed(self):
+        assignments = [_ba(block="A")] * 9 + [_ba(block="B")]
+        m = compute_spread(assignments)
+        assert m.max_block_pct == pytest.approx(0.9)
+        assert m.concentration == pytest.approx(0.82)

--- a/tests/test_codification_demographics.py
+++ b/tests/test_codification_demographics.py
@@ -1,0 +1,118 @@
+"""Tests for demographic enrichment (SU#629)."""
+
+from __future__ import annotations
+
+import pytest
+
+from siege_utilities.geo.codification_demographics import (
+    BlockDemographics,
+    DemographicSignature,
+    DictBlockDemographicsProvider,
+    compute_demographic_signature,
+)
+
+
+def _bd(block="B1", pop=1000, vap=750, white=600, black=200,
+        hispanic=100, asian=50, other=50,
+        housing_total=400, housing_occupied=360, housing_vacant=40):
+    return BlockDemographics(
+        block_geoid=block,
+        total_population=pop,
+        voting_age_population=vap,
+        white=white, black=black, hispanic=hispanic,
+        asian=asian, other_race=other,
+        housing_total=housing_total,
+        housing_occupied=housing_occupied,
+        housing_vacant=housing_vacant,
+    )
+
+
+class TestBlockDemographics:
+    def test_defaults(self):
+        d = BlockDemographics()
+        assert d.total_population == 0
+
+    def test_fields(self):
+        d = _bd(pop=5000)
+        assert d.total_population == 5000
+
+
+class TestDictBlockDemographicsProvider:
+    def test_empty(self):
+        p = DictBlockDemographicsProvider()
+        assert p.get_demographics(["B1"]) == {}
+
+    def test_add_and_get(self):
+        p = DictBlockDemographicsProvider()
+        p.add(_bd(block="B1"))
+        result = p.get_demographics(["B1"])
+        assert "B1" in result
+
+    def test_missing_blocks(self):
+        p = DictBlockDemographicsProvider()
+        p.add(_bd(block="B1"))
+        result = p.get_demographics(["B1", "B2"])
+        assert len(result) == 1
+
+
+class TestComputeDemographicSignature:
+    def test_empty(self):
+        sig = compute_demographic_signature({}, {})
+        assert sig.weighted_blocks == 0
+        assert sig.pct_white == 0.0
+
+    def test_single_block(self):
+        counts = {"B1": 10}
+        demos = {"B1": _bd(pop=1000, white=600, black=200, hispanic=100, asian=50, other=50)}
+        sig = compute_demographic_signature(counts, demos)
+        assert sig.weighted_blocks == 1
+        assert sig.pct_white == pytest.approx(0.6)
+        assert sig.pct_black == pytest.approx(0.2)
+        assert sig.pct_hispanic == pytest.approx(0.1)
+
+    def test_address_weighted(self):
+        counts = {"B1": 9, "B2": 1}
+        demos = {
+            "B1": _bd(block="B1", pop=1000, white=1000, black=0, hispanic=0, asian=0, other=0),
+            "B2": _bd(block="B2", pop=1000, white=0, black=1000, hispanic=0, asian=0, other=0),
+        }
+        sig = compute_demographic_signature(counts, demos)
+        assert sig.pct_white == pytest.approx(0.9)
+        assert sig.pct_black == pytest.approx(0.1)
+
+    def test_skips_zero_population(self):
+        counts = {"B1": 10, "B2": 5}
+        demos = {
+            "B1": _bd(block="B1", pop=1000, white=500),
+            "B2": _bd(block="B2", pop=0),
+        }
+        sig = compute_demographic_signature(counts, demos)
+        assert sig.weighted_blocks == 1
+
+    def test_skips_missing_demographics(self):
+        counts = {"B1": 10, "B2": 5}
+        demos = {"B1": _bd(block="B1")}
+        sig = compute_demographic_signature(counts, demos)
+        assert sig.weighted_blocks == 1
+
+    def test_voting_age(self):
+        counts = {"B1": 10}
+        demos = {"B1": _bd(pop=1000, vap=750)}
+        sig = compute_demographic_signature(counts, demos)
+        assert sig.pct_voting_age == pytest.approx(0.75)
+
+    def test_housing(self):
+        counts = {"B1": 10}
+        demos = {"B1": _bd(housing_total=400, housing_occupied=360, housing_vacant=40)}
+        sig = compute_demographic_signature(counts, demos)
+        assert sig.pct_housing_occupied == pytest.approx(0.9)
+        assert sig.pct_housing_vacant == pytest.approx(0.1)
+
+    def test_total_population(self):
+        counts = {"B1": 5, "B2": 5}
+        demos = {
+            "B1": _bd(block="B1", pop=1000),
+            "B2": _bd(block="B2", pop=2000),
+        }
+        sig = compute_demographic_signature(counts, demos)
+        assert sig.total_block_population == 3000

--- a/tests/test_codification_recency.py
+++ b/tests/test_codification_recency.py
@@ -1,0 +1,99 @@
+"""Tests for recency analysis (SU#631)."""
+
+from __future__ import annotations
+
+import pytest
+
+from siege_utilities.geo.codification_recency import (
+    AddressVintage,
+    DictAddressVintageProvider,
+    RecencyAnalysis,
+    compute_recency,
+)
+
+
+def _av(input_id="0", first_vintage=2020, present_in=None):
+    return AddressVintage(
+        input_id=input_id,
+        first_vintage=first_vintage,
+        present_in=present_in or [2020],
+    )
+
+
+class TestAddressVintage:
+    def test_defaults(self):
+        v = AddressVintage()
+        assert v.first_vintage is None
+        assert not v.is_new_construction
+
+    def test_is_new_construction(self):
+        v = _av(first_vintage=2024, present_in=[2020, 2022, 2024])
+        assert v.is_new_construction
+
+    def test_not_new_construction(self):
+        v = _av(first_vintage=2020, present_in=[2020, 2022, 2024])
+        assert not v.is_new_construction
+
+
+class TestDictAddressVintageProvider:
+    def test_empty(self):
+        p = DictAddressVintageProvider()
+        assert p.get_vintages(["0"]) == []
+
+    def test_add_and_get(self):
+        p = DictAddressVintageProvider()
+        p.add(_av(input_id="0"))
+        result = p.get_vintages(["0"])
+        assert len(result) == 1
+
+
+class TestComputeRecency:
+    def test_empty(self):
+        r = compute_recency([])
+        assert r.total_analyzed == 0
+
+    def test_single_vintage(self):
+        vintages = [_av(first_vintage=2020)] * 10
+        r = compute_recency(vintages)
+        assert r.total_analyzed == 10
+        assert r.vintage_distribution == {2020: 10}
+        assert r.vintage_pct[2020] == pytest.approx(1.0)
+        assert r.new_construction_count == 10
+        assert r.median_vintage == 2020
+
+    def test_mixed_vintages(self):
+        vintages = [
+            _av(first_vintage=2016),
+            _av(first_vintage=2016),
+            _av(first_vintage=2018),
+            _av(first_vintage=2020),
+            _av(first_vintage=2020),
+        ]
+        r = compute_recency(vintages)
+        assert r.total_analyzed == 5
+        assert r.vintage_distribution[2016] == 2
+        assert r.vintage_distribution[2018] == 1
+        assert r.vintage_distribution[2020] == 2
+        assert r.new_construction_count == 2
+        assert r.new_construction_pct == pytest.approx(0.4)
+
+    def test_median_odd(self):
+        vintages = [_av(first_vintage=y) for y in [2010, 2016, 2020]]
+        r = compute_recency(vintages)
+        assert r.median_vintage == 2016
+
+    def test_median_even(self):
+        vintages = [_av(first_vintage=y) for y in [2010, 2016, 2020, 2022]]
+        r = compute_recency(vintages)
+        assert r.median_vintage == 2018
+
+    def test_skips_none_vintage(self):
+        vintages = [_av(first_vintage=2020), AddressVintage(input_id="1")]
+        r = compute_recency(vintages)
+        assert r.total_analyzed == 1
+
+    def test_sorted_distribution(self):
+        vintages = [_av(first_vintage=2020), _av(first_vintage=2010)]
+        r = compute_recency(vintages)
+        keys = list(r.vintage_distribution.keys())
+        assert keys == [2010, 2020]

--- a/tests/test_codification_summary.py
+++ b/tests/test_codification_summary.py
@@ -1,0 +1,241 @@
+"""Tests for summary portrait (SU#632)."""
+
+from __future__ import annotations
+
+import pytest
+
+from siege_utilities.geo.codification import BlockProfile, CodificationResult
+from siege_utilities.geo.codification_blocks import BlockGroup, SpreadMetrics
+from siege_utilities.geo.codification_demographics import DemographicSignature
+from siege_utilities.geo.codification_urbanicity import UrbanicityDistribution
+from siege_utilities.geo.codification_recency import RecencyAnalysis
+from siege_utilities.geo.codification_summary import AreaPortrait, build_portrait
+
+
+def _spread(**kw):
+    defaults = dict(
+        block_count=5, tract_count=3, county_count=2, state_count=1,
+        concentration=0.45, max_block_pct=0.30,
+    )
+    defaults.update(kw)
+    return SpreadMetrics(**defaults)
+
+
+def _demographics(**kw):
+    defaults = dict(
+        total_block_population=5000, weighted_blocks=5,
+        pct_white=0.55, pct_black=0.20, pct_hispanic=0.15,
+        pct_asian=0.05, pct_other=0.05,
+        pct_voting_age=0.72, pct_housing_occupied=0.90,
+        pct_housing_vacant=0.10,
+    )
+    defaults.update(kw)
+    return DemographicSignature(**defaults)
+
+
+def _urbanicity(**kw):
+    defaults = dict(
+        total_classified=100,
+        distribution={"11": 0.7, "21": 0.3},
+        category_distribution={"city": 0.7, "suburb": 0.3},
+        dominant_locale="11",
+        dominant_category="city",
+    )
+    defaults.update(kw)
+    return UrbanicityDistribution(**defaults)
+
+
+def _recency(**kw):
+    defaults = dict(
+        total_analyzed=50,
+        vintage_distribution={2016: 20, 2020: 30},
+        vintage_pct={2016: 0.4, 2020: 0.6},
+        new_construction_count=30,
+        new_construction_pct=0.6,
+        median_vintage=2020,
+    )
+    defaults.update(kw)
+    return RecencyAnalysis(**defaults)
+
+
+def _codification_result(n_blocks=3):
+    blocks = [
+        BlockProfile(
+            block_geoid=f"48045300{i:02d}001{i:03d}",
+            tract_geoid=f"48045300{i:02d}00",
+            county_geoid=f"4804{i}",
+            state_geoid="48",
+            address_count=(n_blocks - i) * 10,
+        )
+        for i in range(n_blocks)
+    ]
+    return CodificationResult(
+        total_addresses=sum(b.address_count for b in blocks),
+        matched_addresses=sum(b.address_count for b in blocks),
+        match_rate=1.0,
+        blocks=blocks,
+        geocoding_backend="test",
+        census_year=2020,
+    )
+
+
+class TestAreaPortraitDefaults:
+    def test_empty_portrait(self):
+        p = AreaPortrait()
+        assert p.geocoding_summary == {}
+        assert p.spread is None
+        assert p.demographics is None
+        assert p.urbanicity is None
+        assert p.recency is None
+        assert p.top_blocks == []
+
+    def test_headline_metrics_empty(self):
+        p = AreaPortrait()
+        assert p.headline_metrics() == {}
+
+    def test_to_dict_empty(self):
+        d = AreaPortrait().to_dict()
+        assert d == {"geocoding": {}}
+
+
+class TestHeadlineMetrics:
+    def test_spread_metrics(self):
+        p = AreaPortrait(spread=_spread())
+        m = p.headline_metrics()
+        assert m["block_count"] == 5
+        assert m["tract_count"] == 3
+        assert m["county_count"] == 2
+        assert m["concentration"] == 0.45
+
+    def test_demographic_metrics(self):
+        p = AreaPortrait(demographics=_demographics())
+        m = p.headline_metrics()
+        assert m["pct_white"] == 0.55
+        assert m["pct_black"] == 0.2
+        assert m["pct_hispanic"] == 0.15
+        assert m["pct_voting_age"] == 0.72
+
+    def test_urbanicity_metrics(self):
+        p = AreaPortrait(urbanicity=_urbanicity())
+        m = p.headline_metrics()
+        assert m["dominant_category"] == "city"
+        assert m["dominant_locale"] == "11"
+
+    def test_recency_metrics(self):
+        p = AreaPortrait(recency=_recency())
+        m = p.headline_metrics()
+        assert m["median_vintage"] == 2020
+        assert m["new_construction_pct"] == 0.6
+
+    def test_all_layers(self):
+        p = AreaPortrait(
+            geocoding_summary={"total_addresses": 100},
+            spread=_spread(),
+            demographics=_demographics(),
+            urbanicity=_urbanicity(),
+            recency=_recency(),
+        )
+        m = p.headline_metrics()
+        assert m["total_addresses"] == 100
+        assert "block_count" in m
+        assert "pct_white" in m
+        assert "dominant_category" in m
+        assert "median_vintage" in m
+
+    def test_rounding(self):
+        p = AreaPortrait(
+            spread=_spread(concentration=0.33333),
+            demographics=_demographics(pct_white=0.55555),
+            recency=_recency(new_construction_pct=0.66666),
+        )
+        m = p.headline_metrics()
+        assert m["concentration"] == 0.333
+        assert m["pct_white"] == 0.556
+        assert m["new_construction_pct"] == 0.667
+
+
+class TestToDict:
+    def test_spread_section(self):
+        p = AreaPortrait(spread=_spread())
+        d = p.to_dict()
+        assert d["spread"]["block_count"] == 5
+        assert d["spread"]["state_count"] == 1
+        assert d["spread"]["max_block_pct"] == 0.30
+
+    def test_demographics_section(self):
+        p = AreaPortrait(demographics=_demographics())
+        d = p.to_dict()
+        assert d["demographics"]["total_block_population"] == 5000
+        assert d["demographics"]["pct_asian"] == 0.05
+        assert d["demographics"]["pct_housing_occupied"] == 0.90
+
+    def test_urbanicity_section(self):
+        p = AreaPortrait(urbanicity=_urbanicity())
+        d = p.to_dict()
+        assert d["urbanicity"]["dominant_locale"] == "11"
+        assert d["urbanicity"]["distribution"] == {"city": 0.7, "suburb": 0.3}
+
+    def test_recency_section(self):
+        p = AreaPortrait(recency=_recency())
+        d = p.to_dict()
+        assert d["recency"]["total_analyzed"] == 50
+        assert d["recency"]["vintage_distribution"] == {2016: 20, 2020: 30}
+
+    def test_top_blocks_section(self):
+        blocks = [
+            BlockGroup(block_geoid="B1", tract_geoid="T1", address_count=10),
+            BlockGroup(block_geoid="B2", tract_geoid="T2", address_count=5),
+        ]
+        p = AreaPortrait(top_blocks=blocks)
+        d = p.to_dict()
+        assert len(d["top_blocks"]) == 2
+        assert d["top_blocks"][0]["block_geoid"] == "B1"
+        assert d["top_blocks"][0]["address_count"] == 10
+
+    def test_no_optional_sections(self):
+        p = AreaPortrait(geocoding_summary={"test": True})
+        d = p.to_dict()
+        assert d == {"geocoding": {"test": True}}
+        assert "spread" not in d
+        assert "demographics" not in d
+        assert "urbanicity" not in d
+        assert "recency" not in d
+        assert "top_blocks" not in d
+
+
+class TestBuildPortrait:
+    def test_basic(self):
+        cr = _codification_result(3)
+        p = build_portrait(cr)
+        assert p.geocoding_summary["total_addresses"] == cr.total_addresses
+        assert len(p.top_blocks) == 3
+
+    def test_top_n_limit(self):
+        cr = _codification_result(5)
+        p = build_portrait(cr, top_n=2)
+        assert len(p.top_blocks) == 2
+        assert p.top_blocks[0].address_count >= p.top_blocks[1].address_count
+
+    def test_enrichment_passthrough(self):
+        cr = _codification_result()
+        s = _spread()
+        d = _demographics()
+        u = _urbanicity()
+        r = _recency()
+        p = build_portrait(cr, spread=s, demographics=d, urbanicity=u, recency=r)
+        assert p.spread is s
+        assert p.demographics is d
+        assert p.urbanicity is u
+        assert p.recency is r
+
+    def test_empty_codification(self):
+        cr = CodificationResult()
+        p = build_portrait(cr)
+        assert p.top_blocks == []
+        assert p.geocoding_summary == cr.summarize()
+
+    def test_block_ordering(self):
+        cr = _codification_result(5)
+        p = build_portrait(cr, top_n=5)
+        counts = [b.address_count for b in p.top_blocks]
+        assert counts == sorted(counts, reverse=True)

--- a/tests/test_codification_urbanicity.py
+++ b/tests/test_codification_urbanicity.py
@@ -1,0 +1,82 @@
+"""Tests for urbanicity enrichment (SU#630)."""
+
+from __future__ import annotations
+
+import pytest
+
+from siege_utilities.geo.codification_urbanicity import (
+    BlockLocale,
+    DictBlockLocaleProvider,
+    UrbanicityDistribution,
+    compute_urbanicity_distribution,
+)
+
+
+def _bl(block="B1", code="11", label="City-Large", category="city"):
+    return BlockLocale(block_geoid=block, locale_code=code,
+                       locale_label=label, category=category)
+
+
+class TestBlockLocale:
+    def test_defaults(self):
+        b = BlockLocale()
+        assert b.locale_code == ""
+
+    def test_fields(self):
+        b = _bl()
+        assert b.locale_code == "11"
+        assert b.category == "city"
+
+
+class TestDictBlockLocaleProvider:
+    def test_empty(self):
+        p = DictBlockLocaleProvider()
+        assert p.classify_blocks(["B1"]) == {}
+
+    def test_add_and_get(self):
+        p = DictBlockLocaleProvider()
+        p.add(_bl(block="B1"))
+        assert "B1" in p.classify_blocks(["B1"])
+
+
+class TestComputeUrbanicityDistribution:
+    def test_empty(self):
+        d = compute_urbanicity_distribution({}, {})
+        assert d.total_classified == 0
+
+    def test_single_locale(self):
+        counts = {"B1": 10}
+        locales = {"B1": _bl(code="11", category="city")}
+        d = compute_urbanicity_distribution(counts, locales)
+        assert d.total_classified == 10
+        assert d.distribution["11"] == pytest.approx(1.0)
+        assert d.dominant_locale == "11"
+        assert d.dominant_category == "city"
+
+    def test_mixed_locales(self):
+        counts = {"B1": 7, "B2": 3}
+        locales = {
+            "B1": _bl(block="B1", code="11", category="city"),
+            "B2": _bl(block="B2", code="21", category="suburb"),
+        }
+        d = compute_urbanicity_distribution(counts, locales)
+        assert d.distribution["11"] == pytest.approx(0.7)
+        assert d.distribution["21"] == pytest.approx(0.3)
+        assert d.category_distribution["city"] == pytest.approx(0.7)
+        assert d.dominant_locale == "11"
+
+    def test_skips_unclassified(self):
+        counts = {"B1": 10, "B2": 5}
+        locales = {"B1": _bl(block="B1")}
+        d = compute_urbanicity_distribution(counts, locales)
+        assert d.total_classified == 10
+
+    def test_same_category_different_codes(self):
+        counts = {"B1": 5, "B2": 5}
+        locales = {
+            "B1": _bl(block="B1", code="11", category="city"),
+            "B2": _bl(block="B2", code="12", category="city"),
+        }
+        d = compute_urbanicity_distribution(counts, locales)
+        assert d.category_distribution["city"] == pytest.approx(1.0)
+        assert len(d.distribution) == 2

--- a/tests/test_composite_geocoder.py
+++ b/tests/test_composite_geocoder.py
@@ -1,0 +1,299 @@
+"""Tests for composite batch geocoder (SU#626)."""
+
+from __future__ import annotations
+
+import pytest
+
+from siege_utilities.geo.providers.batch_geocoder import (
+    AddressInput,
+    BatchGeocoder,
+    BatchGeocodingResult,
+    GeocodingResult,
+    MatchQuality,
+)
+from siege_utilities.geo.providers.composite_geocoder import (
+    CompositeBatchGeocoder,
+    _quality_rank,
+)
+
+
+# ---------------------------------------------------------------------------
+# Stub backends for testing
+# ---------------------------------------------------------------------------
+
+
+class _StubGeocoder(BatchGeocoder):
+    """Configurable stub backend for testing."""
+
+    def __init__(self, name, results=None, available=True, raises=None):
+        self._name = name
+        self._results = results or {}
+        self._available = available
+        self._raises = raises
+        self.called_with = None
+
+    @property
+    def backend_name(self):
+        return self._name
+
+    def is_available(self):
+        return self._available
+
+    def geocode(self, addresses, **kwargs):
+        if self._raises:
+            raise self._raises
+        self.called_with = addresses
+        result = BatchGeocodingResult(backend=self._name)
+        for addr in addresses:
+            key = addr.input_id if isinstance(addr, AddressInput) else str(addr)
+            if key in self._results:
+                result.results.append(self._results[key])
+            else:
+                result.results.append(GeocodingResult(
+                    input_address=addr.one_line if isinstance(addr, AddressInput) else str(addr),
+                    input_id=key,
+                    match_quality=MatchQuality.NO_MATCH.value,
+                    backend=self._name,
+                ))
+        return result
+
+
+def _gr(input_id, quality, backend, lat=41.0, lon=-87.0, **kw):
+    return GeocodingResult(
+        input_address=f"addr-{input_id}",
+        input_id=input_id,
+        lat=lat,
+        lon=lon,
+        match_quality=quality,
+        backend=backend,
+        **kw,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Quality rank tests
+# ---------------------------------------------------------------------------
+
+
+class TestQualityRank:
+    def test_ordering(self):
+        assert _quality_rank(MatchQuality.EXACT.value) > _quality_rank(MatchQuality.INTERPOLATED.value)
+        assert _quality_rank(MatchQuality.INTERPOLATED.value) > _quality_rank(MatchQuality.APPROXIMATE.value)
+        assert _quality_rank(MatchQuality.APPROXIMATE.value) > _quality_rank(MatchQuality.CENTROID.value)
+        assert _quality_rank(MatchQuality.CENTROID.value) > _quality_rank(MatchQuality.NO_MATCH.value)
+
+    def test_unknown_quality(self):
+        assert _quality_rank("unknown") == 0
+
+
+# ---------------------------------------------------------------------------
+# Configuration tests
+# ---------------------------------------------------------------------------
+
+
+class TestCompositeConfig:
+    def test_backend_name(self):
+        g = CompositeBatchGeocoder(backends=[_StubGeocoder("a")])
+        assert g.backend_name == "composite"
+
+    def test_requires_at_least_one_backend(self):
+        with pytest.raises(ValueError, match="At least one backend"):
+            CompositeBatchGeocoder(backends=[])
+
+    def test_empty_input(self):
+        g = CompositeBatchGeocoder(backends=[_StubGeocoder("a")])
+        result = g.geocode([])
+        assert result.total == 0
+
+    def test_all_unavailable_returns_error(self):
+        g = CompositeBatchGeocoder(backends=[
+            _StubGeocoder("a", available=False),
+            _StubGeocoder("b", available=False),
+        ])
+        result = g.geocode(["123 Main St"])
+        assert len(result.errors) == 1
+        assert "No available" in result.errors[0]
+
+
+# ---------------------------------------------------------------------------
+# Fallback behavior tests
+# ---------------------------------------------------------------------------
+
+
+class TestCompositeFallback:
+    def test_first_backend_succeeds(self):
+        b1 = _StubGeocoder("census", results={
+            "0": _gr("0", MatchQuality.EXACT.value, "census"),
+        })
+        b2 = _StubGeocoder("nominatim")
+        g = CompositeBatchGeocoder(backends=[b1, b2])
+        result = g.geocode(["123 Main St"])
+
+        assert result.total == 1
+        assert result.results[0].backend == "census"
+        assert result.results[0].match_quality == MatchQuality.EXACT.value
+        assert b2.called_with is None
+
+    def test_fallback_to_second_backend(self):
+        b1 = _StubGeocoder("census", results={})
+        b2 = _StubGeocoder("nominatim", results={
+            "0": _gr("0", MatchQuality.APPROXIMATE.value, "nominatim"),
+        })
+        g = CompositeBatchGeocoder(backends=[b1, b2])
+        result = g.geocode(["123 Main St"])
+
+        assert result.total == 1
+        assert result.results[0].backend == "nominatim"
+        assert result.results[0].matched
+
+    def test_keeps_best_result_across_backends(self):
+        b1 = _StubGeocoder("census", results={
+            "0": _gr("0", MatchQuality.CENTROID.value, "census"),
+        })
+        b2 = _StubGeocoder("nominatim", results={
+            "0": _gr("0", MatchQuality.APPROXIMATE.value, "nominatim"),
+        })
+        g = CompositeBatchGeocoder(
+            backends=[b1, b2],
+            min_quality=MatchQuality.INTERPOLATED.value,
+        )
+        result = g.geocode(["123 Main St"])
+
+        assert result.results[0].backend == "nominatim"
+        assert result.results[0].match_quality == MatchQuality.APPROXIMATE.value
+
+    def test_mixed_results_partial_fallback(self):
+        b1 = _StubGeocoder("census", results={
+            "0": _gr("0", MatchQuality.EXACT.value, "census"),
+        })
+        b2 = _StubGeocoder("nominatim", results={
+            "1": _gr("1", MatchQuality.APPROXIMATE.value, "nominatim"),
+        })
+        g = CompositeBatchGeocoder(backends=[b1, b2])
+        result = g.geocode(["addr1", "addr2"])
+
+        assert result.total == 2
+        assert result.results[0].backend == "census"
+        assert result.results[1].backend == "nominatim"
+
+    def test_backend_exception_continues_to_next(self):
+        b1 = _StubGeocoder("census", raises=RuntimeError("API down"))
+        b2 = _StubGeocoder("nominatim", results={
+            "0": _gr("0", MatchQuality.APPROXIMATE.value, "nominatim"),
+        })
+        g = CompositeBatchGeocoder(backends=[b1, b2])
+        result = g.geocode(["123 Main St"])
+
+        assert result.total == 1
+        assert result.results[0].backend == "nominatim"
+
+    def test_skip_unavailable_backends(self):
+        b1 = _StubGeocoder("tamu", available=False)
+        b2 = _StubGeocoder("nominatim", results={
+            "0": _gr("0", MatchQuality.APPROXIMATE.value, "nominatim"),
+        })
+        g = CompositeBatchGeocoder(backends=[b1, b2])
+        result = g.geocode(["123 Main St"])
+
+        assert result.results[0].backend == "nominatim"
+        assert b1.called_with is None
+
+    def test_dont_skip_unavailable_when_disabled(self):
+        b1 = _StubGeocoder("tamu", available=False, results={
+            "0": _gr("0", MatchQuality.EXACT.value, "tamu"),
+        })
+        g = CompositeBatchGeocoder(backends=[b1], skip_unavailable=False)
+        result = g.geocode(["123 Main St"])
+
+        assert result.results[0].backend == "tamu"
+
+    def test_all_backends_fail_returns_no_match(self):
+        b1 = _StubGeocoder("census", results={})
+        b2 = _StubGeocoder("nominatim", results={})
+        g = CompositeBatchGeocoder(backends=[b1, b2])
+        result = g.geocode(["123 Main St"])
+
+        assert result.total == 1
+        assert not result.results[0].matched
+
+    def test_quality_threshold_triggers_fallback(self):
+        b1 = _StubGeocoder("census", results={
+            "0": _gr("0", MatchQuality.CENTROID.value, "census"),
+        })
+        b2 = _StubGeocoder("nominatim", results={
+            "0": _gr("0", MatchQuality.INTERPOLATED.value, "nominatim"),
+        })
+        g = CompositeBatchGeocoder(
+            backends=[b1, b2],
+            min_quality=MatchQuality.APPROXIMATE.value,
+        )
+        result = g.geocode(["123 Main St"])
+
+        assert result.results[0].backend == "nominatim"
+
+    def test_exact_threshold_only_accepts_exact(self):
+        b1 = _StubGeocoder("census", results={
+            "0": _gr("0", MatchQuality.INTERPOLATED.value, "census"),
+        })
+        b2 = _StubGeocoder("nominatim", results={
+            "0": _gr("0", MatchQuality.EXACT.value, "nominatim"),
+        })
+        g = CompositeBatchGeocoder(
+            backends=[b1, b2],
+            min_quality=MatchQuality.EXACT.value,
+        )
+        result = g.geocode(["123 Main St"])
+
+        assert result.results[0].backend == "nominatim"
+
+    def test_three_backends_chain(self):
+        b1 = _StubGeocoder("census", results={})
+        b2 = _StubGeocoder("nominatim", results={
+            "0": _gr("0", MatchQuality.CENTROID.value, "nominatim"),
+        })
+        b3 = _StubGeocoder("tamu", results={
+            "0": _gr("0", MatchQuality.EXACT.value, "tamu"),
+        })
+        g = CompositeBatchGeocoder(backends=[b1, b2, b3])
+        result = g.geocode(["123 Main St"])
+
+        assert result.results[0].backend == "tamu"
+
+    def test_preserves_input_ids(self):
+        b1 = _StubGeocoder("census", results={
+            "MY-ID": _gr("MY-ID", MatchQuality.EXACT.value, "census"),
+        })
+        g = CompositeBatchGeocoder(backends=[b1])
+        result = g.geocode([
+            {"street": "123 Main St", "city": "Chicago", "state": "IL", "id": "MY-ID"},
+        ])
+
+        assert result.results[0].input_id == "MY-ID"
+
+    def test_stops_early_when_all_resolved(self):
+        b1 = _StubGeocoder("census", results={
+            "0": _gr("0", MatchQuality.EXACT.value, "census"),
+            "1": _gr("1", MatchQuality.EXACT.value, "census"),
+        })
+        b2 = _StubGeocoder("nominatim")
+        g = CompositeBatchGeocoder(backends=[b1, b2])
+        result = g.geocode(["a", "b"])
+
+        assert result.matched_count == 2
+        assert b2.called_with is None
+
+    def test_multiple_addresses_different_backends(self):
+        b1 = _StubGeocoder("census", results={
+            "0": _gr("0", MatchQuality.EXACT.value, "census"),
+            "2": _gr("2", MatchQuality.EXACT.value, "census"),
+        })
+        b2 = _StubGeocoder("nominatim", results={
+            "1": _gr("1", MatchQuality.APPROXIMATE.value, "nominatim"),
+        })
+        g = CompositeBatchGeocoder(backends=[b1, b2])
+        result = g.geocode(["a", "b", "c"])
+
+        assert result.total == 3
+        assert result.results[0].backend == "census"
+        assert result.results[1].backend == "nominatim"
+        assert result.results[2].backend == "census"

--- a/tests/test_demographics_overlay.py
+++ b/tests/test_demographics_overlay.py
@@ -1,0 +1,224 @@
+"""Tests for demographics overlay (SU#610)."""
+
+from __future__ import annotations
+
+import pytest
+
+from siege_utilities.geo.overlay_registry import PlaceHistoryOverlay
+from siege_utilities.geo.overlays.demographics import (
+    DemographicPoint,
+    DemographicsOverlay,
+    DemographicsOverlayResult,
+    DictDemographicsProvider,
+)
+
+
+def _dp(year=2020, geoid="17031010100", dataset="acs5",
+        total_population=5000, median_household_income=65000.0,
+        median_age=35.0, values=None):
+    return DemographicPoint(
+        year=year, geoid=geoid, dataset=dataset,
+        total_population=total_population,
+        median_household_income=median_household_income,
+        median_age=median_age,
+        values=values or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# DemographicPoint
+# ---------------------------------------------------------------------------
+
+
+class TestDemographicPoint:
+    def test_defaults(self):
+        p = DemographicPoint()
+        assert p.year == 0
+        assert p.total_population is None
+
+    def test_fields(self):
+        p = _dp()
+        assert p.year == 2020
+        assert p.total_population == 5000
+        assert p.dataset == "acs5"
+
+
+# ---------------------------------------------------------------------------
+# DemographicsOverlayResult
+# ---------------------------------------------------------------------------
+
+
+class TestDemographicsOverlayResult:
+    def test_empty(self):
+        r = DemographicsOverlayResult(geoid="A")
+        assert not r.has_data
+        assert r.years == []
+
+    def test_years(self):
+        r = DemographicsOverlayResult(
+            geoid="A",
+            time_series=[_dp(year=2010), _dp(year=2020), _dp(year=2015)],
+        )
+        assert r.years == [2010, 2015, 2020]
+
+    def test_for_year(self):
+        r = DemographicsOverlayResult(
+            geoid="A",
+            time_series=[_dp(year=2010), _dp(year=2020)],
+        )
+        assert len(r.for_year(2020)) == 1
+        assert len(r.for_year(2015)) == 0
+
+    def test_population_series(self):
+        r = DemographicsOverlayResult(
+            geoid="A",
+            time_series=[
+                _dp(year=2010, total_population=4000),
+                _dp(year=2020, total_population=5000),
+            ],
+        )
+        series = r.population_series()
+        assert series == [(2010, 4000), (2020, 5000)]
+
+    def test_population_series_skips_none(self):
+        r = DemographicsOverlayResult(
+            geoid="A",
+            time_series=[
+                _dp(year=2010, total_population=None),
+                _dp(year=2020, total_population=5000),
+            ],
+        )
+        assert len(r.population_series()) == 1
+
+    def test_has_data(self):
+        r = DemographicsOverlayResult(
+            geoid="A", time_series=[_dp()],
+        )
+        assert r.has_data
+
+
+# ---------------------------------------------------------------------------
+# DictDemographicsProvider
+# ---------------------------------------------------------------------------
+
+
+class TestDictDemographicsProvider:
+    def test_empty(self):
+        p = DictDemographicsProvider()
+        assert p.get_snapshots("A", 2000, 2020) == []
+
+    def test_add_and_get(self):
+        p = DictDemographicsProvider()
+        p.add(_dp(geoid="A", year=2020))
+        results = p.get_snapshots("A", 2018, 2022)
+        assert len(results) == 1
+
+    def test_geoid_filtering(self):
+        p = DictDemographicsProvider()
+        p.add(_dp(geoid="A", year=2020))
+        p.add(_dp(geoid="B", year=2020))
+        assert len(p.get_snapshots("A", 2018, 2022)) == 1
+
+    def test_year_range_filtering(self):
+        p = DictDemographicsProvider()
+        p.add(_dp(geoid="A", year=2010))
+        p.add(_dp(geoid="A", year=2015))
+        p.add(_dp(geoid="A", year=2020))
+        assert len(p.get_snapshots("A", 2012, 2018)) == 1
+
+    def test_dataset_filtering(self):
+        p = DictDemographicsProvider()
+        p.add(_dp(geoid="A", year=2020, dataset="acs5"))
+        p.add(_dp(geoid="A", year=2020, dataset="dec"))
+        assert len(p.get_snapshots("A", 2018, 2022, dataset="acs5")) == 1
+
+    def test_sorted_by_year(self):
+        p = DictDemographicsProvider()
+        p.add(_dp(geoid="A", year=2020))
+        p.add(_dp(geoid="A", year=2010))
+        results = p.get_snapshots("A", 2005, 2025)
+        assert results[0].year == 2010
+        assert results[1].year == 2020
+
+    def test_reverse_year_range(self):
+        p = DictDemographicsProvider()
+        p.add(_dp(geoid="A", year=2015))
+        results = p.get_snapshots("A", 2020, 2010)
+        assert len(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# DemographicsOverlay
+# ---------------------------------------------------------------------------
+
+
+class TestDemographicsOverlay:
+    def test_is_overlay(self):
+        o = DemographicsOverlay(provider=DictDemographicsProvider())
+        assert isinstance(o, PlaceHistoryOverlay)
+        assert o.name == "demographics"
+
+    def test_fetch_single_geoid(self):
+        p = DictDemographicsProvider()
+        p.add(_dp(geoid="A", year=2020))
+        o = DemographicsOverlay(provider=p)
+        result = o.fetch("A", 2018, 2022)
+        assert result.geoid == "A"
+        assert len(result.time_series) == 1
+        assert result.geoids_queried == ["A"]
+
+    def test_fetch_empty(self):
+        p = DictDemographicsProvider()
+        o = DemographicsOverlay(provider=p)
+        result = o.fetch("A", 2000, 2020)
+        assert not result.has_data
+
+    def test_no_provider_raises(self):
+        o = DemographicsOverlay(provider=None)
+        with pytest.raises(RuntimeError, match="No demographics data provider"):
+            o.fetch("A", 2000, 2020)
+
+    def test_with_terminal_geoids(self):
+        p = DictDemographicsProvider()
+        p.add(_dp(geoid="A", year=2010))
+        p.add(_dp(geoid="B", year=2020))
+        o = DemographicsOverlay(provider=p)
+        result = o.fetch("A", 2005, 2025, terminal_geoids=["B"])
+        assert len(result.time_series) == 2
+        assert set(result.geoids_queried) == {"A", "B"}
+
+    def test_deduplicates_geoids(self):
+        p = DictDemographicsProvider()
+        p.add(_dp(geoid="A", year=2020))
+        o = DemographicsOverlay(provider=p)
+        result = o.fetch("A", 2018, 2022, terminal_geoids=["A", "A"])
+        assert result.geoids_queried == ["A"]
+
+    def test_dataset_filter(self):
+        p = DictDemographicsProvider()
+        p.add(_dp(geoid="A", year=2020, dataset="acs5"))
+        p.add(_dp(geoid="A", year=2020, dataset="dec"))
+        o = DemographicsOverlay(provider=p, dataset="acs5")
+        result = o.fetch("A", 2018, 2022)
+        assert len(result.time_series) == 1
+        assert result.time_series[0].dataset == "acs5"
+
+    def test_sorted_output(self):
+        p = DictDemographicsProvider()
+        p.add(_dp(geoid="B", year=2020))
+        p.add(_dp(geoid="A", year=2010))
+        o = DemographicsOverlay(provider=p)
+        result = o.fetch("A", 2005, 2025, terminal_geoids=["B"])
+        assert result.time_series[0].year == 2010
+        assert result.time_series[1].year == 2020
+
+    def test_multi_year_timeline(self):
+        p = DictDemographicsProvider()
+        for yr in [2010, 2012, 2015, 2018, 2020]:
+            p.add(_dp(geoid="A", year=yr, total_population=yr * 2))
+        o = DemographicsOverlay(provider=p)
+        result = o.fetch("A", 2010, 2020)
+        assert len(result.time_series) == 5
+        series = result.population_series()
+        assert len(series) == 5
+        assert series[0] == (2010, 4020)

--- a/tests/test_events_overlay.py
+++ b/tests/test_events_overlay.py
@@ -1,0 +1,204 @@
+"""Tests for events overlay (SU#612)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from siege_utilities.geo.overlay_registry import PlaceHistoryOverlay
+from siege_utilities.geo.overlays.events import (
+    DictEventsProvider,
+    EventRecord,
+    EventsOverlay,
+    EventsOverlayResult,
+)
+
+
+def _er(
+    event_id="EVT-1",
+    event_type="court_ruling",
+    title="Redistricting ruling",
+    event_date=date(2020, 6, 15),
+    geoids_affected=None,
+    end_date=None,
+):
+    return EventRecord(
+        event_id=event_id,
+        event_type=event_type,
+        title=title,
+        date=event_date,
+        end_date=end_date,
+        geoids_affected=geoids_affected or ["17031010100"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# EventRecord
+# ---------------------------------------------------------------------------
+
+
+class TestEventRecord:
+    def test_defaults(self):
+        e = EventRecord()
+        assert e.event_id == ""
+        assert e.year == 0
+        assert not e.has_duration
+
+    def test_year(self):
+        e = _er(event_date=date(2020, 3, 1))
+        assert e.year == 2020
+
+    def test_has_duration(self):
+        e = _er(event_date=date(2020, 1, 1), end_date=date(2020, 12, 31))
+        assert e.has_duration
+
+    def test_no_duration(self):
+        e = _er(end_date=None)
+        assert not e.has_duration
+
+
+# ---------------------------------------------------------------------------
+# EventsOverlayResult
+# ---------------------------------------------------------------------------
+
+
+class TestEventsOverlayResult:
+    def test_empty(self):
+        r = EventsOverlayResult(geoid="A")
+        assert not r.has_events
+        assert r.count == 0
+        assert r.event_types == []
+
+    def test_has_events(self):
+        r = EventsOverlayResult(geoid="A", events=[_er()])
+        assert r.has_events
+        assert r.count == 1
+
+    def test_event_types(self):
+        r = EventsOverlayResult(
+            geoid="A",
+            events=[
+                _er(event_type="court_ruling"),
+                _er(event_type="natural_disaster"),
+                _er(event_type="court_ruling"),
+            ],
+        )
+        assert r.event_types == ["court_ruling", "natural_disaster"]
+
+    def test_for_type(self):
+        r = EventsOverlayResult(
+            geoid="A",
+            events=[
+                _er(event_type="court_ruling", event_id="1"),
+                _er(event_type="natural_disaster", event_id="2"),
+                _er(event_type="court_ruling", event_id="3"),
+            ],
+        )
+        rulings = r.for_type("court_ruling")
+        assert len(rulings) == 2
+
+
+# ---------------------------------------------------------------------------
+# DictEventsProvider
+# ---------------------------------------------------------------------------
+
+
+class TestDictEventsProvider:
+    def test_empty(self):
+        p = DictEventsProvider()
+        assert p.get_events("A", 2000, 2020) == []
+
+    def test_add_and_get(self):
+        p = DictEventsProvider()
+        p.add(_er(geoids_affected=["A"]))
+        results = p.get_events("A", 2018, 2022)
+        assert len(results) == 1
+
+    def test_geoid_filtering(self):
+        p = DictEventsProvider()
+        p.add(_er(geoids_affected=["A"]))
+        assert len(p.get_events("B", 2018, 2022)) == 0
+
+    def test_year_range_filtering(self):
+        p = DictEventsProvider()
+        p.add(_er(event_date=date(2015, 1, 1), geoids_affected=["A"]))
+        p.add(_er(event_date=date(2020, 1, 1), geoids_affected=["A"]))
+        assert len(p.get_events("A", 2018, 2022)) == 1
+
+    def test_event_type_filtering(self):
+        p = DictEventsProvider()
+        p.add(_er(event_type="court_ruling", geoids_affected=["A"]))
+        p.add(_er(event_type="natural_disaster", geoids_affected=["A"]))
+        results = p.get_events("A", 2018, 2022, event_types=["court_ruling"])
+        assert len(results) == 1
+
+    def test_sorted_by_date(self):
+        p = DictEventsProvider()
+        p.add(_er(event_date=date(2020, 12, 1), event_id="2", geoids_affected=["A"]))
+        p.add(_er(event_date=date(2020, 1, 1), event_id="1", geoids_affected=["A"]))
+        results = p.get_events("A", 2019, 2021)
+        assert results[0].event_id == "1"
+        assert results[1].event_id == "2"
+
+    def test_reverse_year_range(self):
+        p = DictEventsProvider()
+        p.add(_er(event_date=date(2015, 1, 1), geoids_affected=["A"]))
+        results = p.get_events("A", 2020, 2010)
+        assert len(results) == 1
+
+    def test_multi_geoid_event(self):
+        p = DictEventsProvider()
+        p.add(_er(geoids_affected=["A", "B", "C"]))
+        assert len(p.get_events("A", 2018, 2022)) == 1
+        assert len(p.get_events("B", 2018, 2022)) == 1
+        assert len(p.get_events("D", 2018, 2022)) == 0
+
+
+# ---------------------------------------------------------------------------
+# EventsOverlay
+# ---------------------------------------------------------------------------
+
+
+class TestEventsOverlay:
+    def test_is_overlay(self):
+        o = EventsOverlay(provider=DictEventsProvider())
+        assert isinstance(o, PlaceHistoryOverlay)
+        assert o.name == "events"
+
+    def test_fetch_returns_result(self):
+        p = DictEventsProvider()
+        p.add(_er(geoids_affected=["A"]))
+        o = EventsOverlay(provider=p)
+        result = o.fetch("A", 2018, 2022)
+        assert isinstance(result, EventsOverlayResult)
+        assert result.geoid == "A"
+        assert result.has_events
+
+    def test_fetch_empty(self):
+        p = DictEventsProvider()
+        o = EventsOverlay(provider=p)
+        result = o.fetch("A", 2000, 2020)
+        assert not result.has_events
+
+    def test_no_provider_raises(self):
+        o = EventsOverlay(provider=None)
+        with pytest.raises(RuntimeError, match="No events data provider"):
+            o.fetch("A", 2000, 2020)
+
+    def test_event_type_filter(self):
+        p = DictEventsProvider()
+        p.add(_er(event_type="court_ruling", geoids_affected=["A"]))
+        p.add(_er(event_type="natural_disaster", geoids_affected=["A"]))
+        o = EventsOverlay(provider=p, event_types=["court_ruling"])
+        result = o.fetch("A", 2018, 2022)
+        assert len(result.events) == 1
+
+    def test_multiple_events(self):
+        p = DictEventsProvider()
+        p.add(_er(event_id="1", event_date=date(2020, 1, 1), geoids_affected=["A"]))
+        p.add(_er(event_id="2", event_date=date(2020, 6, 1), geoids_affected=["A"]))
+        p.add(_er(event_id="3", event_date=date(2021, 1, 1), geoids_affected=["A"]))
+        o = EventsOverlay(provider=p)
+        result = o.fetch("A", 2020, 2021)
+        assert result.count == 3

--- a/tests/test_locale.py
+++ b/tests/test_locale.py
@@ -374,6 +374,70 @@ class TestClassifyPolygon:
         assert abs(total - 1.0) < 0.01  # fractions sum to ~1
 
 
+class TestClassifyPolygons:
+    """Test bulk polygon classification."""
+
+    def test_majority_adds_columns(self):
+        """classify_polygons with majority adds locale_code/label/category/subcategory."""
+        ua = _make_ua((-78, 38, -76, 40), pop=500_000)
+        classifier = NCESLocaleClassifier(
+            urbanized_areas=ua,
+            urban_clusters=None,
+            principal_cities=_empty_gdf(),
+            place_populations={},
+            ua_populations={"00001": 500_000},
+        )
+        polys = gpd.GeoDataFrame(
+            {"name": ["A", "B"]},
+            geometry=[box(-77.5, 38.5, -76.5, 39.5), box(-77.5, 38.5, -76.5, 39.5)],
+            crs="EPSG:4269",
+        )
+        result = classifier.classify_polygons(polys, method="majority")
+        assert "locale_code" in result.columns
+        assert "locale_label" in result.columns
+        assert "locale_category" in result.columns
+        assert "locale_subcategory" in result.columns
+        assert len(result) == 2
+
+    def test_distribution_adds_column(self):
+        """classify_polygons with distribution adds locale_distribution column."""
+        ua = _make_ua((-78, 38, -77, 39), pop=500_000)
+        classifier = NCESLocaleClassifier(
+            urbanized_areas=ua,
+            urban_clusters=None,
+            principal_cities=_empty_gdf(),
+            place_populations={},
+        )
+        polys = gpd.GeoDataFrame(
+            {"name": ["A"]},
+            geometry=[box(-77.5, 38.5, -76.5, 39.5)],
+            crs="EPSG:4269",
+        )
+        result = classifier.classify_polygons(polys, method="distribution")
+        assert "locale_distribution" in result.columns
+        dist = result["locale_distribution"].iloc[0]
+        assert isinstance(dist, dict)
+        assert abs(sum(dist.values()) - 1.0) < 0.01
+
+    def test_does_not_mutate_input(self):
+        """classify_polygons should return a copy, not mutate the input."""
+        ua = _make_ua((-78, 38, -76, 40), pop=500_000)
+        classifier = NCESLocaleClassifier(
+            urbanized_areas=ua,
+            urban_clusters=None,
+            principal_cities=_empty_gdf(),
+            place_populations={},
+        )
+        polys = gpd.GeoDataFrame(
+            {"name": ["A"]},
+            geometry=[box(-77.5, 38.5, -76.5, 39.5)],
+            crs="EPSG:4269",
+        )
+        original_cols = set(polys.columns)
+        classifier.classify_polygons(polys, method="majority")
+        assert set(polys.columns) == original_cols
+
+
 class TestLocaleLabel:
     """Test the static locale_label helper."""
 

--- a/tests/test_locale.py
+++ b/tests/test_locale.py
@@ -20,6 +20,7 @@ from siege_utilities.geo.locale import (
     TOWN_FRINGE,
     TOWN_REMOTE,
     LocaleCode,
+    LocaleIndex,
     LocaleType,
     NCESLocaleClassifier,
     locale_from_code,
@@ -372,6 +373,121 @@ class TestClassifyPolygon:
         assert isinstance(result, dict)
         total = sum(result.values())
         assert abs(total - 1.0) < 0.01  # fractions sum to ~1
+
+
+class TestLocaleIndex:
+    """Tests for the LocaleIndex precomputed mapping."""
+
+    def test_add_and_get(self):
+        idx = LocaleIndex()
+        idx.add("48453001100", 11)
+        result = idx.get("48453001100")
+        assert result is not None
+        assert result.code == 11
+
+    def test_get_returns_none_for_missing(self):
+        idx = LocaleIndex()
+        assert idx.get("nonexistent") is None
+
+    def test_add_bulk(self):
+        idx = LocaleIndex()
+        idx.add_bulk({"01001": 11, "01002": 43})
+        assert len(idx) == 2
+        assert idx.get("01001").code == 11
+        assert idx.get("01002").code == 43
+
+    def test_contains(self):
+        idx = LocaleIndex({"01001": 11})
+        assert "01001" in idx
+        assert "99999" not in idx
+
+    def test_from_dataframe(self):
+        df = pd.DataFrame({
+            "geoid": ["01001", "01002", "01003"],
+            "locale_code": [11, 43, 21],
+        })
+        idx = LocaleIndex.from_dataframe(df)
+        assert len(idx) == 3
+        assert idx.get("01001").code == 11
+
+    def test_from_dataframe_skips_invalid_codes(self):
+        df = pd.DataFrame({
+            "geoid": ["01001", "01002"],
+            "locale_code": [11, 99],
+        })
+        idx = LocaleIndex.from_dataframe(df)
+        assert len(idx) == 1
+
+    def test_from_dataframe_custom_columns(self):
+        df = pd.DataFrame({
+            "tract_id": ["48453001100"],
+            "nces_code": [21],
+        })
+        idx = LocaleIndex.from_dataframe(df, geoid_col="tract_id", locale_col="nces_code")
+        assert idx.get("48453001100").code == 21
+
+
+class TestClassifyGeoid:
+    """Tests for GEOID-based classification."""
+
+    def test_classify_geoid_with_index(self):
+        classifier = NCESLocaleClassifier(
+            urbanized_areas=_empty_gdf(),
+            urban_clusters=_empty_gdf(),
+            principal_cities=_empty_gdf(),
+            place_populations={},
+        )
+        classifier.locale_index = LocaleIndex({"48453001100": 11})
+        result = classifier.classify_geoid("48453001100")
+        assert result is not None
+        assert result.code == 11
+
+    def test_classify_geoid_returns_none_without_index(self):
+        classifier = NCESLocaleClassifier(
+            urbanized_areas=_empty_gdf(),
+            urban_clusters=_empty_gdf(),
+            principal_cities=_empty_gdf(),
+            place_populations={},
+        )
+        assert classifier.classify_geoid("48453001100") is None
+
+    def test_classify_geoid_returns_none_for_missing(self):
+        classifier = NCESLocaleClassifier(
+            urbanized_areas=_empty_gdf(),
+            urban_clusters=_empty_gdf(),
+            principal_cities=_empty_gdf(),
+            place_populations={},
+        )
+        classifier.locale_index = LocaleIndex({"48453001100": 11})
+        assert classifier.classify_geoid("nonexistent") is None
+
+    def test_classify_geoid_or_point_uses_index(self):
+        ua = _make_ua((-78, 38, -76, 40), pop=500_000)
+        pc = _make_principal_cities((-78, 38, -76, 40), pop=300_000)
+        classifier = NCESLocaleClassifier(
+            urbanized_areas=ua,
+            urban_clusters=None,
+            principal_cities=pc,
+            place_populations={"00100": 300_000},
+        )
+        classifier.locale_index = LocaleIndex({"48453001100": 43})
+        # GEOID maps to Rural-Remote (43), but point would be City-Large (11)
+        result = classifier.classify_geoid_or_point("48453001100", -77.0, 39.0)
+        assert result.code == 43
+
+    def test_classify_geoid_or_point_falls_back(self):
+        ua = _make_ua((-78, 38, -76, 40), pop=500_000)
+        pc = _make_principal_cities((-78, 38, -76, 40), pop=300_000)
+        classifier = NCESLocaleClassifier(
+            urbanized_areas=ua,
+            urban_clusters=None,
+            principal_cities=pc,
+            place_populations={"00100": 300_000},
+        )
+        classifier.locale_index = LocaleIndex({})
+        # GEOID not in index → falls back to spatial → City-Large
+        result = classifier.classify_geoid_or_point("nonexistent", -77.0, 39.0)
+        assert result.code == 11
 
 
 class TestClassifyPolygons:

--- a/tests/test_naics_soc_integration.py
+++ b/tests/test_naics_soc_integration.py
@@ -1,0 +1,219 @@
+"""Tests for NAICS/SOC integration enhancements (SU#619)."""
+
+from __future__ import annotations
+
+import pytest
+
+from siege_utilities.geo.providers.nlrb_clients import NLRBCaseRecord
+
+# Load the module file directly to avoid reference/__init__.py
+# which eagerly imports pandas via sample_data
+import importlib.util as _ilu
+import pathlib as _pl
+import sys as _sys
+
+_mod_name = "siege_utilities.reference.naics_soc_crosswalk"
+_spec = _ilu.spec_from_file_location(
+    _mod_name,
+    _pl.Path(__file__).resolve().parent.parent
+    / "siege_utilities" / "reference" / "naics_soc_crosswalk.py",
+)
+_nsc = _ilu.module_from_spec(_spec)
+_sys.modules[_mod_name] = _nsc
+_spec.loader.exec_module(_nsc)
+
+NAICS_SECTORS = _nsc.NAICS_SECTORS
+NAICS_SUBSECTORS = _nsc.NAICS_SUBSECTORS
+SOC_MAJOR_GROUPS = _nsc.SOC_MAJOR_GROUPS
+SOC_MINOR_GROUPS = _nsc.SOC_MINOR_GROUPS
+filter_by_naics = _nsc.filter_by_naics
+filter_by_naics_sector = _nsc.filter_by_naics_sector
+get_naics_lookup = _nsc.get_naics_lookup
+get_soc_lookup = _nsc.get_soc_lookup
+group_by_naics_sector = _nsc.group_by_naics_sector
+naics_title = _nsc.naics_title
+soc_title = _nsc.soc_title
+
+
+# ---------------------------------------------------------------------------
+# Bundled lookup table tests
+# ---------------------------------------------------------------------------
+
+
+class TestNAICSSubsectors:
+    def test_has_entries(self):
+        assert len(NAICS_SUBSECTORS) > 80
+
+    def test_hospitals(self):
+        assert NAICS_SUBSECTORS["622"] == "Hospitals"
+
+    def test_ambulatory(self):
+        assert NAICS_SUBSECTORS["621"] == "Ambulatory Health Care Services"
+
+    def test_trucking(self):
+        assert NAICS_SUBSECTORS["484"] == "Truck Transportation"
+
+    def test_all_codes_are_3_digit(self):
+        for code in NAICS_SUBSECTORS:
+            assert len(code) == 3, f"Code {code} is not 3 digits"
+            assert code.isdigit(), f"Code {code} is not numeric"
+
+
+class TestSOCMinorGroups:
+    def test_has_entries(self):
+        assert len(SOC_MINOR_GROUPS) > 70
+
+    def test_top_executives(self):
+        assert SOC_MINOR_GROUPS["11-1000"] == "Top Executives"
+
+    def test_nurses(self):
+        assert "Healthcare" in SOC_MINOR_GROUPS["29-1000"]
+
+    def test_construction(self):
+        assert "Construction" in SOC_MINOR_GROUPS["47-2000"]
+
+
+class TestGetNAICSLookup:
+    def test_combines_sectors_and_subsectors(self):
+        lookup = get_naics_lookup()
+        assert len(lookup) == len(NAICS_SECTORS) + len(NAICS_SUBSECTORS)
+
+    def test_includes_sector(self):
+        lookup = get_naics_lookup()
+        assert "62" in lookup
+
+    def test_includes_subsector(self):
+        lookup = get_naics_lookup()
+        assert "622" in lookup
+
+
+class TestGetSOCLookup:
+    def test_combines_major_and_minor(self):
+        lookup = get_soc_lookup()
+        assert len(lookup) == len(SOC_MAJOR_GROUPS) + len(SOC_MINOR_GROUPS)
+
+    def test_includes_major(self):
+        lookup = get_soc_lookup()
+        assert "11" in lookup
+
+    def test_includes_minor(self):
+        lookup = get_soc_lookup()
+        assert "11-1000" in lookup
+
+
+# ---------------------------------------------------------------------------
+# Title lookup tests
+# ---------------------------------------------------------------------------
+
+
+class TestNAICSTitle:
+    def test_sector_code(self):
+        assert naics_title("62") == "Health Care and Social Assistance"
+
+    def test_subsector_code(self):
+        assert naics_title("622") == "Hospitals"
+
+    def test_longer_code_falls_back_to_sector(self):
+        title = naics_title("622110")
+        assert title == "Health Care and Social Assistance"
+
+    def test_unknown_code(self):
+        assert naics_title("99") == "Unknown"
+
+    def test_whitespace_stripped(self):
+        assert naics_title(" 622 ") == "Hospitals"
+
+
+class TestSOCTitle:
+    def test_major_group(self):
+        assert soc_title("11") == "Management"
+
+    def test_minor_group(self):
+        assert soc_title("11-1000") == "Top Executives"
+
+    def test_detailed_falls_back_to_major(self):
+        assert soc_title("11-1011") == "Management"
+
+    def test_unknown(self):
+        assert soc_title("99") == "Unknown"
+
+
+# ---------------------------------------------------------------------------
+# Query interface tests
+# ---------------------------------------------------------------------------
+
+
+def _make_cases():
+    return [
+        NLRBCaseRecord(case_number="1", case_type="RC", naics_code="622110"),
+        NLRBCaseRecord(case_number="2", case_type="RC", naics_code="622210"),
+        NLRBCaseRecord(case_number="3", case_type="CA", naics_code="445110"),
+        NLRBCaseRecord(case_number="4", case_type="RC", naics_code="621111"),
+        NLRBCaseRecord(case_number="5", case_type="CA", naics_code=""),
+    ]
+
+
+class TestFilterByNAICS:
+    def test_filter_hospitals(self):
+        cases = _make_cases()
+        matches = filter_by_naics(cases, "622")
+        assert len(matches) == 2
+        assert all(c.naics_code.startswith("622") for c in matches)
+
+    def test_filter_health_care_sector(self):
+        cases = _make_cases()
+        matches = filter_by_naics(cases, "62")
+        assert len(matches) == 3
+
+    def test_filter_exact_code(self):
+        cases = _make_cases()
+        matches = filter_by_naics(cases, "622110")
+        assert len(matches) == 1
+
+    def test_no_matches(self):
+        cases = _make_cases()
+        matches = filter_by_naics(cases, "999")
+        assert len(matches) == 0
+
+    def test_empty_naics_excluded(self):
+        cases = _make_cases()
+        matches = filter_by_naics(cases, "")
+        assert len(matches) == 0
+
+    def test_works_with_dicts(self):
+        records = [
+            {"case_number": "1", "naics_code": "622110"},
+            {"case_number": "2", "naics_code": "445110"},
+        ]
+        matches = filter_by_naics(records, "622")
+        assert len(matches) == 1
+
+    def test_whitespace_stripped(self):
+        cases = _make_cases()
+        matches = filter_by_naics(cases, " 622 ")
+        assert len(matches) == 2
+
+
+class TestFilterByNAICSSector:
+    def test_filter_by_sector(self):
+        cases = _make_cases()
+        matches = filter_by_naics_sector(cases, "62")
+        assert len(matches) == 3
+
+    def test_longer_code_truncated(self):
+        cases = _make_cases()
+        matches = filter_by_naics_sector(cases, "622")
+        assert len(matches) == 3
+
+
+class TestGroupByNAICSSector:
+    def test_groups_correctly(self):
+        cases = _make_cases()
+        groups = group_by_naics_sector(cases)
+        assert len(groups["62"]) == 3
+        assert len(groups["44"]) == 1
+        assert len(groups[""]) == 1
+
+    def test_empty_input(self):
+        groups = group_by_naics_sector([])
+        assert groups == {}

--- a/tests/test_nlrb_cache.py
+++ b/tests/test_nlrb_cache.py
@@ -1,0 +1,266 @@
+"""Tests for NLRB data caching (SU#621)."""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from siege_utilities.geo.providers.nlrb_cache import (
+    NLRBCache,
+    NLRBLoader,
+    _date_to_str,
+    _dict_to_result,
+    _result_to_dict,
+    _str_to_date,
+)
+from siege_utilities.geo.providers.nlrb_clients import (
+    ElectionRecord,
+    NLRBCaseRecord,
+    NLRBFetchResult,
+    ULPRecord,
+)
+
+
+# ---------------------------------------------------------------------------
+# Serialization helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestDateHelpers:
+    def test_date_to_str(self):
+        assert _date_to_str(date(2024, 1, 15)) == "2024-01-15"
+
+    def test_date_to_str_none(self):
+        assert _date_to_str(None) is None
+
+    def test_str_to_date(self):
+        assert _str_to_date("2024-01-15") == date(2024, 1, 15)
+
+    def test_str_to_date_none(self):
+        assert _str_to_date(None) is None
+
+    def test_str_to_date_invalid(self):
+        assert _str_to_date("not-a-date") is None
+
+
+class TestSerialization:
+    def _make_result(self):
+        return NLRBFetchResult(
+            source="test",
+            cases=[
+                NLRBCaseRecord(
+                    case_number="05-RC-100001",
+                    case_type="RC",
+                    case_name="Test Corp",
+                    status="Open",
+                    date_filed=date(2024, 1, 15),
+                    region=5,
+                    city="Chicago",
+                    state="IL",
+                    naics_code="622110",
+                    employee_count=150,
+                    source="labordata",
+                ),
+            ],
+            elections=[
+                ElectionRecord(
+                    case_number="05-RC-100001",
+                    tally_date=date(2024, 3, 1),
+                    eligible_voters=200,
+                    votes_for=120,
+                    votes_against=75,
+                    union_name="SEIU",
+                    source="labordata",
+                ),
+            ],
+            ulp_charges=[
+                ULPRecord(
+                    case_number="01-CA-200001",
+                    allegation="8(a)(1) interference",
+                    section_of_act="8(a)(1)",
+                    date_filed=date(2024, 5, 1),
+                    source="labordata",
+                ),
+            ],
+        )
+
+    def test_roundtrip(self):
+        original = self._make_result()
+        data = _result_to_dict(original)
+        restored = _dict_to_result(data)
+
+        assert len(restored.cases) == 1
+        assert restored.cases[0].case_number == "05-RC-100001"
+        assert restored.cases[0].date_filed == date(2024, 1, 15)
+        assert restored.cases[0].employee_count == 150
+
+        assert len(restored.elections) == 1
+        assert restored.elections[0].votes_for == 120
+
+        assert len(restored.ulp_charges) == 1
+        assert restored.ulp_charges[0].section_of_act == "8(a)(1)"
+
+    def test_dict_has_fetched_at(self):
+        result = self._make_result()
+        data = _result_to_dict(result)
+        assert "fetched_at" in data
+
+    def test_dict_is_json_serializable(self):
+        result = self._make_result()
+        data = _result_to_dict(result)
+        json_str = json.dumps(data)
+        assert len(json_str) > 0
+
+    def test_empty_result_roundtrip(self):
+        original = NLRBFetchResult(source="empty")
+        data = _result_to_dict(original)
+        restored = _dict_to_result(data)
+        assert restored.total_records == 0
+
+
+# ---------------------------------------------------------------------------
+# NLRBCache tests
+# ---------------------------------------------------------------------------
+
+
+class TestNLRBCache:
+    def test_get_missing_returns_none(self, tmp_path):
+        cache = NLRBCache(cache_dir=tmp_path, ttl_days=30)
+        assert cache.get("nonexistent") is None
+
+    def test_put_and_get(self, tmp_path):
+        cache = NLRBCache(cache_dir=tmp_path, ttl_days=30)
+        result = NLRBFetchResult(
+            source="test",
+            cases=[NLRBCaseRecord(case_number="1", case_type="RC")],
+        )
+        cache.put("test_key", result)
+        restored = cache.get("test_key")
+
+        assert restored is not None
+        assert len(restored.cases) == 1
+        assert restored.cases[0].case_number == "1"
+
+    def test_creates_cache_dir(self, tmp_path):
+        cache_dir = tmp_path / "nested" / "cache"
+        cache = NLRBCache(cache_dir=cache_dir, ttl_days=30)
+        result = NLRBFetchResult(source="test")
+        cache.put("key", result)
+        assert cache_dir.exists()
+
+    def test_expired_returns_none(self, tmp_path):
+        cache = NLRBCache(cache_dir=tmp_path, ttl_days=1)
+        result = NLRBFetchResult(source="test")
+
+        cache.put("key", result)
+
+        # Backdate the fetched_at timestamp
+        path = tmp_path / "key.json"
+        data = json.loads(path.read_text())
+        data["fetched_at"] = (datetime.now() - timedelta(days=5)).isoformat()
+        path.write_text(json.dumps(data))
+
+        assert cache.get("key") is None
+
+    def test_invalidate_existing(self, tmp_path):
+        cache = NLRBCache(cache_dir=tmp_path, ttl_days=30)
+        cache.put("key", NLRBFetchResult(source="test"))
+        assert cache.invalidate("key")
+        assert cache.get("key") is None
+
+    def test_invalidate_missing(self, tmp_path):
+        cache = NLRBCache(cache_dir=tmp_path, ttl_days=30)
+        assert not cache.invalidate("nonexistent")
+
+    def test_invalidate_all(self, tmp_path):
+        cache = NLRBCache(cache_dir=tmp_path, ttl_days=30)
+        cache.put("a", NLRBFetchResult(source="test"))
+        cache.put("b", NLRBFetchResult(source="test"))
+        count = cache.invalidate_all()
+        assert count == 2
+        assert cache.get("a") is None
+        assert cache.get("b") is None
+
+    def test_invalidate_all_empty(self, tmp_path):
+        cache = NLRBCache(cache_dir=tmp_path / "empty", ttl_days=30)
+        assert cache.invalidate_all() == 0
+
+    def test_corrupted_json_returns_none(self, tmp_path):
+        cache = NLRBCache(cache_dir=tmp_path, ttl_days=30)
+        path = tmp_path / "bad.json"
+        path.write_text("not valid json {{{")
+        assert cache.get("bad") is None
+
+
+# ---------------------------------------------------------------------------
+# NLRBLoader tests
+# ---------------------------------------------------------------------------
+
+
+class TestNLRBLoader:
+    def test_cache_hit(self, tmp_path):
+        cache = NLRBCache(cache_dir=tmp_path, ttl_days=30)
+        cache.put("unified", NLRBFetchResult(
+            source="cached",
+            cases=[NLRBCaseRecord(case_number="cached-1", case_type="RC")],
+        ))
+
+        client = MagicMock()
+        loader = NLRBLoader(cache=cache, client=client)
+        result = loader.load("unified")
+
+        assert len(result.cases) == 1
+        assert result.cases[0].case_number == "cached-1"
+        client.fetch_all.assert_not_called()
+
+    def test_cache_miss_fetches(self, tmp_path):
+        cache = NLRBCache(cache_dir=tmp_path, ttl_days=30)
+        client = MagicMock()
+        client.fetch_all.return_value = NLRBFetchResult(
+            source="fetched",
+            cases=[NLRBCaseRecord(case_number="fresh-1", case_type="RC")],
+        )
+
+        loader = NLRBLoader(cache=cache, client=client)
+        result = loader.load("unified")
+
+        assert result.cases[0].case_number == "fresh-1"
+        client.fetch_all.assert_called_once()
+        assert cache.get("unified") is not None
+
+    def test_force_refresh_skips_cache(self, tmp_path):
+        cache = NLRBCache(cache_dir=tmp_path, ttl_days=30)
+        cache.put("unified", NLRBFetchResult(
+            source="stale",
+            cases=[NLRBCaseRecord(case_number="stale-1", case_type="RC")],
+        ))
+
+        client = MagicMock()
+        client.fetch_all.return_value = NLRBFetchResult(
+            source="fresh",
+            cases=[NLRBCaseRecord(case_number="fresh-1", case_type="RC")],
+        )
+
+        loader = NLRBLoader(cache=cache, client=client)
+        result = loader.load("unified", force_refresh=True)
+
+        assert result.cases[0].case_number == "fresh-1"
+        client.fetch_all.assert_called_once()
+
+    def test_failed_fetch_not_cached(self, tmp_path):
+        cache = NLRBCache(cache_dir=tmp_path, ttl_days=30)
+        client = MagicMock()
+        client.fetch_all.return_value = NLRBFetchResult(
+            source="failed",
+            errors=["network error"],
+        )
+
+        loader = NLRBLoader(cache=cache, client=client)
+        result = loader.load("unified")
+
+        assert not result.success
+        assert cache.get("unified") is None

--- a/tests/test_nlrb_clients.py
+++ b/tests/test_nlrb_clients.py
@@ -1,0 +1,663 @@
+"""Tests for NLRB data source clients (SU#617)."""
+
+from __future__ import annotations
+
+import csv
+import io
+import textwrap
+import xml.etree.ElementTree as ET
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from siege_utilities.geo.providers.nlrb_clients import (
+    CaseStatus,
+    CaseType,
+    ElectionRecord,
+    NLRBCaseRecord,
+    NLRBDataClient,
+    NLRBDatagovClient,
+    NLRBFetchResult,
+    NLRBLabordataClient,
+    NLRBNxGenClient,
+    ULPRecord,
+    _extract_region,
+    _parse_date,
+    _safe_int,
+)
+
+
+def _mock_session():
+    return MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# Record dataclass tests
+# ---------------------------------------------------------------------------
+
+
+class TestNLRBCaseRecord:
+    def test_minimal_construction(self):
+        rec = NLRBCaseRecord(case_number="05-RC-123456", case_type="RC")
+        assert rec.case_number == "05-RC-123456"
+        assert rec.case_type == "RC"
+        assert rec.status == CaseStatus.UNKNOWN.value
+
+    def test_full_construction(self):
+        rec = NLRBCaseRecord(
+            case_number="05-RC-123456",
+            case_type="RC",
+            case_name="ACME Corp",
+            status="Open",
+            date_filed=date(2024, 1, 15),
+            date_closed=None,
+            region=5,
+            city="Chicago",
+            state="IL",
+            union_name="SEIU",
+            unit_description="Warehouse workers",
+            naics_code="493110",
+            employee_count=150,
+            source="labordata",
+        )
+        assert rec.city == "Chicago"
+        assert rec.employee_count == 150
+
+    def test_to_dict(self):
+        rec = NLRBCaseRecord(case_number="01-CA-999", case_type="CA")
+        d = rec.to_dict()
+        assert isinstance(d, dict)
+        assert d["case_number"] == "01-CA-999"
+        assert "source" in d
+
+
+class TestElectionRecord:
+    def test_construction_and_dict(self):
+        rec = ElectionRecord(
+            case_number="05-RC-123456",
+            tally_date=date(2024, 3, 1),
+            eligible_voters=200,
+            votes_for=120,
+            votes_against=75,
+            union_name="UAW",
+        )
+        assert rec.votes_for == 120
+        d = rec.to_dict()
+        assert d["eligible_voters"] == 200
+
+
+class TestULPRecord:
+    def test_construction_and_dict(self):
+        rec = ULPRecord(
+            case_number="01-CA-888",
+            allegation="8(a)(1) interference",
+            charging_party="Local 123",
+            charged_party="ACME Corp",
+            section_of_act="8(a)(1)",
+        )
+        assert rec.section_of_act == "8(a)(1)"
+        d = rec.to_dict()
+        assert d["charging_party"] == "Local 123"
+
+
+class TestNLRBFetchResult:
+    def test_empty_is_success(self):
+        r = NLRBFetchResult()
+        assert r.success
+        assert r.total_records == 0
+
+    def test_with_errors(self):
+        r = NLRBFetchResult(errors=["something failed"])
+        assert not r.success
+
+    def test_total_records(self):
+        r = NLRBFetchResult(
+            cases=[NLRBCaseRecord(case_number="1", case_type="RC")],
+            elections=[ElectionRecord(case_number="1")],
+            ulp_charges=[ULPRecord(case_number="2"), ULPRecord(case_number="3")],
+        )
+        assert r.total_records == 4
+
+
+# ---------------------------------------------------------------------------
+# Enum tests
+# ---------------------------------------------------------------------------
+
+
+class TestCaseType:
+    def test_representation(self):
+        assert CaseType.R.value == "R"
+        assert CaseType.RC.value == "RC"
+
+    def test_ulp_types(self):
+        assert CaseType.C.value == "C"
+        assert CaseType.CA.value == "CA"
+        assert CaseType.CB.value == "CB"
+
+
+# ---------------------------------------------------------------------------
+# Helper function tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseDate:
+    def test_iso_format(self):
+        assert _parse_date("2024-01-15") == date(2024, 1, 15)
+
+    def test_us_format(self):
+        assert _parse_date("01/15/2024") == date(2024, 1, 15)
+
+    def test_us_dash_format(self):
+        assert _parse_date("01-15-2024") == date(2024, 1, 15)
+
+    def test_iso_datetime(self):
+        assert _parse_date("2024-01-15T10:30:00") == date(2024, 1, 15)
+
+    def test_none_input(self):
+        assert _parse_date(None) is None
+
+    def test_empty_string(self):
+        assert _parse_date("") is None
+
+    def test_whitespace(self):
+        assert _parse_date("  ") is None
+
+    def test_invalid_format(self):
+        assert _parse_date("not-a-date") is None
+
+
+class TestSafeInt:
+    def test_int(self):
+        assert _safe_int(42) == 42
+
+    def test_string_int(self):
+        assert _safe_int("42") == 42
+
+    def test_float_string(self):
+        assert _safe_int("42.7") == 42
+
+    def test_none(self):
+        assert _safe_int(None) is None
+
+    def test_invalid(self):
+        assert _safe_int("abc") is None
+
+    def test_empty(self):
+        assert _safe_int("") is None
+
+
+class TestExtractRegion:
+    def test_standard_format(self):
+        assert _extract_region("05-RC-123456") == 5
+
+    def test_two_digit_region(self):
+        assert _extract_region("28-CA-999999") == 28
+
+    def test_empty(self):
+        assert _extract_region("") is None
+
+    def test_none(self):
+        assert _extract_region(None) is None
+
+    def test_no_dash(self):
+        assert _extract_region("ABC") is None
+
+
+# ---------------------------------------------------------------------------
+# data.gov client tests
+# ---------------------------------------------------------------------------
+
+
+class TestNLRBDatagovClient:
+    def _make_xml(self, cases: list[dict]) -> str:
+        root = ET.Element("cases")
+        for c in cases:
+            el = ET.SubElement(root, "case")
+            for k, v in c.items():
+                child = ET.SubElement(el, k)
+                child.text = str(v)
+        return ET.tostring(root, encoding="unicode")
+
+    def test_parse_single_case(self):
+        xml = self._make_xml([{
+            "caseNumber": "05-RC-100001",
+            "caseType": "RC",
+            "caseName": "Acme Corp",
+            "status": "Closed",
+            "dateFiled": "2024-01-10",
+            "dateClosed": "2024-06-15",
+            "city": "Chicago",
+            "state": "IL",
+        }])
+        session = _mock_session()
+        session.get.return_value.text = xml
+        session.get.return_value.raise_for_status = MagicMock()
+        client = NLRBDatagovClient(session=session)
+
+        result = client.fetch_cases()
+
+        assert result.success
+        assert len(result.cases) == 1
+        case = result.cases[0]
+        assert case.case_number == "05-RC-100001"
+        assert case.region == 5
+        assert case.date_filed == date(2024, 1, 10)
+        assert case.source == "datagov"
+
+    def test_empty_xml(self):
+        xml = "<cases></cases>"
+        session = _mock_session()
+        session.get.return_value.text = xml
+        session.get.return_value.raise_for_status = MagicMock()
+        client = NLRBDatagovClient(session=session)
+
+        result = client.fetch_cases()
+
+        assert result.success
+        assert len(result.cases) == 0
+
+    def test_http_error(self):
+        session = _mock_session()
+        session.get.side_effect = ConnectionError("timeout")
+        client = NLRBDatagovClient(session=session)
+
+        result = client.fetch_cases()
+
+        assert not result.success
+        assert "HTTP error" in result.errors[0]
+
+    def test_malformed_xml(self):
+        session = _mock_session()
+        session.get.return_value.text = "not xml at all <<<"
+        session.get.return_value.raise_for_status = MagicMock()
+        client = NLRBDatagovClient(session=session)
+
+        result = client.fetch_cases()
+
+        assert not result.success
+        assert "XML parse error" in result.errors[0]
+
+    def test_skips_case_without_number(self):
+        xml = self._make_xml([{"caseType": "RC", "status": "Open"}])
+        session = _mock_session()
+        session.get.return_value.text = xml
+        session.get.return_value.raise_for_status = MagicMock()
+        client = NLRBDatagovClient(session=session)
+
+        result = client.fetch_cases()
+
+        assert result.success
+        assert len(result.cases) == 0
+
+    def test_alternate_field_names(self):
+        xml = self._make_xml([{
+            "case_number": "12-CA-555555",
+            "case_type": "CA",
+            "case_name": "Test Co",
+            "date_filed": "03/15/2024",
+            "labor_union": "IBEW",
+            "naics": "238210",
+            "num_employees": "45",
+        }])
+        session = _mock_session()
+        session.get.return_value.text = xml
+        session.get.return_value.raise_for_status = MagicMock()
+        client = NLRBDatagovClient(session=session)
+
+        result = client.fetch_cases()
+
+        assert len(result.cases) == 1
+        case = result.cases[0]
+        assert case.union_name == "IBEW"
+        assert case.naics_code == "238210"
+        assert case.employee_count == 45
+
+    def test_multiple_cases(self):
+        xml = self._make_xml([
+            {"caseNumber": "05-RC-100001", "caseType": "RC"},
+            {"caseNumber": "05-RC-100002", "caseType": "RC"},
+            {"caseNumber": "01-CA-200001", "caseType": "CA"},
+        ])
+        session = _mock_session()
+        session.get.return_value.text = xml
+        session.get.return_value.raise_for_status = MagicMock()
+        client = NLRBDatagovClient(session=session)
+
+        result = client.fetch_cases()
+        assert len(result.cases) == 3
+
+
+# ---------------------------------------------------------------------------
+# labordata client tests
+# ---------------------------------------------------------------------------
+
+
+class TestNLRBLabordataClient:
+    def _make_csv(self, rows: list[dict]) -> str:
+        if not rows:
+            return ""
+        output = io.StringIO()
+        writer = csv.DictWriter(output, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+        return output.getvalue()
+
+    def _make_session(self, file_contents: dict[str, str]):
+        """Create a mock session that returns different content per URL."""
+        session = _mock_session()
+
+        def side_effect(url, timeout=None):
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.text = ""
+            for key, content in file_contents.items():
+                if key in url:
+                    resp.text = content
+                    break
+            return resp
+
+        session.get.side_effect = side_effect
+        return session
+
+    def test_parse_cases(self):
+        csv_text = self._make_csv([{
+            "case_number": "05-RC-200001",
+            "case_type": "RC",
+            "case_name": "Test Corp",
+            "status": "Open",
+            "date_filed": "2024-02-01",
+            "city": "Austin",
+            "state": "TX",
+        }])
+        session = self._make_session({"cases.csv": csv_text})
+        client = NLRBLabordataClient(session=session)
+
+        result = client.fetch_cases()
+
+        assert result.success
+        assert len(result.cases) == 1
+        assert result.cases[0].city == "Austin"
+        assert result.source == "labordata"
+
+    def test_parse_elections(self):
+        cases_csv = self._make_csv([{
+            "case_number": "05-RC-200001",
+            "case_type": "RC",
+            "case_name": "Test",
+            "status": "Closed",
+        }])
+        elections_csv = self._make_csv([{
+            "case_number": "05-RC-200001",
+            "tally_date": "2024-04-01",
+            "eligible_voters": "100",
+            "votes_for": "60",
+            "votes_against": "35",
+            "union_name": "SEIU",
+        }])
+        session = self._make_session({
+            "cases.csv": cases_csv,
+            "elections.csv": elections_csv,
+        })
+        client = NLRBLabordataClient(session=session)
+
+        result = client.fetch_cases()
+
+        assert len(result.elections) == 1
+        assert result.elections[0].votes_for == 60
+        assert result.elections[0].eligible_voters == 100
+
+    def test_parse_ulp_charges(self):
+        charges_csv = self._make_csv([{
+            "case_number": "01-CA-300001",
+            "allegation": "8(a)(1) interference",
+            "charging_party": "Local 999",
+            "employer": "Bad Corp",
+            "nlra_section": "8(a)(1)",
+            "date_filed": "2024-05-01",
+        }])
+        session = self._make_session({"charges.csv": charges_csv})
+        client = NLRBLabordataClient(session=session)
+
+        result = client.fetch_cases()
+
+        assert len(result.ulp_charges) == 1
+        assert result.ulp_charges[0].charged_party == "Bad Corp"
+        assert result.ulp_charges[0].section_of_act == "8(a)(1)"
+
+    def test_handles_download_failure(self):
+        session = _mock_session()
+        session.get.side_effect = ConnectionError("network down")
+        client = NLRBLabordataClient(session=session)
+
+        result = client.fetch_cases()
+
+        assert not result.success
+
+    def test_skips_empty_case_number(self):
+        csv_text = self._make_csv([{
+            "case_number": "",
+            "case_type": "RC",
+        }])
+        session = self._make_session({"cases.csv": csv_text})
+        client = NLRBLabordataClient(session=session)
+
+        result = client.fetch_cases()
+
+        assert len(result.cases) == 0
+
+    def test_alternate_field_names(self):
+        csv_text = self._make_csv([{
+            "case_number": "07-RC-400001",
+            "case_type": "RC",
+            "labor_union": "UFCW",
+            "bargaining_unit": "Grocery workers",
+            "naics": "445110",
+            "num_employees": "85",
+        }])
+        session = self._make_session({"cases.csv": csv_text})
+        client = NLRBLabordataClient(session=session)
+
+        result = client.fetch_cases()
+
+        assert len(result.cases) == 1
+        case = result.cases[0]
+        assert case.union_name == "UFCW"
+        assert case.unit_description == "Grocery workers"
+        assert case.naics_code == "445110"
+        assert case.employee_count == 85
+
+
+# ---------------------------------------------------------------------------
+# NxGen client tests
+# ---------------------------------------------------------------------------
+
+
+class TestNLRBNxGenClient:
+    def test_http_error(self):
+        session = _mock_session()
+        session.get.side_effect = ConnectionError("blocked")
+        client = NLRBNxGenClient(session=session)
+
+        result = client.fetch_case("05-RC-000001")
+
+        assert not result.success
+        assert "NxGen HTTP error" in result.errors[0]
+
+    def test_empty_html_returns_empty(self):
+        session = _mock_session()
+        session.get.return_value.text = "<html><body>No results</body></html>"
+        session.get.return_value.raise_for_status = MagicMock()
+        client = NLRBNxGenClient(session=session)
+
+        result = client.fetch_case("05-RC-000001")
+
+        assert result.success
+        assert len(result.cases) == 0
+
+    def test_parses_table_rows(self):
+        html = textwrap.dedent("""\
+            <html><body><table>
+            <tr>
+                <td class="case-number">05-RC-111111</td>
+                <td class="case-name">Test Corp</td>
+                <td class="date-filed">2024-01-01</td>
+                <td class="status">Open</td>
+                <td class="city">Dallas</td>
+                <td class="state">TX</td>
+            </tr>
+            </table></body></html>
+        """)
+        session = _mock_session()
+        session.get.return_value.text = html
+        session.get.return_value.raise_for_status = MagicMock()
+        client = NLRBNxGenClient(session=session)
+
+        result = client.fetch_case("05-RC-111111")
+
+        assert len(result.cases) == 1
+        assert result.cases[0].case_number == "05-RC-111111"
+        assert result.cases[0].city == "Dallas"
+        assert result.cases[0].source == "nxgen"
+
+
+# ---------------------------------------------------------------------------
+# Unified facade tests
+# ---------------------------------------------------------------------------
+
+
+class TestNLRBDataClient:
+    def _mock_labordata_result(self):
+        return NLRBFetchResult(
+            source="labordata",
+            cases=[
+                NLRBCaseRecord(
+                    case_number="05-RC-100001",
+                    case_type="RC",
+                    city="Chicago",
+                    state="IL",
+                    source="labordata",
+                ),
+                NLRBCaseRecord(
+                    case_number="01-CA-200001",
+                    case_type="CA",
+                    source="labordata",
+                ),
+            ],
+            elections=[
+                ElectionRecord(
+                    case_number="05-RC-100001",
+                    tally_date=date(2024, 3, 1),
+                    votes_for=100,
+                    source="labordata",
+                ),
+            ],
+        )
+
+    def _mock_datagov_result(self):
+        return NLRBFetchResult(
+            source="datagov",
+            cases=[
+                NLRBCaseRecord(
+                    case_number="05-RC-100001",
+                    case_type="RC",
+                    city="Chicago",
+                    state="IL",
+                    source="datagov",
+                ),
+                NLRBCaseRecord(
+                    case_number="12-RC-300001",
+                    case_type="RC",
+                    source="datagov",
+                ),
+            ],
+        )
+
+    def test_deduplicates_by_case_number(self):
+        datagov = MagicMock(spec=NLRBDatagovClient)
+        labordata = MagicMock(spec=NLRBLabordataClient)
+
+        labordata.fetch_cases.return_value = self._mock_labordata_result()
+        datagov.fetch_cases.return_value = self._mock_datagov_result()
+
+        client = NLRBDataClient(
+            datagov_client=datagov,
+            labordata_client=labordata,
+        )
+        result = client.fetch_all()
+
+        assert len(result.cases) == 3
+        case_numbers = {c.case_number for c in result.cases}
+        assert case_numbers == {"05-RC-100001", "01-CA-200001", "12-RC-300001"}
+
+    def test_prefers_labordata(self):
+        datagov = MagicMock(spec=NLRBDatagovClient)
+        labordata = MagicMock(spec=NLRBLabordataClient)
+
+        labordata.fetch_cases.return_value = self._mock_labordata_result()
+        datagov.fetch_cases.return_value = self._mock_datagov_result()
+
+        client = NLRBDataClient(
+            datagov_client=datagov,
+            labordata_client=labordata,
+        )
+        result = client.fetch_all()
+
+        shared_case = next(c for c in result.cases if c.case_number == "05-RC-100001")
+        assert shared_case.source == "labordata"
+
+    def test_merges_elections(self):
+        datagov = MagicMock(spec=NLRBDatagovClient)
+        labordata = MagicMock(spec=NLRBLabordataClient)
+
+        labordata.fetch_cases.return_value = self._mock_labordata_result()
+        datagov.fetch_cases.return_value = self._mock_datagov_result()
+
+        client = NLRBDataClient(
+            datagov_client=datagov,
+            labordata_client=labordata,
+        )
+        result = client.fetch_all()
+        assert len(result.elections) == 1
+
+    def test_collects_errors(self):
+        datagov = MagicMock(spec=NLRBDatagovClient)
+        labordata = MagicMock(spec=NLRBLabordataClient)
+
+        labordata.fetch_cases.return_value = NLRBFetchResult(
+            source="labordata", errors=["lab error"]
+        )
+        datagov.fetch_cases.return_value = NLRBFetchResult(
+            source="datagov", errors=["gov error"]
+        )
+
+        client = NLRBDataClient(
+            datagov_client=datagov,
+            labordata_client=labordata,
+        )
+        result = client.fetch_all()
+        assert len(result.errors) == 2
+
+    def test_nxgen_disabled_by_default(self):
+        datagov = MagicMock(spec=NLRBDatagovClient)
+        labordata = MagicMock(spec=NLRBLabordataClient)
+        client = NLRBDataClient(
+            datagov_client=datagov,
+            labordata_client=labordata,
+        )
+        assert client._nxgen is None
+
+    def test_nxgen_enabled(self):
+        datagov = MagicMock(spec=NLRBDatagovClient)
+        labordata = MagicMock(spec=NLRBLabordataClient)
+        nxgen = MagicMock(spec=NLRBNxGenClient)
+        client = NLRBDataClient(
+            datagov_client=datagov,
+            labordata_client=labordata,
+            nxgen_client=nxgen,
+            use_nxgen=True,
+        )
+        assert client._nxgen is not None
+
+    def test_source_priority_order(self):
+        assert NLRBDataClient.SOURCE_PRIORITY == ("labordata", "datagov", "nxgen")

--- a/tests/test_nlrb_models.py
+++ b/tests/test_nlrb_models.py
@@ -1,0 +1,262 @@
+"""Tests for NLRB case data models and DataFrame export (SU#618)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+try:
+    from django.db import models as django_models  # noqa: F401
+
+    _DJANGO_AVAILABLE = True
+except Exception:
+    _DJANGO_AVAILABLE = False
+
+try:
+    import pandas as pd
+
+    _PANDAS_AVAILABLE = True
+except ImportError:
+    _PANDAS_AVAILABLE = False
+
+from siege_utilities.geo.providers.nlrb_clients import (
+    ElectionRecord,
+    NLRBCaseRecord,
+    NLRBFetchResult,
+    ULPRecord,
+)
+
+
+# ---------------------------------------------------------------------------
+# Django model tests (skip if Django not available)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _DJANGO_AVAILABLE, reason="Django not available")
+class TestNLRBCaseModel:
+    def test_import(self):
+        from siege_utilities.geo.django.models.nlrb_cases import NLRBCase
+
+        assert NLRBCase is not None
+
+    def test_has_case_number(self):
+        from siege_utilities.geo.django.models.nlrb_cases import NLRBCase
+
+        field = NLRBCase._meta.get_field("case_number")
+        assert field is not None
+        assert field.unique
+
+    def test_has_case_type(self):
+        from siege_utilities.geo.django.models.nlrb_cases import NLRBCase
+
+        field = NLRBCase._meta.get_field("case_type")
+        assert field is not None
+
+    def test_has_date_fields(self):
+        from siege_utilities.geo.django.models.nlrb_cases import NLRBCase
+
+        assert NLRBCase._meta.get_field("date_filed") is not None
+        assert NLRBCase._meta.get_field("date_closed") is not None
+
+    def test_has_region_fk(self):
+        from siege_utilities.geo.django.models.nlrb_cases import NLRBCase
+
+        field = NLRBCase._meta.get_field("region")
+        assert field.related_model.__name__ == "NLRBRegion"
+
+    def test_has_location_fields(self):
+        from siege_utilities.geo.django.models.nlrb_cases import NLRBCase
+
+        assert NLRBCase._meta.get_field("city") is not None
+        assert NLRBCase._meta.get_field("state") is not None
+
+    def test_has_naics_code(self):
+        from siege_utilities.geo.django.models.nlrb_cases import NLRBCase
+
+        field = NLRBCase._meta.get_field("naics_code")
+        assert field is not None
+
+    def test_str_representation(self):
+        from siege_utilities.geo.django.models.nlrb_cases import NLRBCase
+
+        case = NLRBCase(case_number="05-RC-123456", case_name="Test Corp")
+        assert "05-RC-123456" in str(case)
+        assert "Test Corp" in str(case)
+
+    def test_from_record(self):
+        from siege_utilities.geo.django.models.nlrb_cases import NLRBCase
+
+        record = NLRBCaseRecord(
+            case_number="05-RC-100001",
+            case_type="RC",
+            case_name="Acme Corp",
+            status="Open",
+            date_filed=date(2024, 1, 15),
+            region=5,
+            city="Chicago",
+            state="IL",
+            source="labordata",
+        )
+        instance = NLRBCase.from_record(record)
+        assert instance.case_number == "05-RC-100001"
+        assert instance.region_number == 5
+        assert instance.city == "Chicago"
+
+    def test_to_record(self):
+        from siege_utilities.geo.django.models.nlrb_cases import NLRBCase
+
+        instance = NLRBCase(
+            case_number="05-RC-100001",
+            case_type="RC",
+            case_name="Acme Corp",
+            region_number=5,
+            city="Chicago",
+            state="IL",
+        )
+        record = instance.to_record()
+        assert record.case_number == "05-RC-100001"
+        assert record.region == 5
+        assert record.city == "Chicago"
+
+
+@pytest.mark.skipif(not _DJANGO_AVAILABLE, reason="Django not available")
+class TestElectionResultModel:
+    def test_import(self):
+        from siege_utilities.geo.django.models.nlrb_cases import ElectionResult
+
+        assert ElectionResult is not None
+
+    def test_has_case_fk(self):
+        from siege_utilities.geo.django.models.nlrb_cases import ElectionResult
+
+        field = ElectionResult._meta.get_field("case")
+        assert field.related_model.__name__ == "NLRBCase"
+
+    def test_has_tally_fields(self):
+        from siege_utilities.geo.django.models.nlrb_cases import ElectionResult
+
+        assert ElectionResult._meta.get_field("tally_date") is not None
+        assert ElectionResult._meta.get_field("eligible_voters") is not None
+        assert ElectionResult._meta.get_field("votes_for") is not None
+        assert ElectionResult._meta.get_field("votes_against") is not None
+
+
+@pytest.mark.skipif(not _DJANGO_AVAILABLE, reason="Django not available")
+class TestULPChargeModel:
+    def test_import(self):
+        from siege_utilities.geo.django.models.nlrb_cases import ULPCharge
+
+        assert ULPCharge is not None
+
+    def test_has_case_fk(self):
+        from siege_utilities.geo.django.models.nlrb_cases import ULPCharge
+
+        field = ULPCharge._meta.get_field("case")
+        assert field.related_model.__name__ == "NLRBCase"
+
+    def test_has_allegation_fields(self):
+        from siege_utilities.geo.django.models.nlrb_cases import ULPCharge
+
+        assert ULPCharge._meta.get_field("allegation") is not None
+        assert ULPCharge._meta.get_field("section_of_act") is not None
+
+
+@pytest.mark.skipif(not _DJANGO_AVAILABLE, reason="Django not available")
+class TestBargainingUnitModel:
+    def test_import(self):
+        from siege_utilities.geo.django.models.nlrb_cases import BargainingUnit
+
+        assert BargainingUnit is not None
+
+    def test_has_case_fk(self):
+        from siege_utilities.geo.django.models.nlrb_cases import BargainingUnit
+
+        field = BargainingUnit._meta.get_field("case")
+        assert field.related_model.__name__ == "NLRBCase"
+
+    def test_has_naics_soc_fields(self):
+        from siege_utilities.geo.django.models.nlrb_cases import BargainingUnit
+
+        assert BargainingUnit._meta.get_field("naics_code") is not None
+        assert BargainingUnit._meta.get_field("soc_codes") is not None
+        assert BargainingUnit._meta.get_field("employee_count") is not None
+
+
+# ---------------------------------------------------------------------------
+# DataFrame export tests (skip if pandas not available)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _PANDAS_AVAILABLE, reason="pandas not available")
+class TestDataFrameExport:
+    def test_cases_to_dataframe(self):
+        from siege_utilities.geo.providers.nlrb_export import cases_to_dataframe
+
+        cases = [
+            NLRBCaseRecord(case_number="05-RC-1", case_type="RC", city="Chicago"),
+            NLRBCaseRecord(case_number="01-CA-2", case_type="CA", city="Boston"),
+        ]
+        df = cases_to_dataframe(cases)
+        assert len(df) == 2
+        assert "case_number" in df.columns
+        assert "city" in df.columns
+        assert df.iloc[0]["city"] == "Chicago"
+
+    def test_cases_from_fetch_result(self):
+        from siege_utilities.geo.providers.nlrb_export import cases_to_dataframe
+
+        result = NLRBFetchResult(
+            cases=[NLRBCaseRecord(case_number="05-RC-1", case_type="RC")]
+        )
+        df = cases_to_dataframe(result)
+        assert len(df) == 1
+
+    def test_elections_to_dataframe(self):
+        from siege_utilities.geo.providers.nlrb_export import elections_to_dataframe
+
+        elections = [
+            ElectionRecord(
+                case_number="05-RC-1",
+                tally_date=date(2024, 3, 1),
+                votes_for=100,
+                votes_against=50,
+            ),
+        ]
+        df = elections_to_dataframe(elections)
+        assert len(df) == 1
+        assert df.iloc[0]["votes_for"] == 100
+
+    def test_ulp_to_dataframe(self):
+        from siege_utilities.geo.providers.nlrb_export import ulp_charges_to_dataframe
+
+        charges = [
+            ULPRecord(
+                case_number="01-CA-1",
+                allegation="8(a)(1)",
+                section_of_act="8(a)(1)",
+            ),
+        ]
+        df = ulp_charges_to_dataframe(charges)
+        assert len(df) == 1
+        assert df.iloc[0]["section_of_act"] == "8(a)(1)"
+
+    def test_empty_returns_empty_dataframe(self):
+        from siege_utilities.geo.providers.nlrb_export import cases_to_dataframe
+
+        df = cases_to_dataframe([])
+        assert len(df) == 0
+
+    def test_fetch_result_to_dataframes(self):
+        from siege_utilities.geo.providers.nlrb_export import fetch_result_to_dataframes
+
+        result = NLRBFetchResult(
+            cases=[NLRBCaseRecord(case_number="05-RC-1", case_type="RC")],
+            elections=[ElectionRecord(case_number="05-RC-1")],
+            ulp_charges=[ULPRecord(case_number="01-CA-1")],
+        )
+        dfs = fetch_result_to_dataframes(result)
+        assert "cases" in dfs
+        assert "elections" in dfs
+        assert "ulp_charges" in dfs
+        assert len(dfs["cases"]) == 1

--- a/tests/test_nlrb_regions.py
+++ b/tests/test_nlrb_regions.py
@@ -1,0 +1,188 @@
+"""Tests for NLRB region boundary integration (SU#620)."""
+
+from __future__ import annotations
+
+import pytest
+
+from siege_utilities.geo.providers.nlrb_clients import NLRBCaseRecord
+from siege_utilities.geo.providers.nlrb_regions import (
+    NLRB_REGIONS,
+    STATE_TO_REGIONS,
+    aggregate_by_region,
+    assign_region,
+    lookup_region_by_state,
+    region_summary,
+)
+
+
+# ---------------------------------------------------------------------------
+# Region registry tests
+# ---------------------------------------------------------------------------
+
+
+class TestNLRBRegions:
+    def test_has_expected_regions(self):
+        assert len(NLRB_REGIONS) >= 26
+
+    def test_all_have_office(self):
+        for num, info in NLRB_REGIONS.items():
+            assert info["office"], f"Region {num} missing office"
+
+    def test_all_have_states(self):
+        for num, info in NLRB_REGIONS.items():
+            assert len(info["states"]) > 0, f"Region {num} has no states"
+
+    def test_region_numbers_in_range(self):
+        for num in NLRB_REGIONS:
+            assert 1 <= num <= 31
+
+    def test_known_region(self):
+        assert NLRB_REGIONS[13]["office"] == "Chicago"
+        assert "IL" in NLRB_REGIONS[13]["states"]
+
+
+# ---------------------------------------------------------------------------
+# State → Region lookup tests
+# ---------------------------------------------------------------------------
+
+
+class TestStateToRegions:
+    def test_single_region_state(self):
+        regions = lookup_region_by_state("FL")
+        assert 12 in regions
+
+    def test_multi_region_state(self):
+        regions = lookup_region_by_state("NY")
+        assert len(regions) > 1
+        assert 2 in regions
+        assert 3 in regions
+        assert 29 in regions
+
+    def test_case_insensitive(self):
+        assert lookup_region_by_state("il") == lookup_region_by_state("IL")
+
+    def test_unknown_state(self):
+        assert lookup_region_by_state("XX") == []
+
+    def test_whitespace_stripped(self):
+        assert lookup_region_by_state(" TX ") == lookup_region_by_state("TX")
+
+    def test_all_states_covered(self):
+        all_states = set()
+        for info in NLRB_REGIONS.values():
+            all_states.update(info["states"])
+        assert len(all_states) > 40
+
+
+# ---------------------------------------------------------------------------
+# assign_region tests
+# ---------------------------------------------------------------------------
+
+
+class TestAssignRegion:
+    def test_from_case_number_region(self):
+        case = NLRBCaseRecord(
+            case_number="05-RC-123456", case_type="RC", region=5
+        )
+        assert assign_region(case) == 5
+
+    def test_from_state_fallback(self):
+        case = NLRBCaseRecord(
+            case_number="test", case_type="RC", state="TX"
+        )
+        assert assign_region(case) == 16
+
+    def test_region_takes_priority(self):
+        case = NLRBCaseRecord(
+            case_number="test", case_type="RC", region=13, state="TX"
+        )
+        assert assign_region(case) == 13
+
+    def test_no_info_returns_none(self):
+        case = NLRBCaseRecord(
+            case_number="test", case_type="RC"
+        )
+        assert assign_region(case) is None
+
+    def test_works_with_dict(self):
+        d = {"region": 5, "state": "MD"}
+        assert assign_region(d) == 5
+
+    def test_dict_state_fallback(self):
+        d = {"state": "FL"}
+        assert assign_region(d) == 12
+
+    def test_dict_no_info(self):
+        d = {"case_number": "test"}
+        assert assign_region(d) is None
+
+
+# ---------------------------------------------------------------------------
+# aggregate_by_region tests
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateByRegion:
+    def test_groups_cases(self):
+        cases = [
+            NLRBCaseRecord(case_number="1", case_type="RC", region=5),
+            NLRBCaseRecord(case_number="2", case_type="CA", region=5),
+            NLRBCaseRecord(case_number="3", case_type="RC", region=13),
+        ]
+        groups = aggregate_by_region(cases)
+        assert len(groups[5]) == 2
+        assert len(groups[13]) == 1
+
+    def test_unknown_region_grouped_under_zero(self):
+        cases = [
+            NLRBCaseRecord(case_number="1", case_type="RC"),
+        ]
+        groups = aggregate_by_region(cases)
+        assert 0 in groups
+        assert len(groups[0]) == 1
+
+    def test_empty_input(self):
+        assert aggregate_by_region([]) == {}
+
+
+# ---------------------------------------------------------------------------
+# region_summary tests
+# ---------------------------------------------------------------------------
+
+
+class TestRegionSummary:
+    def test_basic_summary(self):
+        cases = [
+            NLRBCaseRecord(case_number="1", case_type="RC", region=5),
+            NLRBCaseRecord(case_number="2", case_type="CA", region=5),
+            NLRBCaseRecord(case_number="3", case_type="RC", region=13),
+        ]
+        summary = region_summary(cases)
+        assert len(summary) == 2
+
+        r5 = next(s for s in summary if s["region_number"] == 5)
+        assert r5["office"] == "Baltimore"
+        assert r5["case_count"] == 2
+
+        r13 = next(s for s in summary if s["region_number"] == 13)
+        assert r13["office"] == "Chicago"
+        assert r13["case_count"] == 1
+
+    def test_sorted_by_region(self):
+        cases = [
+            NLRBCaseRecord(case_number="1", case_type="RC", region=13),
+            NLRBCaseRecord(case_number="2", case_type="RC", region=5),
+        ]
+        summary = region_summary(cases)
+        assert summary[0]["region_number"] < summary[1]["region_number"]
+
+    def test_unknown_region_labeled(self):
+        cases = [
+            NLRBCaseRecord(case_number="1", case_type="RC"),
+        ]
+        summary = region_summary(cases)
+        assert summary[0]["office"] == "Unknown"
+        assert summary[0]["region_number"] == 0
+
+    def test_empty_input(self):
+        assert region_summary([]) == []

--- a/tests/test_nominatim_batch.py
+++ b/tests/test_nominatim_batch.py
@@ -1,0 +1,190 @@
+"""Tests for Nominatim batch geocoder backend (SU#624)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from siege_utilities.geo.providers.batch_geocoder import MatchQuality
+from siege_utilities.geo.providers.nominatim_batch import (
+    DEFAULT_RATE_LIMIT,
+    NominatimBatchGeocoder,
+    PUBLIC_NOMINATIM_URL,
+    SELF_HOSTED_RATE_LIMIT,
+)
+
+
+class TestNominatimBatchGeocoder:
+    def test_backend_name(self):
+        g = NominatimBatchGeocoder()
+        assert g.backend_name == "nominatim"
+
+    def test_default_rate_limit_public(self):
+        g = NominatimBatchGeocoder()
+        assert g._rate_limit == DEFAULT_RATE_LIMIT
+
+    def test_self_hosted_rate_limit(self):
+        g = NominatimBatchGeocoder(server_url="http://my-nominatim:8080")
+        assert g._rate_limit == SELF_HOSTED_RATE_LIMIT
+
+    def test_custom_rate_limit(self):
+        g = NominatimBatchGeocoder(rate_limit=0.5)
+        assert g._rate_limit == 0.5
+
+    def test_empty_input(self):
+        g = NominatimBatchGeocoder()
+        result = g.geocode([])
+        assert result.total == 0
+
+    @patch("siege_utilities.geo.providers.nominatim_batch.time.sleep")
+    @patch.object(NominatimBatchGeocoder, "_nominatim_request")
+    def test_geocode_single_match(self, mock_request, mock_sleep):
+        mock_request.return_value = (41.8781, -87.6298)
+        g = NominatimBatchGeocoder(rate_limit=0.0)
+        result = g.geocode(["123 Main St, Chicago, IL"])
+
+        assert result.total == 1
+        assert result.results[0].matched
+        assert result.results[0].lat == 41.8781
+        assert result.results[0].lon == -87.6298
+        assert result.results[0].backend == "nominatim"
+
+    @patch("siege_utilities.geo.providers.nominatim_batch.time.sleep")
+    @patch.object(NominatimBatchGeocoder, "_nominatim_request")
+    def test_geocode_no_match(self, mock_request, mock_sleep):
+        mock_request.return_value = None
+        g = NominatimBatchGeocoder(rate_limit=0.0)
+        result = g.geocode(["fake address nowhere"])
+
+        assert result.total == 1
+        assert not result.results[0].matched
+
+    @patch("siege_utilities.geo.providers.nominatim_batch.time.sleep")
+    @patch.object(NominatimBatchGeocoder, "_nominatim_request")
+    def test_geocode_multiple(self, mock_request, mock_sleep):
+        mock_request.side_effect = [
+            (41.8781, -87.6298),
+            None,
+            (42.3601, -71.0589),
+        ]
+        g = NominatimBatchGeocoder(rate_limit=0.0)
+        result = g.geocode(["addr1", "addr2", "addr3"])
+
+        assert result.total == 3
+        assert result.matched_count == 2
+
+    @patch("siege_utilities.geo.providers.nominatim_batch.time.sleep")
+    @patch.object(NominatimBatchGeocoder, "_nominatim_request")
+    def test_handles_exception(self, mock_request, mock_sleep):
+        mock_request.side_effect = Exception("network error")
+        g = NominatimBatchGeocoder(rate_limit=0.0)
+        result = g.geocode(["123 Main St"])
+
+        assert result.total == 1
+        assert not result.results[0].matched
+
+    @patch("siege_utilities.geo.providers.nominatim_batch.time.sleep")
+    @patch.object(NominatimBatchGeocoder, "_nominatim_request")
+    def test_match_quality_is_approximate(self, mock_request, mock_sleep):
+        mock_request.return_value = (41.0, -87.0)
+        g = NominatimBatchGeocoder(rate_limit=0.0)
+        result = g.geocode(["test"])
+        assert result.results[0].match_quality == MatchQuality.APPROXIMATE.value
+
+    @patch("siege_utilities.geo.providers.nominatim_batch.time.sleep")
+    @patch.object(NominatimBatchGeocoder, "_nominatim_request")
+    def test_no_block_geoid(self, mock_request, mock_sleep):
+        mock_request.return_value = (41.0, -87.0)
+        g = NominatimBatchGeocoder(rate_limit=0.0)
+        result = g.geocode(["test"])
+        assert result.results[0].block_geoid == ""
+
+    def test_default_country_codes(self):
+        g = NominatimBatchGeocoder()
+        assert g._country_codes == ["us"]
+
+    def test_is_available(self):
+        g = NominatimBatchGeocoder()
+        assert g.is_available()
+
+    def test_default_server_url(self):
+        g = NominatimBatchGeocoder()
+        assert g._server_url == PUBLIC_NOMINATIM_URL
+
+    def test_custom_server_url(self):
+        g = NominatimBatchGeocoder(server_url="http://local:8080")
+        assert g._server_url == "http://local:8080"
+
+    def test_custom_country_codes(self):
+        g = NominatimBatchGeocoder(country_codes=["de", "at"])
+        assert g._country_codes == ["de", "at"]
+
+    @patch("siege_utilities.geo.providers.nominatim_batch.time.sleep")
+    @patch.object(NominatimBatchGeocoder, "_nominatim_request")
+    def test_empty_query_returns_no_match(self, mock_request, mock_sleep):
+        g = NominatimBatchGeocoder(rate_limit=0.0)
+        result = g.geocode([{"street": "", "city": "", "state": "", "zipcode": ""}])
+        assert result.total == 1
+        assert not result.results[0].matched
+        mock_request.assert_not_called()
+
+
+class TestNominatimRequest:
+    """Tests for the low-level _nominatim_request method."""
+
+    @patch("siege_utilities.geo.providers.nominatim_batch.urllib.request.urlopen")
+    def test_successful_response(self, mock_urlopen):
+        import json
+        resp_data = json.dumps([{"lat": "41.8781", "lon": "-87.6298"}]).encode()
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = resp_data
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        g = NominatimBatchGeocoder(rate_limit=0.0)
+        result = g._nominatim_request("123 Main St, Chicago, IL")
+        assert result == (41.8781, -87.6298)
+
+    @patch("siege_utilities.geo.providers.nominatim_batch.urllib.request.urlopen")
+    def test_empty_response(self, mock_urlopen):
+        import json
+        resp_data = json.dumps([]).encode()
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = resp_data
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        g = NominatimBatchGeocoder(rate_limit=0.0)
+        result = g._nominatim_request("nonexistent place")
+        assert result is None
+
+    @patch("siege_utilities.geo.providers.nominatim_batch.time.sleep")
+    @patch("siege_utilities.geo.providers.nominatim_batch.urllib.request.urlopen")
+    def test_retries_on_failure(self, mock_urlopen, mock_sleep):
+        import json
+        resp_data = json.dumps([{"lat": "41.0", "lon": "-87.0"}]).encode()
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = resp_data
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        mock_urlopen.side_effect = [
+            Exception("timeout"),
+            mock_resp,
+        ]
+        g = NominatimBatchGeocoder(rate_limit=0.0, max_retries=2)
+        result = g._nominatim_request("test")
+        assert result == (41.0, -87.0)
+        assert mock_urlopen.call_count == 2
+
+    @patch("siege_utilities.geo.providers.nominatim_batch.time.sleep")
+    @patch("siege_utilities.geo.providers.nominatim_batch.urllib.request.urlopen")
+    def test_raises_after_max_retries(self, mock_urlopen, mock_sleep):
+        mock_urlopen.side_effect = Exception("persistent failure")
+        g = NominatimBatchGeocoder(rate_limit=0.0, max_retries=1)
+        with pytest.raises(Exception, match="persistent failure"):
+            g._nominatim_request("test")
+        assert mock_urlopen.call_count == 2

--- a/tests/test_overlay_registry.py
+++ b/tests/test_overlay_registry.py
@@ -1,0 +1,217 @@
+"""Tests for overlay registry (SU#608)."""
+
+from __future__ import annotations
+
+import pytest
+
+from siege_utilities.geo.overlay_registry import (
+    OverlayRegistry,
+    PlaceHistoryOverlay,
+    overlay_registry,
+)
+
+
+# ---------------------------------------------------------------------------
+# Concrete overlay for testing
+# ---------------------------------------------------------------------------
+
+
+class _TestOverlay(PlaceHistoryOverlay):
+    @property
+    def name(self):
+        return "test"
+
+    def fetch(self, geoid, from_year, to_year, state_fips=None):
+        return {"geoid": geoid, "years": (from_year, to_year)}
+
+
+class _UnavailableOverlay(PlaceHistoryOverlay):
+    @property
+    def name(self):
+        return "unavailable"
+
+    def fetch(self, geoid, from_year, to_year, state_fips=None):
+        raise RuntimeError("not available")
+
+    def is_available(self):
+        return False
+
+
+# ---------------------------------------------------------------------------
+# PlaceHistoryOverlay ABC
+# ---------------------------------------------------------------------------
+
+
+class TestPlaceHistoryOverlay:
+    def test_cannot_instantiate_abc(self):
+        with pytest.raises(TypeError):
+            PlaceHistoryOverlay()
+
+    def test_concrete_overlay(self):
+        o = _TestOverlay()
+        assert o.name == "test"
+        assert o.is_available()
+
+    def test_fetch_returns_data(self):
+        o = _TestOverlay()
+        result = o.fetch("17031", 2000, 2020)
+        assert result["geoid"] == "17031"
+
+    def test_is_available_override(self):
+        o = _UnavailableOverlay()
+        assert not o.is_available()
+
+
+# ---------------------------------------------------------------------------
+# OverlayRegistry
+# ---------------------------------------------------------------------------
+
+
+class TestOverlayRegistry:
+    def setup_method(self):
+        self.registry = OverlayRegistry()
+
+    def test_empty_registry(self):
+        assert self.registry.list_overlays() == []
+        assert self.registry.get("anything") is None
+
+    def test_register_instance(self):
+        o = _TestOverlay()
+        self.registry.register_instance("test", o)
+        assert self.registry.get("test") is o
+        assert self.registry.is_registered("test")
+
+    def test_register_instance_type_check(self):
+        with pytest.raises(TypeError, match="PlaceHistoryOverlay"):
+            self.registry.register_instance("bad", "not an overlay")
+
+    def test_decorator_registration(self):
+        @self.registry.register("decorated")
+        class DecoratedOverlay(PlaceHistoryOverlay):
+            @property
+            def name(self):
+                return "decorated"
+
+            def fetch(self, geoid, from_year, to_year, state_fips=None):
+                return "data"
+
+        assert self.registry.is_registered("decorated")
+        result = self.registry.get("decorated")
+        assert isinstance(result, DecoratedOverlay)
+
+    def test_decorator_type_check(self):
+        with pytest.raises(TypeError, match="PlaceHistoryOverlay"):
+            @self.registry.register("bad")
+            class NotAnOverlay:
+                pass
+
+    def test_lazy_instantiation(self):
+        instantiated = []
+
+        @self.registry.register("lazy")
+        class LazyOverlay(PlaceHistoryOverlay):
+            def __init__(self):
+                instantiated.append(True)
+
+            @property
+            def name(self):
+                return "lazy"
+
+            def fetch(self, geoid, from_year, to_year, state_fips=None):
+                return None
+
+        assert len(instantiated) == 0
+        self.registry.get("lazy")
+        assert len(instantiated) == 1
+        self.registry.get("lazy")
+        assert len(instantiated) == 1
+
+    def test_list_overlays(self):
+        self.registry.register_instance("b", _TestOverlay())
+        self.registry.register_instance("a", _TestOverlay())
+        assert self.registry.list_overlays() == ["a", "b"]
+
+    def test_list_includes_classes(self):
+        @self.registry.register("cls_only")
+        class Cls(PlaceHistoryOverlay):
+            @property
+            def name(self):
+                return "cls_only"
+
+            def fetch(self, geoid, from_year, to_year, state_fips=None):
+                return None
+
+        self.registry.register_instance("inst", _TestOverlay())
+        names = self.registry.list_overlays()
+        assert "cls_only" in names
+        assert "inst" in names
+
+    def test_unregister_instance(self):
+        self.registry.register_instance("test", _TestOverlay())
+        assert self.registry.unregister("test")
+        assert not self.registry.is_registered("test")
+        assert self.registry.get("test") is None
+
+    def test_unregister_class(self):
+        @self.registry.register("cls")
+        class Cls(PlaceHistoryOverlay):
+            @property
+            def name(self):
+                return "cls"
+
+            def fetch(self, geoid, from_year, to_year, state_fips=None):
+                return None
+
+        assert self.registry.unregister("cls")
+        assert not self.registry.is_registered("cls")
+
+    def test_unregister_nonexistent(self):
+        assert not self.registry.unregister("nope")
+
+    def test_clear(self):
+        self.registry.register_instance("a", _TestOverlay())
+        self.registry.register_instance("b", _TestOverlay())
+        self.registry.clear()
+        assert self.registry.list_overlays() == []
+
+    def test_get_unknown(self):
+        assert self.registry.get("unknown") is None
+
+    def test_instantiation_failure_returns_none(self):
+        @self.registry.register("broken")
+        class BrokenOverlay(PlaceHistoryOverlay):
+            def __init__(self):
+                raise RuntimeError("init failed")
+
+            @property
+            def name(self):
+                return "broken"
+
+            def fetch(self, geoid, from_year, to_year, state_fips=None):
+                return None
+
+        assert self.registry.get("broken") is None
+
+    def test_instance_overrides_class(self):
+        @self.registry.register("dup")
+        class DupOverlay(PlaceHistoryOverlay):
+            @property
+            def name(self):
+                return "dup"
+
+            def fetch(self, geoid, from_year, to_year, state_fips=None):
+                return "from_class"
+
+        instance = _TestOverlay()
+        self.registry.register_instance("dup", instance)
+        assert self.registry.get("dup") is instance
+
+
+# ---------------------------------------------------------------------------
+# Global registry
+# ---------------------------------------------------------------------------
+
+
+class TestGlobalRegistry:
+    def test_global_exists(self):
+        assert isinstance(overlay_registry, OverlayRegistry)

--- a/tests/test_place_history.py
+++ b/tests/test_place_history.py
@@ -1,0 +1,341 @@
+"""Tests for place history query API (SU#607)."""
+
+from __future__ import annotations
+
+import pytest
+
+from siege_utilities.geo.place_history import (
+    CrosswalkRecord,
+    DictCrosswalkProvider,
+    Lineage,
+    LineageStep,
+    PlaceHistoryResult,
+    _build_lineage,
+    _decade_transitions,
+    place_history,
+)
+
+
+# ---------------------------------------------------------------------------
+# Decade transitions
+# ---------------------------------------------------------------------------
+
+
+class TestDecadeTransitions:
+    def test_same_year(self):
+        assert _decade_transitions(2010, 2010) == []
+
+    def test_same_decade(self):
+        assert _decade_transitions(2012, 2018) == []
+
+    def test_single_forward(self):
+        assert _decade_transitions(2005, 2015) == [(2000, 2010)]
+
+    def test_single_forward_exact_decades(self):
+        assert _decade_transitions(2000, 2010) == [(2000, 2010)]
+
+    def test_two_decades_forward(self):
+        assert _decade_transitions(2000, 2020) == [(2000, 2010), (2010, 2020)]
+
+    def test_three_decades_forward(self):
+        result = _decade_transitions(1995, 2025)
+        assert result == [(1990, 2000), (2000, 2010), (2010, 2020)]
+
+    def test_single_reverse(self):
+        result = _decade_transitions(2015, 2005)
+        assert result == [(2010, 2000)]
+
+    def test_two_decades_reverse(self):
+        result = _decade_transitions(2020, 2000)
+        assert result == [(2020, 2010), (2010, 2000)]
+
+
+# ---------------------------------------------------------------------------
+# LineageStep / Lineage dataclasses
+# ---------------------------------------------------------------------------
+
+
+class TestLineageDataclasses:
+    def test_lineage_step_defaults(self):
+        step = LineageStep(
+            source_geoid="A", target_geoid="B",
+            source_year=2000, target_year=2010,
+        )
+        assert step.weight == 1.0
+        assert step.relationship == "IDENTICAL"
+
+    def test_lineage_is_unchanged_true(self):
+        lin = Lineage(
+            origin_geoid="17031010100",
+            origin_year=2000,
+            terminal_geoids=["17031010100"],
+        )
+        assert lin.is_unchanged
+
+    def test_lineage_is_unchanged_false_different(self):
+        lin = Lineage(
+            origin_geoid="17031010100",
+            origin_year=2000,
+            terminal_geoids=["17031010200"],
+        )
+        assert not lin.is_unchanged
+
+    def test_lineage_is_unchanged_false_split(self):
+        lin = Lineage(
+            origin_geoid="17031010100",
+            origin_year=2000,
+            terminal_geoids=["17031010100", "17031010200"],
+        )
+        assert not lin.is_unchanged
+
+
+# ---------------------------------------------------------------------------
+# PlaceHistoryResult
+# ---------------------------------------------------------------------------
+
+
+class TestPlaceHistoryResult:
+    def test_direction_forward(self):
+        r = PlaceHistoryResult(geoid="A", from_year=2000, to_year=2020)
+        assert r.direction == "forward"
+
+    def test_direction_reverse(self):
+        r = PlaceHistoryResult(geoid="A", from_year=2020, to_year=2000)
+        assert r.direction == "reverse"
+
+    def test_has_lineage_false(self):
+        r = PlaceHistoryResult(geoid="A", from_year=2000, to_year=2020)
+        assert not r.has_lineage
+
+    def test_has_lineage_true(self):
+        r = PlaceHistoryResult(
+            geoid="A", from_year=2000, to_year=2020,
+            lineage=Lineage(
+                origin_geoid="A", origin_year=2000,
+                steps=[LineageStep("A", "B", 2000, 2010)],
+            ),
+        )
+        assert r.has_lineage
+
+
+# ---------------------------------------------------------------------------
+# DictCrosswalkProvider
+# ---------------------------------------------------------------------------
+
+
+class TestDictCrosswalkProvider:
+    def test_empty_provider(self):
+        p = DictCrosswalkProvider()
+        assert p.get_forward_mappings("A", 2000, 2010) == []
+
+    def test_add_and_get_forward(self):
+        p = DictCrosswalkProvider()
+        p.add(2000, 2010, "A", "B", weight=0.8, relationship="PARTIAL")
+        records = p.get_forward_mappings("A", 2000, 2010)
+        assert len(records) == 1
+        assert records[0].target_geoid == "B"
+        assert records[0].weight == 0.8
+
+    def test_get_reverse(self):
+        p = DictCrosswalkProvider()
+        p.add(2000, 2010, "A", "B")
+        records = p.get_reverse_mappings("B", 2000, 2010)
+        assert len(records) == 1
+        assert records[0].source_geoid == "A"
+
+    def test_split(self):
+        p = DictCrosswalkProvider()
+        p.add(2000, 2010, "A", "B1", weight=0.6, relationship="SPLIT")
+        p.add(2000, 2010, "A", "B2", weight=0.4, relationship="SPLIT")
+        records = p.get_forward_mappings("A", 2000, 2010)
+        assert len(records) == 2
+
+    def test_wrong_transition(self):
+        p = DictCrosswalkProvider()
+        p.add(2000, 2010, "A", "B")
+        assert p.get_forward_mappings("A", 2010, 2020) == []
+
+
+# ---------------------------------------------------------------------------
+# Lineage building
+# ---------------------------------------------------------------------------
+
+
+class TestBuildLineage:
+    def test_same_decade_no_steps(self):
+        p = DictCrosswalkProvider()
+        lin = _build_lineage("A", 2005, 2008, p)
+        assert lin.terminal_geoids == ["A"]
+        assert len(lin.steps) == 0
+
+    def test_identical_transition(self):
+        p = DictCrosswalkProvider()
+        p.add(2000, 2010, "A", "A", weight=1.0, relationship="IDENTICAL")
+        lin = _build_lineage("A", 2000, 2015, p)
+        assert lin.terminal_geoids == ["A"]
+        assert len(lin.steps) == 1
+        assert lin.steps[0].relationship == "IDENTICAL"
+
+    def test_renamed(self):
+        p = DictCrosswalkProvider()
+        p.add(2000, 2010, "A", "B", weight=1.0, relationship="RENAMED")
+        lin = _build_lineage("A", 2000, 2015, p)
+        assert lin.terminal_geoids == ["B"]
+
+    def test_split(self):
+        p = DictCrosswalkProvider()
+        p.add(2000, 2010, "A", "B1", weight=0.6, relationship="SPLIT")
+        p.add(2000, 2010, "A", "B2", weight=0.4, relationship="SPLIT")
+        lin = _build_lineage("A", 2000, 2015, p)
+        assert set(lin.terminal_geoids) == {"B1", "B2"}
+        assert len(lin.steps) == 2
+
+    def test_multi_decade_chain(self):
+        p = DictCrosswalkProvider()
+        p.add(2000, 2010, "A", "B", weight=1.0, relationship="RENAMED")
+        p.add(2010, 2020, "B", "C", weight=1.0, relationship="RENAMED")
+        lin = _build_lineage("A", 2000, 2025, p)
+        assert lin.terminal_geoids == ["C"]
+        assert len(lin.steps) == 2
+
+    def test_no_crosswalk_data_preserves_geoid(self):
+        p = DictCrosswalkProvider()
+        lin = _build_lineage("A", 2000, 2015, p)
+        assert lin.terminal_geoids == ["A"]
+
+    def test_min_weight_filter(self):
+        p = DictCrosswalkProvider()
+        p.add(2000, 2010, "A", "B1", weight=0.005, relationship="SPLIT")
+        p.add(2000, 2010, "A", "B2", weight=0.995, relationship="SPLIT")
+        lin = _build_lineage("A", 2000, 2015, p, min_weight=0.01)
+        assert lin.terminal_geoids == ["B2"]
+
+    def test_reverse_direction(self):
+        p = DictCrosswalkProvider()
+        p.add(2000, 2010, "A", "B", weight=1.0, relationship="RENAMED")
+        lin = _build_lineage("B", 2015, 2005, p)
+        assert lin.direction == "reverse"
+        assert lin.terminal_geoids == ["A"]
+
+    def test_forward_direction_flag(self):
+        p = DictCrosswalkProvider()
+        lin = _build_lineage("A", 2005, 2015, p)
+        assert lin.direction == "forward"
+
+
+# ---------------------------------------------------------------------------
+# place_history() integration
+# ---------------------------------------------------------------------------
+
+
+class TestPlaceHistory:
+    def test_basic_query(self):
+        p = DictCrosswalkProvider()
+        p.add(2000, 2010, "17031010100", "17031010100", weight=1.0)
+        result = place_history("17031010100", 2000, 2015, provider=p)
+
+        assert result.geoid == "17031010100"
+        assert result.from_year == 2000
+        assert result.to_year == 2015
+        assert result.has_lineage
+        assert result.lineage.terminal_geoids == ["17031010100"]
+        assert len(result.errors) == 0
+
+    def test_no_provider_returns_error(self):
+        result = place_history("A", 2000, 2020, provider=None)
+        assert len(result.errors) >= 1
+
+    def test_with_split(self):
+        p = DictCrosswalkProvider()
+        p.add(2010, 2020, "T1", "T1a", weight=0.6, relationship="SPLIT")
+        p.add(2010, 2020, "T1", "T1b", weight=0.4, relationship="SPLIT")
+        result = place_history("T1", 2010, 2025, provider=p)
+
+        assert set(result.lineage.terminal_geoids) == {"T1a", "T1b"}
+
+    def test_overlays_without_registry(self):
+        p = DictCrosswalkProvider()
+        result = place_history("A", 2000, 2020, overlays=["seats"], provider=p)
+        assert result.overlays == {}
+
+    def test_overlays_with_registry(self):
+        p = DictCrosswalkProvider()
+
+        class MockOverlay:
+            def fetch(self, geoid, from_year, to_year, state_fips):
+                return {"districts": ["CD-1"]}
+
+        class MockRegistry:
+            def get(self, name):
+                if name == "seats":
+                    return MockOverlay()
+                return None
+
+        result = place_history(
+            "A", 2000, 2020,
+            overlays=["seats"],
+            provider=p,
+            overlay_registry=MockRegistry(),
+        )
+        assert "seats" in result.overlays
+        assert result.overlays["seats"]["districts"] == ["CD-1"]
+
+    def test_unknown_overlay_reports_error(self):
+        p = DictCrosswalkProvider()
+
+        class MockRegistry:
+            def get(self, name):
+                return None
+
+        result = place_history(
+            "A", 2000, 2020,
+            overlays=["unknown"],
+            provider=p,
+            overlay_registry=MockRegistry(),
+        )
+        assert any("Unknown overlay" in e for e in result.errors)
+
+    def test_overlay_exception_handled(self):
+        p = DictCrosswalkProvider()
+
+        class FailingOverlay:
+            def fetch(self, geoid, from_year, to_year, state_fips):
+                raise RuntimeError("DB down")
+
+        class MockRegistry:
+            def get(self, name):
+                return FailingOverlay()
+
+        result = place_history(
+            "A", 2000, 2020,
+            overlays=["broken"],
+            provider=p,
+            overlay_registry=MockRegistry(),
+        )
+        assert any("broken" in e for e in result.errors)
+
+    def test_same_decade_no_lineage_steps(self):
+        p = DictCrosswalkProvider()
+        result = place_history("A", 2012, 2018, provider=p)
+        assert not result.has_lineage
+        assert result.lineage.terminal_geoids == ["A"]
+
+    def test_reverse_query(self):
+        p = DictCrosswalkProvider()
+        p.add(2010, 2020, "X", "Y", weight=1.0, relationship="RENAMED")
+        result = place_history("Y", 2025, 2005, provider=p)
+
+        assert result.direction == "reverse"
+        assert result.lineage.terminal_geoids == ["X"]
+
+    def test_state_fips_passed_through(self):
+        calls = []
+
+        class TrackingProvider(DictCrosswalkProvider):
+            def get_forward_mappings(self, geoid, src, tgt, state_fips=None):
+                calls.append(state_fips)
+                return super().get_forward_mappings(geoid, src, tgt, state_fips)
+
+        p = TrackingProvider()
+        place_history("A", 2000, 2015, state_fips="17", provider=p)
+        assert "17" in calls

--- a/tests/test_plan_lifecycle.py
+++ b/tests/test_plan_lifecycle.py
@@ -1,0 +1,289 @@
+"""Tests for plan lifecycle tracking (SU#634)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from siege_utilities.geo.plan_lifecycle import (
+    DictPlanLifecycleProvider,
+    EnactedBy,
+    PlanLifecycleEvent,
+    PlanLifecycleStatus,
+    PlanLineage,
+    PlanType,
+    RedistrictingPlan,
+    build_lineage,
+    resolve_plan_at,
+)
+
+
+def _event(status, dt, **kw):
+    return PlanLifecycleEvent(
+        status=status,
+        effective_date=date.fromisoformat(dt) if isinstance(dt, str) else dt,
+        **kw,
+    )
+
+
+def _plan(plan_id="P1", state="TX", plan_type=PlanType.CONGRESSIONAL,
+          events=None, enacted_date=None, **kw):
+    return RedistrictingPlan(
+        plan_id=plan_id,
+        state=state,
+        plan_type=plan_type,
+        events=events or [],
+        enacted_date=date.fromisoformat(enacted_date) if isinstance(enacted_date, str) else enacted_date,
+        **kw,
+    )
+
+
+class TestPlanLifecycleStatus:
+    def test_values(self):
+        assert PlanLifecycleStatus.PROPOSED.value == "proposed"
+        assert PlanLifecycleStatus.ENACTED.value == "enacted"
+        assert PlanLifecycleStatus.STRUCK.value == "struck"
+
+    def test_string_enum(self):
+        assert PlanLifecycleStatus("enacted") == PlanLifecycleStatus.ENACTED
+
+
+class TestPlanLifecycleEvent:
+    def test_defaults(self):
+        e = PlanLifecycleEvent()
+        assert e.status == PlanLifecycleStatus.PROPOSED
+        assert e.effective_date is None
+
+    def test_fields(self):
+        e = _event(PlanLifecycleStatus.ENACTED, "2022-01-01", source="legislation")
+        assert e.effective_date == date(2022, 1, 1)
+        assert e.source == "legislation"
+
+
+class TestRedistrictingPlan:
+    def test_defaults(self):
+        p = RedistrictingPlan()
+        assert p.current_status is None
+        assert not p.is_terminal
+        assert not p.is_active
+
+    def test_current_status(self):
+        p = _plan(events=[
+            _event(PlanLifecycleStatus.PROPOSED, "2021-01-01"),
+            _event(PlanLifecycleStatus.ENACTED, "2022-01-01"),
+        ])
+        assert p.current_status == PlanLifecycleStatus.ENACTED
+
+    def test_latest_event_by_date(self):
+        e1 = _event(PlanLifecycleStatus.PROPOSED, "2021-06-01")
+        e2 = _event(PlanLifecycleStatus.ENACTED, "2022-01-01")
+        p = _plan(events=[e2, e1])  # out of order
+        assert p.latest_event.status == PlanLifecycleStatus.ENACTED
+
+    def test_is_terminal(self):
+        p = _plan(events=[_event(PlanLifecycleStatus.STRUCK, "2023-01-01")])
+        assert p.is_terminal
+
+    def test_is_active(self):
+        p = _plan(events=[_event(PlanLifecycleStatus.ENACTED, "2022-01-01")])
+        assert p.is_active
+
+    def test_challenged_is_active(self):
+        p = _plan(events=[
+            _event(PlanLifecycleStatus.ENACTED, "2022-01-01"),
+            _event(PlanLifecycleStatus.CHALLENGED, "2023-03-01"),
+        ])
+        assert p.is_active
+
+    def test_superseded_is_terminal(self):
+        p = _plan(events=[_event(PlanLifecycleStatus.SUPERSEDED, "2024-01-01")])
+        assert p.is_terminal
+
+    def test_status_at(self):
+        p = _plan(events=[
+            _event(PlanLifecycleStatus.PROPOSED, "2021-01-01"),
+            _event(PlanLifecycleStatus.ENACTED, "2022-01-01"),
+            _event(PlanLifecycleStatus.CHALLENGED, "2023-06-01"),
+        ])
+        assert p.status_at(date(2021, 6, 1)) == PlanLifecycleStatus.PROPOSED
+        assert p.status_at(date(2022, 6, 1)) == PlanLifecycleStatus.ENACTED
+        assert p.status_at(date(2023, 12, 1)) == PlanLifecycleStatus.CHALLENGED
+
+    def test_status_at_before_any_event(self):
+        p = _plan(events=[_event(PlanLifecycleStatus.PROPOSED, "2021-06-01")])
+        assert p.status_at(date(2020, 1, 1)) is None
+
+    def test_was_active_at(self):
+        p = _plan(events=[
+            _event(PlanLifecycleStatus.ENACTED, "2022-01-01"),
+            _event(PlanLifecycleStatus.STRUCK, "2024-01-01"),
+        ])
+        assert p.was_active_at(date(2023, 1, 1))
+        assert not p.was_active_at(date(2024, 6, 1))
+        assert not p.was_active_at(date(2021, 1, 1))
+
+    def test_to_dict(self):
+        p = _plan(
+            plan_id="TX-CD-2022",
+            state="TX",
+            enacted_date="2021-10-25",
+            events=[_event(PlanLifecycleStatus.ENACTED, "2022-01-01")],
+        )
+        d = p.to_dict()
+        assert d["plan_id"] == "TX-CD-2022"
+        assert d["enacted_date"] == "2021-10-25"
+        assert d["current_status"] == "enacted"
+        assert len(d["events"]) == 1
+
+    def test_to_dict_no_events(self):
+        d = RedistrictingPlan().to_dict()
+        assert d["current_status"] is None
+        assert d["events"] == []
+
+    def test_supersedes_id(self):
+        p = _plan(supersedes_id="OLD-PLAN")
+        assert p.supersedes_id == "OLD-PLAN"
+
+
+class TestPlanLineage:
+    def test_empty(self):
+        lin = PlanLineage()
+        assert lin.current_plan is None
+        assert lin.plan_at(date(2023, 1, 1)) is None
+
+    def test_current_plan(self):
+        p1 = _plan(plan_id="P1", events=[
+            _event(PlanLifecycleStatus.ENACTED, "2012-01-01"),
+            _event(PlanLifecycleStatus.SUPERSEDED, "2022-01-01"),
+        ])
+        p2 = _plan(plan_id="P2", events=[
+            _event(PlanLifecycleStatus.ENACTED, "2022-01-01"),
+        ])
+        lin = PlanLineage(plans=[p1, p2])
+        assert lin.current_plan.plan_id == "P2"
+
+    def test_plan_at(self):
+        p1 = _plan(plan_id="P1", events=[
+            _event(PlanLifecycleStatus.ENACTED, "2012-01-01"),
+            _event(PlanLifecycleStatus.SUPERSEDED, "2022-01-01"),
+        ])
+        p2 = _plan(plan_id="P2", events=[
+            _event(PlanLifecycleStatus.ENACTED, "2022-01-01"),
+        ])
+        lin = PlanLineage(plans=[p1, p2])
+        assert lin.plan_at(date(2015, 6, 1)).plan_id == "P1"
+        assert lin.plan_at(date(2023, 6, 1)).plan_id == "P2"
+
+    def test_no_active_plan(self):
+        p = _plan(events=[_event(PlanLifecycleStatus.STRUCK, "2023-01-01")])
+        lin = PlanLineage(plans=[p])
+        assert lin.current_plan is None
+
+
+class TestBuildLineage:
+    def test_empty(self):
+        lin = build_lineage([])
+        assert lin.plans == []
+
+    def test_sorts_by_enacted_date(self):
+        p1 = _plan(plan_id="P1", enacted_date="2022-01-01")
+        p2 = _plan(plan_id="P2", enacted_date="2012-01-01")
+        lin = build_lineage([p1, p2])
+        assert lin.plans[0].plan_id == "P2"
+        assert lin.plans[1].plan_id == "P1"
+
+    def test_sets_state_and_type(self):
+        p = _plan(state="AL", plan_type=PlanType.STATE_SENATE)
+        lin = build_lineage([p])
+        assert lin.state == "AL"
+        assert lin.plan_type == PlanType.STATE_SENATE
+
+
+class TestDictProvider:
+    def test_empty(self):
+        prov = DictPlanLifecycleProvider()
+        assert prov.get_plans("TX") == []
+        assert prov.get_plan("X") is None
+
+    def test_add_and_get(self):
+        prov = DictPlanLifecycleProvider()
+        p = _plan(plan_id="P1", state="TX")
+        prov.add(p)
+        assert prov.get_plan("P1") is p
+        assert len(prov.get_plans("TX")) == 1
+
+    def test_filter_by_type(self):
+        prov = DictPlanLifecycleProvider()
+        prov.add(_plan(plan_id="CD", state="TX", plan_type=PlanType.CONGRESSIONAL))
+        prov.add(_plan(plan_id="SS", state="TX", plan_type=PlanType.STATE_SENATE))
+        assert len(prov.get_plans("TX", plan_type=PlanType.CONGRESSIONAL)) == 1
+
+    def test_case_insensitive_state(self):
+        prov = DictPlanLifecycleProvider()
+        prov.add(_plan(state="TX"))
+        assert len(prov.get_plans("tx")) == 1
+
+
+class TestResolvePlanAt:
+    def test_basic(self):
+        prov = DictPlanLifecycleProvider()
+        p = _plan(
+            plan_id="P1",
+            state="TX",
+            enacted_date="2022-01-01",
+            events=[_event(PlanLifecycleStatus.ENACTED, "2022-01-01")],
+        )
+        prov.add(p)
+        result = resolve_plan_at(prov, "TX", PlanType.CONGRESSIONAL, date(2023, 1, 1))
+        assert result.plan_id == "P1"
+
+    def test_no_plans(self):
+        prov = DictPlanLifecycleProvider()
+        assert resolve_plan_at(prov, "TX", PlanType.CONGRESSIONAL, date(2023, 1, 1)) is None
+
+    def test_supersession(self):
+        prov = DictPlanLifecycleProvider()
+        p1 = _plan(
+            plan_id="P1", state="TX", enacted_date="2012-01-01",
+            events=[
+                _event(PlanLifecycleStatus.ENACTED, "2012-01-01"),
+                _event(PlanLifecycleStatus.SUPERSEDED, "2022-01-01"),
+            ],
+        )
+        p2 = _plan(
+            plan_id="P2", state="TX", enacted_date="2022-01-01",
+            supersedes_id="P1",
+            events=[_event(PlanLifecycleStatus.ENACTED, "2022-01-01")],
+        )
+        prov.add(p1)
+        prov.add(p2)
+
+        assert resolve_plan_at(prov, "TX", PlanType.CONGRESSIONAL, date(2015, 1, 1)).plan_id == "P1"
+        assert resolve_plan_at(prov, "TX", PlanType.CONGRESSIONAL, date(2023, 1, 1)).plan_id == "P2"
+
+    def test_court_order_branch(self):
+        prov = DictPlanLifecycleProvider()
+        original = _plan(
+            plan_id="AL-CD-2021", state="AL", enacted_date="2021-11-01",
+            events=[
+                _event(PlanLifecycleStatus.ENACTED, "2021-11-01"),
+                _event(PlanLifecycleStatus.CHALLENGED, "2022-01-24",
+                       court_case="Allen v. Milligan"),
+                _event(PlanLifecycleStatus.STRUCK, "2023-06-08",
+                       court_case="Allen v. Milligan"),
+            ],
+        )
+        court_plan = _plan(
+            plan_id="AL-CD-2023-COURT", state="AL", enacted_date="2023-10-05",
+            enacted_by=EnactedBy.COURT,
+            supersedes_id="AL-CD-2021",
+            court_case="Allen v. Milligan",
+            events=[_event(PlanLifecycleStatus.ENACTED, "2023-10-05")],
+        )
+        prov.add(original)
+        prov.add(court_plan)
+
+        assert resolve_plan_at(prov, "AL", PlanType.CONGRESSIONAL, date(2022, 6, 1)).plan_id == "AL-CD-2021"
+        assert resolve_plan_at(prov, "AL", PlanType.CONGRESSIONAL, date(2024, 1, 1)).plan_id == "AL-CD-2023-COURT"
+        assert resolve_plan_at(prov, "AL", PlanType.CONGRESSIONAL, date(2023, 8, 1)) is None

--- a/tests/test_precinct_vtd.py
+++ b/tests/test_precinct_vtd.py
@@ -1,0 +1,313 @@
+"""Tests for precinct-VTD reconciliation (SU#635)."""
+
+from __future__ import annotations
+
+import pytest
+
+from siege_utilities.geo.precinct_vtd import (
+    ConfidenceLevel,
+    DictNameMatchProvider,
+    DictSpatialOverlapProvider,
+    OfficialCrosswalkEntry,
+    PrecinctVTDMapping,
+    PrecinctVTDReconciler,
+    ReconciliationMethod,
+    ReconciliationResult,
+    SpatialOverlap,
+    _confidence_level,
+    _name_similarity,
+    _normalize_name,
+    reconcile_names,
+    reconcile_official,
+    reconcile_spatial,
+)
+
+
+class TestConfidenceLevel:
+    def test_high(self):
+        assert _confidence_level(0.95) == ConfidenceLevel.HIGH
+        assert _confidence_level(0.85) == ConfidenceLevel.HIGH
+
+    def test_medium(self):
+        assert _confidence_level(0.70) == ConfidenceLevel.MEDIUM
+        assert _confidence_level(0.60) == ConfidenceLevel.MEDIUM
+
+    def test_low(self):
+        assert _confidence_level(0.50) == ConfidenceLevel.LOW
+        assert _confidence_level(0.0) == ConfidenceLevel.LOW
+
+
+class TestNormalizeName:
+    def test_basic(self):
+        assert _normalize_name("Precinct 1A") == "precinct 1a"
+
+    def test_strips_punctuation(self):
+        assert _normalize_name("Dist. #5 (North)") == "dist 5 north"
+
+    def test_empty(self):
+        assert _normalize_name("") == ""
+
+
+class TestNameSimilarity:
+    def test_identical(self):
+        assert _name_similarity("Precinct 1", "Precinct 1") == pytest.approx(1.0)
+
+    def test_similar(self):
+        sim = _name_similarity("Precinct 001", "Precinct 1")
+        assert sim > 0.7
+
+    def test_different(self):
+        sim = _name_similarity("North Ward", "South District")
+        assert sim < 0.5
+
+    def test_empty(self):
+        assert _name_similarity("", "test") == 0.0
+        assert _name_similarity("test", "") == 0.0
+
+
+class TestPrecinctVTDMapping:
+    def test_defaults(self):
+        m = PrecinctVTDMapping()
+        assert m.confidence == 0.0
+        assert m.method == ReconciliationMethod.SPATIAL
+
+    def test_to_dict(self):
+        m = PrecinctVTDMapping(
+            precinct_id="P1", vtd_geoid="V1",
+            overlap_pct=0.95, confidence=0.95,
+            confidence_level=ConfidenceLevel.HIGH,
+            method=ReconciliationMethod.SPATIAL,
+        )
+        d = m.to_dict()
+        assert d["precinct_id"] == "P1"
+        assert d["confidence_level"] == "high"
+        assert "name_similarity" not in d
+
+    def test_to_dict_with_name(self):
+        m = PrecinctVTDMapping(name_similarity=0.85, notes="matched")
+        d = m.to_dict()
+        assert d["name_similarity"] == 0.85
+        assert d["notes"] == "matched"
+
+
+class TestReconciliationResult:
+    def test_empty(self):
+        r = ReconciliationResult()
+        assert r.match_rate == 0.0
+        assert r.high_confidence_count == 0
+
+    def test_match_rate(self):
+        r = ReconciliationResult(total_precincts=10, matched_precincts=8)
+        assert r.match_rate == pytest.approx(0.8)
+
+    def test_high_confidence_count(self):
+        r = ReconciliationResult(mappings=[
+            PrecinctVTDMapping(confidence_level=ConfidenceLevel.HIGH),
+            PrecinctVTDMapping(confidence_level=ConfidenceLevel.LOW),
+            PrecinctVTDMapping(confidence_level=ConfidenceLevel.HIGH),
+        ])
+        assert r.high_confidence_count == 2
+
+    def test_for_precinct(self):
+        r = ReconciliationResult(mappings=[
+            PrecinctVTDMapping(precinct_id="P1", vtd_geoid="V1"),
+            PrecinctVTDMapping(precinct_id="P1", vtd_geoid="V2"),
+            PrecinctVTDMapping(precinct_id="P2", vtd_geoid="V3"),
+        ])
+        assert len(r.for_precinct("P1")) == 2
+        assert len(r.for_precinct("P2")) == 1
+
+    def test_to_dict(self):
+        r = ReconciliationResult(
+            total_precincts=5, matched_precincts=4,
+            unmatched_precincts=["P5"],
+            method_counts={"spatial": 3, "name_match": 1},
+        )
+        d = r.to_dict()
+        assert d["match_rate"] == 0.8
+        assert d["unmatched_precincts"] == ["P5"]
+
+
+class TestDictSpatialOverlapProvider:
+    def test_empty(self):
+        p = DictSpatialOverlapProvider()
+        assert p.compute_overlaps(["P1"]) == []
+
+    def test_filters_by_id(self):
+        p = DictSpatialOverlapProvider()
+        p.add(SpatialOverlap(precinct_id="P1", vtd_geoid="V1", overlap_pct=0.9))
+        p.add(SpatialOverlap(precinct_id="P2", vtd_geoid="V2", overlap_pct=0.8))
+        result = p.compute_overlaps(["P1"])
+        assert len(result) == 1
+        assert result[0].precinct_id == "P1"
+
+
+class TestDictNameMatchProvider:
+    def test_empty(self):
+        p = DictNameMatchProvider()
+        assert p.get_precinct_names(["P1"]) == {}
+        assert p.get_vtd_names() == {}
+
+    def test_add_and_get(self):
+        p = DictNameMatchProvider()
+        p.add_precinct("P1", "Ward 1")
+        p.add_vtd("V1", "Ward One")
+        assert p.get_precinct_names(["P1"]) == {"P1": "Ward 1"}
+        assert "V1" in p.get_vtd_names()
+
+
+class TestReconcileSpatial:
+    def test_basic(self):
+        overlaps = [
+            SpatialOverlap(precinct_id="P1", vtd_geoid="V1", overlap_pct=0.95),
+        ]
+        mappings = reconcile_spatial(overlaps)
+        assert len(mappings) == 1
+        assert mappings[0].confidence == 0.95
+        assert mappings[0].confidence_level == ConfidenceLevel.HIGH
+
+    def test_filters_low_overlap(self):
+        overlaps = [
+            SpatialOverlap(precinct_id="P1", vtd_geoid="V1", overlap_pct=0.005),
+        ]
+        assert reconcile_spatial(overlaps) == []
+
+    def test_split_precinct(self):
+        overlaps = [
+            SpatialOverlap(precinct_id="P1", vtd_geoid="V1", overlap_pct=0.60),
+            SpatialOverlap(precinct_id="P1", vtd_geoid="V2", overlap_pct=0.40),
+        ]
+        mappings = reconcile_spatial(overlaps)
+        assert len(mappings) == 2
+
+
+class TestReconcileNames:
+    def test_exact_match(self):
+        mappings = reconcile_names(
+            {"P1": "Precinct 1"}, {"V1": "Precinct 1"},
+        )
+        assert len(mappings) == 1
+        assert mappings[0].name_similarity == pytest.approx(1.0)
+
+    def test_fuzzy_match(self):
+        mappings = reconcile_names(
+            {"P1": "Precinct 001"}, {"V1": "Precinct 1", "V2": "District 99"},
+        )
+        assert len(mappings) == 1
+        assert mappings[0].vtd_geoid == "V1"
+
+    def test_no_match(self):
+        mappings = reconcile_names(
+            {"P1": "Alpha"}, {"V1": "Zulu"},
+        )
+        assert len(mappings) == 0
+
+    def test_best_match_selected(self):
+        mappings = reconcile_names(
+            {"P1": "North Ward 5"},
+            {"V1": "North Ward 5", "V2": "North Ward 6"},
+        )
+        assert mappings[0].vtd_geoid == "V1"
+
+
+class TestReconcileOfficial:
+    def test_basic(self):
+        entries = [
+            OfficialCrosswalkEntry(precinct_id="P1", vtd_geoid="V1", source="NC SBE 2022"),
+        ]
+        mappings = reconcile_official(entries)
+        assert len(mappings) == 1
+        assert mappings[0].confidence == 1.0
+        assert mappings[0].method == ReconciliationMethod.OFFICIAL_CROSSWALK
+        assert "NC SBE 2022" in mappings[0].notes
+
+    def test_empty(self):
+        assert reconcile_official([]) == []
+
+
+class TestPrecinctVTDReconciler:
+    def test_empty_input(self):
+        rec = PrecinctVTDReconciler()
+        result = rec.reconcile([])
+        assert result.total_precincts == 0
+
+    def test_spatial_only(self):
+        sp = DictSpatialOverlapProvider()
+        sp.add(SpatialOverlap(precinct_id="P1", vtd_geoid="V1", overlap_pct=0.90))
+        sp.add(SpatialOverlap(precinct_id="P2", vtd_geoid="V2", overlap_pct=0.85))
+
+        rec = PrecinctVTDReconciler(spatial_provider=sp)
+        result = rec.reconcile(["P1", "P2"])
+        assert result.total_precincts == 2
+        assert result.matched_precincts == 2
+        assert result.method_counts["spatial"] == 2
+
+    def test_name_only(self):
+        np = DictNameMatchProvider()
+        np.add_precinct("P1", "Ward 1")
+        np.add_vtd("V1", "Ward 1")
+
+        rec = PrecinctVTDReconciler(name_provider=np)
+        result = rec.reconcile(["P1"])
+        assert result.matched_precincts == 1
+        assert result.method_counts["name_match"] == 1
+
+    def test_official_crosswalk(self):
+        xw = [OfficialCrosswalkEntry(precinct_id="P1", vtd_geoid="V1")]
+        rec = PrecinctVTDReconciler(official_crosswalk=xw)
+        result = rec.reconcile(["P1"])
+        assert result.matched_precincts == 1
+        assert result.method_counts["official_crosswalk"] == 1
+
+    def test_official_overrides_spatial(self):
+        sp = DictSpatialOverlapProvider()
+        sp.add(SpatialOverlap(precinct_id="P1", vtd_geoid="V_WRONG", overlap_pct=0.95))
+
+        xw = [OfficialCrosswalkEntry(precinct_id="P1", vtd_geoid="V_RIGHT")]
+
+        rec = PrecinctVTDReconciler(spatial_provider=sp, official_crosswalk=xw)
+        result = rec.reconcile(["P1"])
+        official = [m for m in result.mappings if m.method == ReconciliationMethod.OFFICIAL_CROSSWALK]
+        assert len(official) == 1
+        assert official[0].vtd_geoid == "V_RIGHT"
+
+    def test_combined_boost(self):
+        sp = DictSpatialOverlapProvider()
+        sp.add(SpatialOverlap(precinct_id="P1", vtd_geoid="V1", overlap_pct=0.80))
+
+        np = DictNameMatchProvider()
+        np.add_precinct("P1", "Ward 1")
+        np.add_vtd("V1", "Ward 1")
+
+        rec = PrecinctVTDReconciler(spatial_provider=sp, name_provider=np)
+        result = rec.reconcile(["P1"])
+        assert result.matched_precincts == 1
+        combined = [m for m in result.mappings if m.method == ReconciliationMethod.COMBINED]
+        assert len(combined) == 1
+        assert combined[0].confidence > 0.80
+
+    def test_unmatched_tracked(self):
+        sp = DictSpatialOverlapProvider()
+        sp.add(SpatialOverlap(precinct_id="P1", vtd_geoid="V1", overlap_pct=0.90))
+
+        rec = PrecinctVTDReconciler(spatial_provider=sp)
+        result = rec.reconcile(["P1", "P2", "P3"])
+        assert result.matched_precincts == 1
+        assert set(result.unmatched_precincts) == {"P2", "P3"}
+
+    def test_split_precinct(self):
+        sp = DictSpatialOverlapProvider()
+        sp.add(SpatialOverlap(precinct_id="P1", vtd_geoid="V1", overlap_pct=0.60))
+        sp.add(SpatialOverlap(precinct_id="P1", vtd_geoid="V2", overlap_pct=0.40))
+
+        rec = PrecinctVTDReconciler(spatial_provider=sp)
+        result = rec.reconcile(["P1"])
+        assert result.matched_precincts == 1
+        assert len(result.for_precinct("P1")) == 2
+
+    def test_irrelevant_crosswalk_ignored(self):
+        xw = [OfficialCrosswalkEntry(precinct_id="OTHER", vtd_geoid="V1")]
+        rec = PrecinctVTDReconciler(official_crosswalk=xw)
+        result = rec.reconcile(["P1"])
+        assert result.matched_precincts == 0
+        assert result.unmatched_precincts == ["P1"]

--- a/tests/test_rdh_catalog.py
+++ b/tests/test_rdh_catalog.py
@@ -1,0 +1,379 @@
+"""Tests for RDH dataset catalog and discovery (SU#633)."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from siege_utilities.geo.rdh_catalog import (
+    CatalogEntry,
+    CoverageCell,
+    DictRDHCatalogProvider,
+    RDHCatalog,
+    SearchResult,
+    _infer_chamber,
+    _score_entry,
+)
+
+
+def _entry(state="TX", year="2020", dtype="pl94171", fmt="csv", **kw):
+    defaults = dict(
+        title=f"{state} {dtype} {year}",
+        url=f"https://example.com/{state}_{dtype}_{year}.{fmt}",
+        state=state,
+        year=year,
+        dataset_type=dtype,
+        format=fmt,
+    )
+    defaults.update(kw)
+    return CatalogEntry(**defaults)
+
+
+class TestCatalogEntry:
+    def test_defaults(self):
+        e = CatalogEntry()
+        assert e.title == ""
+        assert e.state == ""
+
+    def test_matches_exact(self):
+        e = _entry(state="TX", year="2020", dtype="pl94171")
+        assert e.matches(state="TX")
+        assert e.matches(year="2020")
+        assert e.matches(dataset_type="pl94171")
+        assert e.matches(state="TX", year="2020")
+
+    def test_matches_case_insensitive(self):
+        e = _entry(state="TX", dtype="PL94171")
+        assert e.matches(state="tx")
+        assert e.matches(dataset_type="pl94171")
+
+    def test_matches_no_match(self):
+        e = _entry(state="TX")
+        assert not e.matches(state="CA")
+        assert not e.matches(year="2022")
+
+    def test_matches_no_filters(self):
+        e = _entry()
+        assert e.matches()
+
+    def test_matches_format(self):
+        e = _entry(fmt="csv")
+        assert e.matches(format="csv")
+        assert not e.matches(format="shp")
+
+    def test_matches_chamber(self):
+        e = _entry(chamber="congress")
+        assert e.matches(chamber="congress")
+        assert not e.matches(chamber="state_senate")
+
+    def test_to_dict_roundtrip(self):
+        e = _entry(state="VA", official=True)
+        d = e.to_dict()
+        e2 = CatalogEntry.from_dict(d)
+        assert e2.state == "VA"
+        assert e2.official is True
+        assert e2.url == e.url
+
+    def test_from_dict_missing_keys(self):
+        e = CatalogEntry.from_dict({"title": "Test"})
+        assert e.title == "Test"
+        assert e.state == ""
+        assert e.official is False
+
+
+class TestDictProvider:
+    def test_empty(self):
+        p = DictRDHCatalogProvider()
+        assert p.fetch_all_datasets() == []
+
+    def test_add_and_fetch(self):
+        p = DictRDHCatalogProvider()
+        p.add(_entry())
+        assert len(p.fetch_all_datasets()) == 1
+
+    def test_init_with_entries(self):
+        entries = [_entry(), _entry(state="CA")]
+        p = DictRDHCatalogProvider(entries)
+        assert len(p.fetch_all_datasets()) == 2
+
+    def test_returns_copy(self):
+        p = DictRDHCatalogProvider([_entry()])
+        a = p.fetch_all_datasets()
+        b = p.fetch_all_datasets()
+        assert a is not b
+
+
+class TestInferChamber:
+    def test_congress(self):
+        assert _infer_chamber("TX Congressional Districts 2022") == "congress"
+
+    def test_state_senate(self):
+        assert _infer_chamber("VA State Senate Districts") == "state_senate"
+
+    def test_state_house(self):
+        assert _infer_chamber("OH State House Map") == "state_house"
+
+    def test_sldu(self):
+        assert _infer_chamber("2020 SLDU Boundaries") == "state_senate"
+
+    def test_sldl(self):
+        assert _infer_chamber("2020 SLDL Boundaries") == "state_house"
+
+    def test_no_match(self):
+        assert _infer_chamber("PL 94-171 Block Data") == ""
+
+
+class TestScoreEntry:
+    def test_state_match(self):
+        e = _entry(state="TX")
+        assert _score_entry(e, state="TX") == 10.0
+        assert _score_entry(e, state="CA") == 0.0
+
+    def test_year_match(self):
+        e = _entry(year="2020")
+        assert _score_entry(e, year="2020") == 5.0
+
+    def test_official_bonus(self):
+        e = _entry(official=True)
+        assert _score_entry(e, state=e.state) > _score_entry(
+            _entry(official=False), state=e.state
+        )
+
+    def test_query_exact(self):
+        e = _entry(title="Texas PL 94-171")
+        score = _score_entry(e, query="Texas PL")
+        assert score >= 3.0
+
+    def test_query_partial(self):
+        e = _entry(title="Texas PL 94-171")
+        score = _score_entry(e, query="Texas something")
+        assert 0 < score < 3.0
+
+    def test_combined(self):
+        e = _entry(state="TX", year="2020", dtype="pl94171")
+        score = _score_entry(e, state="TX", year="2020", dataset_type="pl94171")
+        assert score == 20.0  # 10 + 5 + 5
+
+
+class TestRDHCatalogLoad:
+    def test_load_from_provider(self):
+        p = DictRDHCatalogProvider([_entry(), _entry(state="CA")])
+        cat = RDHCatalog(provider=p)
+        count = cat.load()
+        assert count == 2
+        assert cat.is_loaded
+        assert cat.entry_count == 2
+
+    def test_load_no_provider(self):
+        cat = RDHCatalog()
+        count = cat.load()
+        assert count == 0
+        assert not cat.is_loaded
+
+    def test_entries_returns_copy(self):
+        p = DictRDHCatalogProvider([_entry()])
+        cat = RDHCatalog(provider=p)
+        cat.load()
+        a = cat.entries
+        b = cat.entries
+        assert a is not b
+
+
+class TestRDHCatalogSearch:
+    def _loaded_catalog(self, entries):
+        p = DictRDHCatalogProvider(entries)
+        cat = RDHCatalog(provider=p)
+        cat.load()
+        return cat
+
+    def test_search_by_state(self):
+        cat = self._loaded_catalog([
+            _entry(state="TX"),
+            _entry(state="CA"),
+            _entry(state="TX", year="2022"),
+        ])
+        results = cat.search(state="TX")
+        assert len(results) == 2
+        assert all(r.entry.state == "TX" for r in results)
+
+    def test_search_by_type(self):
+        cat = self._loaded_catalog([
+            _entry(dtype="pl94171"),
+            _entry(dtype="cvap"),
+            _entry(dtype="pl94171", state="CA"),
+        ])
+        results = cat.search(dataset_type="pl94171")
+        assert len(results) == 2
+
+    def test_search_format_filter(self):
+        cat = self._loaded_catalog([
+            _entry(fmt="csv"),
+            _entry(fmt="shp"),
+        ])
+        results = cat.search(state="TX", format="csv")
+        assert len(results) == 1
+        assert results[0].entry.format == "csv"
+
+    def test_search_ranked(self):
+        cat = self._loaded_catalog([
+            _entry(state="TX", official=False),
+            _entry(state="TX", official=True),
+        ])
+        results = cat.search(state="TX")
+        assert results[0].score > results[1].score
+        assert results[0].entry.official
+
+    def test_search_limit(self):
+        entries = [_entry(state="TX", year=str(2000 + i)) for i in range(20)]
+        cat = self._loaded_catalog(entries)
+        results = cat.search(state="TX", limit=5)
+        assert len(results) == 5
+
+    def test_search_empty(self):
+        cat = self._loaded_catalog([_entry(state="TX")])
+        results = cat.search(state="CA")
+        assert len(results) == 0
+
+    def test_search_query(self):
+        cat = self._loaded_catalog([
+            _entry(title="Texas Congressional Districts 2022"),
+            _entry(title="Ohio Block Data 2020"),
+        ])
+        results = cat.search(query="Texas Congressional")
+        assert len(results) >= 1
+        assert "Texas" in results[0].entry.title
+
+    def test_search_no_filters_returns_empty(self):
+        cat = self._loaded_catalog([_entry()])
+        results = cat.search()
+        assert len(results) == 0
+
+
+class TestCoverageMatrix:
+    def _loaded_catalog(self, entries):
+        p = DictRDHCatalogProvider(entries)
+        cat = RDHCatalog(provider=p)
+        cat.load()
+        return cat
+
+    def test_basic(self):
+        cat = self._loaded_catalog([
+            _entry(state="TX", year="2020", dtype="pl94171", fmt="csv"),
+            _entry(state="TX", year="2020", dtype="pl94171", fmt="shp"),
+            _entry(state="CA", year="2020", dtype="cvap", fmt="csv"),
+        ])
+        matrix = cat.coverage_matrix()
+        assert len(matrix) == 2
+
+        tx_cell = next(c for c in matrix if c.state == "TX")
+        assert tx_cell.count == 2
+        assert "csv" in tx_cell.formats
+        assert "shp" in tx_cell.formats
+
+    def test_filter_by_type(self):
+        cat = self._loaded_catalog([
+            _entry(dtype="pl94171"),
+            _entry(dtype="cvap"),
+        ])
+        matrix = cat.coverage_matrix(dataset_type="pl94171")
+        assert len(matrix) == 1
+        assert matrix[0].dataset_type == "pl94171"
+
+    def test_empty(self):
+        cat = self._loaded_catalog([])
+        assert cat.coverage_matrix() == []
+
+    def test_sorted(self):
+        cat = self._loaded_catalog([
+            _entry(state="TX", year="2022"),
+            _entry(state="CA", year="2020"),
+        ])
+        matrix = cat.coverage_matrix()
+        states = [c.state for c in matrix]
+        assert states == sorted(states)
+
+
+class TestCatalogHelpers:
+    def _loaded_catalog(self, entries):
+        p = DictRDHCatalogProvider(entries)
+        cat = RDHCatalog(provider=p)
+        cat.load()
+        return cat
+
+    def test_states(self):
+        cat = self._loaded_catalog([_entry(state="TX"), _entry(state="CA")])
+        assert cat.states() == ["CA", "TX"]
+
+    def test_years(self):
+        cat = self._loaded_catalog([_entry(year="2020"), _entry(year="2022")])
+        assert cat.years() == ["2020", "2022"]
+
+    def test_dataset_types(self):
+        cat = self._loaded_catalog([_entry(dtype="pl94171"), _entry(dtype="cvap")])
+        assert cat.dataset_types() == ["cvap", "pl94171"]
+
+    def test_for_state(self):
+        cat = self._loaded_catalog([
+            _entry(state="TX"),
+            _entry(state="CA"),
+            _entry(state="TX", year="2022"),
+        ])
+        assert len(cat.for_state("TX")) == 2
+        assert len(cat.for_state("ca")) == 1
+
+
+class TestCatalogCache:
+    def test_save_and_load(self, tmp_path):
+        p = DictRDHCatalogProvider([
+            _entry(state="TX"),
+            _entry(state="CA", official=True),
+        ])
+        cat = RDHCatalog(provider=p, cache_dir=tmp_path)
+        cat.load()
+
+        cat2 = RDHCatalog(cache_dir=tmp_path)
+        count = cat2.load()
+        assert count == 2
+        assert cat2.is_loaded
+        assert cat2.entry_count == 2
+
+    def test_cache_expired(self, tmp_path):
+        p = DictRDHCatalogProvider([_entry()])
+        cat = RDHCatalog(provider=p, cache_dir=tmp_path, cache_ttl=1)
+        cat.load()
+
+        cache_file = tmp_path / "rdh_catalog.json"
+        data = json.loads(cache_file.read_text())
+        data["cached_at"] = time.time() - 100
+        cache_file.write_text(json.dumps(data))
+
+        cat2 = RDHCatalog(provider=p, cache_dir=tmp_path, cache_ttl=1)
+        count = cat2.load()
+        assert count == 1
+
+    def test_cache_corrupt(self, tmp_path):
+        cache_file = tmp_path / "rdh_catalog.json"
+        cache_file.write_text("not valid json")
+
+        p = DictRDHCatalogProvider([_entry()])
+        cat = RDHCatalog(provider=p, cache_dir=tmp_path)
+        count = cat.load()
+        assert count == 1
+
+    def test_no_cache_dir(self):
+        p = DictRDHCatalogProvider([_entry()])
+        cat = RDHCatalog(provider=p)
+        cat.load()
+        assert cat.entry_count == 1
+
+    def test_force_bypasses_cache(self, tmp_path):
+        p1 = DictRDHCatalogProvider([_entry()])
+        cat1 = RDHCatalog(provider=p1, cache_dir=tmp_path)
+        cat1.load()
+
+        p2 = DictRDHCatalogProvider([_entry(), _entry(state="CA")])
+        cat2 = RDHCatalog(provider=p2, cache_dir=tmp_path)
+        count = cat2.load(force=True)
+        assert count == 2

--- a/tests/test_rdh_overlays.py
+++ b/tests/test_rdh_overlays.py
@@ -1,0 +1,302 @@
+"""Tests for RDH overlays — redistricting + election results (SU#636)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from siege_utilities.geo.overlay_registry import OverlayRegistry
+from siege_utilities.geo.overlays.redistricting import (
+    DictRedistrictingDataProvider,
+    DistrictAssignment,
+    RedistrictingOverlay,
+    RedistrictingOverlayResult,
+)
+from siege_utilities.geo.overlays.election_results import (
+    DictElectionDataProvider,
+    ElectionDataProvider,
+    ElectionResultsOverlay,
+    ElectionResultsOverlayResult,
+    ElectionReturn,
+)
+
+
+def _da(plan_id="P1", plan_name="Plan 2022", plan_type="congressional",
+        district_id="TX-28", state="TX", from_date="2022-01-01",
+        to_date=None, enacted_by="legislature", court_case="", **kw):
+    return DistrictAssignment(
+        plan_id=plan_id, plan_name=plan_name, plan_type=plan_type,
+        district_id=district_id, state=state,
+        from_date=date.fromisoformat(from_date) if isinstance(from_date, str) else from_date,
+        to_date=date.fromisoformat(to_date) if isinstance(to_date, str) and to_date else to_date,
+        enacted_by=enacted_by, court_case=court_case, **kw,
+    )
+
+
+def _er(precinct_id="PCT-1", year=2022, office="US_HOUSE", candidate="Smith",
+        party="DEM", votes=100, total_votes=200, state="TX", **kw):
+    return ElectionReturn(
+        precinct_id=precinct_id, election_year=year, office=office,
+        candidate=candidate, party=party, votes=votes,
+        total_votes=total_votes, vote_share=votes / total_votes if total_votes else 0,
+        state=state, **kw,
+    )
+
+
+# ---- Redistricting Overlay ----
+
+class TestDistrictAssignment:
+    def test_defaults(self):
+        a = DistrictAssignment()
+        assert a.plan_id == ""
+        assert a.from_date is None
+
+    def test_fields(self):
+        a = _da()
+        assert a.plan_id == "P1"
+        assert a.from_date == date(2022, 1, 1)
+
+
+class TestRedistrictingOverlayResult:
+    def test_empty(self):
+        r = RedistrictingOverlayResult(geoid="48453")
+        assert r.plan_count == 0
+        assert not r.had_court_intervention
+
+    def test_plan_count(self):
+        r = RedistrictingOverlayResult(assignments=[
+            _da(plan_id="P1"), _da(plan_id="P2"),
+        ])
+        assert r.plan_count == 2
+
+    def test_had_court_intervention(self):
+        r = RedistrictingOverlayResult(assignments=[
+            _da(court_case="Allen v. Milligan"),
+        ])
+        assert r.had_court_intervention
+
+    def test_plan_types(self):
+        r = RedistrictingOverlayResult(assignments=[
+            _da(plan_type="congressional"),
+            _da(plan_type="state_senate"),
+            _da(plan_type="congressional"),
+        ])
+        assert r.plan_types == ["congressional", "state_senate"]
+
+    def test_for_plan_type(self):
+        r = RedistrictingOverlayResult(assignments=[
+            _da(plan_type="congressional"),
+            _da(plan_type="state_senate"),
+        ])
+        assert len(r.for_plan_type("congressional")) == 1
+
+    def test_active_at(self):
+        r = RedistrictingOverlayResult(assignments=[
+            _da(plan_id="P1", from_date="2012-01-01", to_date="2021-12-31"),
+            _da(plan_id="P2", from_date="2022-01-01"),
+        ])
+        active = r.active_at(date(2015, 6, 1))
+        assert len(active) == 1
+        assert active[0].plan_id == "P1"
+
+    def test_active_at_open_ended(self):
+        r = RedistrictingOverlayResult(assignments=[
+            _da(from_date="2022-01-01", to_date=None),
+        ])
+        assert len(r.active_at(date(2025, 1, 1))) == 1
+
+
+class TestDictRedistrictingProvider:
+    def test_empty(self):
+        p = DictRedistrictingDataProvider()
+        assert p.get_district_assignments("G1", 2020, 2024) == []
+
+    def test_time_range_filter(self):
+        p = DictRedistrictingDataProvider()
+        p.add(_da(from_date="2012-01-01", to_date="2021-12-31"))
+        p.add(_da(plan_id="P2", from_date="2022-01-01"))
+
+        assert len(p.get_district_assignments("G1", 2020, 2024)) == 2
+        assert len(p.get_district_assignments("G1", 2023, 2024)) == 1
+
+    def test_state_filter(self):
+        p = DictRedistrictingDataProvider()
+        p.add(_da(state="TX"))
+        p.add(_da(state="CA"))
+        assert len(p.get_district_assignments("G1", 2020, 2024, state_fips="TX")) == 1
+
+
+class TestRedistrictingOverlay:
+    def test_name(self):
+        ov = RedistrictingOverlay()
+        assert ov.name == "redistricting"
+
+    def test_no_provider(self):
+        ov = RedistrictingOverlay()
+        result = ov.fetch("48453", 2020, 2024)
+        assert result.geoid == "48453"
+        assert result.assignments == []
+
+    def test_is_available(self):
+        assert not RedistrictingOverlay().is_available()
+        assert RedistrictingOverlay(DictRedistrictingDataProvider()).is_available()
+
+    def test_fetch(self):
+        p = DictRedistrictingDataProvider()
+        p.add(_da(plan_id="P1", from_date="2012-01-01", to_date="2021-12-31"))
+        p.add(_da(plan_id="P2", from_date="2022-01-01"))
+
+        ov = RedistrictingOverlay(provider=p)
+        result = ov.fetch("48453", 2020, 2024)
+        assert len(result.assignments) == 2
+        assert result.assignments[0].plan_id == "P1"
+
+    def test_registers_with_registry(self):
+        reg = OverlayRegistry()
+        p = DictRedistrictingDataProvider()
+        ov = RedistrictingOverlay(provider=p)
+        reg.register_instance("redistricting", ov)
+        assert reg.is_registered("redistricting")
+        assert reg.get("redistricting").name == "redistricting"
+
+    def test_court_order_scenario(self):
+        p = DictRedistrictingDataProvider()
+        p.add(_da(
+            plan_id="AL-CD-2021", from_date="2022-01-01", to_date="2023-06-08",
+            state="AL", court_case="",
+        ))
+        p.add(_da(
+            plan_id="AL-CD-2023-COURT", from_date="2023-10-05",
+            state="AL", court_case="Allen v. Milligan",
+            enacted_by="court",
+        ))
+
+        ov = RedistrictingOverlay(provider=p)
+        result = ov.fetch("01001", 2022, 2024, state_fips="AL")
+        assert result.plan_count == 2
+        assert result.had_court_intervention
+
+
+# ---- Election Results Overlay ----
+
+class TestElectionReturn:
+    def test_defaults(self):
+        r = ElectionReturn()
+        assert r.votes == 0
+        assert r.reconciliation_method == "direct"
+
+    def test_fields(self):
+        r = _er()
+        assert r.vote_share == pytest.approx(0.5)
+
+
+class TestElectionResultsOverlayResult:
+    def test_empty(self):
+        r = ElectionResultsOverlayResult(geoid="48453")
+        assert r.election_years == []
+        assert r.offices == []
+
+    def test_election_years(self):
+        r = ElectionResultsOverlayResult(returns=[
+            _er(year=2020), _er(year=2022), _er(year=2020),
+        ])
+        assert r.election_years == [2020, 2022]
+
+    def test_offices(self):
+        r = ElectionResultsOverlayResult(returns=[
+            _er(office="US_HOUSE"), _er(office="US_PRESIDENT"),
+        ])
+        assert r.offices == ["US_HOUSE", "US_PRESIDENT"]
+
+    def test_for_year(self):
+        r = ElectionResultsOverlayResult(returns=[
+            _er(year=2020), _er(year=2022),
+        ])
+        assert len(r.for_year(2020)) == 1
+
+    def test_for_office(self):
+        r = ElectionResultsOverlayResult(returns=[
+            _er(office="US_HOUSE"), _er(office="GOVERNOR"),
+        ])
+        assert len(r.for_office("US_HOUSE")) == 1
+
+    def test_for_year_office(self):
+        r = ElectionResultsOverlayResult(returns=[
+            _er(year=2022, office="US_HOUSE"),
+            _er(year=2022, office="GOVERNOR"),
+            _er(year=2020, office="US_HOUSE"),
+        ])
+        assert len(r.for_year_office(2022, "US_HOUSE")) == 1
+
+    def test_party_totals(self):
+        r = ElectionResultsOverlayResult(returns=[
+            _er(year=2022, office="US_HOUSE", party="DEM", votes=100),
+            _er(year=2022, office="US_HOUSE", party="REP", votes=80),
+            _er(year=2022, office="US_HOUSE", party="DEM", votes=50),
+        ])
+        totals = r.party_totals(2022, "US_HOUSE")
+        assert totals["DEM"] == 150
+        assert totals["REP"] == 80
+
+
+class TestDictElectionDataProvider:
+    def test_empty(self):
+        p = DictElectionDataProvider()
+        assert p.get_election_returns("G1", 2020, 2024) == []
+
+    def test_year_filter(self):
+        p = DictElectionDataProvider()
+        p.add(_er(year=2020))
+        p.add(_er(year=2022))
+        p.add(_er(year=2024))
+        assert len(p.get_election_returns("G1", 2021, 2023)) == 1
+
+    def test_state_filter(self):
+        p = DictElectionDataProvider()
+        p.add(_er(state="TX"))
+        p.add(_er(state="CA"))
+        assert len(p.get_election_returns("G1", 2020, 2024, state_fips="TX")) == 1
+
+
+class TestElectionResultsOverlay:
+    def test_name(self):
+        ov = ElectionResultsOverlay()
+        assert ov.name == "election_results"
+
+    def test_no_provider(self):
+        ov = ElectionResultsOverlay()
+        result = ov.fetch("48453", 2020, 2024)
+        assert result.geoid == "48453"
+        assert result.returns == []
+
+    def test_is_available(self):
+        assert not ElectionResultsOverlay().is_available()
+        assert ElectionResultsOverlay(DictElectionDataProvider()).is_available()
+
+    def test_fetch(self):
+        p = DictElectionDataProvider()
+        p.add(_er(year=2020, party="DEM"))
+        p.add(_er(year=2022, party="REP"))
+
+        ov = ElectionResultsOverlay(provider=p)
+        result = ov.fetch("48453", 2020, 2024)
+        assert len(result.returns) == 2
+        assert result.returns[0].election_year == 2020
+
+    def test_registers_with_registry(self):
+        reg = OverlayRegistry()
+        ov = ElectionResultsOverlay(provider=DictElectionDataProvider())
+        reg.register_instance("election_results", ov)
+        assert reg.is_registered("election_results")
+
+    def test_sorted_output(self):
+        p = DictElectionDataProvider()
+        p.add(_er(year=2022, office="GOVERNOR", party="DEM"))
+        p.add(_er(year=2020, office="US_HOUSE", party="REP"))
+        p.add(_er(year=2022, office="US_HOUSE", party="DEM"))
+
+        ov = ElectionResultsOverlay(provider=p)
+        result = ov.fetch("48453", 2020, 2024)
+        years = [r.election_year for r in result.returns]
+        assert years == sorted(years)

--- a/tests/test_rdh_overlays.py
+++ b/tests/test_rdh_overlays.py
@@ -39,8 +39,7 @@ def _er(precinct_id="PCT-1", year=2022, office="US_HOUSE", candidate="Smith",
     return ElectionReturn(
         precinct_id=precinct_id, election_year=year, office=office,
         candidate=candidate, party=party, votes=votes,
-        total_votes=total_votes, vote_share=votes / total_votes if total_votes else 0,
-        state=state, **kw,
+        total_votes=total_votes, state=state, **kw,
     )
 
 
@@ -184,7 +183,20 @@ class TestElectionReturn:
     def test_defaults(self):
         r = ElectionReturn()
         assert r.votes == 0
+        assert r.vote_share == 0.0
         assert r.reconciliation_method == "direct"
+
+    def test_vote_share_auto_computed(self):
+        r = ElectionReturn(votes=100, total_votes=200)
+        assert r.vote_share == pytest.approx(0.5)
+
+    def test_vote_share_explicit_override(self):
+        r = ElectionReturn(votes=100, total_votes=200, vote_share=0.75)
+        assert r.vote_share == pytest.approx(0.75)
+
+    def test_vote_share_zero_total(self):
+        r = ElectionReturn(votes=0, total_votes=0)
+        assert r.vote_share == 0.0
 
     def test_fields(self):
         r = _er()

--- a/tests/test_seats_overlay.py
+++ b/tests/test_seats_overlay.py
@@ -1,0 +1,235 @@
+"""Tests for seats overlay (SU#609)."""
+
+from __future__ import annotations
+
+import pytest
+
+from siege_utilities.geo.overlay_registry import OverlayRegistry, PlaceHistoryOverlay
+from siege_utilities.geo.overlays.seats import (
+    DictSeatsProvider,
+    SeatAssignment,
+    SeatsOverlay,
+    SeatsOverlayResult,
+)
+
+
+def _sa(
+    seat_label="US House IL-7",
+    office="US_HOUSE",
+    district_label="7",
+    state_fips="17",
+    plan_name="2020 Plan",
+    plan_year=2022,
+    from_year=2022,
+    to_year=2032,
+    containment_pct=1.0,
+):
+    return SeatAssignment(
+        seat_label=seat_label,
+        office=office,
+        district_label=district_label,
+        state_fips=state_fips,
+        plan_name=plan_name,
+        plan_year=plan_year,
+        from_year=from_year,
+        to_year=to_year,
+        containment_pct=containment_pct,
+    )
+
+
+# ---------------------------------------------------------------------------
+# SeatAssignment dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestSeatAssignment:
+    def test_defaults(self):
+        a = SeatAssignment()
+        assert a.seat_label == ""
+        assert a.containment_pct == 1.0
+
+    def test_fields(self):
+        a = _sa()
+        assert a.office == "US_HOUSE"
+        assert a.district_label == "7"
+        assert a.plan_year == 2022
+
+
+# ---------------------------------------------------------------------------
+# SeatsOverlayResult
+# ---------------------------------------------------------------------------
+
+
+class TestSeatsOverlayResult:
+    def test_empty_result(self):
+        r = SeatsOverlayResult(geoid="A")
+        assert r.current_districts == []
+        assert r.offices == []
+
+    def test_current_districts(self):
+        r = SeatsOverlayResult(
+            geoid="A",
+            assignments=[
+                _sa(from_year=2012, to_year=2022, plan_name="2010 Plan"),
+                _sa(from_year=2022, to_year=2032, plan_name="2020 Plan"),
+            ],
+        )
+        current = r.current_districts
+        assert len(current) == 1
+        assert current[0].plan_name == "2020 Plan"
+
+    def test_offices(self):
+        r = SeatsOverlayResult(
+            geoid="A",
+            assignments=[
+                _sa(office="US_HOUSE"),
+                _sa(office="STATE_UPPER"),
+                _sa(office="US_HOUSE"),
+            ],
+        )
+        assert r.offices == ["STATE_UPPER", "US_HOUSE"]
+
+    def test_for_office(self):
+        r = SeatsOverlayResult(
+            geoid="A",
+            assignments=[
+                _sa(office="US_HOUSE", district_label="7"),
+                _sa(office="STATE_UPPER", district_label="3"),
+                _sa(office="US_HOUSE", district_label="4"),
+            ],
+        )
+        house = r.for_office("US_HOUSE")
+        assert len(house) == 2
+        assert all(a.office == "US_HOUSE" for a in house)
+
+
+# ---------------------------------------------------------------------------
+# DictSeatsProvider
+# ---------------------------------------------------------------------------
+
+
+class TestDictSeatsProvider:
+    def test_empty(self):
+        p = DictSeatsProvider()
+        assert p.get_assignments("A", 2000, 2020) == []
+
+    def test_add_and_get(self):
+        p = DictSeatsProvider()
+        p.add(_sa(from_year=2012, to_year=2022))
+        results = p.get_assignments("A", 2010, 2025)
+        assert len(results) == 1
+
+    def test_time_range_filtering(self):
+        p = DictSeatsProvider()
+        p.add(_sa(from_year=2012, to_year=2022))
+        p.add(_sa(from_year=2022, to_year=2032))
+
+        assert len(p.get_assignments("A", 2010, 2015)) == 1
+        assert len(p.get_assignments("A", 2010, 2025)) == 2
+        assert len(p.get_assignments("A", 2025, 2030)) == 1
+
+    def test_state_fips_filtering(self):
+        p = DictSeatsProvider()
+        p.add(_sa(state_fips="17", from_year=2020, to_year=2030))
+        p.add(_sa(state_fips="06", from_year=2020, to_year=2030))
+
+        results = p.get_assignments("A", 2020, 2025, state_fips="17")
+        assert len(results) == 1
+        assert results[0].state_fips == "17"
+
+    def test_sorted_by_from_year(self):
+        p = DictSeatsProvider()
+        p.add(_sa(from_year=2022, to_year=2032))
+        p.add(_sa(from_year=2012, to_year=2022))
+        results = p.get_assignments("A", 2010, 2030)
+        assert results[0].from_year == 2012
+        assert results[1].from_year == 2022
+
+    def test_reverse_year_range(self):
+        p = DictSeatsProvider()
+        p.add(_sa(from_year=2015, to_year=2025))
+        results = p.get_assignments("A", 2025, 2015)
+        assert len(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# SeatsOverlay
+# ---------------------------------------------------------------------------
+
+
+class TestSeatsOverlay:
+    def test_is_overlay(self):
+        o = SeatsOverlay(provider=DictSeatsProvider())
+        assert isinstance(o, PlaceHistoryOverlay)
+        assert o.name == "seats"
+
+    def test_fetch_returns_result(self):
+        p = DictSeatsProvider()
+        p.add(_sa(from_year=2020, to_year=2030))
+        o = SeatsOverlay(provider=p)
+
+        result = o.fetch("17031010100", 2020, 2025)
+        assert isinstance(result, SeatsOverlayResult)
+        assert result.geoid == "17031010100"
+        assert len(result.assignments) == 1
+
+    def test_fetch_empty(self):
+        p = DictSeatsProvider()
+        o = SeatsOverlay(provider=p)
+        result = o.fetch("A", 2000, 2020)
+        assert result.assignments == []
+
+    def test_no_provider_raises(self):
+        o = SeatsOverlay(provider=None)
+        with pytest.raises(RuntimeError, match="No seats data provider"):
+            o.fetch("A", 2000, 2020)
+
+    def test_fetch_multiple_offices(self):
+        p = DictSeatsProvider()
+        p.add(_sa(office="US_HOUSE", from_year=2020, to_year=2030))
+        p.add(_sa(office="STATE_UPPER", from_year=2020, to_year=2030))
+        o = SeatsOverlay(provider=p)
+
+        result = o.fetch("A", 2020, 2025)
+        assert len(result.assignments) == 2
+
+    def test_fetch_passes_state_fips(self):
+        p = DictSeatsProvider()
+        p.add(_sa(state_fips="17", from_year=2020, to_year=2030))
+        p.add(_sa(state_fips="06", from_year=2020, to_year=2030))
+        o = SeatsOverlay(provider=p)
+
+        result = o.fetch("A", 2020, 2025, state_fips="17")
+        assert len(result.assignments) == 1
+
+    def test_multi_plan_timeline(self):
+        p = DictSeatsProvider()
+        p.add(_sa(plan_name="2010 Plan", from_year=2012, to_year=2022))
+        p.add(_sa(plan_name="2020 Plan", from_year=2022, to_year=2032))
+        o = SeatsOverlay(provider=p)
+
+        result = o.fetch("A", 2010, 2030)
+        assert len(result.assignments) == 2
+        assert result.assignments[0].plan_name == "2010 Plan"
+        assert result.assignments[1].plan_name == "2020 Plan"
+
+    def test_registry_integration(self):
+        registry = OverlayRegistry()
+        p = DictSeatsProvider()
+        p.add(_sa(from_year=2020, to_year=2030))
+        registry.register_instance("seats", SeatsOverlay(provider=p))
+
+        overlay = registry.get("seats")
+        assert overlay is not None
+        result = overlay.fetch("A", 2020, 2025)
+        assert isinstance(result, SeatsOverlayResult)
+
+    def test_partial_containment(self):
+        p = DictSeatsProvider()
+        p.add(_sa(containment_pct=0.7, district_label="7", from_year=2020, to_year=2030))
+        p.add(_sa(containment_pct=0.3, district_label="4", from_year=2020, to_year=2030))
+        o = SeatsOverlay(provider=p)
+
+        result = o.fetch("A", 2020, 2025)
+        assert len(result.assignments) == 2
+        assert sum(a.containment_pct for a in result.assignments) == pytest.approx(1.0)

--- a/tests/test_tamu_batch.py
+++ b/tests/test_tamu_batch.py
@@ -1,0 +1,348 @@
+"""Tests for TAMU batch geocoder backend (SU#625)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from siege_utilities.geo.providers.batch_geocoder import MatchQuality
+from siege_utilities.geo.providers.tamu_batch import (
+    DEFAULT_RATE_LIMIT,
+    ENV_API_KEY,
+    TAMU_BASE_URL,
+    TAMUBatchGeocoder,
+)
+
+
+def _tamu_response(
+    lat="41.8781",
+    lon="-87.6298",
+    matched_address="123 MAIN ST, CHICAGO, IL 60601",
+    match_type="Exact",
+    state_fips="17",
+    county_fips="031",
+    tract="010100",
+    block="1001",
+):
+    """Build a mock TAMU JSON response."""
+    return {
+        "OutputGeocodes": [
+            {
+                "OutputGeocode": {
+                    "Latitude": lat,
+                    "Longitude": lon,
+                    "MatchedAddress": matched_address,
+                    "MatchType": match_type,
+                },
+                "CensusValues": [
+                    {
+                        "CensusValue1": {
+                            "CensusStateFips": state_fips,
+                            "CensusCountyFips": county_fips,
+                            "CensusTract": tract,
+                            "CensusBlock": block,
+                        }
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def _mock_urlopen(response_data):
+    """Create a mock urlopen context manager returning given JSON data."""
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = json.dumps(response_data).encode()
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+class TestTAMUBatchGeocoderConfig:
+    def test_backend_name(self):
+        g = TAMUBatchGeocoder(api_key="test-key")
+        assert g.backend_name == "tamu"
+
+    def test_is_available_with_key(self):
+        g = TAMUBatchGeocoder(api_key="test-key")
+        assert g.is_available()
+
+    def test_not_available_without_key(self):
+        g = TAMUBatchGeocoder(api_key="")
+        assert not g.is_available()
+
+    @patch.dict("os.environ", {ENV_API_KEY: "env-key"})
+    def test_api_key_from_env(self):
+        g = TAMUBatchGeocoder()
+        assert g._api_key == "env-key"
+        assert g.is_available()
+
+    def test_explicit_key_overrides_env(self):
+        g = TAMUBatchGeocoder(api_key="explicit")
+        assert g._api_key == "explicit"
+
+    def test_default_rate_limit(self):
+        g = TAMUBatchGeocoder(api_key="k")
+        assert g._rate_limit == DEFAULT_RATE_LIMIT
+
+    def test_custom_rate_limit(self):
+        g = TAMUBatchGeocoder(api_key="k", rate_limit=1.0)
+        assert g._rate_limit == 1.0
+
+    def test_default_census_year(self):
+        g = TAMUBatchGeocoder(api_key="k")
+        assert g._census_year == "2020"
+
+    def test_custom_census_year(self):
+        g = TAMUBatchGeocoder(api_key="k", census_year="2010")
+        assert g._census_year == "2010"
+
+
+class TestTAMUBatchGeocoderGeocode:
+    def test_empty_input(self):
+        g = TAMUBatchGeocoder(api_key="k")
+        result = g.geocode([])
+        assert result.total == 0
+
+    def test_no_api_key_returns_error(self):
+        g = TAMUBatchGeocoder(api_key="")
+        result = g.geocode(["123 Main St"])
+        assert len(result.errors) == 1
+        assert "API key" in result.errors[0]
+
+    @patch("siege_utilities.geo.providers.tamu_batch.time.sleep")
+    @patch.object(TAMUBatchGeocoder, "_tamu_request")
+    def test_single_match(self, mock_request, mock_sleep):
+        mock_request.return_value = GeocodingResult(
+            input_address="123 Main St, Chicago, IL",
+            input_id="0",
+            matched_address="123 MAIN ST",
+            lat=41.8781,
+            lon=-87.6298,
+            match_quality=MatchQuality.EXACT.value,
+            state_geoid="17",
+            county_geoid="17031",
+            tract_geoid="17031010100",
+            block_geoid="170310101001001",
+            backend="tamu",
+        )
+        g = TAMUBatchGeocoder(api_key="k", rate_limit=0.0)
+        result = g.geocode(["123 Main St, Chicago, IL"])
+
+        assert result.total == 1
+        assert result.results[0].matched
+        assert result.results[0].lat == 41.8781
+        assert result.results[0].backend == "tamu"
+        assert result.results[0].block_geoid == "170310101001001"
+
+    @patch("siege_utilities.geo.providers.tamu_batch.time.sleep")
+    @patch.object(TAMUBatchGeocoder, "_tamu_request")
+    def test_no_match(self, mock_request, mock_sleep):
+        mock_request.return_value = None
+        g = TAMUBatchGeocoder(api_key="k", rate_limit=0.0)
+        result = g.geocode(["fake address"])
+
+        assert result.total == 1
+        assert not result.results[0].matched
+
+    @patch("siege_utilities.geo.providers.tamu_batch.time.sleep")
+    @patch.object(TAMUBatchGeocoder, "_tamu_request")
+    def test_multiple_results(self, mock_request, mock_sleep):
+        gr_match = GeocodingResult(
+            input_address="a", input_id="0",
+            lat=41.0, lon=-87.0,
+            match_quality=MatchQuality.EXACT.value, backend="tamu",
+        )
+        mock_request.side_effect = [gr_match, None, gr_match]
+        g = TAMUBatchGeocoder(api_key="k", rate_limit=0.0)
+        result = g.geocode(["a", "b", "c"])
+
+        assert result.total == 3
+        assert result.matched_count == 2
+
+    @patch("siege_utilities.geo.providers.tamu_batch.time.sleep")
+    @patch.object(TAMUBatchGeocoder, "_tamu_request")
+    def test_handles_exception(self, mock_request, mock_sleep):
+        mock_request.side_effect = Exception("API error")
+        g = TAMUBatchGeocoder(api_key="k", rate_limit=0.0)
+        result = g.geocode(["123 Main St"])
+
+        assert result.total == 1
+        assert not result.results[0].matched
+
+    @patch("siege_utilities.geo.providers.tamu_batch.time.sleep")
+    @patch.object(TAMUBatchGeocoder, "_tamu_request")
+    def test_empty_query_returns_no_match(self, mock_request, mock_sleep):
+        g = TAMUBatchGeocoder(api_key="k", rate_limit=0.0)
+        result = g.geocode([{"street": "", "city": "", "state": "", "zipcode": ""}])
+        assert result.total == 1
+        assert not result.results[0].matched
+        mock_request.assert_not_called()
+
+
+# Need to import GeocodingResult for test construction
+from siege_utilities.geo.providers.batch_geocoder import GeocodingResult
+
+
+class TestTAMUParseResponse:
+    """Tests for the TAMU response parser."""
+
+    def _make_geocoder(self):
+        return TAMUBatchGeocoder(api_key="test-key", rate_limit=0.0)
+
+    def _make_addr(self):
+        from siege_utilities.geo.providers.batch_geocoder import AddressInput
+        return AddressInput(
+            street="123 Main St", city="Chicago", state="IL",
+            zipcode="60601", input_id="test-1",
+        )
+
+    def test_exact_match(self):
+        g = self._make_geocoder()
+        addr = self._make_addr()
+        data = _tamu_response(match_type="Exact")
+        result = g._parse_response(data, addr)
+
+        assert result is not None
+        assert result.lat == 41.8781
+        assert result.lon == -87.6298
+        assert result.match_quality == MatchQuality.EXACT.value
+        assert result.state_geoid == "17"
+        assert result.county_geoid == "17031"
+        assert result.tract_geoid == "17031010100"
+        assert result.block_geoid == "170310101001001"
+
+    def test_interpolated_match(self):
+        g = self._make_geocoder()
+        addr = self._make_addr()
+        data = _tamu_response(match_type="Interpolated")
+        result = g._parse_response(data, addr)
+
+        assert result is not None
+        assert result.match_quality == MatchQuality.INTERPOLATED.value
+
+    def test_approximate_match(self):
+        g = self._make_geocoder()
+        addr = self._make_addr()
+        data = _tamu_response(match_type="Approximate")
+        result = g._parse_response(data, addr)
+
+        assert result is not None
+        assert result.match_quality == MatchQuality.APPROXIMATE.value
+
+    def test_nearexact_maps_to_exact(self):
+        g = self._make_geocoder()
+        addr = self._make_addr()
+        data = _tamu_response(match_type="NearExact")
+        result = g._parse_response(data, addr)
+
+        assert result is not None
+        assert result.match_quality == MatchQuality.EXACT.value
+
+    def test_empty_geocodes(self):
+        g = self._make_geocoder()
+        addr = self._make_addr()
+        result = g._parse_response({"OutputGeocodes": []}, addr)
+        assert result is None
+
+    def test_missing_lat_lon(self):
+        g = self._make_geocoder()
+        addr = self._make_addr()
+        data = _tamu_response(lat="", lon="")
+        result = g._parse_response(data, addr)
+        assert result is None
+
+    def test_zero_lat_lon_treated_as_no_match(self):
+        g = self._make_geocoder()
+        addr = self._make_addr()
+        data = _tamu_response(lat="0.0", lon="0.0")
+        result = g._parse_response(data, addr)
+        assert result is None
+
+    def test_no_census_values(self):
+        g = self._make_geocoder()
+        addr = self._make_addr()
+        data = _tamu_response()
+        data["OutputGeocodes"][0]["CensusValues"] = []
+        result = g._parse_response(data, addr)
+
+        assert result is not None
+        assert result.lat == 41.8781
+        assert result.state_geoid == ""
+        assert result.block_geoid == ""
+
+    def test_partial_geoid_hierarchy(self):
+        g = self._make_geocoder()
+        addr = self._make_addr()
+        data = _tamu_response(tract="", block="")
+        result = g._parse_response(data, addr)
+
+        assert result is not None
+        assert result.state_geoid == "17"
+        assert result.county_geoid == "17031"
+        assert result.tract_geoid == ""
+        assert result.block_geoid == ""
+
+    def test_preserves_input_id(self):
+        g = self._make_geocoder()
+        addr = self._make_addr()
+        data = _tamu_response()
+        result = g._parse_response(data, addr)
+        assert result.input_id == "test-1"
+
+    def test_matched_address_preserved(self):
+        g = self._make_geocoder()
+        addr = self._make_addr()
+        data = _tamu_response(matched_address="123 MAIN ST, CHICAGO IL")
+        result = g._parse_response(data, addr)
+        assert result.matched_address == "123 MAIN ST, CHICAGO IL"
+
+
+class TestTAMURequest:
+    """Tests for the low-level _tamu_request method."""
+
+    @patch("siege_utilities.geo.providers.tamu_batch.urllib.request.urlopen")
+    def test_successful_request(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_urlopen(_tamu_response())
+        g = TAMUBatchGeocoder(api_key="test-key", rate_limit=0.0)
+        from siege_utilities.geo.providers.batch_geocoder import AddressInput
+        addr = AddressInput(
+            street="123 Main St", city="Chicago", state="IL",
+            zipcode="60601", input_id="0",
+        )
+        result = g._tamu_request(addr)
+        assert result is not None
+        assert result.lat == 41.8781
+
+    @patch("siege_utilities.geo.providers.tamu_batch.time.sleep")
+    @patch("siege_utilities.geo.providers.tamu_batch.urllib.request.urlopen")
+    def test_retries_on_failure(self, mock_urlopen, mock_sleep):
+        mock_urlopen.side_effect = [
+            Exception("timeout"),
+            _mock_urlopen(_tamu_response()),
+        ]
+        g = TAMUBatchGeocoder(api_key="test-key", rate_limit=0.0, max_retries=2)
+        from siege_utilities.geo.providers.batch_geocoder import AddressInput
+        addr = AddressInput(
+            street="123 Main St", city="Chicago", state="IL",
+            zipcode="60601", input_id="0",
+        )
+        result = g._tamu_request(addr)
+        assert result is not None
+        assert mock_urlopen.call_count == 2
+
+    @patch("siege_utilities.geo.providers.tamu_batch.time.sleep")
+    @patch("siege_utilities.geo.providers.tamu_batch.urllib.request.urlopen")
+    def test_raises_after_max_retries(self, mock_urlopen, mock_sleep):
+        mock_urlopen.side_effect = Exception("persistent failure")
+        g = TAMUBatchGeocoder(api_key="test-key", rate_limit=0.0, max_retries=1)
+        from siege_utilities.geo.providers.batch_geocoder import AddressInput
+        addr = AddressInput(
+            street="123 Main St", city="Chicago", state="IL",
+            zipcode="60601", input_id="0",
+        )
+        with pytest.raises(Exception, match="persistent failure"):
+            g._tamu_request(addr)
+        assert mock_urlopen.call_count == 2

--- a/tests/test_urbanicity_overlay.py
+++ b/tests/test_urbanicity_overlay.py
@@ -1,0 +1,207 @@
+"""Tests for urbanicity overlay (SU#611)."""
+
+from __future__ import annotations
+
+import pytest
+
+from siege_utilities.geo.overlay_registry import PlaceHistoryOverlay
+from siege_utilities.geo.overlays.urbanicity import (
+    DictUrbanicityProvider,
+    UrbanicityOverlay,
+    UrbanicityOverlayResult,
+    UrbanicityPoint,
+)
+
+
+def _up(year=2020, geoid="17031010100", locale_code="11",
+        locale_label="City-Large", category="city", size="large"):
+    return UrbanicityPoint(
+        year=year, geoid=geoid, locale_code=locale_code,
+        locale_label=locale_label, category=category, size=size,
+    )
+
+
+# ---------------------------------------------------------------------------
+# UrbanicityPoint
+# ---------------------------------------------------------------------------
+
+
+class TestUrbanicityPoint:
+    def test_defaults(self):
+        p = UrbanicityPoint()
+        assert p.year == 0
+        assert p.locale_code == ""
+
+    def test_fields(self):
+        p = _up()
+        assert p.locale_code == "11"
+        assert p.category == "city"
+
+
+# ---------------------------------------------------------------------------
+# UrbanicityOverlayResult
+# ---------------------------------------------------------------------------
+
+
+class TestUrbanicityOverlayResult:
+    def test_empty(self):
+        r = UrbanicityOverlayResult(geoid="A")
+        assert not r.has_data
+        assert r.years == []
+        assert r.current_category == ""
+
+    def test_years(self):
+        r = UrbanicityOverlayResult(
+            geoid="A",
+            classifications=[_up(year=2000), _up(year=2020), _up(year=2010)],
+        )
+        assert r.years == [2000, 2010, 2020]
+
+    def test_for_year(self):
+        r = UrbanicityOverlayResult(
+            geoid="A", classifications=[_up(year=2010), _up(year=2020)],
+        )
+        assert r.for_year(2020).year == 2020
+        assert r.for_year(2015) is None
+
+    def test_changed_true(self):
+        r = UrbanicityOverlayResult(
+            geoid="A",
+            classifications=[
+                _up(year=2010, locale_code="11"),
+                _up(year=2020, locale_code="21"),
+            ],
+        )
+        assert r.changed
+
+    def test_changed_false(self):
+        r = UrbanicityOverlayResult(
+            geoid="A",
+            classifications=[
+                _up(year=2010, locale_code="11"),
+                _up(year=2020, locale_code="11"),
+            ],
+        )
+        assert not r.changed
+
+    def test_current_category(self):
+        r = UrbanicityOverlayResult(
+            geoid="A",
+            classifications=[
+                _up(year=2010, category="city"),
+                _up(year=2020, category="suburb"),
+            ],
+        )
+        assert r.current_category == "suburb"
+
+    def test_has_data(self):
+        r = UrbanicityOverlayResult(geoid="A", classifications=[_up()])
+        assert r.has_data
+
+
+# ---------------------------------------------------------------------------
+# DictUrbanicityProvider
+# ---------------------------------------------------------------------------
+
+
+class TestDictUrbanicityProvider:
+    def test_empty(self):
+        p = DictUrbanicityProvider()
+        assert p.classify("A", 2020) is None
+
+    def test_add_and_classify(self):
+        p = DictUrbanicityProvider()
+        p.add(_up(geoid="A", year=2020))
+        result = p.classify("A", 2020)
+        assert result is not None
+        assert result.locale_code == "11"
+
+    def test_wrong_geoid(self):
+        p = DictUrbanicityProvider()
+        p.add(_up(geoid="A", year=2020))
+        assert p.classify("B", 2020) is None
+
+    def test_wrong_year(self):
+        p = DictUrbanicityProvider()
+        p.add(_up(geoid="A", year=2020))
+        assert p.classify("A", 2010) is None
+
+
+# ---------------------------------------------------------------------------
+# UrbanicityOverlay
+# ---------------------------------------------------------------------------
+
+
+class TestUrbanicityOverlay:
+    def test_is_overlay(self):
+        o = UrbanicityOverlay(provider=DictUrbanicityProvider())
+        assert isinstance(o, PlaceHistoryOverlay)
+        assert o.name == "urbanicity"
+
+    def test_fetch_single_vintage(self):
+        p = DictUrbanicityProvider()
+        p.add(_up(geoid="A", year=2020))
+        o = UrbanicityOverlay(provider=p)
+        result = o.fetch("A", 2015, 2025)
+        assert len(result.classifications) == 1
+
+    def test_fetch_multiple_vintages(self):
+        p = DictUrbanicityProvider()
+        p.add(_up(geoid="A", year=2000))
+        p.add(_up(geoid="A", year=2010))
+        p.add(_up(geoid="A", year=2020))
+        o = UrbanicityOverlay(provider=p)
+        result = o.fetch("A", 1995, 2025)
+        assert len(result.classifications) == 3
+
+    def test_fetch_filters_by_range(self):
+        p = DictUrbanicityProvider()
+        p.add(_up(geoid="A", year=2000))
+        p.add(_up(geoid="A", year=2010))
+        p.add(_up(geoid="A", year=2020))
+        o = UrbanicityOverlay(provider=p)
+        result = o.fetch("A", 2005, 2015)
+        assert len(result.classifications) == 1
+        assert result.classifications[0].year == 2010
+
+    def test_fetch_empty(self):
+        p = DictUrbanicityProvider()
+        o = UrbanicityOverlay(provider=p)
+        result = o.fetch("A", 2000, 2020)
+        assert not result.has_data
+
+    def test_no_provider_raises(self):
+        o = UrbanicityOverlay(provider=None)
+        with pytest.raises(RuntimeError, match="No urbanicity data provider"):
+            o.fetch("A", 2000, 2020)
+
+    def test_reverse_year_range(self):
+        p = DictUrbanicityProvider()
+        p.add(_up(geoid="A", year=2010))
+        o = UrbanicityOverlay(provider=p)
+        result = o.fetch("A", 2020, 2005)
+        assert len(result.classifications) == 1
+
+    def test_custom_vintage_years(self):
+        p = DictUrbanicityProvider()
+        p.add(_up(geoid="A", year=2015))
+        o = UrbanicityOverlay(provider=p, vintage_years=[2005, 2015, 2025])
+        result = o.fetch("A", 2010, 2020)
+        assert len(result.classifications) == 1
+
+    def test_sorted_output(self):
+        p = DictUrbanicityProvider()
+        p.add(_up(geoid="A", year=2020))
+        p.add(_up(geoid="A", year=2010))
+        p.add(_up(geoid="A", year=2000))
+        o = UrbanicityOverlay(provider=p)
+        result = o.fetch("A", 1995, 2025)
+        years = [c.year for c in result.classifications]
+        assert years == [2000, 2010, 2020]
+
+    def test_missing_vintage_skipped(self):
+        p = DictUrbanicityProvider()
+        p.add(_up(geoid="A", year=2010))
+        o = UrbanicityOverlay(provider=p)
+        result = o.fetch("A", 1995, 2025)
+        assert len(result.classifications) == 1

--- a/tests/test_variable_groups_deprecation.py
+++ b/tests/test_variable_groups_deprecation.py
@@ -1,0 +1,65 @@
+"""Tests for VARIABLE_GROUPS deprecation warning."""
+
+import warnings
+
+import pytest
+
+
+def _reset_warned():
+    from siege_utilities.geo.census.variable_registry import _DeprecatedDict
+    _DeprecatedDict._warned = False
+
+
+class TestVariableGroupsDeprecation:
+    def test_access_emits_deprecation_warning(self):
+        _reset_warned()
+        from siege_utilities.geo.census.variable_registry import VARIABLE_GROUPS
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _ = VARIABLE_GROUPS["total_population"]
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "CensusCatalog" in str(w[0].message)
+
+    def test_warns_only_once(self):
+        _reset_warned()
+        from siege_utilities.geo.census.variable_registry import VARIABLE_GROUPS
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _ = VARIABLE_GROUPS["total_population"]
+            _ = VARIABLE_GROUPS["demographics_basic"]
+            assert len(w) == 1
+
+    def test_data_still_accessible(self):
+        _reset_warned()
+        from siege_utilities.geo.census.variable_registry import VARIABLE_GROUPS
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            assert "B01001_001E" in VARIABLE_GROUPS["total_population"]
+
+    def test_iteration_emits_warning(self):
+        _reset_warned()
+        from siege_utilities.geo.census.variable_registry import VARIABLE_GROUPS
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            keys = list(VARIABLE_GROUPS.keys())
+            assert len(w) == 1
+            assert len(keys) > 0
+
+    def test_get_emits_warning(self):
+        _reset_warned()
+        from siege_utilities.geo.census.variable_registry import VARIABLE_GROUPS
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = VARIABLE_GROUPS.get("total_population")
+            assert len(w) == 1
+            assert result is not None
+
+    def test_registry_init_does_not_warn(self):
+        _reset_warned()
+        from siege_utilities.geo.census.variable_registry import VariableRegistry
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            reg = VariableRegistry()
+            _ = reg.resolve_variables("total_population")
+            assert len(w) == 0


### PR DESCRIPTION
## Summary
- `ElectionReturn.__post_init__` auto-computes `vote_share` from `votes / total_votes` when not explicitly set, eliminating silent-zero bugs when callers forget to compute it
- Removed unused `PlanType` import from redistricting overlay (verified no downstream re-export consumers exist)
- Simplified `_er()` test helper — no longer manually computes vote_share

## Test plan
- [x] `test_vote_share_auto_computed`: 100/200 → 0.5
- [x] `test_vote_share_explicit_override`: explicit 0.75 preserved
- [x] `test_vote_share_zero_total`: 0/0 stays 0.0
- [x] All 111 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Census table catalog with hierarchical discovery and full-text search functionality.
  * Introduced batch geocoding with multiple backends (Census, Nominatim, TAMU) and automatic quality-based fallback.
  * Enabled spatio-temporal place history queries with overlay system for demographics, urbanicity, elections, and redistricting data.
  * Integrated NLRB labor relations data sources with caching and deduplication.
  * Enhanced area codification with enriched demographics, urbanicity, recency, and block-level analysis.
  * Added plan lifecycle tracking and precinct-to-VTD reconciliation for redistricting workflows.
  * Implemented RDH dataset catalog with intelligent search and coverage matrix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siege-analytics/siege_utilities/pull/673?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->