### PR TITLE
fix(geo): add missing columns to areal weight matrix (#676)

### DIFF
--- a/siege_utilities/geo/interpolation/areal.py
+++ b/siege_utilities/geo/interpolation/areal.py
@@ -268,11 +268,17 @@ def compute_area_weights(
     """
     source, target, _ = _ensure_common_crs(source_gdf, target_gdf)
 
-    # Use an equal-area projection for accurate area computation
     source_ea = source.to_crs("ESRI:54009")
     target_ea = target.to_crs("ESRI:54009")
 
-    # Compute intersections via spatial overlay
+    source_areas = source_ea.geometry.area
+    target_areas = target_ea.geometry.area
+
+    source_ea = source_ea.copy()
+    target_ea = target_ea.copy()
+    source_ea["_src_idx"] = range(len(source_ea))
+    target_ea["_tgt_idx"] = range(len(target_ea))
+
     overlay = gpd.overlay(source_ea, target_ea, how="intersection", keep_geom_type=False)
 
     if overlay.empty:
@@ -284,15 +290,17 @@ def compute_area_weights(
 
     overlap_areas = overlay.geometry.area
 
-    # Build result — use overlay's index tracking
-    # gpd.overlay preserves original indices in columns if they were set
     records = []
     for i, row in overlay.iterrows():
-        overlap_area = overlap_areas[i]
-        # Source and target indices depend on overlay behavior
-        # For now, return the raw intersection areas
+        src_i = int(row["_src_idx"])
+        tgt_i = int(row["_tgt_idx"])
+        ov_area = overlap_areas[i]
         records.append({
-            "overlap_area": overlap_area,
+            "source_idx": src_i,
+            "target_idx": tgt_i,
+            "overlap_area": ov_area,
+            "source_fraction": ov_area / source_areas.iloc[src_i] if source_areas.iloc[src_i] > 0 else 0.0,
+            "target_fraction": ov_area / target_areas.iloc[tgt_i] if target_areas.iloc[tgt_i] > 0 else 0.0,
             "geometry": row.geometry,
         })
 

--- a/tests/test_areal_interpolation.py
+++ b/tests/test_areal_interpolation.py
@@ -194,6 +194,18 @@ class TestComputeAreaWeights:
         weights = compute_area_weights(source_gdf, target_gdf)
         assert len(weights) > 0
 
+    def test_documented_columns_present(self, source_gdf, target_gdf):
+        from siege_utilities.geo.interpolation import compute_area_weights
+
+        weights = compute_area_weights(source_gdf, target_gdf)
+        assert len(weights) > 0
+        for col in ("source_idx", "target_idx", "overlap_area",
+                     "source_fraction", "target_fraction"):
+            assert col in weights.columns, f"Missing documented column: {col}"
+        assert (weights["source_fraction"] >= 0).all()
+        assert (weights["source_fraction"] <= 1.0 + 1e-6).all()
+        assert (weights["target_fraction"] >= 0).all()
+
     def test_no_overlap_returns_empty(self):
         from siege_utilities.geo.interpolation import compute_area_weights
 


### PR DESCRIPTION
## Summary

- `compute_area_weights()` now returns all 5 documented columns: `source_idx`, `target_idx`, `overlap_area`, `source_fraction`, `target_fraction`
- Previously only returned `overlap_area` and `geometry`, silently violating the docstring contract
- Added test `test_documented_columns_present` verifying column presence and fraction bounds

## Test plan

- [x] `test_documented_columns_present` checks all 5 columns exist
- [x] `test_documented_columns_present` validates fraction values in [0, 1]
- [x] Existing `test_full_overlap_returns_data` and `test_no_overlap_returns_empty` still pass

Closes #676