### PR TITLE
fix(data): warn when moe_proportion receives non-nested inputs (#679)

### DIFF
--- a/siege_utilities/data/statistics/moe_propagation.py
+++ b/siege_utilities/data/statistics/moe_propagation.py
@@ -15,9 +15,12 @@ Reference:
 
 from __future__ import annotations
 
+import logging
 import math
 from dataclasses import dataclass
 from typing import Sequence
+
+log = logging.getLogger(__name__)
 
 
 Z_90 = 1.645  # z-score for 90% confidence (ACS default)
@@ -134,6 +137,15 @@ def moe_proportion(
     """
     if denominator.value == 0:
         return Estimate(value=0.0, moe=0.0)
+
+    if numerator.value > denominator.value:
+        log.warning(
+            "moe_proportion called with numerator (%.2f) > denominator (%.2f). "
+            "The proportion formula assumes the numerator is a subset of the "
+            "denominator. Use moe_ratio() for non-nested estimates.",
+            numerator.value,
+            denominator.value,
+        )
 
     p = numerator.value / denominator.value
 

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -118,11 +118,18 @@ class TestMoeProportion:
         assert result.moe > 0
 
     def test_bounded_to_01(self):
-        # Numerator > denominator (unusual but possible)
         num = Estimate(value=110, moe=10)
         den = Estimate(value=100, moe=5)
         result = moe_proportion(num, den)
         assert result.value <= 1.0
+
+    def test_non_nested_warns(self, caplog):
+        num = Estimate(value=110, moe=10)
+        den = Estimate(value=100, moe=5)
+        import logging
+        with caplog.at_level(logging.WARNING, logger="siege_utilities.data.statistics.moe_propagation"):
+            moe_proportion(num, den)
+        assert any("moe_ratio()" in m for m in caplog.messages)
 
     def test_zero_denominator(self):
         num = Estimate(value=50, moe=10)


### PR DESCRIPTION
## Summary

- `moe_proportion()` now logs a warning when `numerator.value > denominator.value`, directing callers to `moe_ratio()` for non-nested estimates
- The Census proportion formula assumes the numerator is a subset of the denominator; without this guard, the function silently produced invalid confidence intervals
- Added test verifying the warning is emitted

## Test plan

- [x] `test_non_nested_warns` — verifies warning logged when numerator > denominator
- [x] Existing `test_bounded_to_01` still passes (behavior unchanged, just adds a warning)
- [x] `test_half` and `test_zero_denominator` unaffected

Closes #679