### PR TITLE
fix(survey): t-dist for small n, chi-square None, SE underflow warn, weight validation (#680)

### DIFF
--- a/siege_utilities/survey/crosstab.py
+++ b/siege_utilities/survey/crosstab.py
@@ -15,6 +15,20 @@ from .models import Chain, View
 
 DEFAULT_Z_VALUE = 1.96
 
+try:
+    from scipy.stats import t as _scipy_t
+    _SCIPY_T_AVAILABLE = True
+except ImportError:
+    _scipy_t = None
+    _SCIPY_T_AVAILABLE = False
+
+
+def _critical_value(n: int, confidence: float = 0.95) -> float:
+    """Return the appropriate critical value: t for n<30, z otherwise."""
+    if n < 30 and _SCIPY_T_AVAILABLE:
+        return float(_scipy_t.ppf((1 + confidence) / 2, df=n - 1))
+    return DEFAULT_Z_VALUE
+
 
 class CrosstabInputError(ValueError):
     """Raised when build_chain receives an empty or schema-incompatible DataFrame.
@@ -328,7 +342,7 @@ def _build_mean_scale(
                 if len(cat_vals) == 0:
                     continue
                 mean = float(cat_vals.mean())
-                ci = DEFAULT_Z_VALUE * float(cat_vals.std(ddof=1)) / (len(cat_vals) ** 0.5) if len(cat_vals) > 1 else 0.0
+                ci = _critical_value(len(cat_vals)) * float(cat_vals.std(ddof=1)) / (len(cat_vals) ** 0.5) if len(cat_vals) > 1 else 0.0
                 v = View(metric=str(cat), base=base, count=mean, pct=None, ci=ci)
                 cell_views.append(v)
             if top_n:

--- a/siege_utilities/survey/significance.py
+++ b/siege_utilities/survey/significance.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from siege_utilities.core.logging import log_error
+from siege_utilities.core.logging import log_error, log_warning
 
 try:
     import pandas as pd
@@ -87,6 +87,12 @@ def column_proportion_test(chain: "Chain", alpha: float = 0.05) -> "Chain":
                 # threshold instead of an exact-zero check.
                 se = np.sqrt(p_pool * (1 - p_pool) * (1 / n1 + 1 / n2))
                 if not np.isfinite(se) or se <= 1e-12:
+                    log_warning(
+                        f"SE underflow in column proportion test: "
+                        f"p_pool={p_pool:.4f}, se={se}, "
+                        f"columns=({key_i!r}, {key_j!r}), metric={metric!r}. "
+                        f"Test skipped for this pair."
+                    )
                     continue
                 z = abs(p1 - p2) / se
                 if _SCIPY_AVAILABLE:
@@ -147,7 +153,7 @@ def chi_square_flag(chain: "Chain", alpha: float = 0.05) -> "Chain":
         df = df.drop(index=["Total"])
 
     if df.empty or df.shape[0] < 2 or df.shape[1] < 2:
-        chain.chi_square_significant = False
+        chain.chi_square_significant = None
         chain.chi_square_p = None
         return chain
 

--- a/siege_utilities/survey/weights.py
+++ b/siege_utilities/survey/weights.py
@@ -97,6 +97,16 @@ def apply_rim_weights(
                 f"category from targets or fix the upstream filter."
             )
 
+    for col, cats in targets.items():
+        if isinstance(cats, dict):
+            total = sum(v for v in cats.values() if isinstance(v, (int, float)))
+            if abs(total - 1.0) > 0.01:
+                raise ValueError(
+                    f"apply_rim_weights: targets[{col!r}] proportions sum to "
+                    f"{total:.4f}, expected 1.0. RIM weighting requires target "
+                    f"proportions that sum to 1.0."
+                )
+
     # Map our convergence param to weightipy's Rim-class ``convcrit`` via
     # the rim_params passthrough. See weightipy.internal.rim.Rim.__init__.
     scheme = wp.scheme_from_dict(


### PR DESCRIPTION
## Summary

- **crosstab.py**: CI computation uses t-distribution for n<30 instead of hardcoded z=1.96
- **significance.py**: `chi_square_flag` sets `significant=None` (not `False`) when table is too small to test
- **significance.py**: SE underflow in `column_proportion_test` logs a warning instead of silently skipping
- **weights.py**: Validates RIM target proportions sum to 1.0 before passing to weightipy

## Test plan

- [ ] Mean-scale CI with n=10 sample should produce wider CI than z=1.96 (manual verification)
- [ ] Degenerate chi-square with 1-row table returns `significant=None`, not `False`
- [ ] SE underflow produces log warning with diagnostic context
- [ ] `apply_rim_weights` raises `ValueError` when target proportions sum to 0.8

Closes #680