### PR TITLE
fix(core): add MySQL backslash escaping to sql_safety (#681)

### DIFF
--- a/siege_utilities/core/sql_safety.py
+++ b/siege_utilities/core/sql_safety.py
@@ -109,7 +109,7 @@ def validate_sql_identifier_in(
     return name
 
 
-def escape_sql_string_literal(value: str) -> str:
+def escape_sql_string_literal(value: str, *, dialect: str = "standard") -> str:
     """SQL-escape a string for use inside single-quoted SQL literals.
 
     Use sparingly -- parameter binding is always preferred. The cases
@@ -121,13 +121,21 @@ def escape_sql_string_literal(value: str) -> str:
       re-import -- defensive escaping in case the row data is later
       hand-edited.
 
-    The escape rule is the SQL standard: replace ``'`` with ``''``. NUL
-    bytes are rejected -- most drivers refuse to send them anyway and
-    they can split a query in C-string-aware backends.
+    The escape rule is the SQL standard: replace ``'`` with ``''``. For
+    MySQL (``dialect="mysql"``), backslashes are also doubled because
+    MySQL treats ``\\`` as an escape character by default
+    (``NO_BACKSLASH_ESCAPES`` off).
+
+    NUL bytes are rejected -- most drivers refuse to send them anyway
+    and they can split a query in C-string-aware backends.
+
+    Args:
+        value: The string to escape.
+        dialect: ``"standard"`` (default) or ``"mysql"``.
 
     Raises:
         TypeError: *value* is not a string.
-        ValueError: *value* contains a NUL byte.
+        ValueError: *value* contains a NUL byte or *dialect* is unknown.
     """
     if not isinstance(value, str):
         raise TypeError(
@@ -135,4 +143,11 @@ def escape_sql_string_literal(value: str) -> str:
         )
     if "\x00" in value:
         raise ValueError("escape_sql_string_literal: NUL byte in string literal")
-    return value.replace("'", "''")
+
+    dialect_lower = dialect.lower()
+    if dialect_lower == "mysql":
+        value = value.replace("\\", "\\\\")
+        return value.replace("'", "\\'")
+    if dialect_lower == "standard":
+        return value.replace("'", "''")
+    raise ValueError(f"escape_sql_string_literal: unknown dialect {dialect!r}")

--- a/tests/test_sql_safety_escape.py
+++ b/tests/test_sql_safety_escape.py
@@ -1,0 +1,46 @@
+"""Tests for SQL string literal escaping, including MySQL backslash handling."""
+
+import pytest
+
+from siege_utilities.core.sql_safety import escape_sql_string_literal
+
+
+class TestStandardDialect:
+    def test_single_quotes_doubled(self):
+        assert escape_sql_string_literal("it's") == "it''s"
+
+    def test_backslash_unchanged(self):
+        assert escape_sql_string_literal("C:\\path") == "C:\\path"
+
+    def test_empty_string(self):
+        assert escape_sql_string_literal("") == ""
+
+    def test_nul_rejected(self):
+        with pytest.raises(ValueError, match="NUL"):
+            escape_sql_string_literal("ab\x00cd")
+
+    def test_non_string_rejected(self):
+        with pytest.raises(TypeError):
+            escape_sql_string_literal(42)
+
+
+class TestMySQLDialect:
+    def test_backslash_doubled(self):
+        assert escape_sql_string_literal("C:\\path", dialect="mysql") == "C:\\\\path"
+
+    def test_single_quote_backslash_escaped(self):
+        assert escape_sql_string_literal("it's", dialect="mysql") == "it\\'s"
+
+    def test_combined(self):
+        result = escape_sql_string_literal("a\\b'c", dialect="mysql")
+        assert result == "a\\\\b\\'c"
+
+    def test_nul_rejected(self):
+        with pytest.raises(ValueError, match="NUL"):
+            escape_sql_string_literal("\x00", dialect="mysql")
+
+
+class TestUnknownDialect:
+    def test_raises(self):
+        with pytest.raises(ValueError, match="unknown dialect"):
+            escape_sql_string_literal("test", dialect="oracle")


### PR DESCRIPTION
## Summary

- `escape_sql_string_literal()` gains a `dialect` keyword parameter (`"standard"` or `"mysql"`)
- MySQL mode doubles backslashes and uses `\'` escaping, matching MySQL's default `NO_BACKSLASH_ESCAPES=OFF` behavior
- Default remains SQL-standard (quote-doubling only) — fully backward compatible
- Unknown dialect raises `ValueError`
- 10 new tests covering both dialects, edge cases, and error paths

## Test plan

- [x] Standard dialect: single quotes doubled, backslashes unchanged
- [x] MySQL dialect: backslashes doubled, quotes use `\'`
- [x] Combined `a\b'c` → `a\\b\'c` in MySQL mode
- [x] NUL byte rejection in both dialects
- [x] Unknown dialect raises `ValueError`

Closes #681