### PR TITLE
fix(geo): read SRID from PostGIS instead of hardcoding EPSG:4326 (SU#690)

### DIFF
--- a/siege_utilities/geo/spatial_transformations.py
+++ b/siege_utilities/geo/spatial_transformations.py
@@ -402,7 +402,8 @@ class PostGISConnector:
             table_name: Source table name
             crs: Output CRS. Defaults to
                 :func:`~siege_utilities.geo.crs.get_default_crs`.
-            **kwargs: Additional parameters
+            **kwargs: Additional parameters. Accepts ``geom_col``
+                (default ``'geom'``) to specify the geometry column name.
 
         Returns:
             GeoDataFrame with spatial data or None if failed
@@ -419,22 +420,15 @@ class PostGISConnector:
         # schema-qualified names by splitting on '.'.
         validate_identifier(table_name, label="table name", allow_dotted=True)
         try:
-            cursor = self.connection.cursor()
-            cursor.execute(
-                _pg_sql.SQL("SELECT ST_AsText(geom) as geometry FROM {}")
-                .format(_pg_sql.Identifier(*table_name.split(".")))
+            geom_col = kwargs.get('geom_col', 'geom')
+            query = _pg_sql.SQL("SELECT * FROM {}").format(
+                _pg_sql.Identifier(*table_name.split("."))
             )
-
-            rows = cursor.fetchall()
-            geometries = []
-
-            for row in rows:
-                from shapely import wkt
-                geom = wkt.loads(row[0])
-                geometries.append(geom)
-
-            # Create GeoDataFrame
-            gdf = gpd.GeoDataFrame(geometry=geometries, crs="EPSG:4326")
+            gdf = gpd.read_postgis(
+                query.as_string(self.connection),
+                self.connection,
+                geom_col=geom_col,
+            )
             log.info(f"Successfully downloaded from PostGIS: {table_name}")
             return reproject_if_needed(gdf, crs)
 


### PR DESCRIPTION
## Summary

- `download_spatial_data()` hardcoded `crs="EPSG:4326"` when creating GeoDataFrame from PostGIS WKT, silently corrupting coordinates from non-WGS84 tables
- Replaced manual `ST_AsText` + WKT parsing with `gpd.read_postgis()`, which reads the SRID from the geometry column automatically
- Now consistent with sibling `execute_spatial_query()` which already uses `read_postgis` correctly
- Also fixes secondary issue: old query discarded all non-geometry columns

## Test plan

- [ ] Verify `read_postgis` reads correct SRID from a PostGIS table in a non-4326 projection
- [ ] Verify `geom_col` kwarg works for tables with non-default geometry column names
- [ ] Verify `reproject_if_needed` still applies when caller requests a different output CRS

Closes #690