### PR TITLE
fix(analytics): raise on API failure instead of returning empty DataFrame (SU#689)

### DIFF
--- a/siege_utilities/analytics/facebook_business.py
+++ b/siege_utilities/analytics/facebook_business.py
@@ -162,7 +162,7 @@ class FacebookBusinessConnector:
 
         except Exception as e:
             logger.error("Failed to retrieve ad insights: %s", e, exc_info=True)
-            return pd.DataFrame()
+            raise
 
     def get_page_insights(self, page_id: str, start_date: str, end_date: str,
                           metrics: List[str] = None) -> pd.DataFrame:
@@ -216,7 +216,7 @@ class FacebookBusinessConnector:
 
         except Exception as e:
             logger.error("Failed to retrieve page insights: %s", e, exc_info=True)
-            return pd.DataFrame()
+            raise
 
     def get_business_insights(self, business_id: str, start_date: str, end_date: str,
                               metrics: List[str] = None) -> pd.DataFrame:
@@ -265,7 +265,7 @@ class FacebookBusinessConnector:
 
         except Exception as e:
             logger.error("Failed to retrieve business insights: %s", e, exc_info=True)
-            return pd.DataFrame()
+            raise
 
     def save_as_pandas(self, df: pd.DataFrame, output_path: str,
                        format: str = 'parquet') -> bool:

--- a/siege_utilities/analytics/google_analytics.py
+++ b/siege_utilities/analytics/google_analytics.py
@@ -304,7 +304,7 @@ class GoogleAnalyticsConnector:
 
         except Exception as e:
             logger.error("Failed to retrieve GA4 data: %s", e, exc_info=True)
-            return pd.DataFrame()
+            raise
 
     def get_ua_data(self, view_id: str, start_date: str, end_date: str,
                     metrics: List[str], dimensions: List[str] = None,
@@ -358,7 +358,7 @@ class GoogleAnalyticsConnector:
 
         except Exception as e:
             logger.error("Failed to retrieve UA data: %s", e, exc_info=True)
-            return pd.DataFrame()
+            raise
 
     def save_as_pandas(self, df: pd.DataFrame, output_path: str,
                        format: str = 'parquet') -> bool:


### PR DESCRIPTION
## Summary

- 5 analytics connector methods returned `pd.DataFrame()` in except blocks, making API failures indistinguishable from "no data"
- Changed all 5 to re-raise after logging — callers should decide how to handle failure
- Principle: errors are not data

## Affected methods

- `GoogleAnalyticsConnector.get_ga4_data()` (google_analytics.py:307)
- `GoogleAnalyticsConnector.get_ua_data()` (google_analytics.py:361)
- `FacebookBusinessConnector.get_ad_insights()` (facebook_business.py:165)
- `FacebookBusinessConnector.get_page_insights()` (facebook_business.py:219)
- `FacebookBusinessConnector.get_business_insights()` (facebook_business.py:268)

## Test plan

- [ ] Verify exceptions propagate to callers instead of returning empty DataFrame
- [ ] Verify logging still captures the error with exc_info before re-raise

Closes #689