### PR TITLE
fix(geo): validate geometry before GEOSGeometry conversion in rdh_loader (SU#691)

### DIFF
--- a/siege_utilities/geo/django/services/rdh_loader.py
+++ b/siege_utilities/geo/django/services/rdh_loader.py
@@ -134,10 +134,21 @@ class RDHLoaderService:
             district_number = str(row[district_col]) if district_col else str(_ + 1)
 
             geom = row.geometry
-            # Ensure MultiPolygon
+            if geom is None or geom.is_empty:
+                logger.warning(
+                    "Skipping row %s: null or empty geometry", geoid or _
+                )
+                continue
+
             from django.contrib.gis.geos import GEOSGeometry
 
             geos_geom = GEOSGeometry(geom.wkt, srid=4326)
+            if geos_geom.geom_type not in ("Polygon", "MultiPolygon"):
+                logger.warning(
+                    "Skipping row %s: expected Polygon/MultiPolygon, got %s",
+                    geoid or _, geos_geom.geom_type,
+                )
+                continue
             if geos_geom.geom_type == "Polygon":
                 from django.contrib.gis.geos import MultiPolygon
 


### PR DESCRIPTION
## Summary

- `load_enacted_plan()` crashed on null geometries (AttributeError) and silently stored non-polygon types
- Now skips null/empty geometries and non-Polygon/MultiPolygon types with warning log

## Test plan

- [ ] Verify null geometry rows are skipped with warning
- [ ] Verify Point/LineString rows are skipped with warning
- [ ] Verify valid Polygon/MultiPolygon rows still load correctly

Closes #691