### PR TITLE
fix(geo): raise on Census API failure in list_available_variables (SU#693)

### DIFF
--- a/siege_utilities/geo/census/variable_registry.py
+++ b/siege_utilities/geo/census/variable_registry.py
@@ -485,7 +485,7 @@ class VariableRegistry:
 
         except Exception as e:
             log.error(f"Failed to list variables: {e}")
-            return pd.DataFrame(columns=['code', 'label', 'concept', 'predicateType'])
+            raise
 
     def list_groups(self) -> Dict[str, int]:
         """Return available variable groups and their variable counts."""


### PR DESCRIPTION
## Summary

- `list_available_variables()` returned empty DataFrame on exception, masking Census API failures
- Now re-raises after logging

Closes #693