### PR TITLE
fix(geo): log PostGIS rollback failures instead of silently passing (SU#696)

### DIFF
--- a/siege_utilities/geo/spatial_transformations.py
+++ b/siege_utilities/geo/spatial_transformations.py
@@ -480,8 +480,8 @@ class PostGISConnector:
                 if self.connection:
                     try:
                         self.connection.rollback()
-                    except Exception:
-                        pass
+                    except Exception as rb_exc:
+                        log.warning("Failed to rollback PostGIS transaction: %s", rb_exc)
                 return None
 
         cursor = None
@@ -496,8 +496,8 @@ class PostGISConnector:
             if self.connection:
                 try:
                     self.connection.rollback()
-                except Exception:
-                    pass
+                except Exception as rb_exc:
+                    log.warning("Failed to rollback PostGIS transaction: %s", rb_exc)
             return None
         finally:
             if cursor is not None:


### PR DESCRIPTION
Two rollback `except Exception: pass` blocks in `execute_spatial_query()` silently swallowed failures, making connection-state debugging impossible.

**Change:** Replace `pass` with `log.warning("Failed to rollback PostGIS transaction: %s", rb_exc)` at both rollback sites (lines 483 and 499).

Closes #696