### PR TITLE
fix(geo): log warning when _get_crs_bounds falls back to world bounds (SU#697)

### DIFF
--- a/siege_utilities/geo/geocoding.py
+++ b/siege_utilities/geo/geocoding.py
@@ -587,8 +587,11 @@ def _get_crs_bounds(crs) -> Tuple[float, float, float, float]:
         aou = crs.area_of_use
         if aou is not None:
             return (aou.south, aou.north, aou.west, aou.east)
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning(
+            "Could not derive bounds from CRS %r, falling back to world bounds: %s",
+            crs, exc,
+        )
     return (-90.0, 90.0, -180.0, 180.0)
 
 


### PR DESCRIPTION
`_get_crs_bounds()` silently returned world bounds (-90..90, -180..180) when CRS area-of-use lookup failed, making coordinate-validation misconfigurations invisible.

**Change:** Replace `except Exception: pass` with a `logger.warning` that includes the CRS value and exception, so fallback behavior is diagnosable.

Closes #697