### PR TITLE
fix(geo): log warning when _create_spatial_table SRID derivation fails (SU#698)

### DIFF
--- a/siege_utilities/geo/spatial_transformations.py
+++ b/siege_utilities/geo/spatial_transformations.py
@@ -530,7 +530,12 @@ class PostGISConnector:
         if gdf.crs is not None:
             try:
                 srid = gdf.crs.to_epsg()
-            except Exception:
+            except Exception as exc:
+                log.warning(
+                    "Could not derive EPSG code from CRS %r, "
+                    "falling back to STORAGE_CRS (%s): %s",
+                    gdf.crs, settings.STORAGE_CRS, exc,
+                )
                 srid = None
         srid = srid or settings.STORAGE_CRS
         if not isinstance(srid, int):


### PR DESCRIPTION
`_create_spatial_table()` silently set `srid = None` when `gdf.crs.to_epsg()` failed, falling back to `settings.STORAGE_CRS` with no diagnostic trail. Geometry data could be stored under the wrong SRID invisibly.

**Change:** Add `log.warning` with the original CRS, fallback SRID, and exception message.

Closes #698