### PR TITLE
fix(geo): add logging for SpatiaLite extension load failures (SU#699)

### DIFF
--- a/siege_utilities/geo/geocoding.py
+++ b/siege_utilities/geo/geocoding.py
@@ -703,10 +703,11 @@ class SpatiaLiteCache:
             try:
                 self._conn.enable_load_extension(True)
                 self._conn.load_extension("mod_spatialite")
-            except Exception:
-                # SpatiaLite not available — fall back to plain SQLite
-                # Spatial index won't work, but the cache is still functional
-                pass
+            except Exception as exc:
+                logger.info(
+                    "SpatiaLite extension not available, falling back to plain SQLite "
+                    "(spatial index disabled): %s", exc,
+                )
         return self._conn
 
     def _init_db(self):
@@ -716,8 +717,10 @@ class SpatiaLiteCache:
         # Check if SpatiaLite is available
         try:
             cur.execute("SELECT spatialite_version()")
+            version = cur.fetchone()
+            logger.debug("SpatiaLite version: %s", version[0] if version else "unknown")
         except sqlite3.OperationalError:
-            pass
+            logger.debug("SpatiaLite not loaded; spatial features unavailable for geocode cache")
 
         # Geocode results table
         cur.execute("""


### PR DESCRIPTION
Two silent `except: pass` blocks in the geocode cache connector hid SpatiaLite availability status:

1. Extension load failure (line 706): now logs at INFO with the exception
2. Version check (line 719): now logs version at DEBUG on success, or a message at DEBUG on failure

Closes #699