### PR TITLE
fix(geo): raise ValueError when areal interpolation inputs lack CRS (SU#700)

### DIFF
--- a/siege_utilities/geo/interpolation/areal.py
+++ b/siege_utilities/geo/interpolation/areal.py
@@ -61,14 +61,14 @@ def _ensure_common_crs(
     """Ensure both GeoDataFrames share the same CRS, reprojecting if needed."""
     warnings = []
 
-    if source.crs is None or target.crs is None:
-        warnings.append(
-            "One or both GeoDataFrames lack a CRS. Assuming EPSG:4326."
+    if source.crs is None:
+        raise ValueError(
+            "source GeoDataFrame has no CRS. Set one with .set_crs() before interpolation."
         )
-        if source.crs is None:
-            source = source.set_crs("EPSG:4326")
-        if target.crs is None:
-            target = target.set_crs("EPSG:4326")
+    if target.crs is None:
+        raise ValueError(
+            "target GeoDataFrame has no CRS. Set one with .set_crs() before interpolation."
+        )
 
     if source.crs != target.crs:
         warnings.append(


### PR DESCRIPTION
`_ensure_common_crs()` silently assumed EPSG:4326 when source or target GeoDataFrames had no CRS. Since areal interpolation computes area ratios, a wrong CRS assumption corrupts every output value with no diagnostic trail.

**Change:** Replace the silent EPSG:4326 assumption with a `ValueError` that tells the caller to set a CRS explicitly via `.set_crs()`.

Closes #700