### PR TITLE
fix(geo): log warning when isochrone drops non-polygon features (SU#701)

### DIFF
--- a/siege_utilities/geo/django/services/isochrone_service.py
+++ b/siege_utilities/geo/django/services/isochrone_service.py
@@ -183,6 +183,11 @@ class IsochroneComputeService:
             elif geom.geom_type == "MultiPolygon":
                 for poly in geom:
                     polygons.append(poly)
+            else:
+                log.warning(
+                    "Skipping non-polygon feature (type=%s) in isochrone GeoJSON",
+                    geom.geom_type,
+                )
 
         if not polygons:
             raise ValueError("No polygon geometries found in GeoJSON features")


### PR DESCRIPTION
`_geojson_to_multipolygon()` silently discarded non-polygon features from isochrone GeoJSON responses. If the API returned unexpected geometry types, they vanished without trace.

**Change:** Add `log.warning` in the else branch that logs the skipped geometry type.

Closes #701