### PR TITLE
fix(config): raise ValueError for unknown database type instead of returning empty string (SU#702)

### DIFF
--- a/siege_utilities/config/user_config.py
+++ b/siege_utilities/config/user_config.py
@@ -279,8 +279,10 @@ class UserConfigManager:
         elif database_type == "duckdb":
             return self.user_profile.duckdb_path
         else:
-            log.warning(f"Unknown database type: {database_type}")
-            return ""
+            raise ValueError(
+                f"Unknown database type: {database_type!r}. "
+                f"Supported types: postgresql, duckdb"
+            )
     
     def set_database_connection(self, database_type: str, connection_string: str):
         """
@@ -295,7 +297,10 @@ class UserConfigManager:
         elif database_type == "duckdb":
             self.update_user_profile(duckdb_path=connection_string)
         else:
-            log.warning(f"Unknown database type: {database_type}")
+            raise ValueError(
+                f"Unknown database type: {database_type!r}. "
+                f"Supported types: postgresql, duckdb"
+            )
     
     def export_config(self, output_path: str):
         """


### PR DESCRIPTION
`get_database_connection()` returned `""` for unknown database types — an empty string that callers would pass to a DB driver, producing confusing errors far from the actual mistake. `set_database_connection()` had the same pattern (log + silently succeed with no effect).

**Change:** Both methods now raise `ValueError` with the unsupported type and list of supported types.

Closes #702