### PR TITLE
fix(config): correct import_entities return type annotation (SU#703)

### DIFF
--- a/siege_utilities/config/models/export.py
+++ b/siege_utilities/config/models/export.py
@@ -80,7 +80,7 @@ def export_entities(
     return yaml_str
 
 
-def import_entities(yaml_str_or_path: Union[str, Path]) -> Dict[str, list]:
+def import_entities(yaml_str_or_path: Union[str, Path]) -> Dict[str, Any]:
     """
     Import entities from a YAML document.
 


### PR DESCRIPTION
`import_entities()` was annotated as returning `Dict[str, list]` but actually returns `Dict[str, Any]` — the dictionary includes `version` (str) and `exported_at` (str/None) alongside the entity lists.

**Change:** Fix return type to `Dict[str, Any]`, matching the internal variable annotation.

Closes #703