### PR TITLE
fix(reporting): reject empty polygons in hex cartogram before NaN centroid (SU#705)

### DIFF
--- a/siege_utilities/reporting/hex_cartogram/algorithms.py
+++ b/siege_utilities/reporting/hex_cartogram/algorithms.py
@@ -372,6 +372,11 @@ def _normalized_centroids(
                 f"hex cartogram requires Polygon/MultiPolygon geometries; "
                 f"row {row[code_col]!r} has {gtype!r}"
             )
+        if geom.is_empty:
+            raise ValueError(
+                f"hex cartogram cannot compute centroid for empty geometry; "
+                f"row {row[code_col]!r}"
+            )
         codes.append(str(row[code_col]))
         c = geom.centroid
         raw.append((float(c.x), float(c.y)))


### PR DESCRIPTION
An empty polygon's centroid is `POINT EMPTY`, and `float(POINT_EMPTY.x)` returns NaN. This NaN propagated silently through the normalization math, producing a hex tile at an arbitrary position.

**Change:** Add `geom.is_empty` check before centroid computation, raising `ValueError` with the offending row's code.

Closes #705