### PR TITLE
fix(reporting): reproject to WGS84 before pydeck view/GeoJSON in map_3d (SU#706)

### DIFF
--- a/siege_utilities/reporting/map_3d.py
+++ b/siege_utilities/reporting/map_3d.py
@@ -254,6 +254,10 @@ class ThreeDMapRenderer:
         if not GEOPANDAS_AVAILABLE:
             raise ImportError("geopandas is required for create_choropleth_3d")
 
+        if gdf.crs is not None and not gdf.crs.equals("EPSG:4326"):
+            log.info("Reprojecting GeoDataFrame from %s to EPSG:4326 for pydeck", gdf.crs)
+            gdf = gdf.to_crs("EPSG:4326")
+
         # Convert GeoDataFrame to GeoJSON for pydeck
         geojson = json.loads(gdf.to_json())
 


### PR DESCRIPTION
`create_choropleth_3d()` passed raw centroid coordinates to `pdk.ViewState(latitude=, longitude=)` and raw geometry to GeoJSON — both of which require WGS84. A projected CRS (e.g., State Plane in meters) would produce a view centered at meters-as-degrees and invisible polygons.

**Change:** Reproject to EPSG:4326 before centroid computation and GeoJSON conversion, with `log.info` when reprojection occurs.

Closes #706