### PR TITLE
fix(geo): raise ValueError when longitudinal merge receives empty yearly data (SU#707)

### DIFF
--- a/siege_utilities/geo/timeseries/longitudinal_data.py
+++ b/siege_utilities/geo/timeseries/longitudinal_data.py
@@ -319,7 +319,10 @@ def _merge_to_wide_format(
         Wide-format DataFrame
     """
     if not yearly_data:
-        return pd.DataFrame()
+        raise ValueError(
+            "No yearly data to merge: yearly_data is empty. "
+            "Check that the Census API returned data for the requested years."
+        )
 
     # Start with the most recent year for base info
     years = sorted(yearly_data.keys())


### PR DESCRIPTION
`_merge_to_wide_format()` returned a bare `pd.DataFrame()` (no columns) when `yearly_data` was empty. Downstream code immediately failed with a confusing KeyError on 'GEOID' — far from the actual root cause.

**Change:** Raise `ValueError` with an actionable message pointing at the Census API call.

Closes #707