### PR TITLE
fix(geo): log failed numeric conversion in Census API (SU#741)

### DIFF
--- a/siege_utilities/geo/census/api.py
+++ b/siege_utilities/geo/census/api.py
@@ -298,8 +298,8 @@ class CensusAPI:
                 continue
             try:
                 df[col] = pd.to_numeric(df[col], errors='coerce')
-            except Exception:
-                pass
+            except Exception as exc:
+                log.warning("Could not convert column %s to numeric: %s", col, exc)
         return df
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
Replaces `except Exception: pass` with warning log in `_convert_numeric_columns`. Fixes #741