### PR TITLE
fix(geo): log overlay provider init failures instead of swallowing (SU#743)

### DIFF
--- a/siege_utilities/geo/overlays/demographics.py
+++ b/siege_utilities/geo/overlays/demographics.py
@@ -191,5 +191,9 @@ class DemographicsOverlay(PlaceHistoryOverlay):
         try:
             from siege_utilities.geo.django.providers import DjangoDemographicsProvider
             return DjangoDemographicsProvider()
-        except Exception:
+        except ImportError:
+            log.debug("Django demographics provider not available (Django not installed or not configured)")
+            return None
+        except Exception as exc:
+            log.warning("Failed to initialise Django demographics provider: %s", exc)
             return None

--- a/siege_utilities/geo/overlays/events.py
+++ b/siege_utilities/geo/overlays/events.py
@@ -183,5 +183,9 @@ class EventsOverlay(PlaceHistoryOverlay):
         try:
             from siege_utilities.geo.django.providers import DjangoEventsProvider
             return DjangoEventsProvider()
-        except Exception:
+        except ImportError:
+            log.debug("Django events provider not available (Django not installed or not configured)")
+            return None
+        except Exception as exc:
+            log.warning("Failed to initialise Django events provider: %s", exc)
             return None

--- a/siege_utilities/geo/overlays/seats.py
+++ b/siege_utilities/geo/overlays/seats.py
@@ -179,5 +179,9 @@ class SeatsOverlay(PlaceHistoryOverlay):
         try:
             from siege_utilities.geo.django.providers import DjangoSeatsProvider
             return DjangoSeatsProvider()
-        except Exception:
+        except ImportError:
+            log.debug("Django seats provider not available (Django not installed or not configured)")
+            return None
+        except Exception as exc:
+            log.warning("Failed to initialise Django seats provider: %s", exc)
             return None

--- a/siege_utilities/geo/overlays/urbanicity.py
+++ b/siege_utilities/geo/overlays/urbanicity.py
@@ -177,5 +177,9 @@ class UrbanicityOverlay(PlaceHistoryOverlay):
         try:
             from siege_utilities.geo.django.providers import DjangoUrbanicityProvider
             return DjangoUrbanicityProvider()
-        except Exception:
+        except ImportError:
+            log.debug("Django urbanicity provider not available (Django not installed or not configured)")
+            return None
+        except Exception as exc:
+            log.warning("Failed to initialise Django urbanicity provider: %s", exc)
             return None

--- a/siege_utilities/geo/place_history.py
+++ b/siege_utilities/geo/place_history.py
@@ -397,5 +397,9 @@ def _get_default_provider() -> Optional[CrosswalkProvider]:
     try:
         from siege_utilities.geo.django.providers import DjangoCrosswalkProvider
         return DjangoCrosswalkProvider()
-    except Exception:
+    except ImportError:
+        log.debug("Django crosswalk provider not available (Django not installed or not configured)")
+        return None
+    except Exception as exc:
+        log.warning("Failed to initialise Django crosswalk provider: %s", exc)
         return None


### PR DESCRIPTION
Split bare `except Exception: return None` into `ImportError` (expected,
DEBUG-logged) and `Exception` (unexpected, WARNING-logged) in 5 default-
provider factories.

**Files changed:**
- `geo/overlays/demographics.py` — `DjangoDemographicsProvider`
- `geo/overlays/events.py` — `DjangoEventsProvider`
- `geo/overlays/seats.py` — `DjangoSeatsProvider`
- `geo/overlays/urbanicity.py` — `DjangoUrbanicityProvider`
- `geo/place_history.py` — `DjangoCrosswalkProvider`

Closes #743