### PR TITLE
fix(git): capture exceptions in git ops and workflow (SU#745)

### DIFF
--- a/siege_utilities/git/git_operations.py
+++ b/siege_utilities/git/git_operations.py
@@ -35,8 +35,8 @@ def create_feature_branch(
         try:
             run_git_command("pull", "origin", base_branch, repo_path=repo_path, check=False)
             log_info(f"Pulled latest changes from {base_branch}")
-        except Exception:
-            log_warning(f"Could not pull latest from {base_branch} (continuing anyway)")
+        except Exception as exc:
+            log_warning(f"Could not pull latest from {base_branch} (continuing anyway): {exc}")
 
     # Create and switch to new branch
     run_git_command("checkout", "-b", branch_name, repo_path=repo_path)
@@ -47,8 +47,8 @@ def create_feature_branch(
         try:
             run_git_command("push", "-u", "origin", branch_name, repo_path=repo_path, check=False)
             log_info(f"Pushed branch to remote: origin/{branch_name}")
-        except Exception:
-            log_warning("Could not push to remote (continuing anyway)")
+        except Exception as exc:
+            log_warning(f"Could not push to remote (continuing anyway): {exc}")
 
     return {
         "branch_name": branch_name,

--- a/siege_utilities/git/git_workflow.py
+++ b/siege_utilities/git/git_workflow.py
@@ -268,8 +268,8 @@ def complete_feature_workflow(
             try:
                 run_git_command("push", "origin", "--delete", feature_branch, repo_path=repo_path)
                 log_info(f"Deleted remote branch: origin/{feature_branch}")
-            except Exception:
-                log_warning(f"Could not delete remote branch: origin/{feature_branch}")
+            except Exception as exc:
+                log_warning(f"Could not delete remote branch: origin/{feature_branch}: {exc}")
 
         return {
             "status": "success",
@@ -474,11 +474,12 @@ def get_workflow_status(repo_path: str = ".") -> Dict[str, Union[str, List[str],
                     "commits_behind": int(behind),
                     "ready_for_merge": int(ahead) > 0 and int(behind) == 0
                 })
-            except Exception:
+            except Exception as exc:
+                log_warning(f"Could not determine ahead/behind counts: {exc}")
                 workflow_info.update({
-                    "commits_ahead": 0,
-                    "commits_behind": 0,
-                    "ready_for_merge": False
+                    "commits_ahead": None,
+                    "commits_behind": None,
+                    "ready_for_merge": None
                 })
 
         return workflow_info


### PR DESCRIPTION
- `git_operations.py`: bare `except Exception:` now captures the exception
  and includes it in warning messages for pull/push failures
- `git_workflow.py`: same for remote-branch-delete warning
- `git_workflow.py`: `commits_ahead`/`commits_behind`/`ready_for_merge`
  now return `None` instead of fabricated `0`/`False` when `rev-list` fails
  (SU-1 violation: errors are not data)

Closes #745