### PR TITLE
fix(reporting): re-raise on summary generation failure (SU#746)

### DIFF
--- a/siege_utilities/reporting/analytics_reports.py
+++ b/siege_utilities/reporting/analytics_reports.py
@@ -298,7 +298,7 @@ class AnalyticsReportGenerator:
             
         except Exception as e:
             log.error(f"Error generating GA executive summary: {e}")
-            return "Executive summary could not be generated due to data processing errors."
+            raise
 
     def _extract_ga_metrics(self, ga_data: Dict[str, Any]) -> Dict[str, Any]:
         """Extract key metrics from Google Analytics data."""


### PR DESCRIPTION
`_generate_ga_executive_summary` returned an error message string on
failure, indistinguishable from a valid summary. Callers embedded it
in the final PDF report. Now re-raises so the caller can handle or
surface the error appropriately.

Closes #746