### PR TITLE
fix: log or narrow bare except blocks in 4 modules (SU#755-758)

### DIFF
--- a/siege_utilities/config/credential_manager.py
+++ b/siege_utilities/config/credential_manager.py
@@ -429,9 +429,10 @@ class CredentialManager:
                 return result.stdout.strip()
             return None
             
-        except Exception:
+        except Exception as exc:
+            log_warning(f"Keychain lookup failed for {service}/{username}: {exc}")
             return None
-    
+
     def _get_from_prompt(self, service: str, username: str, field: str) -> Optional[str]:
         """Get credential via interactive prompt."""
         # Only prompt in interactive shells

--- a/siege_utilities/geo/codification.py
+++ b/siege_utilities/geo/codification.py
@@ -206,5 +206,9 @@ def _get_default_geocoder():
     try:
         from siege_utilities.geo.providers.census_batch import CensusBatchGeocoder
         return CensusBatchGeocoder()
-    except Exception:
+    except ImportError:
+        log.debug("CensusBatchGeocoder not available (missing dependency)")
+        return None
+    except Exception as exc:
+        log.warning("Failed to initialise CensusBatchGeocoder: %s", exc)
         return None

--- a/siege_utilities/geo/crs.py
+++ b/siege_utilities/geo/crs.py
@@ -147,7 +147,8 @@ def _normalize_crs(value: Any) -> str:
 
     try:
         crs = CRS.from_user_input(value)
-    except Exception:
+    except Exception as exc:
+        log.debug("Could not parse CRS from %r, falling back to str(): %s", value, exc)
         return str(value)
     epsg = crs.to_epsg()
     if epsg:

--- a/siege_utilities/geo/spatial_runtime.py
+++ b/siege_utilities/geo/spatial_runtime.py
@@ -10,10 +10,13 @@ from __future__ import annotations
 
 import base64
 import json
+import logging
 import os
 import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
+
+log = logging.getLogger(__name__)
 
 try:
     import shapely.geometry.base  # noqa: F401
@@ -70,7 +73,10 @@ def _detect_sedona_available() -> bool:
         import sedona  # type: ignore  # noqa: F401
 
         return True
-    except Exception:
+    except ImportError:
+        return False
+    except Exception as exc:
+        log.warning("Unexpected error detecting Sedona availability: %s", exc)
         return False
 
 


### PR DESCRIPTION
Round 4 hostile review fixes:

- **credential_manager.py** — log keychain subprocess failures instead of swallowing (#755)
- **codification.py** — split bare except into ImportError/Exception for geocoder init (#756)
- **crs.py** — log CRS parse fallback at debug level (#757)
- **spatial_runtime.py** — narrow sedona detection to ImportError, log unexpected errors (#758)

Closes #755, closes #756, closes #757, closes #758