### PR TITLE
fix: add exception chaining (from e) in 6 modules (SU#760)

### DIFF
--- a/siege_utilities/files/shell.py
+++ b/siege_utilities/files/shell.py
@@ -71,7 +71,7 @@ def validate_command_safety(command: Union[str, List[str]],
         try:
             parts = shlex.split(command)
         except ValueError as e:
-            raise ValueError(f"Invalid command syntax: {e}")
+            raise ValueError(f"Invalid command syntax: {e}") from e
     else:
         parts = list(command)
 

--- a/siege_utilities/files/validation.py
+++ b/siege_utilities/files/validation.py
@@ -242,7 +242,7 @@ def validate_safe_path(path: FilePath,
         raise
     except Exception as e:
         # Other errors during validation
-        raise ValueError(f"Invalid path: {path_str} - {e}")
+        raise ValueError(f"Invalid path: {path_str} - {e}") from e
 
 
 def validate_file_path(file_path: FilePath,

--- a/siege_utilities/geo/census/api.py
+++ b/siege_utilities/geo/census/api.py
@@ -228,7 +228,7 @@ class CensusAPI:
                     time.sleep(2 ** attempt)
                 elif isinstance(e, ValueError):
                     log.error(f"Failed to parse API response: {e}")
-                    raise CensusAPIError(f"Invalid API response: {e}")
+                    raise CensusAPIError(f"Invalid API response: {e}") from e
                 else:
                     raise
 

--- a/siege_utilities/geo/django/management/commands/populate_pl_demographics.py
+++ b/siege_utilities/geo/django/management/commands/populate_pl_demographics.py
@@ -78,7 +78,7 @@ class Command(BaseCommand):
         try:
             state_fips = normalize_state_identifier(state)
         except ValueError as e:
-            raise CommandError(str(e))
+            raise CommandError(str(e)) from e
 
         self.stdout.write(
             f"Loading PL 94-171 data: state={state_fips}, year={year}, "
@@ -95,7 +95,7 @@ class Command(BaseCommand):
                 tables=tables,
             )
         except Exception as e:
-            raise CommandError(f"Failed to download PL data: {e}")
+            raise CommandError(f"Failed to download PL data: {e}") from e
 
         if df.empty:
             self.stdout.write(self.style.WARNING("No data returned."))

--- a/siege_utilities/git/_utils.py
+++ b/siege_utilities/git/_utils.py
@@ -19,5 +19,5 @@ def run_git_command(*args, repo_path: str = ".", check: bool = True) -> str:
         return result.stdout.strip()
     except subprocess.CalledProcessError as e:
         if check:
-            raise GitError(f"Git command failed: {' '.join(args)} - {e.stderr}")
+            raise GitError(f"Git command failed: {' '.join(args)} - {e.stderr}") from e
         return ""

--- a/siege_utilities/git/validation.py
+++ b/siege_utilities/git/validation.py
@@ -355,7 +355,7 @@ def validate_repo_path(repo_path: str) -> Path:
         validated_path = validate_directory_path(repo_path, must_exist=False)
         return validated_path
     except PathSecurityError as e:
-        raise GitSecurityError(f"Repository path validation failed: {e}")
+        raise GitSecurityError(f"Repository path validation failed: {e}") from e
 
 
 __all__ = [


### PR DESCRIPTION
Six locations raised a new exception type without `from e`, discarding
the original traceback. Fixed in:

- `geo/django/management/commands/populate_pl_demographics.py` (2 sites)
- `files/validation.py`
- `git/validation.py`
- `files/shell.py`
- `git/_utils.py`
- `geo/census/api.py`

Closes #760