### PR TITLE
fix: raise instead of returning empty results on error in 4 modules (SU#763)

### DIFF
--- a/siege_utilities/geo/census/api.py
+++ b/siege_utilities/geo/census/api.py
@@ -199,13 +199,8 @@ class CensusAPI:
                 data = response.json()
 
                 if not data or len(data) < 2:
-                    from siege_utilities.exceptions import SiegeAPIError, handle_error
-                    return handle_error(
-                        SiegeAPIError("Census API returned empty response (< 2 rows)"),
-                        on_error=getattr(self, '_on_error', 'skip'),
-                        fallback=pd.DataFrame(),
-                        context="Census API query",
-                    )
+                    from siege_utilities.geo.census_api_client import CensusAPIError
+                    raise CensusAPIError("Census API returned empty response (< 2 rows)")
 
                 df = pd.DataFrame(data[1:], columns=data[0])
                 return df

--- a/siege_utilities/geo/overlays/election_results.py
+++ b/siege_utilities/geo/overlays/election_results.py
@@ -151,7 +151,8 @@ class ElectionResultsOverlay(PlaceHistoryOverlay):
         state_fips: Optional[str] = None,
     ) -> ElectionResultsOverlayResult:
         if self._provider is None:
-            return ElectionResultsOverlayResult(geoid=geoid)
+            log.warning("ElectionResultsOverlay: no provider configured")
+            raise RuntimeError("ElectionResultsOverlay requires a provider")
 
         returns = self._provider.get_election_returns(
             geoid, from_year, to_year, state_fips,

--- a/siege_utilities/geo/overlays/redistricting.py
+++ b/siege_utilities/geo/overlays/redistricting.py
@@ -156,7 +156,8 @@ class RedistrictingOverlay(PlaceHistoryOverlay):
         state_fips: Optional[str] = None,
     ) -> RedistrictingOverlayResult:
         if self._provider is None:
-            return RedistrictingOverlayResult(geoid=geoid)
+            log.warning("RedistrictingOverlay: no provider configured")
+            raise RuntimeError("RedistrictingOverlay requires a provider")
 
         assignments = self._provider.get_district_assignments(
             geoid, from_year, to_year, state_fips,

--- a/siege_utilities/geo/providers/redistricting_data_hub.py
+++ b/siege_utilities/geo/providers/redistricting_data_hub.py
@@ -230,7 +230,7 @@ class RDHClient:
         list of RDHDataset
         """
         if not self.validate_credentials():
-            return []
+            raise ValueError("RDH credentials are invalid or missing")
 
         if format is not None:
             format = format.value if isinstance(format, RDHDataFormat) else format
@@ -272,8 +272,7 @@ class RDHClient:
             resp = self._session.get(self.base_url, params=params, timeout=60)
             resp.raise_for_status()
         except requests.RequestException as e:
-            log_error(f"RDH API request failed: {e}")
-            return []
+            raise ConnectionError(f"RDH API request failed: {e}") from e
 
         raw_data = resp.json()
         if not isinstance(raw_data, list):


### PR DESCRIPTION
## Summary

Round 7 hostile review found SU-1 violations where error paths returned valid-shaped empty results instead of raising.

- **census/api.py**: `_make_request_with_retry()` used `handle_error()` with `fallback=pd.DataFrame()` and a never-set `_on_error` attribute (always defaulted to `'skip'`). Now raises `CensusAPIError`.
- **redistricting_data_hub.py**: `list_datasets()` returned `[]` on invalid credentials; `_fetch_datasets()` returned `[]` on network failure. Both indistinguishable from "no datasets found". Now raises `ValueError`/`ConnectionError`.
- **overlays/election_results.py, overlays/redistricting.py**: returned empty result objects when provider was None. Now raises `RuntimeError`, matching the pattern from rounds 3-4 for the other 4 overlays.

## Test plan

- [ ] Verify existing tests still pass (error paths may need updated assertions)
- [ ] Callers of `CensusAPI.fetch_data()` should handle `CensusAPIError`
- [ ] Callers of `RDHClient.list_datasets()` should handle `ValueError`/`ConnectionError`