### PR TITLE
fix: align contracts with implementations in 6 modules (SU#764)

### DIFF
--- a/siege_utilities/files/operations.py
+++ b/siege_utilities/files/operations.py
@@ -481,10 +481,12 @@ def run_command(command: Union[str, List[str]],
             not when you need shell features.
 
     Returns:
-        CompletedProcess object, or None if failed
+        CompletedProcess object on success or non-zero exit.
+        None on timeout or unexpected error (when unsafe=True).
 
     Raises:
-        SecurityError: If command fails security validation (when unsafe=False)
+        SecurityError: If command fails security validation (when unsafe=False).
+        Exception: Re-raised on unexpected errors when unsafe=False.
 
     Example:
         >>> # Safe command (works by default)

--- a/siege_utilities/geo/census/catalog.py
+++ b/siege_utilities/geo/census/catalog.py
@@ -469,6 +469,16 @@ class CensusCatalog:
         dataset: Optional[str] = None,
         max_results: int = 25,
     ) -> list[SearchResult]:
+        """Search the catalog across multiple levels.
+
+        Args:
+            query: Free-text search query.
+            level: Restrict to a single search level, or None for all.
+            dataset: Filter TABLE and VARIABLE results to tables belonging
+                to this dataset. Has no effect on FAMILY, SUBJECT, or
+                DATASET level results (those are cross-dataset).
+            max_results: Maximum results to return.
+        """
         tokens = _tokenize_query(query)
         if not tokens:
             return []

--- a/siege_utilities/geo/providers/batch_geocoder.py
+++ b/siege_utilities/geo/providers/batch_geocoder.py
@@ -237,13 +237,11 @@ class BatchGeocoder(abc.ABC):
     def geocode(
         self,
         addresses: Union[list[dict], list[str], list[AddressInput]],
-        **kwargs,
     ) -> BatchGeocodingResult:
         """Geocode a batch of addresses.
 
         Args:
             addresses: List of addresses in any supported format.
-            **kwargs: Backend-specific options.
 
         Returns:
             BatchGeocodingResult with one GeocodingResult per input address.

--- a/siege_utilities/geo/providers/census_batch.py
+++ b/siege_utilities/geo/providers/census_batch.py
@@ -72,13 +72,11 @@ class CensusBatchGeocoder(BatchGeocoder):
     def geocode(
         self,
         addresses: Union[list[dict], list[str], list[AddressInput]],
-        **kwargs,
     ) -> BatchGeocodingResult:
         """Geocode addresses via the Census Bureau batch API.
 
         Args:
             addresses: Addresses in any supported format.
-            **kwargs: Passed through to geocode_batch_chunked.
         """
         from .census_geocoder import (
             CensusVintage,

--- a/siege_utilities/geo/providers/composite_geocoder.py
+++ b/siege_utilities/geo/providers/composite_geocoder.py
@@ -71,7 +71,6 @@ class CompositeBatchGeocoder(BatchGeocoder):
     def geocode(
         self,
         addresses: Union[list[dict], list[str], list[AddressInput]],
-        **kwargs,
     ) -> BatchGeocodingResult:
         """Geocode addresses through chained backends.
 
@@ -100,7 +99,7 @@ class CompositeBatchGeocoder(BatchGeocoder):
             pending_indices = sorted(pending)
 
             try:
-                batch_result = backend.geocode(pending_addrs, **kwargs)
+                batch_result = backend.geocode(pending_addrs)
             except Exception as exc:
                 log.warning(
                     "Backend %s failed: %s", backend.backend_name, exc

--- a/siege_utilities/geo/providers/nominatim_batch.py
+++ b/siege_utilities/geo/providers/nominatim_batch.py
@@ -70,7 +70,6 @@ class NominatimBatchGeocoder(BatchGeocoder):
     def geocode(
         self,
         addresses: Union[list[dict], list[str], list[AddressInput]],
-        **kwargs,
     ) -> BatchGeocodingResult:
         """Geocode addresses via Nominatim (one at a time with rate limiting).
 

--- a/siege_utilities/geo/providers/tamu_batch.py
+++ b/siege_utilities/geo/providers/tamu_batch.py
@@ -75,7 +75,6 @@ class TAMUBatchGeocoder(BatchGeocoder):
     def geocode(
         self,
         addresses: Union[list[dict], list[str], list[AddressInput]],
-        **kwargs,
     ) -> BatchGeocodingResult:
         """Geocode addresses via the TAMU Geoservices API.
 

--- a/siege_utilities/git/_utils.py
+++ b/siege_utilities/git/_utils.py
@@ -6,7 +6,12 @@ from siege_utilities.exceptions import GitError
 
 
 def run_git_command(*args, repo_path: str = ".", check: bool = True) -> str:
-    """Run a git command and return the output."""
+    """Run a git command and return stdout.
+
+    When ``check=True`` (default), raises ``GitError`` on non-zero exit.
+    When ``check=False``, returns ``""`` on failure — callers must treat
+    empty string as a potential error signal, not as valid empty output.
+    """
     try:
         result = subprocess.run(
             ["git"] + list(args),


### PR DESCRIPTION
## Summary

Round 7 hostile review found SU-2 violations where function contracts (signatures, docstrings, type hints) didn't match implementations.

- **BatchGeocoder ABC + 4 backends**: removed `**kwargs` from `geocode()` — the ABC documented it as "backend-specific options" but no backend used it. Census backend's docstring even claimed kwargs were "passed through to geocode_batch_chunked" but they weren't.
- **census/catalog.py**: added docstring to `search()` documenting that the `dataset` parameter only filters TABLE and VARIABLE results (FAMILY, SUBJECT, DATASET are cross-dataset aggregations).
- **git/_utils.py**: documented the `check=False` contract — empty string return is a failure signal.
- **files/operations.py**: clarified which failure modes return None vs. raise in `run_command()`.

## Test plan

- [ ] Verify no tests pass `**kwargs` to `geocode()` (grepped: none do)
- [ ] Verify existing tests still pass