### PR TITLE
fix(SU-1): narrow except-Exception in credential_manager

### DIFF
--- a/siege_utilities/config/credential_manager.py
+++ b/siege_utilities/config/credential_manager.py
@@ -327,7 +327,7 @@ class CredentialManager:
                     content = f.read().strip()
                     return content if content else None
                     
-        except Exception as e:
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError) as e:
             log_warning(f"Error reading credential file {file_path}: {e}")
             return None
     
@@ -429,7 +429,7 @@ class CredentialManager:
                 return result.stdout.strip()
             return None
             
-        except Exception as exc:
+        except (subprocess.SubprocessError, OSError) as exc:
             log_warning(f"Keychain lookup failed for {service}/{username}: {exc}")
             return None
 
@@ -516,7 +516,7 @@ class CredentialManager:
                 log_error(f"Failed to store in 1Password: {_redact(result.stderr)}")
                 return False
                 
-        except Exception as e:
+        except (subprocess.SubprocessError, OSError) as e:
             log_error(f"Error storing in 1Password: {e}")
             return False
     
@@ -538,7 +538,7 @@ class CredentialManager:
                 log_error(f"Failed to store in Keychain: {_redact(result.stderr)}")
                 return False
                 
-        except Exception as e:
+        except (subprocess.SubprocessError, OSError) as e:
             log_error(f"Error storing in Keychain: {e}")
             return False
     
@@ -615,7 +615,7 @@ class CredentialManager:
                 log_error(f"Failed to store GA credentials: {_redact(result.stderr)}")
                 return False
                 
-        except Exception as e:
+        except (subprocess.SubprocessError, OSError, KeyError) as e:
             log_error(f"Error storing Google Analytics credentials: {e}")
             return False
     
@@ -647,7 +647,7 @@ class CredentialManager:
             log_error("Could not retrieve Google Analytics credentials")
             return None
             
-        except Exception as e:
+        except (subprocess.SubprocessError, OSError) as e:
             log_error(f"Error retrieving Google Analytics credentials: {e}")
             return None
     
@@ -704,7 +704,7 @@ class CredentialManager:
                         f"({total} total items in vault). "
                         f"Tag items with 'siege-utilities' to include them."
                     )
-            except Exception as e:
+            except (subprocess.SubprocessError, OSError, json.JSONDecodeError) as e:
                 log_warning(f"Error listing 1Password credentials: {e}")
         
         # List environment variables (siege-utilities related)
@@ -752,7 +752,7 @@ class CredentialManager:
                         'status': 'Not authenticated',
                         'description': '1Password CLI (run: op signin)'
                     }
-            except Exception:
+            except (subprocess.SubprocessError, OSError):
                 status['1password'] = {
                     'available': False,
                     'status': 'Error checking status',
@@ -889,7 +889,7 @@ def store_ga_credentials_from_file(credentials_file: Union[str, Path],
         
         return success
         
-    except Exception as e:
+    except (subprocess.SubprocessError, OSError, json.JSONDecodeError, KeyError) as e:
         log_error(f"Error storing GA credentials from file: {e}")
         return False
 
@@ -996,8 +996,8 @@ def store_ga_service_account_from_file(credentials_file: Union[str, Path],
     except subprocess.CalledProcessError as e:
         log_error(f"Failed to store service account credentials: {e.stderr}")
         return False
-    except Exception as e:
-        log_error(f"Error storing service account credentials: {str(e)}")
+    except (subprocess.SubprocessError, OSError, json.JSONDecodeError, KeyError) as e:
+        log_error(f"Error storing service account credentials: {e}")
         return False
 
 
@@ -1087,7 +1087,7 @@ def get_google_service_account_from_1password(item_title: str = "Google Analytic
     except subprocess.CalledProcessError as e:
         log_error(f"Failed to get Google service account from 1Password: {e}")
         return None
-    except Exception as e:
+    except (subprocess.SubprocessError, OSError) as e:
         log_error(f"Error retrieving Google service account: {e}")
         return None
 
@@ -1159,7 +1159,7 @@ def get_google_oauth_from_1password(
     except subprocess.CalledProcessError as e:
         log_error(f"Failed to get Google OAuth2 credentials from 1Password: {e}")
         return None
-    except Exception as e:
+    except (subprocess.SubprocessError, OSError) as e:
         log_error(f"Error retrieving Google OAuth2 credentials: {e}")
         return None
 
@@ -1207,7 +1207,7 @@ def get_google_oauth_document_from_1password(
     except json.JSONDecodeError as e:
         log_error(f"Invalid JSON in 1Password document '{item_title}': {e}")
         return None
-    except Exception as e:
+    except (subprocess.SubprocessError, OSError) as e:
         log_error(f"Error retrieving Google OAuth document: {e}")
         return None
 
@@ -1234,6 +1234,6 @@ def create_temporary_service_account_file(service_account_data: Dict[str, str]) 
         log_info(f"Created temporary service account file: {temp_file_path}")
         return temp_file_path
         
-    except Exception as e:
+    except OSError as e:
         log_error(f"Failed to create temporary service account file: {e}")
         return None

--- a/tests/test_credential_manager.py
+++ b/tests/test_credential_manager.py
@@ -18,6 +18,7 @@ Covers:
 - store_ga_credentials_from_file and store_ga_service_account_from_file
 """
 
+import importlib.util
 import json
 import os
 import subprocess
@@ -526,7 +527,7 @@ class TestGetFromKeychain:
 
     def test_returns_none_on_exception(self, mock_op_available):
         manager = CredentialManager()
-        mock_op_available.side_effect = Exception("keychain error")
+        mock_op_available.side_effect = OSError("keychain error")
 
         result = manager._get_from_keychain('my-service', 'my-user')
         assert result is None
@@ -735,7 +736,7 @@ class TestStoreIn1Password:
         manager, mock_run = manager_with_account
 
         mock_run.reset_mock()
-        mock_run.side_effect = Exception("network error")
+        mock_run.side_effect = OSError("network error")
 
         result = manager._store_in_1password('test-svc', 'user', 'pass', 'password')
         assert result is False
@@ -764,7 +765,7 @@ class TestStoreInKeychain:
 
     def test_returns_false_on_exception(self, mock_op_available):
         manager = CredentialManager()
-        mock_op_available.side_effect = Exception("keychain write error")
+        mock_op_available.side_effect = OSError("keychain write error")
 
         result = manager._store_in_keychain('svc', 'user', 'secret')
         assert result is False
@@ -863,7 +864,7 @@ class TestGetGoogleAnalyticsCredentials:
 
     def test_returns_none_on_exception(self, mock_op_available):
         manager = CredentialManager()
-        mock_op_available.side_effect = Exception("unexpected error")
+        mock_op_available.side_effect = OSError("unexpected error")
 
         result = manager.get_google_analytics_credentials()
         assert result is None
@@ -913,7 +914,7 @@ class TestListStoredCredentials:
 
     def test_handles_1password_exception(self, mock_op_available):
         manager = CredentialManager()
-        mock_op_available.side_effect = Exception("op error")
+        mock_op_available.side_effect = OSError("op error")
 
         # Should not raise
         results = manager.list_stored_credentials()
@@ -990,7 +991,7 @@ class TestBackendStatus:
 
     def test_1password_status_on_exception(self, mock_op_available):
         manager = CredentialManager()
-        mock_op_available.side_effect = Exception("error")
+        mock_op_available.side_effect = OSError("error")
         status = manager.backend_status()
         assert status['1password']['available'] is False
 
@@ -1086,7 +1087,7 @@ class TestGetGoogleSAFrom1Password:
 
     def test_returns_none_on_general_exception(self):
         with patch('siege_utilities.config.credential_manager.subprocess.run') as mock_run:
-            mock_run.side_effect = RuntimeError("unexpected")
+            mock_run.side_effect = OSError("unexpected")
             result = get_google_service_account_from_1password()
             assert result is None
 
@@ -1304,7 +1305,7 @@ class TestGetGoogleOAuthDocumentFrom1Password:
 
     def test_returns_none_on_general_exception(self):
         with patch('siege_utilities.config.credential_manager.subprocess.run') as mock_run:
-            mock_run.side_effect = RuntimeError("unexpected")
+            mock_run.side_effect = OSError("unexpected")
             result = get_google_oauth_document_from_1password()
             assert result is None
 
@@ -1509,6 +1510,10 @@ class TestGetGAServiceAccountCredentials:
 # fetch_real_ga4_data OAuth2 FALLBACK TESTS
 # =============================================================================
 
+@pytest.mark.skipif(
+    not importlib.util.find_spec("pandas"),
+    reason="pandas not installed",
+)
 class TestFetchRealGA4DataOAuth2Fallback:
     """Tests for the OAuth2 fallback path in fetch_real_ga4_data()."""
 


### PR DESCRIPTION
## Summary
- Narrowed 14 `except Exception` clauses in `credential_manager.py` to specific types (`OSError`, `subprocess.SubprocessError`, `json.JSONDecodeError`, `KeyError`, `UnicodeDecodeError`) so programming errors propagate immediately instead of being silently swallowed as credential-not-found
- Updated 8 test mocks that injected bare `Exception(...)` to use the appropriate narrowed type
- Added `importorskip` guard for 3 pandas-dependent GA4 OAuth2 fallback tests

## Test plan
- [x] `pytest tests/test_credential_manager.py` — 133 passed, 3 skipped (pandas not installed)
- [x] No regressions in other test files