### PR TITLE
fix(SU-1): narrow except-Exception in files/ package

### DIFF
--- a/siege_utilities/files/hashing.py
+++ b/siege_utilities/files/hashing.py
@@ -97,7 +97,7 @@ def generate_sha256_hash_for_file(file_path) ->Optional[str]:
         with open(path_obj, 'rb') as f:
             _update_from_file(sha256_hash, f)
         return sha256_hash.hexdigest()
-    except Exception as e:
+    except OSError as e:
         log_error(f'Error generating SHA256 hash for {file_path}: {e}')
         return None
 
@@ -144,7 +144,7 @@ def get_file_hash(file_path, algorithm='sha256') ->Optional[str]:
         with open(path_obj, 'rb') as f:
             _update_from_file(hash_func, f)
         return hash_func.hexdigest()
-    except Exception as e:
+    except (OSError, ValueError) as e:
         log_error(f'Error generating {algorithm} hash for {file_path}: {e}')
         return None
 
@@ -208,12 +208,12 @@ def get_quick_file_signature(file_path) ->str:
         return hash_obj.hexdigest()
     except PathSecurityError:
         raise
-    except Exception as e:
+    except OSError as e:
         log_error(f'Error generating quick signature for {file_path}: {e}')
         try:
             stat = pathlib.Path(file_path).stat()
             return f'fallback_{stat.st_size}_{stat.st_mtime}'
-        except Exception as fallback_exc:
+        except OSError as fallback_exc:
             log_error(f'Fallback signature also failed for {file_path}: {fallback_exc}')
             raise
 
@@ -253,7 +253,7 @@ def verify_file_integrity(file_path, expected_hash, algorithm='sha256') ->bool:
         current_hash = get_file_hash(file_path, algorithm)
         return current_hash is not None and current_hash.lower(
             ) == expected_hash.lower()
-    except Exception as exc:
+    except (OSError, ValueError) as exc:
         log_error(f"Failed to verify hash for {file_path}: {exc}")
         raise
 

--- a/siege_utilities/files/operations.py
+++ b/siege_utilities/files/operations.py
@@ -57,7 +57,7 @@ def remove_tree(path: FilePath) -> bool:
 
     except PathSecurityError:
         raise
-    except Exception as e:
+    except OSError as e:
         log.error(f"Failed to remove {path}: {e}")
         return False
 
@@ -111,7 +111,7 @@ def file_exists(path: FilePath) -> bool:
     except PathSecurityError:
         # Re-raise security errors
         raise
-    except Exception as e:
+    except OSError as e:
         log.error(f"Error checking file existence for {path}: {e}")
         return False
 
@@ -152,7 +152,7 @@ def touch_file(path: FilePath, create_parents: bool = True) -> bool:
 
     except PathSecurityError:
         raise
-    except Exception as e:
+    except OSError as e:
         log.error(f"Failed to create file {path}: {e}")
         return False
 
@@ -218,7 +218,7 @@ def count_lines(file_path: FilePath, encoding: str = 'utf-8') -> Optional[int]:
     except PathSecurityError:
         # Re-raise security errors
         raise
-    except Exception as e:
+    except OSError as e:
         log.error(f"Failed to count lines in {file_path}: {e}")
         return None
 
@@ -275,7 +275,7 @@ def copy_file(source: FilePath, destination: FilePath, overwrite: bool = False) 
 
     except PathSecurityError:
         raise
-    except Exception as e:
+    except OSError as e:
         log.error(f"Failed to copy {source} to {destination}: {e}")
         return False
 
@@ -332,7 +332,7 @@ def move_file(source: FilePath, destination: FilePath, overwrite: bool = False) 
 
     except PathSecurityError:
         raise
-    except Exception as e:
+    except OSError as e:
         log.error(f"Failed to move {source} to {destination}: {e}")
         return False
 
@@ -394,7 +394,7 @@ def get_file_size(file_path: FilePath) -> Optional[int]:
     except PathSecurityError:
         # Re-raise security errors
         raise
-    except Exception as e:
+    except OSError as e:
         log.error(f"Failed to get file size for {file_path}: {e}")
         return None
 
@@ -452,7 +452,7 @@ def list_directory(path: FilePath,
 
     except PathSecurityError:
         raise
-    except Exception as e:
+    except OSError as e:
         log.error(f"Failed to list directory {path}: {e}")
         return None
 
@@ -589,7 +589,7 @@ def run_command(command: Union[str, List[str]],
     except subprocess.TimeoutExpired:
         log.error(f"Command timed out: {command}")
         return None
-    except Exception as e:
+    except (subprocess.SubprocessError, OSError, ValueError) as e:
         log.error(f"Failed to run command {command}: {e}")
         if not unsafe:
             raise  # Re-raise security exceptions
@@ -666,7 +666,7 @@ def delete_existing_file_and_replace_it_with_an_empty_file(file_path: FilePath, 
         return True
     except PathSecurityError:
         raise
-    except Exception as e:
+    except OSError as e:
         log.error(f"Failed to create empty file {file_path}: {e}")
         return False
 
@@ -713,7 +713,7 @@ def safe_file_write(
         with open(file_path, "w", encoding=encoding) as f:
             f.write(content)
         return True
-    except Exception as e:
+    except OSError as e:
         log.error(f"Error writing to {file_path}: {e}")
         return False
 
@@ -740,7 +740,7 @@ def safe_file_read(
             return default
         with open(file_path, "r", encoding=encoding) as f:
             return f.read()
-    except Exception as e:
+    except (OSError, UnicodeDecodeError) as e:
         log.error(f"Error reading {file_path}: {e}")
         return default
 
@@ -770,7 +770,7 @@ def safe_json_write(
         with open(file_path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=indent, ensure_ascii=False)
         return True
-    except Exception as e:
+    except (OSError, TypeError, ValueError) as e:
         log.error(f"Error writing JSON to {file_path}: {e}")
         return False
 
@@ -795,7 +795,7 @@ def safe_json_read(
             return default
         with open(file_path, "r", encoding="utf-8") as f:
             return json.load(f)
-    except Exception as e:
+    except (OSError, json.JSONDecodeError) as e:
         log.error(f"Error reading JSON from {file_path}: {e}")
         return default
 

--- a/siege_utilities/files/paths.py
+++ b/siege_utilities/files/paths.py
@@ -55,7 +55,7 @@ def ensure_path_exists(desired_path: FilePath) -> Path:
         log.info(f"Ensured path exists: {path_obj}")
         return path_obj
 
-    except Exception as e:
+    except OSError as e:
         log.error(f"Failed to create path {desired_path}: {e}")
         raise
 
@@ -147,7 +147,7 @@ def unzip_file_to_directory(zip_file_path: FilePath,
         return None
     except PathSecurityError:
         raise
-    except Exception as e:
+    except OSError as e:
         log.error(f"Failed to extract {zip_file_path}: {e}")
         return None
 
@@ -184,7 +184,7 @@ def get_file_extension(file_path: FilePath) -> str:
         return path_obj.suffix
     except PathSecurityError:
         raise
-    except Exception as e:
+    except OSError as e:
         log.error(f"Failed to get extension for {file_path}: {e}")
         raise
 
@@ -221,7 +221,7 @@ def get_file_name_without_extension(file_path: FilePath) -> str:
         return path_obj.stem
     except PathSecurityError:
         raise
-    except Exception as e:
+    except OSError as e:
         log.error(f"Failed to get filename for {file_path}: {e}")
         raise
 
@@ -258,7 +258,7 @@ def is_hidden_file(file_path: FilePath) -> bool:
         return path_obj.name.startswith('.')
     except PathSecurityError:
         raise
-    except Exception as e:
+    except OSError as e:
         log.error(f"Failed to check if hidden: {file_path}: {e}")
         raise
 
@@ -303,7 +303,7 @@ def get_relative_path(base_path: FilePath, target_path: FilePath) -> Optional[Pa
             return None
     except PathSecurityError:
         raise
-    except Exception as e:
+    except OSError as e:
         log.error(f"Failed to get relative path: {e}")
         return None
 
@@ -357,7 +357,7 @@ def find_files_by_pattern(directory: FilePath,
         return sorted(files)
     except PathSecurityError:
         raise
-    except Exception as e:
+    except OSError as e:
         log.error(f"Failed to find files in {directory}: {e}")
         return []
 
@@ -415,7 +415,7 @@ def create_backup_path(original_path: FilePath,
         return backup_path
     except PathSecurityError:
         raise
-    except Exception as e:
+    except OSError as e:
         log.error(f"Failed to create backup path for {original_path}: {e}")
         raise
 
@@ -444,7 +444,7 @@ def normalize_path(path: FilePath) -> Path:
         path_obj = Path(path).expanduser().resolve()
         log.debug(f"Normalized {path} to {path_obj}")
         return path_obj
-    except Exception as e:
+    except OSError as e:
         log.error(f"Failed to normalize path {path}: {e}")
         raise
 

--- a/siege_utilities/files/remote.py
+++ b/siege_utilities/files/remote.py
@@ -197,17 +197,17 @@ def download_file(url: str, local_filename: FilePath,
                 log.info(f'Successfully downloaded {url} to {local_path} without SSL verification')
                 return str(local_path)
                 
-        except Exception as retry_error:
+        except (requests.exceptions.RequestException, OSError) as retry_error:
             log.error(f'Download failed even without SSL verification: {retry_error}')
             return False
-            
+
     except requests.exceptions.Timeout:
         log.error(f'Download timed out for {url}')
         return False
     except requests.exceptions.RequestException as e:
         log.error(f'Request error downloading {url}: {e}')
         return False
-    except Exception as e:
+    except OSError as e:
         log.error(f'Unexpected error downloading {url}: {e}')
         return False
 
@@ -269,7 +269,7 @@ def generate_local_path_from_url(url: str, directory_path: FilePath,
             return local_path
     except PathSecurityError:
         raise
-    except Exception as e:
+    except OSError as e:
         log.error(f'Error generating local path from {url}: {e}')
         return False
 
@@ -307,7 +307,7 @@ def download_file_with_retry(url: str, local_filename: FilePath,
             if result:
                 return result
                 
-        except Exception as e:
+        except (requests.exceptions.RequestException, OSError) as e:
             log.warning(f'Download attempt {attempt + 1} failed: {e}')
     
     log.error(f'Download failed after {max_retries + 1} attempts for {url}')
@@ -349,7 +349,7 @@ def get_file_info(url: str, timeout: int = 10) -> Optional[dict]:
         log.debug(f'File info for {url}: {info}')
         return info
         
-    except Exception as e:
+    except requests.exceptions.RequestException as e:
         log.error(f'Error getting file info for {url}: {e}')
         return None
 
@@ -379,8 +379,8 @@ def is_downloadable(url: str, timeout: int = 10) -> bool:
         # Try a GET request to see if we can access the content
         response = requests.get(url, stream=True, timeout=timeout)
         return response.ok
-
-    except Exception as exc:
+        
+    except requests.exceptions.RequestException as exc:
         log.warning("Could not check if URL is downloadable %s: %s", url, exc)
         raise
 

--- a/siege_utilities/files/shell.py
+++ b/siege_utilities/files/shell.py
@@ -194,7 +194,7 @@ def run_subprocess(command_list: Union[str, List[str]],
     except (SecurityError, ValueError) as e:
         log_error(f"Security validation failed: {e}")
         raise
-    except Exception as e:
+    except (subprocess.SubprocessError, OSError) as e:
         log_error(f"Command execution failed: {e}")
         raise
 

--- a/siege_utilities/files/validation.py
+++ b/siege_utilities/files/validation.py
@@ -145,7 +145,7 @@ def is_sensitive_path(path: FilePath) -> bool:
 
         return False
 
-    except Exception:
+    except OSError:
         # If we can't resolve, assume it's potentially dangerous
         return True
 
@@ -240,7 +240,7 @@ def validate_safe_path(path: FilePath,
     except PathSecurityError:
         # Re-raise our security errors
         raise
-    except Exception as e:
+    except (OSError, ValueError) as e:
         # Other errors during validation
         raise ValueError(f"Invalid path: {path_str} - {e}") from e
 


### PR DESCRIPTION
## Summary
- Narrowed 36 `except Exception` blocks across 6 files in `siege_utilities/files/` to specific exception types
- `operations.py` (14), `hashing.py` (5), `paths.py` (9), `validation.py` (2), `shell.py` (1), `remote.py` (5)
- `PathSecurityError` continues to propagate — security errors are never swallowed

## Test plan
- [x] All 6 files parse cleanly
- [x] `pytest tests/test_file_operations.py tests/test_file_hashing.py tests/test_files_paths.py` — 73 passed