### PR TITLE
fix(SU-1): narrow broad except handlers in analytics/

### DIFF
--- a/siege_utilities/analytics/facebook_business.py
+++ b/siege_utilities/analytics/facebook_business.py
@@ -24,9 +24,12 @@ try:
     from facebook_business.adobjects.adaccount import AdAccount
     from facebook_business.adobjects.page import Page
     from facebook_business.adobjects.business import Business
+    from facebook_business.exceptions import FacebookRequestError
     FACEBOOK_BUSINESS_AVAILABLE = True
+    _FB_API_ERRORS = (FacebookRequestError, KeyError, ValueError)
 except ImportError:
     FACEBOOK_BUSINESS_AVAILABLE = False
+    _FB_API_ERRORS = (KeyError, ValueError)
 
 try:
     from pyspark.sql import DataFrame as SparkDataFrame
@@ -103,7 +106,7 @@ class FacebookBusinessConnector:
             log_info(f"Retrieved {len(accounts)} Facebook ad accounts")
             return accounts
 
-        except Exception as e:
+        except (*_FB_API_ERRORS, AttributeError) as e:
             logger.error("Failed to retrieve ad accounts: %s", e, exc_info=True)
             return []
 
@@ -296,7 +299,7 @@ class FacebookBusinessConnector:
             log_info(f"Saved DataFrame to {output_path} ({format} format)")
             return True
 
-        except Exception as e:
+        except (OSError, ValueError) as e:
             logger.error("Failed to save DataFrame: %s", e, exc_info=True)
             return False
 
@@ -332,7 +335,7 @@ class FacebookBusinessConnector:
             log_info(f"Saved DataFrame as Spark DataFrame to {output_path}")
             return True
 
-        except Exception as e:
+        except (ImportError, OSError, TypeError, RuntimeError) as e:
             logger.error("Failed to save as Spark DataFrame: %s", e, exc_info=True)
             return False
 
@@ -422,7 +425,7 @@ def load_facebook_account_profile(account_id: str,
         log_info(f"Loaded Facebook account profile: {account_id}")
         return profile
 
-    except Exception as e:
+    except (OSError, json.JSONDecodeError) as e:
         logger.error("Failed to load Facebook account profile %s: %s", account_id, e, exc_info=True)
         return None
 
@@ -453,7 +456,7 @@ def list_facebook_accounts_for_client(client_id: str,
             if profile.get('client_id') == client_id:
                 accounts.append(profile)
 
-        except Exception as e:
+        except (OSError, json.JSONDecodeError) as e:
             logger.error("Error reading Facebook account file %s: %s", config_file, e, exc_info=True)
 
     log_info(f"Found {len(accounts)} Facebook accounts for client: {client_id}")
@@ -565,7 +568,7 @@ def batch_retrieve_facebook_data(client_id: str, start_date: str, end_date: str,
 
                     log_info(f"Processed Facebook account: {account['fb_account_id']} - {len(df)} rows")
 
-            except Exception as e:
+            except (*_FB_API_ERRORS, OSError, TypeError) as e:
                 error_msg = f"Error processing account {account['fb_account_id']}: {e}"
                 results['errors'].append(error_msg)
                 logger.error("Error processing account %s", account['fb_account_id'], exc_info=True)
@@ -573,7 +576,7 @@ def batch_retrieve_facebook_data(client_id: str, start_date: str, end_date: str,
         log_info(f"Batch Facebook data retrieval completed: {results['accounts_processed']} accounts, {results['total_rows']} rows")
         return results
 
-    except Exception as e:
+    except (OSError, KeyError, AttributeError) as e:
         logger.error("Batch Facebook data retrieval failed: %s", e, exc_info=True)
         return {
             'success': False,

--- a/siege_utilities/analytics/google_analytics.py
+++ b/siege_utilities/analytics/google_analytics.py
@@ -36,9 +36,15 @@ try:
     from google.analytics.data_v1beta.types import (
         RunReportRequest, DateRange, Metric, Dimension
     )
+    from google.auth.exceptions import GoogleAuthError
+    from google.api_core.exceptions import GoogleAPICallError
     GOOGLE_ANALYTICS_AVAILABLE = True
+    _GA_AUTH_ERRORS = (GoogleAuthError, GoogleAPICallError, ValueError)
+    _GA_API_ERRORS = (GoogleAPICallError, KeyError, ValueError)
 except ImportError:
     GOOGLE_ANALYTICS_AVAILABLE = False
+    _GA_AUTH_ERRORS = (ValueError, OSError)
+    _GA_API_ERRORS = (KeyError, ValueError)
 
 try:
     from pyspark.sql import DataFrame as SparkDataFrame
@@ -159,7 +165,7 @@ class GoogleAnalyticsConnector:
 
             return True
 
-        except Exception as e:
+        except (*_GA_AUTH_ERRORS, OSError) as e:
             logger.error("Google Analytics authentication failed: %s", e, exc_info=True)
             return False
 
@@ -210,7 +216,7 @@ class GoogleAnalyticsConnector:
                 # Clean up temporary file
                 Path(temp_file).unlink(missing_ok=True)
 
-        except Exception as e:
+        except (*_GA_AUTH_ERRORS, OSError) as e:
             logger.error("Service account authentication failed: %s", e, exc_info=True)
             return False
 
@@ -389,7 +395,7 @@ class GoogleAnalyticsConnector:
             log_info(f"Saved DataFrame to {output_path} ({format} format)")
             return True
 
-        except Exception as e:
+        except (OSError, ValueError) as e:
             logger.error("Failed to save DataFrame: %s", e, exc_info=True)
             return False
 
@@ -425,7 +431,7 @@ class GoogleAnalyticsConnector:
             log_info(f"Saved DataFrame as Spark DataFrame to {output_path}")
             return True
 
-        except Exception as e:
+        except (ImportError, OSError, TypeError, RuntimeError) as e:
             logger.error("Failed to save as Spark DataFrame: %s", e, exc_info=True)
             return False
 
@@ -515,7 +521,7 @@ def load_ga_account_profile(account_id: str,
         log_info(f"Loaded GA account profile: {account_id}")
         return profile
 
-    except Exception as e:
+    except (OSError, json.JSONDecodeError) as e:
         logger.error("Failed to load GA account profile %s: %s", account_id, e, exc_info=True)
         return None
 
@@ -546,7 +552,7 @@ def list_ga_accounts_for_client(client_id: str,
             if profile.get('client_id') == client_id:
                 accounts.append(profile)
 
-        except Exception as e:
+        except (OSError, json.JSONDecodeError) as e:
             logger.error("Error reading GA account file %s: %s", config_file, e, exc_info=True)
 
     log_info(f"Found {len(accounts)} GA accounts for client: {client_id}")
@@ -645,7 +651,7 @@ def batch_retrieve_ga_data(client_id: str, start_date: str, end_date: str,
 
                     log_info(f"Processed GA account: {account['ga_account_id']} - {len(df)} rows")
 
-            except Exception as e:
+            except (*_GA_API_ERRORS, OSError, json.JSONDecodeError) as e:
                 error_msg = f"Error processing account {account['ga_account_id']}: {e}"
                 results['errors'].append(error_msg)
                 logger.error("Error processing account %s", account['ga_account_id'], exc_info=True)
@@ -653,7 +659,7 @@ def batch_retrieve_ga_data(client_id: str, start_date: str, end_date: str,
         log_info(f"Batch GA data retrieval completed: {results['accounts_processed']} accounts, {results['total_rows']} rows")
         return results
 
-    except Exception as e:
+    except (OSError, KeyError, AttributeError) as e:
         logger.error("Batch GA data retrieval failed: %s", e, exc_info=True)
         return {
             'success': False,

--- a/siege_utilities/analytics/google_slides.py
+++ b/siege_utilities/analytics/google_slides.py
@@ -403,7 +403,7 @@ def create_argument_slide(
             img_url = upload_figure_to_drive(client, fig, fig_name)
             insert_image(client, presentation_id, slide_id, img_url,
                          left=fl, top=ft, width=fw, height=fh)
-        except Exception as exc:
+        except (OSError, ValueError, RuntimeError, KeyError) as exc:
             log.warning("Could not upload figure for slide %s: %s", slide_id, exc)
 
     return slide_id
@@ -439,7 +439,7 @@ def create_report_from_arguments(
     for i, argument in enumerate(arguments):
         try:
             create_argument_slide(client, pres_id, argument, slide_index=i)
-        except Exception as exc:
+        except (OSError, ValueError, TypeError, KeyError, AttributeError, RuntimeError) as exc:
             log.error("Failed to create slide %d for argument %r: %s",
                       i, argument.headline, exc)
 

--- a/siege_utilities/analytics/snowflake_connector.py
+++ b/siege_utilities/analytics/snowflake_connector.py
@@ -13,9 +13,18 @@ import os
 try:
     import snowflake.connector
     from snowflake.connector.pandas_tools import write_pandas, read_pandas
+    from snowflake.connector.errors import (
+        DatabaseError as _SnowflakeDatabaseError,
+        ProgrammingError as _SnowflakeProgrammingError,
+        OperationalError as _SnowflakeOperationalError,
+    )
     SNOWFLAKE_AVAILABLE = True
+    _SF_CONN_ERRORS = (_SnowflakeDatabaseError, _SnowflakeOperationalError)
+    _SF_QUERY_ERRORS = (_SnowflakeProgrammingError, _SnowflakeDatabaseError)
 except ImportError:
     SNOWFLAKE_AVAILABLE = False
+    _SF_CONN_ERRORS = (OSError,)
+    _SF_QUERY_ERRORS = (ValueError,)
 
 try:
     import pandas as pd
@@ -120,10 +129,10 @@ class SnowflakeConnector:
             log.info("Successfully connected to Snowflake")
             return True
             
-        except Exception as e:
+        except (*_SF_CONN_ERRORS, TypeError) as e:
             log.error(f"Failed to connect to Snowflake: {e}")
             return False
-    
+
     def disconnect(self) -> None:
         """Close Snowflake connection."""
         try:
@@ -132,7 +141,7 @@ class SnowflakeConnector:
             if self.connection:
                 self.connection.close()
             log.info("Disconnected from Snowflake")
-        except Exception as e:
+        except (*_SF_CONN_ERRORS, AttributeError) as e:
             log.error(f"Error disconnecting from Snowflake: {e}")
     
     def execute_query(self, query: str, params: Optional[Dict[str, Any]] = None) -> Optional[List[tuple]]:
@@ -160,10 +169,10 @@ class SnowflakeConnector:
             log.info(f"Query executed successfully. Rows returned: {len(results)}")
             return results
             
-        except Exception as e:
+        except (*_SF_QUERY_ERRORS, ValueError) as e:
             log.error(f"Query execution failed: {e}")
             return None
-    
+
     def execute_ddl(self, ddl_statement: str) -> bool:
         """
         Execute DDL statements (CREATE, ALTER, DROP, etc.).
@@ -184,11 +193,11 @@ class SnowflakeConnector:
             log.info("DDL statement executed successfully")
             return True
             
-        except Exception as e:
+        except (*_SF_QUERY_ERRORS,) as e:
             log.error(f"DDL execution failed: {e}")
             return False
-    
-    def upload_dataframe(self, 
+
+    def upload_dataframe(self,
                         df: 'pd.DataFrame',
                         table_name: str,
                         database: Optional[str] = None,
@@ -249,11 +258,11 @@ class SnowflakeConnector:
                 log.error(f"Failed to upload data to table {table_name}")
                 return False
                 
-        except Exception as e:
+        except (*_SF_QUERY_ERRORS, ValueError) as e:
             log.error(f"DataFrame upload failed: {e}")
             return False
-    
-    def download_dataframe(self, 
+
+    def download_dataframe(self,
                           query: str,
                           params: Optional[Dict[str, Any]] = None) -> Optional['pd.DataFrame']:
         """
@@ -279,7 +288,7 @@ class SnowflakeConnector:
             log.info(f"Successfully downloaded {len(df)} rows as DataFrame")
             return df
             
-        except Exception as e:
+        except (*_SF_QUERY_ERRORS, ValueError) as e:
             log.error(f"DataFrame download failed: {e}")
             return None
     
@@ -378,7 +387,7 @@ class SnowflakeConnector:
             
             return table_info
             
-        except Exception as e:
+        except (*_SF_QUERY_ERRORS, ValueError, IndexError) as e:
             log.error(f"Failed to get table info: {e}")
             return None
     
@@ -413,7 +422,7 @@ class SnowflakeConnector:
             
             return tables
             
-        except Exception as e:
+        except (*_SF_QUERY_ERRORS, ValueError, IndexError) as e:
             log.error(f"Failed to list tables: {e}")
             return None
     

--- a/tests/test_snowflake_connector.py
+++ b/tests/test_snowflake_connector.py
@@ -104,7 +104,7 @@ def test_execute_query_returns_none_on_driver_error(_patch_snowflake):
 
     c = SnowflakeConnector(account="acc", user="u", password="p")
     cursor = MagicMock()
-    cursor.execute.side_effect = RuntimeError("boom")
+    cursor.execute.side_effect = ValueError("boom")
     c.connection = MagicMock()
     c.cursor = cursor
 


### PR DESCRIPTION
Parent: #778 (WS1: SU-1 Broad-Except Cleanup)
Epic: #776 (Usability)

## Summary

- Narrowed 25 `except Exception` handlers across 4 analytics modules to specific types
- Added conditional SDK exception tuples (`_FB_API_ERRORS`, `_GA_AUTH_ERRORS`, `_GA_API_ERRORS`, `_SF_CONN_ERRORS`, `_SF_QUERY_ERRORS`) that fall back gracefully when SDKs not installed
- Updated 1 test (`side_effect=RuntimeError` → `ValueError`) to match narrowed handler

| File | Handlers Fixed | Pattern |
|---|---|---|
| facebook_business.py | 7 | `_FB_API_ERRORS` + OSError/json.JSONDecodeError |
| google_analytics.py | 8 | `_GA_AUTH_ERRORS`/`_GA_API_ERRORS` + OSError/json |
| google_slides.py | 2 | OSError/ValueError/RuntimeError/KeyError |
| snowflake_connector.py | 8 | `_SF_CONN_ERRORS`/`_SF_QUERY_ERRORS` + ValueError |

## Test plan

- [x] All 4 files parse cleanly (`ast.parse`)
- [x] 7 existing tests pass, 1 pre-existing failure (missing pandas — not a regression)
- [x] SU-1 linter reports 0 violations for analytics/ (excl datadotworld, fixed in #772)