### PR TITLE
fix(SU-1): narrow broad except handlers in admin/

### DIFF
--- a/siege_utilities/admin/profile_manager.py
+++ b/siege_utilities/admin/profile_manager.py
@@ -102,7 +102,7 @@ def validate_profile_location(location: Path) -> bool:
         test_file.unlink()
         
         return True
-    except Exception as e:
+    except OSError as e:
         log.debug(f"Profile location validation failed: {e}")
         return False
 
@@ -241,32 +241,32 @@ def migrate_profiles(
                     shutil.copy2(user_file, target_users / user_file.name)
                     stats["users_migrated"] += 1
                     stats["files_copied"] += 1
-                except Exception as e:
+                except OSError as e:
                     log.error(f"Failed to migrate user file {user_file}: {e}")
                     stats["errors"] += 1
-        
+
         # Migrate client profiles
         source_clients = source_location / "clients"
         if source_clients.exists():
             target_clients = target_location / "clients"
             target_clients.mkdir(parents=True, exist_ok=True)
-            
+
             for client_file in source_clients.glob("*.yaml"):
                 try:
                     shutil.copy2(client_file, target_clients / client_file.name)
                     stats["clients_migrated"] += 1
                     stats["files_copied"] += 1
-                except Exception as e:
+                except OSError as e:
                     log.error(f"Failed to migrate client file {client_file}: {e}")
                     stats["errors"] += 1
-        
+
         # Copy any other configuration files
         for config_file in source_location.glob("*.yaml"):
             if config_file.name not in ["user_config.yaml"]:
                 try:
                     shutil.copy2(config_file, target_location / config_file.name)
                     stats["files_copied"] += 1
-                except Exception as e:
+                except OSError as e:
                     log.error(f"Failed to migrate config file {config_file}: {e}")
                     stats["errors"] += 1
         


### PR DESCRIPTION
Parent: #778 (WS1: SU-1 Broad-Except Cleanup)
Epic: #776 (Usability)

## Summary

- Narrowed 4 `except Exception` handlers in `admin/profile_manager.py` to `except OSError`
- All are file I/O operations (mkdir, write_text, shutil.copy2)
- The outer re-raise handler at line 276 is correctly exempt (unconditional re-raise)

## Test plan

- [x] File parses cleanly
- [x] No existing tests to regress (profiles/ has no direct tests — tracked as WS6-T2 in #783)