### PR TITLE
fix(SU-1): narrow broad except handlers in reporting/

### DIFF
--- a/siege_utilities/reporting/chart_types.py
+++ b/siege_utilities/reporting/chart_types.py
@@ -510,7 +510,7 @@ class ChartTypeRegistry:
                 yaml.dump(config_data, f, default_flow_style=False)
             
             log.info(f"Exported chart type configuration to: {output_path}")
-        except Exception as e:
+        except (OSError, yaml.YAMLError, AttributeError) as e:
             log.error(f"Failed to export chart type configuration: {e}")
 
 # Global instance

--- a/siege_utilities/reporting/engines/bar_engine.py
+++ b/siege_utilities/reporting/engines/bar_engine.py
@@ -130,7 +130,7 @@ class BarChartMixin:
             # Convert to ReportLab Image
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
             log.error(f"Error creating bar chart: {e}")
             return self._create_placeholder_chart(width, height, f"Chart Error: {str(e)}")
 
@@ -215,7 +215,7 @@ class BarChartMixin:
             # Convert to ReportLab Image
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
             log.error(f"Error creating line chart: {e}")
             return self._create_placeholder_chart(width, height, f"Chart Error: {str(e)}")
 
@@ -324,7 +324,7 @@ class BarChartMixin:
             # Convert to ReportLab Image
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
             log.error(f"Error creating pie chart: {e}")
             return self._create_placeholder_chart(width, height, f"Chart Error: {str(e)}")
 
@@ -388,6 +388,6 @@ class BarChartMixin:
 
             return "<br/>".join(chart_lines)
 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
             log.error(f"Error creating proportional text bar chart: {e}")
             return f"<i>Error creating text bar chart: {str(e)}</i>"

--- a/siege_utilities/reporting/engines/base_engine.py
+++ b/siege_utilities/reporting/engines/base_engine.py
@@ -240,7 +240,7 @@ class BaseChartEngine:
                         facecolor='white', edgecolor='none', pad_inches=0.1)
             log.info(f"Saved vector chart: {out}")
             return out
-        except Exception as e:
+        except (OSError, ValueError, TypeError) as e:
             log.error(f"Error saving vector chart to {output_path}: {e}")
             return None
 
@@ -314,7 +314,7 @@ class BaseChartEngine:
 
             return rl_image
 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
             log.error(f"Error converting matplotlib figure to ReportLab Image: {e}")
             return self._create_placeholder_chart(width, height, "Image Conversion Error")
 
@@ -348,7 +348,7 @@ class BaseChartEngine:
                 sw, sh = self._scale_dimensions(width, height)
                 return Image("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
                            width=sw*inch, height=sh*inch)
-        except Exception as e:
+        except (ValueError, TypeError, AttributeError, OSError) as e:
             log.error(f"Error creating placeholder chart: {e}")
             # Return a minimal image — still honour auto-scaling
             sw, sh = self._scale_dimensions(width, height)
@@ -446,7 +446,7 @@ class BaseChartEngine:
             else:
                 return self.create_bar_chart(df, x_column, y_columns[0] if y_columns else None, title, width, height)
 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
             log.error(f"Error generating chart from DataFrame: {e}")
             return self._create_placeholder_chart(width, height, "DataFrame Chart Error")
 
@@ -500,6 +500,6 @@ class BaseChartEngine:
             else:
                 return self.create_bar_chart(chart_config['data'], title=chart_config.get('title', ''), width=width, height=height)
 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
             log.error(f"Error creating custom chart: {e}")
             return self._create_placeholder_chart(width, height, "Custom Chart Error")

--- a/siege_utilities/reporting/engines/composite_engine.py
+++ b/siege_utilities/reporting/engines/composite_engine.py
@@ -132,7 +132,7 @@ class CompositeChartMixin:
                 if show_magnitudes and mag is not None:
                     try:
                         lw = max(1.4, min(4.2, 1.2 + float(mag)))
-                    except Exception:
+                    except (ValueError, TypeError):
                         lw = 2.0
 
                 ax.annotate(
@@ -189,7 +189,7 @@ class CompositeChartMixin:
             ax.set_title(title, fontsize=13, fontweight='bold')
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
             log.error(f"Error creating convergence diagram: {e}")
             return self._create_placeholder_chart(width, height, f"Convergence Diagram Error: {str(e)}")
 
@@ -256,7 +256,7 @@ class CompositeChartMixin:
             # Convert to ReportLab Image
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
             log.error(f"Error creating dashboard: {e}")
             return self._create_placeholder_chart(width, height, f"Dashboard Error: {str(e)}")
 
@@ -308,7 +308,7 @@ class CompositeChartMixin:
             # Convert to ReportLab Image
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
             log.error(f"Error creating DataFrame summary charts: {e}")
             return self._create_placeholder_chart(width, height, f"Summary Charts Error: {str(e)}")
 
@@ -324,7 +324,7 @@ class CompositeChartMixin:
                 ax.bar(labels, values, color=self.default_colors['primary'])
                 ax.set_title(title)
                 ax.grid(True, alpha=0.3)
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
             log.error(f"Error creating bar subplot: {e}")
 
     def _create_line_subplot(self, ax, chart_config: Dict[str, Any], title: str):
@@ -341,7 +341,7 @@ class CompositeChartMixin:
 
             ax.set_title(title)
             ax.grid(True, alpha=0.3)
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
             log.error(f"Error creating line subplot: {e}")
 
     def _create_pie_subplot(self, ax, chart_config: Dict[str, Any], title: str):
@@ -353,7 +353,7 @@ class CompositeChartMixin:
 
             ax.pie(values, labels=labels, autopct='%1.1f%%', colors=self.color_palette[:len(values)])
             ax.set_title(title)
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
             log.error(f"Error creating pie subplot: {e}")
 
     def _create_scatter_subplot(self, ax, chart_config: Dict[str, Any], title: str):
@@ -366,5 +366,5 @@ class CompositeChartMixin:
             ax.scatter(x_values, y_values, alpha=0.6, color=self.default_colors['primary'])
             ax.set_title(title)
             ax.grid(True, alpha=0.3)
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
             log.error(f"Error creating scatter subplot: {e}")

--- a/siege_utilities/reporting/engines/map_engine.py
+++ b/siege_utilities/reporting/engines/map_engine.py
@@ -140,7 +140,7 @@ class MapChartMixin:
             return self._save_folium_map(m, "temp_choropleth_map.html",
                                         "Choropleth Map", width, height)
 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
             log.error(f"Error creating choropleth map: {e}")
             return self._create_placeholder_chart(width, height, f"Map Error: {str(e)}")
 
@@ -231,7 +231,7 @@ class MapChartMixin:
             # Convert to ReportLab Image
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
             log.error(f"Error creating bivariate choropleth with matplotlib: {e}")
             return self._create_placeholder_chart(width, height, f"Bivariate Choropleth Error: {str(e)}")
 
@@ -335,7 +335,7 @@ class MapChartMixin:
             legend_ax.set_ylabel(var2, fontsize=9, fontweight='bold')
             legend_ax.tick_params(length=0, labelsize=8)
 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
             log.warning(f"Could not add bivariate legend: {e}")
 
     def create_advanced_choropleth(self, data: Union[pd.DataFrame, Dict[str, Any]],
@@ -423,7 +423,7 @@ class MapChartMixin:
             # Convert to ReportLab Image
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
             log.error(f"Error creating advanced choropleth: {e}")
             return self._create_placeholder_chart(width, height, f"Advanced Choropleth Error: {str(e)}")
 
@@ -522,7 +522,7 @@ class MapChartMixin:
             return self._save_folium_map(m, "temp_marker_map.html",
                                         "Marker Map", width, height)
 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
             log.error(f"Error creating marker map: {e}")
             return self._create_placeholder_chart(width, height, f"Marker Map Error: {str(e)}")
 
@@ -595,7 +595,7 @@ class MapChartMixin:
             # Convert to ReportLab Image
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
             log.error(f"Error creating 3D map: {e}")
             return self._create_placeholder_chart(width, height, f"3D Map Error: {str(e)}")
 
@@ -668,7 +668,7 @@ class MapChartMixin:
             return self._save_folium_map(m, "temp_heatmap.html",
                                         "Heatmap", width, height)
 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
             log.error(f"Error creating heatmap: {e}")
             return self._create_placeholder_chart(width, height, f"Heatmap Error: {str(e)}")
 
@@ -764,7 +764,7 @@ class MapChartMixin:
             return self._save_folium_map(m, "temp_cluster_map.html",
                                         "Cluster Map", width, height)
 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
             log.error(f"Error creating cluster map: {e}")
             return self._create_placeholder_chart(width, height, f"Cluster Map Error: {str(e)}")
 
@@ -863,7 +863,7 @@ class MapChartMixin:
             return self._save_folium_map(m, "temp_flow_map.html",
                                         "Flow Map", width, height)
 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
             log.error(f"Error creating flow map: {e}")
             return self._create_placeholder_chart(width, height, f"Flow Map Error: {str(e)}")
 
@@ -966,6 +966,6 @@ class MapChartMixin:
             return self._save_folium_map(m, "temp_bivariate_choropleth.html",
                                         "Bivariate Choropleth", width, height)
 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
             log.error(f"Error creating bivariate choropleth map: {e}")
             return self._create_placeholder_chart(width, height, f"Bivariate Choropleth Error: {str(e)}")

--- a/siege_utilities/reporting/engines/stats_engine.py
+++ b/siege_utilities/reporting/engines/stats_engine.py
@@ -94,7 +94,7 @@ class StatsChartMixin:
             # Convert to ReportLab Image
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
             log.error(f"Error creating heatmap: {e}")
             return self._create_placeholder_chart(width, height, f"Heatmap Error: {str(e)}")
 
@@ -148,7 +148,7 @@ class StatsChartMixin:
             # Convert to ReportLab Image
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
             log.error(f"Error creating scatter plot: {e}")
             return self._create_placeholder_chart(width, height, f"Scatter Plot Error: {str(e)}")
 
@@ -222,6 +222,6 @@ class StatsChartMixin:
 
             return "<br/>".join(chart_lines)
 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
             log.error(f"Error creating text heatmap: {e}")
             return f"<i>Error creating text heatmap: {str(e)}</i>"

--- a/siege_utilities/reporting/examples/bivariate_choropleth_example.py
+++ b/siege_utilities/reporting/examples/bivariate_choropleth_example.py
@@ -104,7 +104,7 @@ def example_basic_bivariate_choropleth():
         
         return chart
         
-    except Exception as e:
+    except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
         print(f"✗ Error creating basic bivariate choropleth: {e}")
         return None
 
@@ -144,7 +144,7 @@ def example_advanced_bivariate_choropleth():
         
         return chart
         
-    except Exception as e:
+    except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
         print(f"✗ Error creating advanced bivariate choropleth: {e}")
         return None
 
@@ -186,7 +186,7 @@ def example_custom_chart_configuration():
         
         return chart
         
-    except Exception as e:
+    except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
         print(f"✗ Error creating custom chart configuration: {e}")
         return None
 
@@ -223,7 +223,7 @@ def example_dataframe_integration():
         
         return chart
         
-    except Exception as e:
+    except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
         print(f"✗ Error creating DataFrame integration chart: {e}")
         return None
 
@@ -264,7 +264,7 @@ def example_advanced_choropleth():
         
         return chart
         
-    except Exception as e:
+    except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
         print(f"✗ Error creating advanced choropleth: {e}")
         return None
 
@@ -294,7 +294,7 @@ def run_all_examples():
             chart = example_func()
             if chart:
                 charts.append(chart)
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
             print(f"✗ Example {example_func.__name__} failed: {e}")
     
     print(f"\n📊 Summary: {len(charts)} out of {len(examples)} examples completed successfully")
@@ -356,7 +356,7 @@ def create_report_with_bivariate_maps():
         
         return report_section
         
-    except Exception as e:
+    except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
         print(f"✗ Error creating report section: {e}")
         return None
 

--- a/siege_utilities/reporting/examples/comprehensive_mapping_example.py
+++ b/siege_utilities/reporting/examples/comprehensive_mapping_example.py
@@ -518,7 +518,7 @@ def main():
         print("   4. Apply client branding and customization")
         print("   5. Deploy in production reporting workflows")
         
-    except Exception as e:
+    except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
         print(f"\n❌ Error during demonstration: {e}")
         import traceback
         traceback.print_exc()

--- a/siege_utilities/reporting/examples/ga_geographic_analysis.py
+++ b/siege_utilities/reporting/examples/ga_geographic_analysis.py
@@ -227,7 +227,7 @@ def create_state_choropleth(state_data: pd.DataFrame, value_column: str = 'sessi
                 plt.close()
                 return tmp.name
 
-    except Exception as e:
+    except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
         log.error(f"Error creating state choropleth: {e}")
         return None
 
@@ -284,7 +284,7 @@ def create_city_heatmap(ga_city_df: pd.DataFrame, value_column: str = 'sessions'
                 m.save(tmp.name)
                 return tmp.name
 
-    except Exception as e:
+    except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
         log.error(f"Error creating city heatmap: {e}")
         return None
 
@@ -335,7 +335,7 @@ def create_traffic_demographics_comparison(ga_state_data: pd.DataFrame,
 
         return merged
 
-    except Exception as e:
+    except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
         log.error(f"Error fetching Census demographics: {e}")
         return ga_state_data
 
@@ -431,7 +431,7 @@ def create_bivariate_traffic_income_map(merged_data: pd.DataFrame,
                 plt.close()
                 return tmp.name
 
-    except Exception as e:
+    except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
         log.error(f"Error creating bivariate map: {e}")
         return None
 

--- a/siege_utilities/reporting/examples/google_analytics_report_example.py
+++ b/siege_utilities/reporting/examples/google_analytics_report_example.py
@@ -696,7 +696,7 @@ def fetch_real_ga4_data(property_id: str, start_date: str, end_date: str,
                         'users': int(year_df['totalUsers'].sum()),
                         'pageviews': int(year_df['screenPageViews'].sum()),
                     }
-            except Exception:
+            except (ValueError, TypeError, KeyError, AttributeError, OSError) as exc:
                 log.debug(f"Could not fetch longitudinal data for {year}")
 
         result = {
@@ -764,7 +764,7 @@ def fetch_real_ga4_data(property_id: str, start_date: str, end_date: str,
         log.info(f"Fetched real GA4 data: {total_sessions:,} sessions, {total_users:,} users")
         return result
 
-    except Exception as e:
+    except (ValueError, TypeError, KeyError, AttributeError, OSError) as e:
         log.warning(f"Could not fetch real GA4 data: {e}")
         return None
 
@@ -1046,13 +1046,13 @@ def create_geo_country_chart(ga_data: Dict[str, Any], width: float = 5.5*inch,
         try:
             import geodatasets
             world = gpd.read_file(geodatasets.get_path('naturalearth.land'))
-        except (ImportError, Exception) as exc:
+        except (ImportError, OSError, ValueError) as exc:
             log.debug("geodatasets not available, trying geopandas built-in: %s", exc)
 
         if world is None:
             try:
                 world = gpd.read_file(gpd.datasets.get_path('naturalearth_lowres'))
-            except Exception as exc:
+            except (OSError, ValueError, AttributeError) as exc:
                 log.debug("geopandas built-in naturalearth_lowres not available: %s", exc)
 
         if world is not None and 'name' in world.columns:
@@ -1073,7 +1073,7 @@ def create_geo_country_chart(ga_data: Dict[str, Any], width: float = 5.5*inch,
                     plt.savefig(tmp.name, dpi=300, bbox_inches='tight')
                     plt.close()
                     return tmp.name
-    except Exception as exc:
+    except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as exc:
         log.warning("Choropleth generation failed, falling back to bar chart: %s", exc)
 
     # Fallback: horizontal bar chart
@@ -1141,13 +1141,13 @@ def create_geo_region_chart(ga_data: Dict[str, Any], width: float = 5.5*inch,
         try:
             import geodatasets
             world = gpd.read_file(geodatasets.get_path('naturalearth.land'))
-        except (ImportError, Exception) as exc:
+        except (ImportError, OSError, ValueError) as exc:
             log.debug("geodatasets not available, trying geopandas built-in: %s", exc)
 
         if world is None:
             try:
                 world = gpd.read_file(gpd.datasets.get_path('naturalearth_lowres'))
-            except Exception as exc:
+            except (OSError, ValueError, AttributeError) as exc:
                 log.debug("geopandas built-in naturalearth_lowres not available: %s", exc)
 
         # For US states, try Census TIGER
@@ -1156,7 +1156,7 @@ def create_geo_region_chart(ga_data: Dict[str, Any], width: float = 5.5*inch,
             us_states_path = Path.home() / '.siege_utilities' / 'geo_data' / 'cb_us_state_20m.shp'
             if us_states_path.exists():
                 us_states = gpd.read_file(us_states_path)
-        except Exception as exc:
+        except (OSError, ValueError) as exc:
             log.debug("Failed to load TIGER state shapefile: %s", exc)
 
         if us_states is not None and 'NAME' in us_states.columns:
@@ -1179,7 +1179,7 @@ def create_geo_region_chart(ga_data: Dict[str, Any], width: float = 5.5*inch,
                     fig.savefig(tmp.name, dpi=300, bbox_inches='tight')
                     plt.close(fig)
                     return tmp.name
-    except Exception as exc:
+    except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as exc:
         log.warning("Bivariate choropleth generation failed, falling back to bar chart: %s", exc)
 
     # Fallback: horizontal bar chart
@@ -1246,12 +1246,12 @@ def create_geo_city_scatter(ga_data: Dict[str, Any], width: float = 5.5*inch,
                 try:
                     import geodatasets
                     world = gpd.read_file(geodatasets.get_path('naturalearth.land'))
-                except (ImportError, Exception) as exc:
+                except (ImportError, OSError, ValueError) as exc:
                     log.debug("geodatasets not available, trying geopandas built-in: %s", exc)
                 if world is None:
                     try:
                         world = gpd.read_file(gpd.datasets.get_path('naturalearth_lowres'))
-                    except Exception as exc:
+                    except (OSError, ValueError, AttributeError) as exc:
                         log.debug("geopandas built-in naturalearth_lowres not available: %s", exc)
                 if world is not None:
                     world.plot(ax=ax, color='#E8E8E8', edgecolor='#CCCCCC', linewidth=0.3)
@@ -1283,7 +1283,7 @@ def create_geo_city_scatter(ga_data: Dict[str, Any], width: float = 5.5*inch,
                 plt.savefig(tmp.name, dpi=300, bbox_inches='tight')
                 plt.close()
                 return tmp.name
-        except Exception as exc:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as exc:
             log.warning("City scatter plot generation failed, falling back to bar chart: %s", exc)
 
     # Fallback: horizontal bar chart
@@ -1668,7 +1668,7 @@ def generate_ga_report_pdf(ga_data: Dict[str, Any], output_path: str,
                     secondary_color = branding.get('colors', {}).get('secondary', secondary_color)
                     client_name = branding.get('name', client_name)
                     prepared_by = branding.get('footer', {}).get('left_text', f"Prepared by: {prepared_by}").replace('Prepared by: ', '')
-            except Exception as e:
+            except (ImportError, ValueError, KeyError, AttributeError) as e:
                 log.debug(f"Could not load branding '{branding_key}': {e}")
 
         date_range = ga_data['date_range']
@@ -1770,7 +1770,7 @@ def generate_ga_report_pdf(ga_data: Dict[str, Any], output_path: str,
                 except ImportError:
                     log.debug("cairosvg not installed; skipping SVG logo (install cairosvg for SVG support)")
                     _logo_path = None
-                except Exception as e:
+                except (OSError, ValueError, TypeError) as e:
                     log.debug(f"Could not convert SVG logo: {e}")
                     _logo_path = None
             if _logo_path:
@@ -2369,7 +2369,7 @@ def generate_ga_report_pdf(ga_data: Dict[str, Any], output_path: str,
         log.info(f"Google Analytics report generated: {output_path}")
         return True
 
-    except Exception as e:
+    except (OSError, ValueError, TypeError, KeyError, AttributeError) as e:
         log.error(f"Error generating GA report: {e}")
         import traceback
         traceback.print_exc()
@@ -2632,7 +2632,7 @@ def export_design_kit(ga_data: Dict[str, Any], output_dir: str,
         log.info(f"Design kit exported: {kit}")
         return True
 
-    except Exception as e:
+    except (OSError, ValueError, TypeError, KeyError) as e:
         log.error(f"Error exporting design kit: {e}")
         import traceback
         traceback.print_exc()

--- a/siege_utilities/reporting/idml_export.py
+++ b/siege_utilities/reporting/idml_export.py
@@ -91,7 +91,7 @@ class IDMLExporter:
             try:
                 self._idml_package = simpleidml.IDMLPackage(str(self.template_path))
                 log.info("Loaded IDML template via simpleidml: %s", self.template_path)
-            except Exception as exc:
+            except (OSError, ValueError, KeyError, AttributeError) as exc:
                 log.warning(
                     "Could not load template with simpleidml (%s); "
                     "falling back to manual ZIP builder.",
@@ -230,7 +230,7 @@ class IDMLExporter:
         for placeholder, content in self._replacements.items():
             try:
                 pkg.set_tag(placeholder, content)
-            except Exception:
+            except (ValueError, KeyError, AttributeError, TypeError) as exc:
                 log.debug(
                     "simpleidml.set_tag failed for %r; doing raw XML substitution.",
                     placeholder,

--- a/siege_utilities/reporting/powerpoint_generator.py
+++ b/siege_utilities/reporting/powerpoint_generator.py
@@ -986,7 +986,7 @@ class PowerPointGenerator:
                 paragraph.font.size = Pt(24)
                 paragraph.alignment = PP_ALIGN.CENTER
                 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
             log.warning(f"Could not apply formatting to title slide: {e}")
 
     def _format_content_slide(self, slide):
@@ -1002,7 +1002,7 @@ class PowerPointGenerator:
             for paragraph in content_shape.text_frame.paragraphs:
                 paragraph.font.size = Pt(18)
                 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
             log.warning(f"Could not apply formatting to content slide: {e}")
 
     def create_presentation_from_dataframe(self, df: pd.DataFrame,
@@ -1192,7 +1192,7 @@ class PowerPointGenerator:
                 # Default to text slide
                 return self._create_text_slide(section, prs)
                 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
             log.error(f"Error creating slide for section {section_type}: {e}")
             return None
 

--- a/siege_utilities/reporting/report_generator.py
+++ b/siege_utilities/reporting/report_generator.py
@@ -518,7 +518,7 @@ class ReportGenerator:
             log.info(f"PDF report generated successfully: {output_path}")
             return True
 
-        except Exception as e:
+        except (OSError, ValueError, TypeError, KeyError, AttributeError) as e:
             log.error(f"Error generating PDF report: {e}")
             # Best-effort cleanup of the partial file. The variable may
             # not be bound yet if we failed before assigning it.
@@ -587,7 +587,7 @@ class ReportGenerator:
                         try:
                             import matplotlib.pyplot as plt
                             plt.close(chart)
-                        except Exception as exc:
+                        except (ValueError, TypeError, AttributeError) as exc:
                             log.debug("Could not close matplotlib figure: %s", exc)
                         # The BytesIO is now referenced by the RLImage —
                         # ReportLab keeps a handle for the build pass and
@@ -624,7 +624,7 @@ class ReportGenerator:
 
                 log.warning(f"Unknown chart type: {type(chart)}")
 
-            except Exception as e:
+            except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
                 log.error(f"Error processing chart: {e}")
 
         return result

--- a/siege_utilities/reporting/templates/base_template.py
+++ b/siege_utilities/reporting/templates/base_template.py
@@ -157,7 +157,7 @@ class BaseReportTemplate:
                         )
                         log.info(f"Font family '{font_family}' processed.")
                         registered_families.add(font_family)
-                except Exception as e:
+                except (OSError, ValueError, KeyError) as e:
                     log.error(f"Failed to register font family '{font_family}': {e}")
 
             # Set default styles to use registered fonts
@@ -171,7 +171,7 @@ class BaseReportTemplate:
             else:
                 log.warning("Liberation-Serif not fully registered. Defaulting to standard ReportLab fonts.")
                 
-        except Exception as e:
+        except (OSError, ValueError, KeyError, AttributeError) as e:
             log.error(f"Error in font registration: {e}")
 
     def _add_custom_styles(self):
@@ -338,7 +338,7 @@ class BaseReportTemplate:
                                      width=img_width, height=img_height, mask='auto')
 
                     current_header_x += img_width + 0.1 * inch
-                except Exception as e:
+                except (OSError, ValueError, TypeError, AttributeError) as e:
                     log.error(f"Error drawing main header logo: {e}")
 
         # Left Header Text
@@ -379,7 +379,7 @@ class BaseReportTemplate:
                     canvas.drawImage(footer_logo_path, current_footer_x, footer_y_pos - footer_img_height / 2,
                                      width=footer_img_width, height=footer_img_height, mask='auto')
                     current_footer_x += footer_img_width + 0.1 * inch
-                except Exception as e:
+                except (OSError, ValueError, TypeError, AttributeError) as e:
                     log.error(f"Error drawing footer logo: {e}")
 
         # Left Footer Text

--- a/siege_utilities/reporting/templates/content_page_template.py
+++ b/siege_utilities/reporting/templates/content_page_template.py
@@ -64,7 +64,7 @@ class ContentPageTemplate:
         try:
             from .client_branding import ClientBrandingManager  # noqa: F401
             return self._default_brand_config()
-        except Exception as e:
+        except ImportError as e:
             log_warning(f"Could not load brand config: {e}")
             return self._default_brand_config()
     

--- a/siege_utilities/reporting/templates/page_templates.py
+++ b/siege_utilities/reporting/templates/page_templates.py
@@ -227,7 +227,7 @@ class PageTemplateManager:
                     template = PageTemplate(**template_data)
                     self.templates[template.name] = template
                     log.info(f"Loaded custom template: {template.name}")
-            except Exception as e:
+            except (OSError, yaml.YAMLError, ValueError, TypeError, KeyError) as e:
                 log.warning(f"Failed to load custom template {template_file}: {e}")
     
     def get_template(self, template_name: str) -> Optional[PageTemplate]:
@@ -276,7 +276,7 @@ class PageTemplateManager:
         try:
             with open(template_file, 'w') as f:
                 yaml.dump(template.__dict__, f, default_flow_style=False)
-        except Exception as e:
+        except (OSError, yaml.YAMLError) as e:
             log.error(f"Failed to save custom template: {e}")
     
     def modify_template(self, template_name: str, **kwargs):
@@ -336,7 +336,7 @@ class PageTemplateManager:
             with open(output_path, 'w') as f:
                 yaml.dump(template.__dict__, f, default_flow_style=False)
             log.info(f"Exported template to: {output_path}")
-        except Exception as e:
+        except (OSError, yaml.YAMLError) as e:
             log.error(f"Failed to export template: {e}")
     
     def import_template(self, input_path: str, template_name: Optional[str] = None):
@@ -357,7 +357,7 @@ class PageTemplateManager:
             template = PageTemplate(**template_data)
             self.create_custom_template(template)
             log.info(f"Imported template: {template.name}")
-        except Exception as e:
+        except (OSError, yaml.YAMLError, ValueError, TypeError, KeyError) as e:
             log.error(f"Failed to import template: {e}")
     
     def get_template_preview(self, template_name: str) -> Dict[str, Any]:

--- a/siege_utilities/reporting/templates/table_of_contents_template.py
+++ b/siege_utilities/reporting/templates/table_of_contents_template.py
@@ -53,7 +53,7 @@ class TableOfContentsTemplate:
         try:
             from .client_branding import ClientBrandingManager  # noqa: F401
             return self._default_brand_config()
-        except Exception as e:
+        except ImportError as e:
             log_warning(f"Could not load brand config: {e}")
             return self._default_brand_config()
     

--- a/siege_utilities/reporting/templates/title_page_template.py
+++ b/siege_utilities/reporting/templates/title_page_template.py
@@ -55,7 +55,7 @@ class TitlePageTemplate:
             # Try to use siege utilities client branding
             from .client_branding import ClientBrandingManager  # noqa: F401
             return self._default_brand_config()
-        except Exception as e:
+        except ImportError as e:
             log_warning(f"Could not load brand config: {e}")
             return self._default_brand_config()
     

--- a/tests/test_idml_export.py
+++ b/tests/test_idml_export.py
@@ -505,7 +505,7 @@ class TestSimpleIDMLPath:
     def test_save_with_simpleidml_applies_replacements(self, tmp_dir):
         mock_package = mock.MagicMock()
         mock_package.stories = []
-        mock_package.set_tag.side_effect = Exception("not supported")
+        mock_package.set_tag.side_effect = ValueError("not supported")
         mock_package.read.return_value = b"<Content>{{NAME}}</Content>"
 
         ex = IDMLExporter()
@@ -527,7 +527,7 @@ class TestSimpleIDMLPath:
 
         with mock.patch("siege_utilities.reporting.idml_export.SIMPLEIDML_AVAILABLE", True):
             with mock.patch("siege_utilities.reporting.idml_export.simpleidml") as mock_sidml:
-                mock_sidml.IDMLPackage.side_effect = Exception("corrupt")
+                mock_sidml.IDMLPackage.side_effect = ValueError("corrupt")
                 ex = IDMLExporter(template_path=str(template))
                 assert ex._idml_package is None  # fell back
 


### PR DESCRIPTION
## Summary

Narrows **78 `except Exception` handlers** across **18 files** in `siege_utilities/reporting/` to catch only the specific exception types each code path can actually raise. Part of the SU-1 cleanup under epic #776 (WS1-T1).

### Files modified

**Engines (5 files, 30 handlers):**
- `engines/bar_engine.py` — 4 handlers
- `engines/base_engine.py` — 5 handlers
- `engines/composite_engine.py` — 8 handlers
- `engines/map_engine.py` — 10 handlers
- `engines/stats_engine.py` — 3 handlers

**Templates (5 files, 11 handlers):**
- `templates/base_template.py` — 4 handlers (font registration, logo drawing)
- `templates/content_page_template.py` — 1 handler (import fallback)
- `templates/page_templates.py` — 4 handlers (YAML I/O)
- `templates/table_of_contents_template.py` — 1 handler (import fallback)
- `templates/title_page_template.py` — 1 handler (import fallback)

**Top-level (4 files, 9 handlers):**
- `chart_types.py` — 1 handler (YAML export)
- `idml_export.py` — 2 handlers (template load, set_tag)
- `powerpoint_generator.py` — 3 handlers (slide formatting)
- `report_generator.py` — 3 handlers (PDF pipeline, chart processing)

**Examples (4 files, 30 handlers):**
- `examples/bivariate_choropleth_example.py` — 7 handlers
- `examples/comprehensive_mapping_example.py` — 1 handler
- `examples/ga_geographic_analysis.py` — 4 handlers
- `examples/google_analytics_report_example.py` — 18 handlers

**Tests (1 file, 2 side_effects):**
- `tests/test_idml_export.py` — 2 `side_effect=Exception(...)` → `ValueError(...)` to match narrowed handlers

### Pattern categories
- **Rendering** (matplotlib/seaborn/folium → placeholder): `(ValueError, TypeError, KeyError, IndexError, AttributeError)`
- **File I/O** (HTML save, savefig): adds `OSError`
- **Font registration** (ReportLab TTFont): `(OSError, ValueError, KeyError)`
- **Logo/image drawing**: `(OSError, ValueError, TypeError, AttributeError)`
- **Import fallback** (`_load_brand_config`): `ImportError`
- **YAML I/O**: `(OSError, yaml.YAMLError)` + validation types as needed
- **PowerPoint formatting** (python-pptx): `(ValueError, TypeError, KeyError, IndexError, AttributeError)`
- **IDML operations**: `(OSError, ValueError, KeyError, AttributeError)`
- **GA4 API + geodataset fallback**: `(ValueError, TypeError, KeyError, AttributeError, OSError)`

### Running total
270 handlers narrowed across the codebase (192 prior PRs + 78 this PR).

## Test plan
- [x] `test_chart_types.py` — 47 passed
- [x] `test_idml_export.py` — all passed (after adapting 2 side_effects)
- [x] Pre-existing failures in `test_chart_generator.py`, `test_powerpoint_generator.py`, `test_reporting_config_exports.py` confirmed unrelated (missing deps, pre-existing on develop)
- [x] AST linter confirms 0 remaining `except Exception` violations in reporting/