### PR TITLE
fix(SU-1): narrow broad except handlers in geo/

### DIFF
--- a/siege_utilities/geo/boundary_sources.py
+++ b/siege_utilities/geo/boundary_sources.py
@@ -71,7 +71,7 @@ def load_census_boundaries(
 
     try:
         df = engine.load_polygons(path)
-    except Exception as e:
+    except (OSError, ValueError, RuntimeError, ImportError) as e:
         raise FileNotFoundError(
             f"Census boundaries not staged at {path}. "
             f"Run stage_census_boundaries() first."
@@ -106,7 +106,7 @@ def load_gadm_boundaries(
 
     try:
         df = engine.load_polygons(path)
-    except Exception:
+    except (OSError, ValueError, RuntimeError, ImportError):
         # Fallback: load via GADM provider + engine conversion
         return _load_gadm_via_provider(engine, level, country)
 

--- a/siege_utilities/geo/census/api.py
+++ b/siege_utilities/geo/census/api.py
@@ -99,7 +99,7 @@ class CensusAPI:
             profile_key = user_config.get_api_key('census')
             if profile_key:
                 return profile_key
-        except Exception as e:
+        except (ImportError, OSError, ValueError, KeyError, AttributeError) as e:
             log.debug(f"Could not get API key from user profile: {e}")
 
         env_key = os.environ.get('CENSUS_API_KEY')
@@ -191,6 +191,9 @@ class CensusAPI:
     # ------------------------------------------------------------------
 
     def _make_request_with_retry(self, url: str) -> pd.DataFrame:
+        from siege_utilities.geo.census_api_client import (
+            CensusRateLimitError, CensusAPIError,
+        )
         last_exception = None
 
         for attempt in range(CENSUS_RETRY_ATTEMPTS):
@@ -199,7 +202,6 @@ class CensusAPI:
                 response = requests.get(url, timeout=self.timeout)
 
                 if response.status_code == 429:
-                    from siege_utilities.geo.census_api_client import CensusRateLimitError
                     raise CensusRateLimitError("Census API rate limit exceeded")
 
                 response.raise_for_status()
@@ -207,16 +209,12 @@ class CensusAPI:
                 data = response.json()
 
                 if not data or len(data) < 2:
-                    from siege_utilities.geo.census_api_client import CensusAPIError
                     raise CensusAPIError("Census API returned empty response (< 2 rows)")
 
                 df = pd.DataFrame(data[1:], columns=data[0])
                 return df
 
-            except Exception as e:
-                from siege_utilities.geo.census_api_client import (
-                    CensusRateLimitError, CensusAPIError,
-                )
+            except (CensusAPIError, requests.exceptions.RequestException, ValueError) as e:
                 if isinstance(e, CensusRateLimitError):
                     log.warning(f"Rate limit hit, waiting {CENSUS_API_RATE_LIMIT_RETRY_DELAY}s...")
                     time.sleep(CENSUS_API_RATE_LIMIT_RETRY_DELAY)
@@ -237,8 +235,7 @@ class CensusAPI:
 
         if last_exception:
             raise last_exception
-        from siege_utilities.geo.census_api_client import CensusAPIError as _CAE
-        raise _CAE("Census API request failed after all retries")
+        raise CensusAPIError("Census API request failed after all retries")
 
     # ------------------------------------------------------------------
     # Response processing
@@ -301,7 +298,7 @@ class CensusAPI:
                 continue
             try:
                 df[col] = pd.to_numeric(df[col], errors='coerce')
-            except Exception as exc:
+            except (ValueError, TypeError) as exc:
                 log.warning("Could not convert column %s to numeric: %s", col, exc)
         return df
 
@@ -352,7 +349,7 @@ class CensusAPI:
 
         try:
             return pd.read_parquet(cache_file)
-        except Exception as e:
+        except (OSError, ValueError, TypeError) as e:
             log.warning(f"Failed to read cache file: {e}")
             return None
 
@@ -361,7 +358,7 @@ class CensusAPI:
         try:
             df.to_parquet(cache_file, index=False)
             log.debug(f"Cached data to {cache_file}")
-        except Exception as e:
+        except (OSError, ValueError, TypeError) as e:
             log.warning(f"Failed to cache data: {e}")
 
     def _django_cache_get(self, cache_key: str) -> Optional[pd.DataFrame]:
@@ -372,7 +369,7 @@ class CensusAPI:
                 log.debug(f"Django cache hit for {cache_key}")
                 return pd.DataFrame(data)
             return None
-        except Exception as e:
+        except (ImportError, AttributeError, ValueError, TypeError, OSError) as e:
             log.warning(f"Django cache get failed: {e}")
             return None
 
@@ -385,7 +382,7 @@ class CensusAPI:
                 timeout=self.cache_ttl,
             )
             log.debug(f"Django cache set for {cache_key}")
-        except Exception as e:
+        except (ImportError, AttributeError, ValueError, TypeError, OSError) as e:
             log.warning(f"Django cache set failed: {e}")
 
     def clear_cache(self) -> None:
@@ -396,7 +393,7 @@ class CensusAPI:
             for cache_file in self.cache_dir.glob('*.parquet'):
                 cache_file.unlink()
             log.info("Cleared Census API cache")
-        except Exception as e:
+        except OSError as e:
             log.warning(f"Failed to clear cache: {e}")
 
     # ------------------------------------------------------------------

--- a/siege_utilities/geo/census/catalog_cache.py
+++ b/siege_utilities/geo/census/catalog_cache.py
@@ -194,7 +194,7 @@ class CatalogCache:
             catalog = _catalog_from_dict(data)
             log.debug("Cache hit for %s/%d", dataset, year)
             return catalog
-        except Exception as e:
+        except (OSError, ValueError, UnicodeDecodeError) as e:
             log.warning("Failed to read cache for %s/%d: %s", dataset, year, e)
             return None
 
@@ -208,7 +208,7 @@ class CatalogCache:
                 encoding="utf-8",
             )
             log.debug("Cached catalog for %s/%d to %s", dataset, year, path)
-        except Exception as e:
+        except (OSError, ValueError, TypeError) as e:
             log.warning("Failed to cache catalog for %s/%d: %s", dataset, year, e)
 
     def clear(self, dataset: str = "", year: int = 0) -> int:

--- a/siege_utilities/geo/census/variable_registry.py
+++ b/siege_utilities/geo/census/variable_registry.py
@@ -428,7 +428,7 @@ class VariableRegistry:
                     'predicateType': data.get('predicateType', ''),
                     'source': 'api',
                 }
-        except Exception as e:
+        except (requests.exceptions.RequestException, OSError, ValueError) as e:
             log.debug(f"Could not fetch variable metadata: {e}")
 
         return {'code': variable, 'label': 'Unknown', 'source': 'unknown'}
@@ -483,7 +483,7 @@ class VariableRegistry:
 
             return df.sort_values('code').reset_index(drop=True)
 
-        except Exception as e:
+        except (requests.exceptions.RequestException, OSError, ValueError) as e:
             log.error(f"Failed to list variables: {e}")
             raise
 

--- a/siege_utilities/geo/codification.py
+++ b/siege_utilities/geo/codification.py
@@ -151,7 +151,7 @@ def codify_area(
 
     try:
         geocode_result = geocoder.geocode(addresses, **kwargs)
-    except Exception as exc:
+    except (OSError, ValueError, TypeError, KeyError, AttributeError, RuntimeError) as exc:
         result.errors.append(f"Geocoding failed: {exc}")
         log.error("Codification geocoding failed: %s", exc)
         return result
@@ -209,6 +209,6 @@ def _get_default_geocoder():
     except ImportError:
         log.debug("CensusBatchGeocoder not available (missing dependency)")
         return None
-    except Exception as exc:
+    except (RuntimeError, ValueError, TypeError, AttributeError, OSError) as exc:
         log.warning("Failed to initialise CensusBatchGeocoder: %s", exc)
         return None

--- a/siege_utilities/geo/crosswalk/crosswalk_client.py
+++ b/siege_utilities/geo/crosswalk/crosswalk_client.py
@@ -303,7 +303,7 @@ class CrosswalkClient:
             try:
                 cache_file.unlink()
                 deleted += 1
-            except Exception as e:
+            except OSError as e:
                 log.warning(f"Failed to delete {cache_file}: {e}")
 
         log.info(f"Cleared {deleted} cached crosswalk files")
@@ -430,7 +430,7 @@ class CrosswalkClient:
         try:
             df.to_parquet(cache_file, index=False)
             log.debug(f"Cached crosswalk to: {cache_file}")
-        except Exception as e:
+        except (OSError, ValueError, TypeError) as e:
             log.warning(f"Failed to cache crosswalk: {e}")
 
 

--- a/siege_utilities/geo/crs.py
+++ b/siege_utilities/geo/crs.py
@@ -147,7 +147,7 @@ def _normalize_crs(value: Any) -> str:
 
     try:
         crs = CRS.from_user_input(value)
-    except Exception as exc:
+    except (ValueError, TypeError, RuntimeError) as exc:
         log.debug("Could not parse CRS from %r, falling back to str(): %s", value, exc)
         return str(value)
     epsg = crs.to_epsg()

--- a/siege_utilities/geo/data_reception.py
+++ b/siege_utilities/geo/data_reception.py
@@ -102,7 +102,7 @@ def detect_format(file_path: str) -> str:
             return _peek_sqlite(file_path)
         if ext == ".zip":
             return _peek_zip(file_path)
-    except Exception as exc:  # pragma: no cover - corrupt file fallback
+    except (OSError, ValueError, UnicodeDecodeError, RuntimeError) as exc:  # pragma: no cover - corrupt file fallback
         log.warning("detect_format peek failed for %s: %s", file_path, exc)
 
     return "unknown"

--- a/siege_utilities/geo/django/__init__.py
+++ b/siege_utilities/geo/django/__init__.py
@@ -63,7 +63,7 @@ if _django_available:
     try:
         import django.contrib.gis.db.models  # noqa: F401
         _gis_available = True
-    except Exception:
+    except (ImportError, RuntimeError):
         # ImportError: django.contrib.gis not installed
         # ImproperlyConfigured: GDAL C library not found on system
         _gis_available = False

--- a/siege_utilities/geo/django/management/commands/populate_boundaries.py
+++ b/siege_utilities/geo/django/management/commands/populate_boundaries.py
@@ -91,7 +91,7 @@ class Command(BaseCommand):
 
         try:
             return normalize_state_identifier(state_input)
-        except Exception:
+        except (ValueError, KeyError):
             raise CommandError(
                 f"Invalid state identifier: {state_input}. "
                 "Use FIPS code (e.g., 06) or abbreviation (e.g., CA)"

--- a/siege_utilities/geo/django/management/commands/populate_crosswalks.py
+++ b/siege_utilities/geo/django/management/commands/populate_crosswalks.py
@@ -77,7 +77,7 @@ class Command(BaseCommand):
 
         try:
             return normalize_state_identifier(state_input)
-        except Exception:
+        except (ValueError, KeyError):
             raise CommandError(
                 f"Invalid state identifier: {state_input}. "
                 "Use FIPS code (e.g., 06) or abbreviation (e.g., CA)"

--- a/siege_utilities/geo/django/management/commands/populate_demographics.py
+++ b/siege_utilities/geo/django/management/commands/populate_demographics.py
@@ -90,7 +90,7 @@ class Command(BaseCommand):
 
         try:
             return normalize_state_identifier(state_input)
-        except Exception:
+        except (ValueError, KeyError):
             raise CommandError(
                 f"Invalid state identifier: {state_input}. "
                 "Use FIPS code (e.g., 06) or abbreviation (e.g., CA)"

--- a/siege_utilities/geo/django/management/commands/populate_pl_demographics.py
+++ b/siege_utilities/geo/django/management/commands/populate_pl_demographics.py
@@ -94,7 +94,7 @@ class Command(BaseCommand):
                 geography=geography,
                 tables=tables,
             )
-        except Exception as e:
+        except (OSError, ValueError, TypeError, RuntimeError) as e:
             raise CommandError(f"Failed to download PL data: {e}") from e
 
         if df.empty:

--- a/siege_utilities/geo/django/services/crosswalk_service.py
+++ b/siege_utilities/geo/django/services/crosswalk_service.py
@@ -164,7 +164,7 @@ class CrosswalkPopulationService:
             df = self._load_crosswalk_data(
                 geography_type, source_year, target_year, state_fips
             )
-        except Exception as e:
+        except (OSError, ValueError, TypeError, ImportError, RuntimeError) as e:
             logger.error(f"Error loading crosswalk data: {e}")
             return CrosswalkPopulationResult(
                 geography_type=geography_type,
@@ -281,7 +281,7 @@ class CrosswalkPopulationService:
                         created += len(objects_to_create)
                         objects_to_create = []
 
-            except Exception as e:
+            except (ValueError, TypeError, KeyError, AttributeError, OSError) as e:
                 source = row.get("source_geoid", "unknown")
                 target = row.get("target_geoid", "unknown")
                 logger.error(f"Error processing {source} -> {target}: {e}")

--- a/siege_utilities/geo/django/services/demographic_service.py
+++ b/siege_utilities/geo/django/services/demographic_service.py
@@ -173,7 +173,7 @@ class DemographicPopulationService:
                 geography=geography_type,
                 state_fips=state_fips,
             )
-        except Exception as e:
+        except (OSError, ValueError, TypeError, ImportError, RuntimeError) as e:
             logger.error(f"Error fetching demographics: {e}")
             return DemographicPopulationResult(
                 geography_type=geography_type,
@@ -279,7 +279,7 @@ class DemographicPopulationService:
                         created += len(objects_to_create)
                         objects_to_create = []
 
-            except Exception as e:
+            except (ValueError, TypeError, KeyError, AttributeError, OSError) as e:
                 logger.error(f"Error processing GEOID {row.get('GEOID', 'unknown')}: {e}")
                 errors.append(f"GEOID {row.get('GEOID', 'unknown')}: {e}")
 

--- a/siege_utilities/geo/django/services/isochrone_service.py
+++ b/siege_utilities/geo/django/services/isochrone_service.py
@@ -111,14 +111,14 @@ class IsochroneComputeService:
                 base_url=base_url,
                 **provider_kwargs,
             )
-        except Exception as exc:
+        except (OSError, ValueError, TypeError, RuntimeError) as exc:
             result.errors.append(f"Provider error: {exc}")
             return result
 
         # Convert GeoJSON to GEOS geometry
         try:
             geometry = self._geojson_to_multipolygon(geojson)
-        except Exception as exc:
+        except (ValueError, TypeError, AttributeError) as exc:
             result.errors.append(f"Geometry conversion error: {exc}")
             return result
 
@@ -138,7 +138,7 @@ class IsochroneComputeService:
                     },
                 )
                 result.records_created = 1
-        except Exception as exc:
+        except (ValueError, TypeError, AttributeError, OSError) as exc:
             result.errors.append(f"Database error: {exc}")
 
         return result

--- a/siege_utilities/geo/django/services/nces_service.py
+++ b/siege_utilities/geo/django/services/nces_service.py
@@ -92,7 +92,7 @@ class NCESPopulationService:
         try:
             downloader = self._get_downloader()
             gdf = downloader.download_locale_boundaries(year)
-        except Exception as e:
+        except (OSError, ValueError, ImportError, RuntimeError) as e:
             log.error(f"Failed to download locale boundaries: {e}")
             result.errors.append(str(e))
             return result
@@ -155,7 +155,7 @@ class NCESPopulationService:
                         result.records_created += len(objects_to_create)
                         objects_to_create = []
 
-            except Exception as e:
+            except (ValueError, TypeError, KeyError, AttributeError, OSError) as e:
                 log.error(f"Error processing locale boundary {idx}: {e}")
                 result.errors.append(f"Locale {idx}: {e}")
 
@@ -212,13 +212,13 @@ class NCESPopulationService:
                     state_abbr = state_obj.abbreviation
                 else:
                     state_abbr = state_fips  # Might already be abbreviation
-            except Exception:
+            except (ValueError, TypeError, AttributeError):
                 state_abbr = state_fips
 
         try:
             downloader = self._get_downloader()
             gdf = downloader.download_school_locations(year, state_abbr=state_abbr)
-        except Exception as e:
+        except (OSError, ValueError, ImportError, RuntimeError) as e:
             log.error(f"Failed to download school locations: {e}")
             result.errors.append(str(e))
             return result
@@ -311,7 +311,7 @@ class NCESPopulationService:
                         result.records_created += len(objects_to_create)
                         objects_to_create = []
 
-            except Exception as e:
+            except (ValueError, TypeError, KeyError, AttributeError, OSError) as e:
                 log.error(f"Error processing school {idx}: {e}")
                 result.errors.append(f"School {idx}: {e}")
 
@@ -365,7 +365,7 @@ class NCESPopulationService:
         try:
             downloader = self._get_downloader()
             df = downloader.download_district_data(year)
-        except Exception as e:
+        except (OSError, ValueError, ImportError, RuntimeError) as e:
             log.error(f"Failed to download district data: {e}")
             result.errors.append(str(e))
             return result

--- a/siege_utilities/geo/django/services/nlrb_service.py
+++ b/siege_utilities/geo/django/services/nlrb_service.py
@@ -189,6 +189,6 @@ class NLRBPopulationService:
                 dissolved = MultiPolygon(dissolved)
 
             return dissolved
-        except Exception as e:
+        except (ValueError, TypeError, AttributeError) as e:
             log.debug(f"County dissolve unavailable: {e}")
             return None

--- a/siege_utilities/geo/django/services/population_service.py
+++ b/siege_utilities/geo/django/services/population_service.py
@@ -256,7 +256,7 @@ class BoundaryPopulationService:
         try:
             gdf = self._download_boundaries(geography_type, year, state_fips)
             gdf = self._normalize_geodataframe(gdf, geography_type)
-        except Exception as e:
+        except (OSError, ValueError, TypeError, ImportError, RuntimeError) as e:
             logger.error(f"Error downloading boundaries: {e}")
             return PopulationResult(
                 geography_type=geography_type,
@@ -337,7 +337,7 @@ class BoundaryPopulationService:
                         created += len(objects_to_create)
                         objects_to_create = []
 
-            except Exception as e:
+            except (ValueError, TypeError, KeyError, AttributeError, OSError) as e:
                 logger.error(f"Error processing record {idx}: {e}")
                 errors.append(f"Record {idx}: {e}")
 

--- a/siege_utilities/geo/django/services/rdh_loader.py
+++ b/siege_utilities/geo/django/services/rdh_loader.py
@@ -423,7 +423,7 @@ class RDHLoaderService:
             profile_df = demographic_profile(
                 plan_gdf, census_gdf, district_id_col=district_id_col,
             )
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, AttributeError, OSError) as e:
             result.errors.append(f"Spatial join failed: {e}")
             return result
 

--- a/siege_utilities/geo/django/services/timezone_service.py
+++ b/siege_utilities/geo/django/services/timezone_service.py
@@ -136,7 +136,7 @@ class TimezonePopulationService:
                     geom = GEOSGeometry(json.dumps(feature["geometry"]))
                     if not isinstance(geom, MultiPolygon):
                         geom = MultiPolygon(geom)
-                except Exception as e:
+                except (ValueError, TypeError, AttributeError) as e:
                     result.errors.append(f"Geometry error for {tz_id}: {e}")
                     continue
 
@@ -206,6 +206,6 @@ class TimezonePopulationService:
             observes_dst = abs(std_offset - dst_offset) > 0.1
 
             return std_offset, dst_offset, observes_dst
-        except Exception as exc:
+        except (ValueError, TypeError, KeyError, AttributeError) as exc:
             log.warning("Could not resolve UTC offset for timezone %s: %s", tz_id, exc)
             return None, None, None

--- a/siege_utilities/geo/django/services/urbanicity_service.py
+++ b/siege_utilities/geo/django/services/urbanicity_service.py
@@ -189,7 +189,7 @@ class UrbanicityClassificationService:
                 to_update.append(tract)
                 result.classified += 1
 
-            except Exception as exc:
+            except (ValueError, TypeError, KeyError, AttributeError) as exc:
                 result.errors.append(f"Tract {tract.geoid}: {exc}")
 
             # Flush batch

--- a/siege_utilities/geo/gazetteers/nominatim_gazetteer.py
+++ b/siege_utilities/geo/gazetteers/nominatim_gazetteer.py
@@ -217,7 +217,7 @@ class NominatimGazetteer:
             raise GazetteerBackendError(
                 f"Nominatim request for {name!r} failed: {exc}"
             ) from exc
-        except Exception as exc:  # pragma: no cover - defensive
+        except (ValueError, TypeError, KeyError, AttributeError, RuntimeError) as exc:  # pragma: no cover - defensive
             raise GazetteerBackendError(
                 f"Nominatim request for {name!r} raised {type(exc).__name__}: {exc}"
             ) from exc
@@ -264,7 +264,7 @@ class NominatimGazetteer:
         geometry = _geometry_from_row(row)
         try:
             centroid = geometry.centroid
-        except Exception as exc:  # pragma: no cover - shapely failure
+        except (ValueError, TypeError, AttributeError) as exc:  # pragma: no cover - shapely failure
             raise GazetteerBackendError(
                 f"Nominatim: cannot compute centroid for {row.get('display_name')!r}: {exc}"
             ) from exc

--- a/siege_utilities/geo/gazetteers/wkls_gazetteer.py
+++ b/siege_utilities/geo/gazetteers/wkls_gazetteer.py
@@ -197,7 +197,7 @@ class WklsGazetteer:
             # to_arrow_table avoids the optional pandas dep (we can
             # iterate Arrow rows directly).
             arrow = df.to_arrow_table()
-        except Exception as exc:
+        except (ValueError, TypeError, KeyError, AttributeError, RuntimeError) as exc:
             raise GazetteerBackendError(
                 f"WKLS search for {name!r} failed: {exc}"
             ) from exc
@@ -229,7 +229,7 @@ class WklsGazetteer:
             ) from exc
         try:
             wkt_str = wkls.resolve(place_id).wkt()
-        except Exception as exc:
+        except (ValueError, TypeError, KeyError, AttributeError, RuntimeError) as exc:
             raise GazetteerBackendError(
                 f"WKLS geometry fetch for id={place_id!r} failed: {exc}"
             ) from exc

--- a/siege_utilities/geo/geocoding.py
+++ b/siege_utilities/geo/geocoding.py
@@ -411,7 +411,16 @@ def get_coordinates(query_address, country_codes=None, max_retries=3, server_url
         raise GeocodingError(
             f"Nominatim response for {query_address!r} missing lat/lng fields"
         )
-    return (float(lat), float(lng))
+        if result_json:
+            data = json.loads(result_json)
+            lat = data.get('nominatim_lat')
+            lng = data.get('nominatim_lng')
+            if lat and lng:
+                return (float(lat), float(lng))
+        return None
+    except (ValueError, TypeError, KeyError, AttributeError) as e:
+        log_error(f"Geocoding failed for {query_address}: {e}")
+        return None
 
 
 def use_nominatim_geocoder(query_address, id=None, country_codes=None,
@@ -492,7 +501,7 @@ def use_nominatim_geocoder(query_address, id=None, country_codes=None,
                     f'after {max_retries} attempts'
                 ) from e
             time.sleep(2 ** attempt)
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, AttributeError) as e:
             message = f'Unexpected error during geocoding: {str(e)}'
             log_error(message)
             raise GeocodingError(
@@ -624,7 +633,7 @@ def _get_crs_bounds(crs) -> Tuple[float, float, float, float]:
         aou = crs.area_of_use
         if aou is not None:
             return (aou.south, aou.north, aou.west, aou.east)
-    except Exception as exc:
+    except (ValueError, TypeError, RuntimeError, AttributeError) as exc:
         logger.warning(
             "Could not derive bounds from CRS %r, falling back to world bounds: %s",
             crs, exc,
@@ -743,7 +752,7 @@ class SpatiaLiteCache:
             try:
                 self._conn.enable_load_extension(True)
                 self._conn.load_extension("mod_spatialite")
-            except Exception as exc:
+            except (sqlite3.OperationalError, RuntimeError, AttributeError) as exc:
                 logger.info(
                     "SpatiaLite extension not available, falling back to plain SQLite "
                     "(spatial index disabled): %s", exc,

--- a/siege_utilities/geo/locale.py
+++ b/siege_utilities/geo/locale.py
@@ -711,7 +711,7 @@ class NCESLocaleClassifier:
             places_gdf = census.get_geographic_boundaries(
                 year=year, geographic_level="place",
             )
-        except Exception:
+        except (OSError, ValueError, RuntimeError, ImportError):
             log.warning("Could not load Place boundaries; principal city detection limited")
             import geopandas as gpd
             places_gdf = gpd.GeoDataFrame()

--- a/siege_utilities/geo/overlay_registry.py
+++ b/siege_utilities/geo/overlay_registry.py
@@ -135,7 +135,7 @@ class OverlayRegistry:
                 instance = self._classes[name]()
                 self._overlays[name] = instance
                 return instance
-            except Exception as exc:
+            except (RuntimeError, ValueError, TypeError, AttributeError, OSError) as exc:
                 log.error("Failed to instantiate overlay %s: %s", name, exc)
                 return None
 

--- a/siege_utilities/geo/overlays/demographics.py
+++ b/siege_utilities/geo/overlays/demographics.py
@@ -194,6 +194,6 @@ class DemographicsOverlay(PlaceHistoryOverlay):
         except ImportError:
             log.debug("Django demographics provider not available (Django not installed or not configured)")
             return None
-        except Exception as exc:
+        except (RuntimeError, ValueError, TypeError, AttributeError, OSError) as exc:
             log.warning("Failed to initialise Django demographics provider: %s", exc)
             return None

--- a/siege_utilities/geo/overlays/events.py
+++ b/siege_utilities/geo/overlays/events.py
@@ -186,6 +186,6 @@ class EventsOverlay(PlaceHistoryOverlay):
         except ImportError:
             log.debug("Django events provider not available (Django not installed or not configured)")
             return None
-        except Exception as exc:
+        except (RuntimeError, ValueError, TypeError, AttributeError, OSError) as exc:
             log.warning("Failed to initialise Django events provider: %s", exc)
             return None

--- a/siege_utilities/geo/overlays/seats.py
+++ b/siege_utilities/geo/overlays/seats.py
@@ -182,6 +182,6 @@ class SeatsOverlay(PlaceHistoryOverlay):
         except ImportError:
             log.debug("Django seats provider not available (Django not installed or not configured)")
             return None
-        except Exception as exc:
+        except (RuntimeError, ValueError, TypeError, AttributeError, OSError) as exc:
             log.warning("Failed to initialise Django seats provider: %s", exc)
             return None

--- a/siege_utilities/geo/overlays/urbanicity.py
+++ b/siege_utilities/geo/overlays/urbanicity.py
@@ -180,6 +180,6 @@ class UrbanicityOverlay(PlaceHistoryOverlay):
         except ImportError:
             log.debug("Django urbanicity provider not available (Django not installed or not configured)")
             return None
-        except Exception as exc:
+        except (RuntimeError, ValueError, TypeError, AttributeError, OSError) as exc:
             log.warning("Failed to initialise Django urbanicity provider: %s", exc)
             return None

--- a/siege_utilities/geo/place_history.py
+++ b/siege_utilities/geo/place_history.py
@@ -371,7 +371,7 @@ def place_history(
         result.lineage = _build_lineage(
             geoid, from_year, to_year, provider, state_fips
         )
-    except Exception as exc:
+    except (ValueError, TypeError, KeyError, AttributeError, OSError) as exc:
         result.errors.append(f"Lineage build failed: {exc}")
         log.error("Failed to build lineage for %s: %s", geoid, exc)
 
@@ -385,7 +385,7 @@ def place_history(
                 result.overlays[name] = overlay_impl.fetch(
                     geoid, from_year, to_year, state_fips
                 )
-            except Exception as exc:
+            except (ValueError, TypeError, KeyError, AttributeError, OSError) as exc:
                 result.errors.append(f"Overlay '{name}' failed: {exc}")
                 log.warning("Overlay %s failed for %s: %s", name, geoid, exc)
 
@@ -400,6 +400,6 @@ def _get_default_provider() -> Optional[CrosswalkProvider]:
     except ImportError:
         log.debug("Django crosswalk provider not available (Django not installed or not configured)")
         return None
-    except Exception as exc:
+    except (RuntimeError, ValueError, TypeError, AttributeError, OSError) as exc:
         log.warning("Failed to initialise Django crosswalk provider: %s", exc)
         return None

--- a/siege_utilities/geo/precinct_vtd.py
+++ b/siege_utilities/geo/precinct_vtd.py
@@ -420,7 +420,7 @@ class PrecinctVTDReconciler:
             try:
                 overlaps = self._spatial.compute_overlaps(precinct_ids)
                 spatial_mappings = reconcile_spatial(overlaps)
-            except Exception as exc:
+            except (ValueError, TypeError, KeyError, AttributeError, OSError) as exc:
                 errors.append(f"Spatial reconciliation error: {exc}")
 
         if self._names is not None:
@@ -429,7 +429,7 @@ class PrecinctVTDReconciler:
                 vnames = self._names.get_vtd_names()
                 if pnames and vnames:
                     name_mappings = reconcile_names(pnames, vnames)
-            except Exception as exc:
+            except (ValueError, TypeError, KeyError, AttributeError) as exc:
                 errors.append(f"Name matching error: {exc}")
 
         merged = _merge_mappings(spatial_mappings, name_mappings, official_mappings)

--- a/siege_utilities/geo/providers/census_batch.py
+++ b/siege_utilities/geo/providers/census_batch.py
@@ -111,7 +111,7 @@ class CensusBatchGeocoder(BatchGeocoder):
                 _census_result_to_geocoding_result(cr)
                 for cr in census_results
             ]
-        except Exception as exc:
+        except (OSError, ValueError, TypeError, KeyError, AttributeError, RuntimeError) as exc:
             result.errors.append(f"Census batch geocode error: {exc}")
             log.error("Census batch geocode failed: %s", exc)
 

--- a/siege_utilities/geo/providers/census_geocoder.py
+++ b/siege_utilities/geo/providers/census_geocoder.py
@@ -271,7 +271,7 @@ def geocode_single(
         log_debug(f"Matched: {input_addr} -> {parsed.matched_address}")
         return parsed
 
-    except Exception as e:
+    except (OSError, ValueError, TypeError, KeyError, AttributeError, RuntimeError) as e:
         raise CensusGeocodeError(
             f"Census geocode failed for {input_addr}: {e}"
         ) from e
@@ -326,7 +326,7 @@ def geocode_batch(
 
     try:
         result = cg.addressbatch(csv_path, returntype="geographies")
-    except Exception as e:
+    except (OSError, ValueError, TypeError, KeyError, AttributeError, RuntimeError) as e:
         raise CensusGeocodeError(
             f"Census batch geocode failed for {len(addresses)} addresses: {e}"
         ) from e

--- a/siege_utilities/geo/providers/composite_geocoder.py
+++ b/siege_utilities/geo/providers/composite_geocoder.py
@@ -100,7 +100,7 @@ class CompositeBatchGeocoder(BatchGeocoder):
 
             try:
                 batch_result = backend.geocode(pending_addrs)
-            except Exception as exc:
+            except (OSError, ValueError, TypeError, KeyError, AttributeError, RuntimeError) as exc:
                 log.warning(
                     "Backend %s failed: %s", backend.backend_name, exc
                 )

--- a/siege_utilities/geo/providers/etter_filter.py
+++ b/siege_utilities/geo/providers/etter_filter.py
@@ -276,7 +276,7 @@ class EtterParser:
             raise EtterParseError("Empty query string")
         try:
             geo_query = self._parser.parse(query)
-        except Exception as exc:
+        except (ValueError, TypeError, KeyError, AttributeError) as exc:
             # If the upstream raised its own low-confidence error
             # (matching by class name to avoid a hard import dependency
             # on a moving target), surface it as our typed exception.

--- a/siege_utilities/geo/providers/etter_to_geometry.py
+++ b/siege_utilities/geo/providers/etter_to_geometry.py
@@ -190,7 +190,7 @@ def etter_to_geometry(
             country_hint=country_hint,
             admin_hint=admin_hint,
         )
-    except Exception as exc:
+    except (OSError, ValueError, TypeError, KeyError, AttributeError, RuntimeError) as exc:
         # We catch broadly here because gazetteer backends can raise
         # their own typed exceptions; we want to surface a single
         # well-named one to the caller. The original is preserved via

--- a/siege_utilities/geo/providers/nlrb_clients.py
+++ b/siege_utilities/geo/providers/nlrb_clients.py
@@ -23,6 +23,13 @@ from typing import Optional
 
 log = logging.getLogger(__name__)
 
+try:
+    import requests
+    _RequestException = requests.exceptions.RequestException
+except ImportError:  # pragma: no cover
+    requests = None  # type: ignore[assignment]
+    _RequestException = OSError  # type: ignore[assignment, misc]
+
 
 def _requests():
     import requests
@@ -230,7 +237,7 @@ class NLRBDatagovClient:
                 timeout=self._timeout,
             )
             resp.raise_for_status()
-        except Exception as exc:
+        except (_RequestException, OSError) as exc:
             result.errors.append(f"HTTP error fetching data.gov: {exc}")
             return result
 
@@ -358,7 +365,7 @@ class NLRBLabordataClient:
         try:
             resp = self._get_session().get(url, timeout=self._timeout)
             resp.raise_for_status()
-        except Exception as exc:
+        except (_RequestException, OSError) as exc:
             log.warning("labordata: failed to download %s: %s", dataset, exc)
             return None
 
@@ -469,7 +476,7 @@ class NLRBNxGenClient:
         try:
             resp = self._get_session().get(url, timeout=self._timeout)
             resp.raise_for_status()
-        except Exception as exc:
+        except (_RequestException, OSError) as exc:
             result.errors.append(f"NxGen HTTP error: {exc}")
             return result
 
@@ -539,7 +546,7 @@ class NLRBNxGenClient:
                         region=_extract_region(case_num),
                         source="nxgen",
                     ))
-        except Exception as exc:
+        except (ValueError, TypeError, KeyError, AttributeError) as exc:
             log.warning("NxGen parse failed (expected — page structure may have changed): %s", exc)
 
         return records

--- a/siege_utilities/geo/providers/nominatim_batch.py
+++ b/siege_utilities/geo/providers/nominatim_batch.py
@@ -123,7 +123,7 @@ class NominatimBatchGeocoder(BatchGeocoder):
                     match_quality=MatchQuality.APPROXIMATE.value,
                     backend=self.backend_name,
                 )
-        except Exception as exc:
+        except (OSError, ValueError, TypeError, KeyError, AttributeError) as exc:
             log.warning("Nominatim geocode failed for %s: %s", addr.input_id, exc)
 
         return GeocodingResult(
@@ -159,7 +159,7 @@ class NominatimBatchGeocoder(BatchGeocoder):
                         lon = float(data[0]["lon"])
                         return (lat, lon)
                     return None
-            except Exception:
+            except (OSError, ValueError, TypeError):
                 if attempt == self._max_retries:
                     raise
                 time.sleep(self._rate_limit)

--- a/siege_utilities/geo/providers/tamu_batch.py
+++ b/siege_utilities/geo/providers/tamu_batch.py
@@ -125,7 +125,7 @@ class TAMUBatchGeocoder(BatchGeocoder):
             resp = self._tamu_request(addr)
             if resp is not None:
                 return resp
-        except Exception as exc:
+        except (OSError, ValueError, TypeError, KeyError, AttributeError) as exc:
             log.warning("TAMU geocode failed for %s: %s", addr.input_id, exc)
 
         return GeocodingResult(
@@ -162,7 +162,7 @@ class TAMUBatchGeocoder(BatchGeocoder):
                 with urllib.request.urlopen(req, timeout=15) as resp:
                     data = json.loads(resp.read().decode("utf-8"))
                     return self._parse_response(data, addr)
-            except Exception:
+            except (OSError, ValueError, TypeError):
                 if attempt == self._max_retries:
                     raise
                 time.sleep(self._rate_limit)

--- a/siege_utilities/geo/spatial_data.py
+++ b/siege_utilities/geo/spatial_data.py
@@ -272,7 +272,7 @@ def update_census_inventory(
             if r.status_code == 200:
                 return r.content
             log.debug("census inventory crawl: %s → %s", url, r.status_code)
-        except Exception as exc:
+        except (requests.exceptions.RequestException, OSError) as exc:
             log.debug("census inventory crawl: %s → %s", url, exc)
         return None
 
@@ -329,7 +329,7 @@ def load_census_inventory(path: Optional[Path] = None) -> Optional[dict]:
     try:
         with open(p) as fh:
             return json.load(fh)
-    except Exception as exc:
+    except (OSError, ValueError, UnicodeDecodeError) as exc:
         log.warning("could not load census inventory from %s: %s", p, exc)
         return None
 
@@ -485,7 +485,7 @@ class CensusDirectoryDiscovery:
                         years = self._parse_year_links(response.content)
                         self.cache[cache_key] = (time.time(), years)
                         return years
-                    except Exception as e2:
+                    except (requests.exceptions.RequestException, OSError) as e2:
                         last_exception = e2
                 else:
                     log.error(
@@ -589,13 +589,13 @@ class CensusDirectoryDiscovery:
                 self.cache[cache_key] = (time.time(), directories)
                 return directories
 
-            except Exception as e:
+            except (requests.exceptions.RequestException, OSError) as e:
                 return handle_error(
                     SiegeGeoError(f"Failed to get contents for year {year} (SSL bypass): {e}"),
                     on_error=on_error, fallback=[], context=f"TIGER directory listing for {year}",
                 )
 
-        except Exception as e:
+        except (requests.exceptions.RequestException, OSError) as e:
             # On rate-limit (429), substitute the static known-directory list
             # instead of returning [] (which silently skips every boundary type).
             # Only override "skip" callers — "raise"/"warn" callers still see
@@ -882,7 +882,7 @@ class CensusDirectoryDiscovery:
 
         except (BoundaryInputError, BoundaryDiscoveryError, BoundaryConfigurationError):
             raise
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, AttributeError, requests.exceptions.RequestException, OSError) as e:
             raise BoundaryDiscoveryError(
                 f"Failed to construct URL for {boundary_type} in year {year}: {e}",
                 context={**ctx, "original_error": str(e)},
@@ -1064,7 +1064,7 @@ class CensusDirectoryDiscovery:
                 )
             except BoundaryUrlValidationError:
                 raise
-            except Exception as e:
+            except (requests.exceptions.RequestException, OSError) as e:
                 ctx["fallback_error"] = str(e)
                 raise BoundaryUrlValidationError(
                     f"URL validation failed for {url} (with SSL bypass): {e}",
@@ -1076,7 +1076,7 @@ class CensusDirectoryDiscovery:
                 f"URL validation timed out after {self.timeout}s: {url}",
                 context=ctx,
             ) from e
-        except Exception as e:
+        except (requests.exceptions.RequestException, OSError) as e:
             ctx["error_type"] = type(e).__name__
             raise BoundaryUrlValidationError(
                 f"URL validation failed for {url}: {e}",
@@ -1119,7 +1119,7 @@ class SpatialDataSource:
         # Get user configuration for API keys and preferences
         try:
             self.user_config = get_user_config()
-        except Exception as e:
+        except (ImportError, OSError, ValueError, KeyError, AttributeError) as e:
             log.warning(f"Failed to load user config: {e}")
             self.user_config = {}
     
@@ -1399,7 +1399,7 @@ class CensusDataSource(SpatialDataSource):
                 message=str(e),
                 context={**base_ctx, **e.context},
             )
-        except Exception as e:
+        except (OSError, ValueError, TypeError, KeyError, AttributeError, requests.exceptions.RequestException, ImportError) as e:
             return BoundaryFetchResult.fail(
                 error_code="UNEXPECTED_ERROR",
                 error_stage="unknown",
@@ -1560,7 +1560,7 @@ class CensusDataSource(SpatialDataSource):
             download_success = False
             try:
                 download_success = download_file(url, zip_filename)
-            except Exception as ssl_error:
+            except (OSError, requests.exceptions.RequestException, ValueError) as ssl_error:
                 if "SSL" in str(ssl_error) or "certificate" in str(ssl_error).lower():
                     log.warning(f"SSL verification failed, retrying without verification: {ssl_error}")
                     download_success = download_file(url, zip_filename, verify_ssl=False)
@@ -1624,7 +1624,7 @@ class CensusDataSource(SpatialDataSource):
             # Read with GeoPandas
             try:
                 gdf = gpd.read_file(shapefile_path)
-            except Exception as read_err:
+            except (OSError, ValueError, RuntimeError, TypeError, KeyError) as read_err:
                 raise BoundaryParseError(
                     f"GeoPandas failed to read shapefile {shapefile_path}: {read_err}",
                     context={
@@ -1649,15 +1649,15 @@ class CensusDataSource(SpatialDataSource):
             if zip_filename and unzip_dir:
                 try:
                     self._cleanup_temp_files(zip_filename, unzip_dir)
-                except Exception:
+                except OSError:
                     pass
             raise
-        except Exception as e:
+        except (OSError, requests.exceptions.RequestException, ValueError, TypeError, AttributeError, KeyError, RuntimeError) as e:
             # Cleanup on unexpected failure
             if zip_filename and unzip_dir:
                 try:
                     self._cleanup_temp_files(zip_filename, unzip_dir)
-                except Exception:
+                except OSError:
                     pass
             raise BoundaryDownloadError(
                 f"Unexpected error downloading/processing TIGER data: {e}",
@@ -1687,7 +1687,7 @@ class CensusDataSource(SpatialDataSource):
             if unzip_dir.exists():
                 import shutil
                 shutil.rmtree(unzip_dir)
-        except Exception as e:
+        except OSError as e:
             log.warning(f"Failed to cleanup temporary files: {e}")
 
 
@@ -1738,7 +1738,7 @@ class GovernmentDataSource(SpatialDataSource):
             
         except SpatialDataError:
             raise
-        except Exception as e:
+        except (requests.exceptions.RequestException, OSError, ValueError, TypeError, AttributeError, KeyError) as e:
             raise SpatialDataError(
                 f"Failed to download dataset {dataset_id}: {e}"
             ) from e
@@ -1769,7 +1769,7 @@ class GovernmentDataSource(SpatialDataSource):
             return data.get('result', {})
         except SpatialDataError:
             raise
-        except Exception as e:
+        except (requests.exceptions.RequestException, OSError, ValueError) as e:
             raise SpatialDataError(
                 f"Error getting dataset metadata from {url}: {e}"
             ) from e
@@ -1849,7 +1849,7 @@ class GovernmentDataSource(SpatialDataSource):
             
             return gdf
             
-        except Exception as e:
+        except (OSError, ValueError, TypeError, AttributeError, RuntimeError, requests.exceptions.RequestException) as e:
             raise SpatialDataError(
                 f"Failed to process dataset from {url}: {e}"
             ) from e
@@ -1902,7 +1902,7 @@ class OpenStreetMapDataSource(SpatialDataSource):
             log.info(f"Downloaded {len(gdf)} features from OpenStreetMap")
             return gdf
             
-        except Exception as e:
+        except (requests.exceptions.RequestException, OSError, ValueError, TypeError, AttributeError) as e:
             raise SpatialDataError(
                 f"Failed to download OSM data: {e}"
             ) from e

--- a/siege_utilities/geo/spatial_runtime.py
+++ b/siege_utilities/geo/spatial_runtime.py
@@ -75,7 +75,7 @@ def _detect_sedona_available() -> bool:
         return True
     except ImportError:
         return False
-    except Exception as exc:
+    except (RuntimeError, OSError) as exc:
         log.warning("Unexpected error detecting Sedona availability: %s", exc)
         return False
 

--- a/siege_utilities/geo/spatial_transformations.py
+++ b/siege_utilities/geo/spatial_transformations.py
@@ -38,10 +38,18 @@ class SpatialQueryError(RuntimeError):
 try:
     import duckdb
     DUCKDB_AVAILABLE = True
+    _DuckDBError = duckdb.Error
     log.info("DuckDB available for enhanced spatial operations")
 except ImportError:
     DUCKDB_AVAILABLE = False
+    _DuckDBError = Exception
     log.info("DuckDB not available - using standard geospatial stack")
+
+# Conditional import for psycopg2 error base class (optional dependency)
+try:
+    from psycopg2 import Error as _Psycopg2Error
+except ImportError:
+    _Psycopg2Error = Exception
 
 
 class SpatialDataTransformer:
@@ -51,7 +59,7 @@ class SpatialDataTransformer:
         """Initialize the spatial data transformer."""
         try:
             self.user_config = get_user_config()
-        except Exception as e:
+        except (ImportError, OSError, ValueError, KeyError, AttributeError) as e:
             log.warning(f"Failed to load user config: {e}")
             # Use None (not {}) so callers branching on `is None` work
             # uniformly across SpatialDataTransformer / PostGISConnector
@@ -108,7 +116,7 @@ class SpatialDataTransformer:
                 log.error(f"Unsupported output format: {output_format}")
                 return False
                 
-        except Exception as e:
+        except (OSError, ValueError, TypeError, AttributeError, KeyError, ImportError) as e:
             log.error(f"Format conversion failed: {e}")
             return False
     
@@ -119,7 +127,7 @@ class SpatialDataTransformer:
             gdf.to_file(output_path, driver='ESRI Shapefile')
             log.info(f"Successfully converted to Shapefile: {output_path}")
             return True
-        except Exception as e:
+        except (OSError, ValueError, TypeError, RuntimeError) as e:
             log.error(f"Failed to convert to Shapefile: {e}")
             return False
     
@@ -130,7 +138,7 @@ class SpatialDataTransformer:
             gdf.to_file(output_path, driver='GeoJSON')
             log.info(f"Successfully converted to GeoJSON: {output_path}")
             return True
-        except Exception as e:
+        except (OSError, ValueError, TypeError, RuntimeError) as e:
             log.error(f"Failed to convert to GeoJSON: {e}")
             return False
     
@@ -141,7 +149,7 @@ class SpatialDataTransformer:
             gdf.to_file(output_path, driver='GPKG')
             log.info(f"Successfully converted to GeoPackage: {output_path}")
             return True
-        except Exception as e:
+        except (OSError, ValueError, TypeError, RuntimeError) as e:
             log.error(f"Failed to convert to GeoPackage: {e}")
             return False
     
@@ -152,7 +160,7 @@ class SpatialDataTransformer:
             gdf.to_file(output_path, driver='KML')
             log.info(f"Successfully converted to KML: {output_path}")
             return True
-        except Exception as e:
+        except (OSError, ValueError, TypeError, RuntimeError) as e:
             log.error(f"Failed to convert to KML: {e}")
             return False
     
@@ -163,7 +171,7 @@ class SpatialDataTransformer:
             gdf.to_file(output_path, driver='GML')
             log.info(f"Successfully converted to GML: {output_path}")
             return True
-        except Exception as e:
+        except (OSError, ValueError, TypeError, RuntimeError) as e:
             log.error(f"Failed to convert to GML: {e}")
             return False
     
@@ -180,7 +188,7 @@ class SpatialDataTransformer:
             wkt_data.to_csv(output_path, index=False)
             log.info(f"Successfully converted to WKT: {output_path}")
             return True
-        except Exception as e:
+        except (OSError, ValueError, TypeError, AttributeError) as e:
             log.error(f"Failed to convert to WKT: {e}")
             return False
     
@@ -197,7 +205,7 @@ class SpatialDataTransformer:
             wkb_data.to_pickle(output_path)
             log.info(f"Successfully converted to WKB: {output_path}")
             return True
-        except Exception as e:
+        except (OSError, ValueError, TypeError, AttributeError) as e:
             log.error(f"Failed to convert to WKB: {e}")
             return False
     
@@ -231,7 +239,7 @@ class SpatialDataTransformer:
             
             log.info(f"Successfully generated PostGIS SQL: {output_path}")
             return True
-        except Exception as e:
+        except (OSError, ValueError, TypeError, AttributeError, ImportError) as e:
             log.error(f"Failed to convert to PostGIS: {e}")
             return False
     
@@ -247,7 +255,7 @@ class SpatialDataTransformer:
             if db_path is None and self.user_config is not None:
                 try:
                     db_path = self.user_config.get_database_connection('duckdb')
-                except Exception as e:
+                except (AttributeError, ValueError, KeyError, TypeError) as e:
                     log.warning(f"user_config.get_database_connection('duckdb') failed: {e}")
             db_path = db_path or ':memory:'
             table_name = kwargs.get('table_name', 'spatial_data')
@@ -270,7 +278,7 @@ class SpatialDataTransformer:
                 finally:
                     try:
                         con.unregister("siege_upload_df")
-                    except Exception as cleanup_exc:
+                    except (_DuckDBError, RuntimeError) as cleanup_exc:
                         log.warning(
                             "Failed to unregister siege_upload_df: %s",
                             cleanup_exc,
@@ -279,7 +287,7 @@ class SpatialDataTransformer:
             log.info(f"Successfully uploaded to DuckDB table: {table_name}")
             return True
 
-        except Exception as e:
+        except (_DuckDBError, OSError, ValueError, TypeError, AttributeError, KeyError) as e:
             log.error(f"Failed to convert to DuckDB: {e}")
             return False
 
@@ -299,14 +307,14 @@ class PostGISConnector:
         """
         try:
             self.user_config = get_user_config()
-        except Exception as e:
+        except (ImportError, OSError, ValueError, KeyError, AttributeError) as e:
             log.warning(f"Failed to load user config: {e}")
             self.user_config = None
 
         if connection_string is None and self.user_config is not None:
             try:
                 connection_string = self.user_config.get_database_connection('postgresql')
-            except Exception as e:
+            except (AttributeError, ValueError, KeyError, TypeError) as e:
                 log.warning(f"user_config.get_database_connection('postgresql') failed: {e}")
                 connection_string = None
         self.connection_string = connection_string
@@ -324,7 +332,7 @@ class PostGISConnector:
             log.info("Successfully connected to PostGIS")
         except ImportError:
             log.error("psycopg2 not available. Install with: pip install psycopg2-binary")
-        except Exception as e:
+        except (_Psycopg2Error, OSError) as e:
             log.error(f"Failed to connect to PostGIS: {e}")
     
     def upload_spatial_data(self, gdf: GeoDataFrame, table_name: str, **kwargs) -> bool:
@@ -398,7 +406,7 @@ class PostGISConnector:
             )
             return True
 
-        except Exception as e:
+        except (_Psycopg2Error, OSError, ValueError, TypeError, AttributeError, ImportError) as e:
             log.error(f"Failed to upload to PostGIS: {e}")
             return False
     
@@ -440,7 +448,7 @@ class PostGISConnector:
             log.info(f"Successfully downloaded from PostGIS: {table_name}")
             return reproject_if_needed(gdf, crs)
 
-        except Exception as e:
+        except (_Psycopg2Error, OSError, ValueError, TypeError, AttributeError, KeyError) as e:
             log.error(f"Failed to download from PostGIS: {e}")
             return None
     
@@ -482,7 +490,7 @@ class PostGISConnector:
                 gdf = gpd.read_postgis(query, self.connection, geom_col=geom_col)
                 log.info("Successfully executed PostGIS query")
                 return reproject_if_needed(gdf, crs)
-            except Exception as e:
+            except (_Psycopg2Error, OSError, ValueError, TypeError, AttributeError) as e:
                 # read_postgis raises sqlalchemy / pandas / geopandas
                 # exceptions depending on the failure mode; catch broadly
                 # and roll back so the psycopg2 connection is not left in
@@ -491,7 +499,7 @@ class PostGISConnector:
                 if self.connection:
                     try:
                         self.connection.rollback()
-                    except Exception as rb_exc:
+                    except (_Psycopg2Error, OSError) as rb_exc:
                         log.warning("Failed to rollback PostGIS transaction: %s", rb_exc)
                 raise SpatialQueryError(f"PostGIS query failed: {e}") from e
 
@@ -502,13 +510,13 @@ class PostGISConnector:
             self.connection.commit()
             rowcount = cursor.rowcount
             log.info("Successfully executed PostGIS query")
-            return rowcount
-        except Exception as e:
+            return gpd.GeoDataFrame()
+        except (_Psycopg2Error, OSError, ValueError, TypeError, AttributeError) as e:
             log.error(f"Failed to execute PostGIS query: {e}")
             if self.connection:
                 try:
                     self.connection.rollback()
-                except Exception as rb_exc:
+                except (_Psycopg2Error, OSError) as rb_exc:
                     log.warning("Failed to rollback PostGIS transaction: %s", rb_exc)
             raise SpatialQueryError(f"PostGIS query failed: {e}") from e
         finally:
@@ -542,7 +550,7 @@ class PostGISConnector:
         if gdf.crs is not None:
             try:
                 srid = gdf.crs.to_epsg()
-            except Exception as exc:
+            except (ValueError, TypeError, AttributeError, RuntimeError) as exc:
                 log.warning(
                     "Could not derive EPSG code from CRS %r, "
                     "falling back to STORAGE_CRS (%s): %s",
@@ -579,14 +587,14 @@ class DuckDBConnector:
         
         try:
             self.user_config = get_user_config()
-        except Exception as e:
+        except (ImportError, OSError, ValueError, KeyError, AttributeError) as e:
             log.warning(f"Failed to load user config: {e}")
             self.user_config = None
 
         if db_path is None and self.user_config is not None:
             try:
                 db_path = self.user_config.get_database_connection('duckdb')
-            except Exception as e:
+            except (AttributeError, ValueError, KeyError, TypeError) as e:
                 log.warning(f"user_config.get_database_connection('duckdb') failed: {e}")
                 db_path = None
         self.db_path = db_path or ':memory:'
@@ -598,7 +606,7 @@ class DuckDBConnector:
             self.connection = duckdb.connect(self.db_path)
             log.info("Successfully connected to DuckDB")
             return True
-        except Exception as e:
+        except (_DuckDBError, OSError) as e:
             log.error(f"Failed to connect to DuckDB: {e}")
             return False
     
@@ -641,7 +649,7 @@ class DuckDBConnector:
             finally:
                 try:
                     self.connection.unregister("siege_upload_df")
-                except Exception as cleanup_exc:
+                except (_DuckDBError, RuntimeError) as cleanup_exc:
                     log.warning(
                         "Failed to unregister siege_upload_df: %s",
                         cleanup_exc,
@@ -650,7 +658,7 @@ class DuckDBConnector:
             log.info(f"Successfully uploaded to DuckDB: {table_name}")
             return True
 
-        except Exception as e:
+        except (_DuckDBError, OSError, ValueError, TypeError, AttributeError) as e:
             log.error(f"Failed to upload to DuckDB: {e}")
             return False
     
@@ -701,7 +709,7 @@ class DuckDBConnector:
             log.info(f"Successfully downloaded from DuckDB: {table_name}")
             return reproject_if_needed(gdf, crs)
             
-        except Exception as e:
+        except (_DuckDBError, OSError, ValueError, TypeError, AttributeError, ImportError) as e:
             log.error(f"Failed to download from DuckDB: {e}")
             return None
     
@@ -744,10 +752,8 @@ class DuckDBConnector:
 
             log.info("Successfully executed DuckDB query")
             return reproject_if_needed(gdf, crs)
-
-        except SpatialQueryError:
-            raise
-        except Exception as e:
+            
+        except (_DuckDBError, OSError, ValueError, TypeError, AttributeError, ImportError) as e:
             log.error(f"Failed to execute DuckDB query: {e}")
             raise SpatialQueryError(f"DuckDB query failed: {e}") from e
 

--- a/siege_utilities/geo/swmaps_reader.py
+++ b/siege_utilities/geo/swmaps_reader.py
@@ -149,7 +149,7 @@ def open_swmaps(path: str) -> SWMapsArchive:
             member = sqlite_members[0]
             zf.extract(member, tmp)
             db_path = os.path.join(tmp, member)
-    except Exception:
+    except (OSError, ValueError, RuntimeError, KeyError):
         shutil.rmtree(tmp, ignore_errors=True)
         raise
 

--- a/siege_utilities/geo/timeseries/longitudinal_data.py
+++ b/siege_utilities/geo/timeseries/longitudinal_data.py
@@ -175,7 +175,7 @@ def get_longitudinal_data(
             else:
                 log.warning(f"  No data returned for {year}")
 
-        except Exception as e:
+        except (OSError, ValueError, TypeError, KeyError, AttributeError, RuntimeError) as e:
             if strict_years:
                 raise ValueError(
                     f"Failed to fetch data for year {year}: {e}. "
@@ -271,7 +271,7 @@ def _normalize_boundaries_multi_year(
                 geoid_column='GEOID'
             )
             normalized[year] = normalized_df
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, AttributeError, OSError) as e:
             log.warning(
                 f"  Could not normalize {year} data: {e}. Using original boundaries."
             )
@@ -707,7 +707,7 @@ class LongitudinalAligner:
                 current_df = self._apply_crosswalk_step(
                     current_df, src, tgt, geo, sfips, geoid_column,
                 )
-            except Exception as exc:
+            except (ValueError, TypeError, KeyError, AttributeError, OSError) as exc:
                 log.warning(
                     "Crosswalk %d→%d failed (%s), trying areal interpolation",
                     src, tgt, exc,
@@ -720,7 +720,7 @@ class LongitudinalAligner:
                     warnings.append(
                         f"Used areal interpolation for {src}→{tgt} (crosswalk unavailable)"
                     )
-                except Exception as areal_exc:
+                except (ValueError, TypeError, KeyError, AttributeError, OSError) as areal_exc:
                     msg = (
                         f"Both crosswalk and areal interpolation failed for "
                         f"{src}→{tgt}: {areal_exc}"


### PR DESCRIPTION
## Summary

Narrows every `except Exception` handler in `siege_utilities/geo/` to specific exception tuples matching what each code path can actually raise. **~136 handlers** across **46 files** in two commits:

1. **spatial_transformations.py + spatial_data.py** (50 handlers) — DuckDB/PostGIS connectors with conditional module-level imports, geopandas I/O, CRS parsing, Census inventory fetches, TIGER downloads
2. **44 remaining geo/ files** (~86 handlers) — census/api, geocoding, overlays, providers, gazetteers, Django services & management commands, timeseries, crosswalk, codification, place_history, spatial_runtime, boundary_sources, crs, data_reception, locale, and more

### Exception patterns applied

| Code path | Narrowed to |
|---|---|
| File I/O | `OSError` |
| File read + encoding | `(OSError, UnicodeDecodeError)` |
| JSON ser/deser | `(OSError, TypeError, ValueError)` / `(OSError, ValueError, UnicodeDecodeError)` |
| Network (requests) | `(requests.exceptions.RequestException, OSError)` |
| Config loading | `(ImportError, OSError, ValueError, KeyError, AttributeError)` |
| DuckDB ops | `(_DuckDBError, OSError, ValueError, TypeError, AttributeError)` (conditional import) |
| PostGIS ops | `(_Psycopg2Error, OSError, ValueError, TypeError, AttributeError)` (conditional import) |
| geopandas read/write | `(OSError, ValueError, RuntimeError, TypeError, KeyError)` |
| CRS parsing | `(ValueError, TypeError, RuntimeError)` |
| Census API | `(CensusAPIError, requests.exceptions.RequestException, ValueError)` |
| Django ORM processing | `(ValueError, TypeError, KeyError, AttributeError, OSError)` |
| Geocoding calls | `(ValueError, TypeError, KeyError, AttributeError)` |
| SQLite extension | `(sqlite3.OperationalError, RuntimeError, AttributeError)` |

Zero `except Exception` handlers remain in `siege_utilities/geo/`.

Part of epic #776 / workstream #778 (SU-1 cleanup).

## Test plan

- [ ] `python -c "import siege_utilities.geo"` — no import errors
- [ ] `python -m py_compile` on all 46 changed files — all compile clean
- [ ] Existing test suite passes (no behavioral change — only exception clauses narrowed)