### PR TITLE
feat(WS0): bookshelf principles and security/property-testing (#777)

### DIFF
--- a/docs/PROPERTY_TESTING_GUIDE.md
+++ b/docs/PROPERTY_TESTING_GUIDE.md
@@ -1,0 +1,190 @@
+# Property Testing Guide for siege_utilities
+
+This guide covers adopting [Hypothesis](https://hypothesis.readthedocs.io/)
+for property-based testing in siege_utilities. Property tests complement
+example-based tests by generating random inputs and checking that
+invariants hold across the input space.
+
+## Setup
+
+Hypothesis is already in `[project.optional-dependencies] dev`. The
+pytest integration works automatically — just use the `@given` decorator.
+
+### Profiles in conftest.py
+
+Add to `conftest.py`:
+
+```python
+from hypothesis import settings, HealthCheck
+
+settings.register_profile("ci", max_examples=100)
+settings.register_profile("dev", max_examples=50)
+settings.register_profile("thorough", max_examples=1000)
+settings.load_profile("ci")
+```
+
+Select a profile with `HYPOTHESIS_PROFILE=thorough pytest`.
+
+## When to Use Property Tests
+
+Use property tests when:
+
+1. **The input domain is large or combinatorial** — GEOIDs, CRS codes,
+   coordinate pairs, date ranges, Census variable names.
+2. **You can state an invariant** — "normalized output is idempotent,"
+   "total population >= 0," "geocoded result is within state bounds."
+3. **Example-based tests feel like guessing** — if you're picking
+   arbitrary test values and hoping they cover edge cases, a property
+   test will find the edges for you.
+
+## Property Patterns
+
+### 1. Round-trip (encode/decode, serialize/deserialize)
+
+```python
+from hypothesis import given
+import hypothesis.strategies as st
+
+@given(st.text(min_size=1, max_size=100))
+def test_normalize_state_roundtrip(name):
+    """Normalizing a state identifier twice gives the same result."""
+    from siege_utilities.config.census_constants import normalize_state_identifier
+    try:
+        result = normalize_state_identifier(name)
+        assert normalize_state_identifier(result) == result
+    except (ValueError, KeyError):
+        pass  # invalid input is fine — we're testing idempotency of valid ones
+```
+
+### 2. Invariant preservation
+
+```python
+@given(
+    st.floats(min_value=-90, max_value=90),
+    st.floats(min_value=-180, max_value=180),
+)
+def test_geocoding_coordinates_in_bounds(lat, lon):
+    """get_coordinates should never return coordinates outside WGS84 bounds."""
+    from siege_utilities.geo.geocoding import get_coordinates
+    try:
+        result = get_coordinates(f"{lat},{lon}")
+        if result and result.get("lat") is not None:
+            assert -90 <= result["lat"] <= 90
+            assert -180 <= result["lon"] <= 180
+    except (ValueError, TypeError, KeyError, AttributeError):
+        pass  # invalid input handling is tested elsewhere
+```
+
+### 3. No-crash (defensive)
+
+```python
+@given(st.text(max_size=200))
+def test_path_sanitizer_never_crashes(raw_path):
+    """ensure_path_exists should not raise on arbitrary string input."""
+    from siege_utilities.files.paths import sanitize_path
+    try:
+        sanitize_path(raw_path)
+    except (ValueError, OSError):
+        pass  # expected rejections
+    # No bare Exception should escape
+```
+
+### 4. Oracle comparison
+
+```python
+import math
+
+@given(st.lists(st.floats(allow_nan=False, allow_infinity=False), min_size=1))
+def test_survey_weight_sum(weights):
+    """Normalized survey weights must sum to the original count."""
+    from siege_utilities.survey.weights import normalize_weights
+    try:
+        normalized = normalize_weights(weights)
+        assert math.isclose(sum(normalized), len(weights), rel_tol=1e-6)
+    except (ValueError, ZeroDivisionError):
+        pass  # zero-sum weights are a known rejection
+```
+
+## Custom Strategies
+
+Build domain-specific strategies for reuse:
+
+```python
+import hypothesis.strategies as st
+
+# Valid 2-digit state FIPS codes
+state_fips = st.sampled_from([
+    "01", "02", "04", "05", "06", "08", "09", "10", "11", "12",
+    "13", "15", "16", "17", "18", "19", "20", "21", "22", "23",
+    "24", "25", "26", "27", "28", "29", "30", "31", "32", "33",
+    "34", "35", "36", "37", "38", "39", "40", "41", "42", "44",
+    "45", "46", "47", "48", "49", "50", "51", "53", "54", "55", "56",
+])
+
+# Valid Census geography levels
+geography_level = st.sampled_from([
+    "state", "county", "tract", "block_group", "block", "place", "zcta",
+])
+
+# WGS84 coordinate pairs
+wgs84_point = st.tuples(
+    st.floats(min_value=-90, max_value=90),
+    st.floats(min_value=-180, max_value=180),
+)
+```
+
+## Health Checks and Slow Tests
+
+For tests that need expensive setup (database, large fixtures):
+
+```python
+from hypothesis import given, settings, HealthCheck
+
+@settings(
+    suppress_health_check=[HealthCheck.too_slow],
+    max_examples=20,
+)
+@given(state_fips)
+def test_boundary_fetch_idempotent(fips):
+    ...
+```
+
+Mark slow property tests:
+
+```python
+import pytest
+
+@pytest.mark.slow
+@given(...)
+def test_expensive_property(...):
+    ...
+```
+
+## File Organization
+
+Place property tests alongside their example-based counterparts:
+
+```
+tests/
+  test_geocoding.py             # example-based tests
+  test_geocoding_properties.py  # property tests
+  test_census_constants.py
+  test_census_constants_properties.py
+  strategies.py                 # shared custom strategies
+```
+
+## Running
+
+```bash
+# Default CI profile (100 examples)
+pytest tests/test_geocoding_properties.py
+
+# Thorough run (1000 examples)
+HYPOTHESIS_PROFILE=thorough pytest tests/test_geocoding_properties.py
+
+# Only property tests
+pytest -k properties
+
+# Reproduce a specific failure (Hypothesis caches the seed)
+pytest tests/test_geocoding_properties.py --hypothesis-seed=12345
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,6 +200,7 @@ dev = [
     "nbformat>=5.7.0",
     "black>=21.0.0",
     "flake8>=3.8.0",
+    "bandit>=1.7.0",
     "astor>=0.8.1",
     "django>=4.2.0",
     "djangorestframework>=3.14.0",
@@ -325,6 +326,17 @@ markers = [
     "databricks: tests requiring Databricks runtime or SDK",
     "requires_api_key: connector smoke tests that hit a live external API; require ~/.siege-test-credentials.yaml. Skipped by default; opt in with `pytest -m requires_api_key`.",
 ]
+
+[tool.bandit]
+exclude_dirs = ["tests", "scripts/archive"]
+skips = [
+    "B101",  # assert used — acceptable in tests and invariant checks
+    "B404",  # import subprocess — used by CI scripts and shell utilities
+    "B603",  # subprocess without shell=True — already the safe pattern
+]
+
+[tool.bandit.assert_used]
+skips = ["*_test.py", "test_*.py"]
 
 [tool.coverage.report]
 fail_under = 20

--- a/scripts/check_security.py
+++ b/scripts/check_security.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Run Bandit security scanner on siege_utilities and report findings.
+
+Usage:
+    python scripts/check_security.py                  # fail on high/medium
+    python scripts/check_security.py --update-baseline  # capture current state
+    python scripts/check_security.py --severity high    # only high severity
+
+Reads Bandit configuration from [tool.bandit] in pyproject.toml.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+BASELINE_FILE = Path("security_baselines/bandit_baseline.json")
+TARGETS = ["siege_utilities"]
+
+
+def run_bandit(severity: str) -> tuple[int, list[dict], str]:
+    """Run Bandit and return (exit_code, results, stderr)."""
+    sev_flag = {"low": "l", "medium": "m", "high": "h"}[severity]
+    cmd = [
+        "bandit",
+        "-r",
+        *TARGETS,
+        f"-{'i' * 1}{sev_flag}",
+        "-f", "json",
+        "-c", "pyproject.toml",
+        "--quiet",
+    ]
+    cp = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+    results = []
+    if cp.stdout.strip():
+        try:
+            data = json.loads(cp.stdout)
+            results = data.get("results", [])
+        except (json.JSONDecodeError, ValueError):
+            pass
+    return cp.returncode, results, cp.stderr.strip()
+
+
+def fingerprint(finding: dict) -> str:
+    """Stable fingerprint for deduplication against baseline."""
+    return f"{finding.get('filename', '')}::{finding.get('test_id', '')}::{finding.get('line_number', '')}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Bandit security scan for siege_utilities.")
+    parser.add_argument(
+        "--severity", choices=["low", "medium", "high"], default="medium",
+        help="Minimum severity to report (default: medium)",
+    )
+    parser.add_argument(
+        "--update-baseline", action="store_true",
+        help="Save current findings as the baseline",
+    )
+    args = parser.parse_args()
+
+    try:
+        subprocess.run(["bandit", "--version"], capture_output=True, check=True, timeout=10)
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        print("Security scan: FAIL")
+        print("- bandit is not installed. Install: pip install bandit")
+        return 1
+
+    exit_code, results, stderr = run_bandit(args.severity)
+    if stderr:
+        print(stderr, file=sys.stderr)
+
+    current_fps = {fingerprint(r) for r in results}
+
+    if args.update_baseline:
+        BASELINE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        baseline_data = {
+            "fingerprints": sorted(current_fps),
+            "count": len(current_fps),
+            "severity": args.severity,
+        }
+        BASELINE_FILE.write_text(json.dumps(baseline_data, indent=2) + "\n")
+        print(f"Security baseline updated: {len(current_fps)} findings at severity >= {args.severity}")
+        return 0
+
+    if BASELINE_FILE.exists():
+        baseline = json.loads(BASELINE_FILE.read_text())
+        baseline_fps = set(baseline.get("fingerprints", []))
+    else:
+        baseline_fps = set()
+
+    new_findings = current_fps - baseline_fps
+    resolved = baseline_fps - current_fps
+
+    print(f"Security scan (severity >= {args.severity}):")
+    print(f"- Current findings: {len(current_fps)}")
+    print(f"- Baseline findings: {len(baseline_fps)}")
+    print(f"- New since baseline: {len(new_findings)}")
+    print(f"- Resolved since baseline: {len(resolved)}")
+
+    if new_findings:
+        print("\nNew security findings:")
+        for r in results:
+            if fingerprint(r) in new_findings:
+                print(f"  [{r.get('issue_severity', '?')}] {r.get('filename', '?')}:{r.get('line_number', '?')}")
+                print(f"    {r.get('test_id', '')}: {r.get('issue_text', '')}")
+        print("\nSecurity scan: FAIL")
+        print("Fix the new findings or update the baseline with --update-baseline")
+        return 1
+
+    print("\nSecurity scan: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,16 @@ import sys
 import shutil
 from unittest.mock import Mock
 
+try:
+    from hypothesis import settings as hyp_settings
+
+    hyp_settings.register_profile("ci", max_examples=100)
+    hyp_settings.register_profile("dev", max_examples=50)
+    hyp_settings.register_profile("thorough", max_examples=1000)
+    hyp_settings.load_profile(os.environ.get("HYPOTHESIS_PROFILE", "ci"))
+except (ImportError, RuntimeError):
+    pass
+
 # Add the package to Python path for testing
 sys.path.insert(0, os.path.abspath('.'))
 

--- a/tests/test_property_census_constants.py
+++ b/tests/test_property_census_constants.py
@@ -1,0 +1,72 @@
+"""Property tests for census_constants — SU-1 invariants.
+
+Tests that normalization functions are idempotent and that
+invalid inputs produce clear errors, not silent garbage.
+"""
+
+import pytest
+
+hypothesis = pytest.importorskip("hypothesis")
+from hypothesis import given, example, settings
+import hypothesis.strategies as st
+
+
+VALID_STATE_FIPS = [
+    "01", "02", "04", "05", "06", "08", "09", "10", "11", "12",
+    "13", "15", "16", "17", "18", "19", "20", "21", "22", "23",
+    "24", "25", "26", "27", "28", "29", "30", "31", "32", "33",
+    "34", "35", "36", "37", "38", "39", "40", "41", "42", "44",
+    "45", "46", "47", "48", "49", "50", "51", "53", "54", "55", "56",
+]
+
+
+class TestNormalizeStateIdentifierProperties:
+    """Property tests for normalize_state_identifier."""
+
+    @given(st.sampled_from(VALID_STATE_FIPS))
+    def test_idempotent_on_valid_fips(self, fips):
+        """Normalizing a valid FIPS code twice returns the same result."""
+        from siege_utilities.config.census_constants import normalize_state_identifier
+
+        result = normalize_state_identifier(fips)
+        assert normalize_state_identifier(result) == result
+
+    @given(st.text(max_size=50))
+    @settings(max_examples=100)
+    def test_never_returns_invalid_fips(self, raw):
+        """If normalization succeeds, the result must be a 2-digit string."""
+        from siege_utilities.config.census_constants import normalize_state_identifier
+
+        try:
+            result = normalize_state_identifier(raw)
+            assert isinstance(result, str)
+            assert len(result) == 2
+            assert result.isdigit()
+        except (ValueError, KeyError):
+            pass
+
+    @given(st.integers(min_value=100, max_value=99999))
+    def test_rejects_out_of_range_numbers(self, n):
+        """Numbers outside valid FIPS range should raise, not return garbage."""
+        from siege_utilities.config.census_constants import normalize_state_identifier
+
+        try:
+            result = normalize_state_identifier(str(n))
+            assert result in VALID_STATE_FIPS, f"Unexpected FIPS: {result} from {n}"
+        except (ValueError, KeyError):
+            pass
+
+    @example("")
+    @example("ZZ")
+    @example("00")
+    @example("99")
+    @given(st.text(alphabet="ABCDEFGHIJKLMNOPQRSTUVWXYZ", min_size=3, max_size=20))
+    def test_invalid_alpha_rejects_or_resolves(self, name):
+        """Arbitrary alpha strings either resolve to valid FIPS or raise."""
+        from siege_utilities.config.census_constants import normalize_state_identifier
+
+        try:
+            result = normalize_state_identifier(name)
+            assert result in VALID_STATE_FIPS
+        except (ValueError, KeyError):
+            pass

--- a/tests/test_property_geocoding.py
+++ b/tests/test_property_geocoding.py
@@ -1,0 +1,57 @@
+"""Property tests for geocoding — SU-1 invariants.
+
+These tests verify that geocoding functions handle arbitrary inputs
+without crashing and that outputs satisfy domain invariants.
+"""
+
+import pytest
+
+hypothesis = pytest.importorskip("hypothesis")
+from hypothesis import given, assume, settings, HealthCheck
+import hypothesis.strategies as st
+
+
+# Valid WGS84 coordinate ranges
+latitudes = st.floats(min_value=-90, max_value=90, allow_nan=False, allow_infinity=False)
+longitudes = st.floats(min_value=-180, max_value=180, allow_nan=False, allow_infinity=False)
+
+
+class TestGetCoordinatesProperties:
+    """Property tests for get_coordinates."""
+
+    @given(st.text(max_size=200))
+    @settings(suppress_health_check=[HealthCheck.too_slow], max_examples=50)
+    def test_never_crashes_on_arbitrary_input(self, address):
+        """get_coordinates must not raise unexpected exceptions on any string."""
+        from siege_utilities.geo.geocoding import get_coordinates
+
+        try:
+            get_coordinates(address)
+        except (ValueError, TypeError, KeyError, AttributeError):
+            pass
+
+    @given(latitudes, longitudes)
+    @settings(max_examples=30)
+    def test_coordinate_string_does_not_crash(self, lat, lon):
+        """Coordinate-like strings should not crash the function."""
+        from siege_utilities.geo.geocoding import get_coordinates
+
+        try:
+            get_coordinates(f"{lat}, {lon}")
+        except (ValueError, TypeError, KeyError, AttributeError):
+            pass
+
+
+class TestNominatimGeocoderProperties:
+    """Property tests for use_nominatim_geocoder."""
+
+    @given(st.text(min_size=1, max_size=100))
+    @settings(suppress_health_check=[HealthCheck.too_slow], max_examples=30)
+    def test_never_crashes_on_arbitrary_query(self, query):
+        """use_nominatim_geocoder must not raise unexpected exceptions."""
+        from siege_utilities.geo.geocoding import use_nominatim_geocoder
+
+        try:
+            use_nominatim_geocoder(query)
+        except (ValueError, TypeError, KeyError, AttributeError):
+            pass

--- a/tests/test_property_paths.py
+++ b/tests/test_property_paths.py
@@ -1,0 +1,60 @@
+"""Property tests for file path utilities — SU-1 invariants.
+
+Tests that path functions handle arbitrary input without crashing
+and that sanitization is idempotent.
+"""
+
+import os
+
+import pytest
+
+hypothesis = pytest.importorskip("hypothesis")
+from hypothesis import given, assume, settings
+import hypothesis.strategies as st
+
+
+class TestSanitizePathProperties:
+    """Property tests for path sanitization."""
+
+    @given(st.text(max_size=300))
+    @settings(max_examples=100)
+    def test_sanitize_never_crashes(self, raw_path):
+        """sanitize_filename must not raise on arbitrary string input."""
+        from siege_utilities.files.operations import sanitize_filename
+
+        try:
+            result = sanitize_filename(raw_path)
+            assert isinstance(result, str)
+        except (ValueError, TypeError):
+            pass
+
+    @given(st.text(min_size=1, max_size=100, alphabet=st.characters(
+        whitelist_categories=("L", "N", "P", "Z"),
+        blacklist_characters="\x00",
+    )))
+    @settings(max_examples=100)
+    def test_sanitize_idempotent(self, raw_path):
+        """Sanitizing twice gives the same result as sanitizing once."""
+        from siege_utilities.files.operations import sanitize_filename
+
+        try:
+            once = sanitize_filename(raw_path)
+            twice = sanitize_filename(once)
+            assert once == twice, f"Not idempotent: {raw_path!r} -> {once!r} -> {twice!r}"
+        except (ValueError, TypeError):
+            pass
+
+
+class TestEnsurePathExistsProperties:
+    """Property tests for ensure_path_exists."""
+
+    @given(st.text(max_size=200))
+    @settings(max_examples=50)
+    def test_never_crashes_on_arbitrary_input(self, raw_path):
+        """ensure_path_exists should handle arbitrary strings gracefully."""
+        from siege_utilities.files.paths import ensure_path_exists
+
+        try:
+            ensure_path_exists(raw_path)
+        except (OSError, ValueError, TypeError):
+            pass


### PR DESCRIPTION
## Summary

Siege_utilities side of WS0 (issue #777):

- **WS0-T2 (Bandit)**: Add `bandit` to dev deps, `[tool.bandit]` config in pyproject.toml, and `scripts/check_security.py` CI gate with baseline ratchet pattern (matches existing lint ratchet approach).
- **WS0-T3 (Hypothesis)**: Add `docs/PROPERTY_TESTING_GUIDE.md`, Hypothesis profile registration in conftest.py, and 3 example property test files demonstrating SU-1 invariants (geocoding no-crash, census constant idempotency, path sanitization).

Companion PR in claude-configs-public adds the 6 bookshelf rules files and cross-reference table.

## Test plan

- [ ] All new files compile clean (`py_compile`)
- [ ] `pytest tests/test_property_census_constants.py -v` passes
- [ ] `pytest tests/test_property_paths.py -v` passes
- [ ] `python scripts/check_security.py --update-baseline` creates baseline
- [ ] `python scripts/check_security.py` passes against baseline