### PR TITLE
fix(#796): add beautifulsoup4 to [geo] optional dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,8 @@ geo = [
     # Required by PostGISConnector.upload_spatial_data for full-column
     # writes via gpd.GeoDataFrame.to_postgis (closes #516).
     "geoalchemy2>=0.14.0",
+    # Required by geo/spatial_data.py (BeautifulSoup HTML/XML parsing).
+    "beautifulsoup4>=4.12.0",
 ]
 # H3 hexagonal spatial index (lightweight spatial joins)
 h3 = [


### PR DESCRIPTION
## Summary
- Add beautifulsoup4>=4.12.0 to [geo] optional-dependencies in pyproject.toml
- geo/spatial_data.py imports bs4.BeautifulSoup but it was only declared in [web] group

Closes #796