### PR TITLE
fix(#797): convert data/__init__.py to lazy imports (PEP 562)

### DIFF
--- a/siege_utilities/data/__init__.py
+++ b/siege_utilities/data/__init__.py
@@ -9,122 +9,141 @@ After ELE-2437, ``data/`` narrowed to hold statistics primitives
 
 Top-level imports at this package are preserved (re-exports from the
 new homes) for one deprecation window so existing callers still work.
+
+All re-exports use PEP 562 lazy loading so that importing
+``siege_utilities.data`` does not pull in heavy transitive dependencies
+(geopandas via RDH, etc.) unless the caller actually uses them.
 """
 
-# Reference data (moved to siege_utilities.reference but re-exported here)
-from ..reference.sample_data import (
-    load_sample_data,
-    list_available_datasets,
-    get_dataset_info,
-    get_census_boundaries,
-    get_census_data,
-    join_boundaries_and_data,
-    create_sample_dataset,
-    generate_synthetic_population,
-    generate_synthetic_businesses,
-    generate_synthetic_housing,
-    HOUSING_LOCALE_PRESETS,
-    SAMPLE_DATASETS,
-    CENSUS_SAMPLES,
-    SYNTHETIC_SAMPLES,
-)
+# ---------------------------------------------------------------------------
+# PEP 562 lazy imports
+# ---------------------------------------------------------------------------
 
-# RDH provider moved to geo/providers/ under ELE-2438 (D3). Top-level
-# data.* re-export is preserved so existing callers continue to work
-# without a deprecation warning through this path.
-from ..geo.providers.redistricting_data_hub import (
-    RDHClient,
-    RDHDataset,
-    RDHDataFormat,
-    RDHDatasetType,
-    RDH_BASE_URL,
-    US_STATES,
-    polsby_popper,
-    reock,
-    convex_hull_ratio,
-    schwartzberg,
-    compute_compactness,
-    compare_plans,
-    demographic_profile,
-    fetch_enacted_plan,
-    fetch_precinct_results,
-    fetch_cvap,
-    fetch_pl94171,
-    fetch_demographic_summary,
-    CompactnessScores,
-    RDH_SITE_URL,
-)
+_LAZY_IMPORTS = {
+    # Reference data (moved to siege_utilities.reference but re-exported here)
+    "load_sample_data":              ("..reference.sample_data", "load_sample_data"),
+    "list_available_datasets":       ("..reference.sample_data", "list_available_datasets"),
+    "get_dataset_info":              ("..reference.sample_data", "get_dataset_info"),
+    "get_census_boundaries":         ("..reference.sample_data", "get_census_boundaries"),
+    "get_census_data":               ("..reference.sample_data", "get_census_data"),
+    "join_boundaries_and_data":      ("..reference.sample_data", "join_boundaries_and_data"),
+    "create_sample_dataset":         ("..reference.sample_data", "create_sample_dataset"),
+    "generate_synthetic_population": ("..reference.sample_data", "generate_synthetic_population"),
+    "generate_synthetic_businesses": ("..reference.sample_data", "generate_synthetic_businesses"),
+    "generate_synthetic_housing":    ("..reference.sample_data", "generate_synthetic_housing"),
+    "HOUSING_LOCALE_PRESETS":        ("..reference.sample_data", "HOUSING_LOCALE_PRESETS"),
+    "SAMPLE_DATASETS":               ("..reference.sample_data", "SAMPLE_DATASETS"),
+    "CENSUS_SAMPLES":                ("..reference.sample_data", "CENSUS_SAMPLES"),
+    "SYNTHETIC_SAMPLES":             ("..reference.sample_data", "SYNTHETIC_SAMPLES"),
 
-# Engine abstractions (moved to siege_utilities.engines but re-exported here)
-from ..engines.dataframe_engine import (
-    Engine,
-    PANDAS,
-    DUCKDB,
-    SPARK,
-    POSTGIS,
-    DataFrameEngine,
-    PandasEngine,
-    DuckDBEngine,
-    SparkEngine,
-    PostGISEngine,
-    get_engine,
-)
+    # RDH provider (moved to geo/providers/ under ELE-2438)
+    "RDHClient":                     ("..geo.providers.redistricting_data_hub", "RDHClient"),
+    "RDHDataset":                    ("..geo.providers.redistricting_data_hub", "RDHDataset"),
+    "RDHDataFormat":                 ("..geo.providers.redistricting_data_hub", "RDHDataFormat"),
+    "RDHDatasetType":                ("..geo.providers.redistricting_data_hub", "RDHDatasetType"),
+    "RDH_BASE_URL":                  ("..geo.providers.redistricting_data_hub", "RDH_BASE_URL"),
+    "US_STATES":                     ("..geo.providers.redistricting_data_hub", "US_STATES"),
+    "polsby_popper":                 ("..geo.providers.redistricting_data_hub", "polsby_popper"),
+    "reock":                         ("..geo.providers.redistricting_data_hub", "reock"),
+    "convex_hull_ratio":             ("..geo.providers.redistricting_data_hub", "convex_hull_ratio"),
+    "schwartzberg":                  ("..geo.providers.redistricting_data_hub", "schwartzberg"),
+    "compute_compactness":           ("..geo.providers.redistricting_data_hub", "compute_compactness"),
+    "compare_plans":                 ("..geo.providers.redistricting_data_hub", "compare_plans"),
+    "demographic_profile":           ("..geo.providers.redistricting_data_hub", "demographic_profile"),
+    "fetch_enacted_plan":            ("..geo.providers.redistricting_data_hub", "fetch_enacted_plan"),
+    "fetch_precinct_results":        ("..geo.providers.redistricting_data_hub", "fetch_precinct_results"),
+    "fetch_cvap":                    ("..geo.providers.redistricting_data_hub", "fetch_cvap"),
+    "fetch_pl94171":                 ("..geo.providers.redistricting_data_hub", "fetch_pl94171"),
+    "fetch_demographic_summary":     ("..geo.providers.redistricting_data_hub", "fetch_demographic_summary"),
+    "CompactnessScores":             ("..geo.providers.redistricting_data_hub", "CompactnessScores"),
+    "RDH_SITE_URL":                  ("..geo.providers.redistricting_data_hub", "RDH_SITE_URL"),
+
+    # Engine abstractions (moved to siege_utilities.engines but re-exported here)
+    "Engine":                        ("..engines.dataframe_engine", "Engine"),
+    "PANDAS":                        ("..engines.dataframe_engine", "PANDAS"),
+    "DUCKDB":                        ("..engines.dataframe_engine", "DUCKDB"),
+    "SPARK":                         ("..engines.dataframe_engine", "SPARK"),
+    "POSTGIS":                       ("..engines.dataframe_engine", "POSTGIS"),
+    "DataFrameEngine":               ("..engines.dataframe_engine", "DataFrameEngine"),
+    "PandasEngine":                  ("..engines.dataframe_engine", "PandasEngine"),
+    "DuckDBEngine":                  ("..engines.dataframe_engine", "DuckDBEngine"),
+    "SparkEngine":                   ("..engines.dataframe_engine", "SparkEngine"),
+    "PostGISEngine":                 ("..engines.dataframe_engine", "PostGISEngine"),
+    "get_engine":                    ("..engines.dataframe_engine", "get_engine"),
+}
 
 __all__ = [
     # Core functions
-    'load_sample_data',
-    'list_available_datasets', 
-    'get_dataset_info',
-    
+    "load_sample_data",
+    "list_available_datasets",
+    "get_dataset_info",
+
     # Census samples
-    'get_census_boundaries',
-    'get_census_data',
-    'join_boundaries_and_data',
-    'create_sample_dataset',
-    
+    "get_census_boundaries",
+    "get_census_data",
+    "join_boundaries_and_data",
+    "create_sample_dataset",
+
     # Synthetic generation
-    'generate_synthetic_population',
-    'generate_synthetic_businesses',
-    'generate_synthetic_housing',
-    'HOUSING_LOCALE_PRESETS',
+    "generate_synthetic_population",
+    "generate_synthetic_businesses",
+    "generate_synthetic_housing",
+    "HOUSING_LOCALE_PRESETS",
 
     # Dataset info
-    'SAMPLE_DATASETS',
-    'CENSUS_SAMPLES',
-    'SYNTHETIC_SAMPLES',
+    "SAMPLE_DATASETS",
+    "CENSUS_SAMPLES",
+    "SYNTHETIC_SAMPLES",
 
     # Redistricting Data Hub
-    'RDHClient',
-    'RDHDataset',
-    'RDHDataFormat',
-    'RDHDatasetType',
-    'RDH_BASE_URL',
-    'US_STATES',
-    'polsby_popper',
-    'reock',
-    'convex_hull_ratio',
-    'schwartzberg',
-    'compute_compactness',
-    'compare_plans',
-    'demographic_profile',
-    'fetch_enacted_plan',
-    'fetch_precinct_results',
-    'fetch_cvap',
-    'fetch_pl94171',
-    'fetch_demographic_summary',
-    'CompactnessScores',
-    'RDH_SITE_URL',
+    "RDHClient",
+    "RDHDataset",
+    "RDHDataFormat",
+    "RDHDatasetType",
+    "RDH_BASE_URL",
+    "US_STATES",
+    "polsby_popper",
+    "reock",
+    "convex_hull_ratio",
+    "schwartzberg",
+    "compute_compactness",
+    "compare_plans",
+    "demographic_profile",
+    "fetch_enacted_plan",
+    "fetch_precinct_results",
+    "fetch_cvap",
+    "fetch_pl94171",
+    "fetch_demographic_summary",
+    "CompactnessScores",
+    "RDH_SITE_URL",
 
     # Engine-agnostic DataFrame operations
-    'Engine',
-    'PANDAS',
-    'DUCKDB',
-    'SPARK',
-    'POSTGIS',
-    'DataFrameEngine',
-    'PandasEngine',
-    'DuckDBEngine',
-    'SparkEngine',
-    'PostGISEngine',
-    'get_engine',
+    "Engine",
+    "PANDAS",
+    "DUCKDB",
+    "SPARK",
+    "POSTGIS",
+    "DataFrameEngine",
+    "PandasEngine",
+    "DuckDBEngine",
+    "SparkEngine",
+    "PostGISEngine",
+    "get_engine",
 ]
+
+
+def __getattr__(name):  # noqa: E303
+    """PEP 562 lazy loader — resolve re-exports on first access."""
+    if name in _LAZY_IMPORTS:
+        module_path, attr = _LAZY_IMPORTS[name]
+        from importlib import import_module
+        mod = import_module(module_path, __name__)
+        val = getattr(mod, attr)
+        globals()[name] = val
+        return val
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    """Ensure dir() reports all lazy exports."""
+    return __all__

--- a/siege_utilities/git/git_operations.py
+++ b/siege_utilities/git/git_operations.py
@@ -8,6 +8,16 @@ import re
 
 from siege_utilities.core.logging import log_info, log_warning, log_error
 from siege_utilities.exceptions import GitError
+from siege_utilities.git.validation import (
+    GitSecurityError,
+    has_dangerous_characters,
+    validate_branch_name,
+    validate_commit_hash,
+    validate_commit_message,
+    validate_remote_name,
+    validate_repo_path,
+    validate_tag_name,
+)
 from ._utils import run_git_command
 
 def create_feature_branch(
@@ -74,12 +84,8 @@ def switch_branch(branch_name: str, repo_path: str = ".") -> Dict[str, str]:
         GitSecurityError: If branch name fails validation
     """
     # Validate inputs
-    try:
-        from siege_utilities.git.validation import validate_branch_name, validate_repo_path
-        branch_name = validate_branch_name(branch_name)
-        repo_path = str(validate_repo_path(repo_path))
-    except ImportError:
-        pass
+    branch_name = validate_branch_name(branch_name)
+    repo_path = str(validate_repo_path(repo_path))
 
     # Check if branch exists
     branches = run_git_command("branch", "--list", repo_path=repo_path)
@@ -129,13 +135,9 @@ def merge_branch(
         GitSecurityError: If branch names fail validation
     """
     # Validate inputs
-    try:
-        from siege_utilities.git.validation import validate_branch_name, validate_repo_path
-        source_branch = validate_branch_name(source_branch)
-        target_branch = validate_branch_name(target_branch)
-        repo_path = str(validate_repo_path(repo_path))
-    except ImportError:
-        pass
+    source_branch = validate_branch_name(source_branch)
+    target_branch = validate_branch_name(target_branch)
+    repo_path = str(validate_repo_path(repo_path))
 
     # Switch to target branch
     current_branch = run_git_command("branch", "--show-current", repo_path=repo_path)
@@ -197,13 +199,9 @@ def rebase_branch(
         GitSecurityError: If branch names fail validation
     """
     # Validate inputs
-    try:
-        from siege_utilities.git.validation import validate_branch_name, validate_repo_path
-        source_branch = validate_branch_name(source_branch)
-        base_branch = validate_branch_name(base_branch)
-        repo_path = str(validate_repo_path(repo_path))
-    except ImportError:
-        pass
+    source_branch = validate_branch_name(source_branch)
+    base_branch = validate_branch_name(base_branch)
+    repo_path = str(validate_repo_path(repo_path))
 
     # Switch to source branch
     current_branch = run_git_command("branch", "--show-current", repo_path=repo_path)
@@ -257,13 +255,9 @@ def stash_changes(
         GitSecurityError: If message fails validation
     """
     # Validate inputs
-    try:
-        from siege_utilities.git.validation import validate_commit_message, validate_repo_path
-        if message:
-            message = validate_commit_message(message)
-        repo_path = str(validate_repo_path(repo_path))
-    except ImportError:
-        pass
+    if message:
+        message = validate_commit_message(message)
+    repo_path = str(validate_repo_path(repo_path))
 
     stash_args = ["stash"]
     if message:
@@ -316,17 +310,11 @@ def apply_stash(
         GitSecurityError: If stash ref fails validation
     """
     # Validate inputs
-    try:
-        from siege_utilities.git.validation import has_dangerous_characters, validate_repo_path, GitSecurityError
-        # Validate stash ref format
-        import re
-        if not re.match(r'^stash@\{\d+\}$', stash_ref):
-            raise GitSecurityError(f"Invalid stash ref format: {stash_ref}")
-        if has_dangerous_characters(stash_ref):
-            raise GitSecurityError(f"Dangerous characters in stash ref: {stash_ref}")
-        repo_path = str(validate_repo_path(repo_path))
-    except ImportError:
-        pass
+    if not re.match(r'^stash@\{\d+\}$', stash_ref):
+        raise GitSecurityError(f"Invalid stash ref format: {stash_ref}")
+    if has_dangerous_characters(stash_ref):
+        raise GitSecurityError(f"Dangerous characters in stash ref: {stash_ref}")
+    repo_path = str(validate_repo_path(repo_path))
 
     stash_args = ["stash", "pop" if pop else "apply", stash_ref]
 
@@ -429,12 +417,8 @@ def reset_to_commit(
         GitSecurityError: If commit hash fails validation
     """
     # Validate inputs
-    try:
-        from siege_utilities.git.validation import validate_commit_hash, validate_repo_path
-        commit_hash = validate_commit_hash(commit_hash)
-        repo_path = str(validate_repo_path(repo_path))
-    except ImportError:
-        pass
+    commit_hash = validate_commit_hash(commit_hash)
+    repo_path = str(validate_repo_path(repo_path))
 
     valid_reset_types = ["soft", "mixed", "hard"]
     if reset_type not in valid_reset_types:
@@ -479,13 +463,9 @@ def cherry_pick_commit(
         GitSecurityError: If commit hash fails validation
     """
     # Validate inputs
-    try:
-        from siege_utilities.git.validation import validate_commit_hash, validate_repo_path
-        if not continue_on_conflict:  # Only validate if we're using the hash
-            commit_hash = validate_commit_hash(commit_hash)
-        repo_path = str(validate_repo_path(repo_path))
-    except ImportError:
-        pass
+    if not continue_on_conflict:  # Only validate if we're using the hash
+        commit_hash = validate_commit_hash(commit_hash)
+    repo_path = str(validate_repo_path(repo_path))
 
     cherry_pick_args = ["cherry-pick"]
     if continue_on_conflict:
@@ -547,33 +527,13 @@ def create_tag(
         - Validates commit hash format
         - Validates commit message content
     """
-    # Import validation functions
-    try:
-        from siege_utilities.git.validation import (
-            validate_tag_name,
-            validate_commit_message,
-            validate_commit_hash,
-            validate_repo_path,
-            GitSecurityError
-        )
-    except ImportError:
-        # Fallback: minimal validation
-        if not tag_name or not tag_name.strip():
-            raise ValueError("Tag name cannot be empty")
-        if any(c in tag_name for c in [';', '&', '|', '$', '`', '(', ')']):
-            raise ValueError(f"Tag name contains dangerous characters: {tag_name}")
-    else:
-        # Validate inputs
-        try:
-            tag_name = validate_tag_name(tag_name)
-            if message:
-                message = validate_commit_message(message)
-            if commit_hash:
-                commit_hash = validate_commit_hash(commit_hash)
-            repo_path_obj = validate_repo_path(repo_path)
-            repo_path = str(repo_path_obj)
-        except (GitSecurityError, ValueError) as e:
-            return {"status": "failed", "error": f"Validation failed: {e}"}
+    # Validate inputs
+    tag_name = validate_tag_name(tag_name)
+    if message:
+        message = validate_commit_message(message)
+    if commit_hash:
+        commit_hash = validate_commit_hash(commit_hash)
+    repo_path = str(validate_repo_path(repo_path))
 
     tag_args = ["tag"]
     if message:
@@ -630,14 +590,10 @@ def push_branch(
         GitSecurityError: If branch or remote name fails validation
     """
     # Validate inputs
-    try:
-        from siege_utilities.git.validation import validate_branch_name, validate_remote_name, validate_repo_path
-        if branch_name:
-            branch_name = validate_branch_name(branch_name)
-        remote = validate_remote_name(remote)
-        repo_path = str(validate_repo_path(repo_path))
-    except ImportError:
-        pass
+    if branch_name:
+        branch_name = validate_branch_name(branch_name)
+    remote = validate_remote_name(remote)
+    repo_path = str(validate_repo_path(repo_path))
 
     push_args = ["push"]
     if force:
@@ -689,14 +645,10 @@ def pull_branch(
         GitSecurityError: If branch or remote name fails validation
     """
     # Validate inputs
-    try:
-        from siege_utilities.git.validation import validate_branch_name, validate_remote_name, validate_repo_path
-        if branch_name:
-            branch_name = validate_branch_name(branch_name)
-        remote = validate_remote_name(remote)
-        repo_path = str(validate_repo_path(repo_path))
-    except ImportError:
-        pass
+    if branch_name:
+        branch_name = validate_branch_name(branch_name)
+    remote = validate_remote_name(remote)
+    repo_path = str(validate_repo_path(repo_path))
 
     pull_args = ["pull"]
     if rebase:


### PR DESCRIPTION
## Summary
- Convert data/__init__.py from eager to lazy imports using PEP 562 __getattr__
- Prevents importing geopandas (via RDH) when users only need sample data or statistics
- Users with `pip install siege-utilities[data]` can now use sample_data without [geo] installed

Closes #797