### PR TITLE
fix(#805): add pandas and scipy to dep groups that import them

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ data = [
     "openpyxl>=3.1.0",
     "pyarrow>=14.0.0",
     "faker>=35.2.2",
+    "scipy>=1.11.0",
 ]
 # Geospatial (geopandas, shapely, pyproj, etc.)
 geo = [
@@ -92,6 +93,8 @@ reporting = [
     "pillow>=10.0.0",
     "fonttools>=4.40.0",
     "geopandas>=0.13.2",
+    "pandas>=2.0.0",
+    "scipy>=1.11.0",
 ]
 # Analytics connectors (GA, Facebook, Snowflake, data.world)
 analytics = [
@@ -101,6 +104,7 @@ analytics = [
     "google-api-python-client>=2.181.0",
     "google-analytics-data>=0.18.19",
     "google-analytics-admin>=0.25.0",
+    "pandas>=2.0.0",
     "facebook-business>=20.0.0",
     "datadotworld>=1.7.0",
     "snowflake-connector-python>=3.0.0",
@@ -211,6 +215,8 @@ dev = [
 # Survey/polling report engine (RIM weighting)
 survey = [
     "weightipy>=0.4.0",
+    "pandas>=2.0.0",
+    "scipy>=1.11.0",
 ]
 # Everything — convenience meta-extra for full installs
 all = [


### PR DESCRIPTION
## Summary
- Add `pandas>=2.0.0` to `[survey]`, `[analytics]`, and `[reporting]` optional-dependency groups
- Add `scipy>=1.11.0` to `[survey]`, `[reporting]`, and `[data]` groups (used by significance tests, hex cartogram, and cross-tabulation)
- Ensures `pip install siege-utilities[survey]` etc. pull in their actual runtime requirements

Closes #805