### PR TITLE
fix(#799): point notebook install cells at real extras

### DIFF
--- a/notebooks/engines/01_multi_engine_dataframes.ipynb
+++ b/notebooks/engines/01_multi_engine_dataframes.ipynb
@@ -4,23 +4,7 @@
    "cell_type": "markdown",
    "id": "title",
    "metadata": {},
-   "source": [
-    "# ElectInfo: rank TX committees two ways — pandas vs DuckDB\n",
-    "\n",
-    "## What this shows\n",
-    "How to run the same analysis against two execution engines through the `DataFrameEngine` abstraction. We build a synthetic FEC-shaped committee-receipts parquet on disk, then rank the top 20 TX committees by total receipts through both pandas and DuckDB, proving the outputs are identical.\n",
-    "\n",
-    "## Why it matters\n",
-    "When ElectInfo's dataset grows past what pandas handles comfortably (tens of millions of rows), DuckDB takes over the same query without rewriting the analysis layer. Swap the engine constructor, the rest of the code is unchanged. `engines/02_distributed_spark.ipynb` then extends the same pattern to Spark.\n",
-    "\n",
-    "## Prereqs\n",
-    "- `pip install 'siege-utilities[engines]'` (pulls in DuckDB).\n",
-    "- No credentials.\n",
-    "\n",
-    "## Next\n",
-    "- `engines/02_distributed_spark.ipynb` — Spark + Sedona for 40M-row FEC batches.\n",
-    "- `engines/03_databricks_geo.ipynb` — same patterns on Azure Databricks where Sedona isn't available.\n"
-   ]
+   "source": "# ElectInfo: rank TX committees two ways — pandas vs DuckDB\n\n## What this shows\nHow to run the same analysis against two execution engines through the `DataFrameEngine` abstraction. We build a synthetic FEC-shaped committee-receipts parquet on disk, then rank the top 20 TX committees by total receipts through both pandas and DuckDB, proving the outputs are identical.\n\n## Why it matters\nWhen ElectInfo's dataset grows past what pandas handles comfortably (tens of millions of rows), DuckDB takes over the same query without rewriting the analysis layer. Swap the engine constructor, the rest of the code is unchanged. `engines/02_distributed_spark.ipynb` then extends the same pattern to Spark.\n\n## Prereqs\n- `pip install 'siege-utilities[performance]'` (pulls in DuckDB).\n- No credentials.\n\n## Next\n- `engines/02_distributed_spark.ipynb` — Spark + Sedona for 40M-row FEC batches.\n- `engines/03_databricks_geo.ipynb` — same patterns on Azure Databricks where Sedona isn't available.\n"
   },
   {
    "cell_type": "markdown",

--- a/notebooks/foundations/01_configuration.ipynb
+++ b/notebooks/foundations/01_configuration.ipynb
@@ -4,22 +4,7 @@
    "cell_type": "markdown",
    "id": "cell-title",
    "metadata": {},
-   "source": [
-    "# ElectInfo bootstraps its reporting environment\n",
-    "\n",
-    "## What this shows\n",
-    "How to load a layered Hydra configuration, validate it with a Pydantic model, override one field via env var, and catch a bad override at load time. Uses ElectInfo — one of two partner firms that thread through these demos — onboarding a new TX analysis engagement.\n",
-    "\n",
-    "## Why it matters\n",
-    "Every other capability in `siege_utilities` reads settings (cache dirs, API keys, output preferences) from the config layer. Getting this right once means the rest of the library uses sensible, client-scoped defaults automatically — no config re-plumbing inside each downstream notebook.\n",
-    "\n",
-    "## Prereqs\n",
-    "- `pip install 'siege-utilities[config]'`\n",
-    "- No credentials.\n",
-    "\n",
-    "## Next\n",
-    "- `02_profiles_branding.ipynb` — register ElectInfo and Masai Interactive as branded client profiles.\n"
-   ]
+   "source": "# ElectInfo bootstraps its reporting environment\n\n## What this shows\nHow to load a layered Hydra configuration, validate it with a Pydantic model, override one field via env var, and catch a bad override at load time. Uses ElectInfo — one of two partner firms that thread through these demos — onboarding a new TX analysis engagement.\n\n## Why it matters\nEvery other capability in `siege_utilities` reads settings (cache dirs, API keys, output preferences) from the config layer. Getting this right once means the rest of the library uses sensible, client-scoped defaults automatically — no config re-plumbing inside each downstream notebook.\n\n## Prereqs\n- `pip install 'siege-utilities[config-extras]'`\n- No credentials.\n\n## Next\n- `02_profiles_branding.ipynb` — register ElectInfo and Masai Interactive as branded client profiles.\n"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Closes #799 (epic #776).

## Problem
Two notebook install cells reference pip extras that don't exist in `pyproject.toml`, so the documented `pip install` fails for users following the notebooks:

- `notebooks/engines/01_multi_engine_dataframes.ipynb` → `siege-utilities[engines]`
- `notebooks/foundations/01_configuration.ipynb` → `siege-utilities[config]`

## Fix
- `engines/01` → `[performance]` (provides `duckdb`; that notebook only uses the DuckDB engine — Spark lives in `engines/02`).
- `foundations/01` → `[config-extras]` (provides `hydra-core` + `omegaconf`; the notebook drives `HydraConfigManager`).

Markdown-only edit in the Prereqs cell of each notebook. No library code or contract changes.

## Verification
- Confirmed extras exist on current `develop` HEAD `pyproject.toml`.
- Both notebooks re-parse as valid nbformat JSON after edit.
- Sibling-grep across `notebooks/**/*.ipynb` found two further phantom extras out of scope here: `[stats]` in `engines/04_statistics_primitives.ipynb` and `[pptx]` in `reports/02_slides_pptx_and_google.ipynb`. These deserve their own tickets under epic #776; this PR stays scoped to #799.

## Test plan
- [ ] `python -c "import json; json.load(open('notebooks/engines/01_multi_engine_dataframes.ipynb'))"` parses
- [ ] `python -c "import json; json.load(open('notebooks/foundations/01_configuration.ipynb'))"` parses
- [ ] Open both notebooks in Jupyter — Prereqs cell shows the corrected extras
- [ ] `pip install 'siege-utilities[performance]'` and `pip install 'siege-utilities[config-extras]'` succeed against the current package