### PR TITLE
fix(#800): raise GeocodingError on Nominatim failures (SU-1)

### DIFF
--- a/siege_utilities/__init__.py
+++ b/siege_utilities/__init__.py
@@ -194,6 +194,7 @@ _register_lazy([
 _register_lazy([
     'concatenate_addresses', 'use_nominatim_geocoder',
     'get_country_name', 'get_country_code', 'list_countries', 'get_coordinates',
+    'GeocodingError',
 ], '.geo.geocoding', deps=['geopandas'])
 
 _register_lazy([

--- a/siege_utilities/geo/__init__.py
+++ b/siege_utilities/geo/__init__.py
@@ -93,7 +93,7 @@ _register([
 _register([
     'concatenate_addresses', 'use_nominatim_geocoder', 'NominatimGeoClassifier',
     'get_country_name', 'get_country_code', 'list_countries', 'get_coordinates',
-    'NOMINATIM_INTERNAL_URL',
+    'NOMINATIM_INTERNAL_URL', 'GeocodingError',
     'validate_geocode_data_pandas', 'mark_valid_geocode_data_pandas',
 ], '.geocoding')
 

--- a/siege_utilities/geo/geocoding.py
+++ b/siege_utilities/geo/geocoding.py
@@ -34,6 +34,21 @@ def log_debug(message: str) -> None:
 def log_error(message: str) -> None:
     logger.error(message)
 
+
+class GeocodingError(RuntimeError):
+    """Raised when Nominatim geocoding fails for reasons other than 'no match'.
+
+    Covers network timeouts (after retries exhausted), service errors,
+    parse errors, and other unexpected failures from the geocoder.
+    Distinct from a legitimate "no result found" outcome, which still
+    returns ``None``. Use ``__cause__`` to inspect the underlying
+    exception.
+
+    Mirrors
+    :class:`siege_utilities.geo.providers.census_geocoder.CensusGeocodeError`.
+    """
+
+
 # Country code mapping for Nominatim geocoding
 COUNTRY_CODES = {
     # North America
@@ -359,7 +374,6 @@ def concatenate_addresses(street=None, city=None, state_province_area=None,
 def get_coordinates(query_address, country_codes=None, max_retries=3, server_url=None):
     """
     Get coordinates (latitude, longitude) for an address using Nominatim.
-    Returns a tuple of (latitude, longitude) or None if geocoding fails.
 
     Args:
         query_address: The address to geocode
@@ -370,23 +384,34 @@ def get_coordinates(query_address, country_codes=None, max_retries=3, server_url
             Defaults to None (public OSM Nominatim).
 
     Returns:
-        tuple: (latitude, longitude) or None if geocoding fails
+        tuple: (latitude, longitude), or ``None`` when Nominatim returned
+        no match for the address (a legitimate non-error outcome).
+
+    Raises:
+        ValueError: If ``query_address`` is empty or None.
+        GeocodingError: If geocoding failed due to a network, service, or
+            parse error — i.e., the geocoder could not even attempt to
+            match. Wraps the underlying exception via ``__cause__``.
     """
+    result_json = use_nominatim_geocoder(
+        query_address, country_codes=country_codes,
+        max_retries=max_retries, server_url=server_url,
+    )
+    if result_json is None:
+        return None
     try:
-        result_json = use_nominatim_geocoder(
-            query_address, country_codes=country_codes,
-            max_retries=max_retries, server_url=server_url,
+        data = json.loads(result_json)
+    except json.JSONDecodeError as e:
+        raise GeocodingError(
+            f"Could not parse Nominatim response for {query_address!r}"
+        ) from e
+    lat = data.get('nominatim_lat')
+    lng = data.get('nominatim_lng')
+    if lat is None or lng is None:
+        raise GeocodingError(
+            f"Nominatim response for {query_address!r} missing lat/lng fields"
         )
-        if result_json:
-            data = json.loads(result_json)
-            lat = data.get('nominatim_lat')
-            lng = data.get('nominatim_lng')
-            if lat and lng:
-                return (float(lat), float(lng))
-        return None
-    except Exception as e:
-        log_error(f"Geocoding failed for {query_address}: {e}")
-        return None
+    return (float(lat), float(lng))
 
 
 def use_nominatim_geocoder(query_address, id=None, country_codes=None,
@@ -407,18 +432,20 @@ def use_nominatim_geocoder(query_address, id=None, country_codes=None,
             don't require it).
 
     Returns:
-        JSON string of geocoding result or None if failed
+        JSON string of the geocoding result, or ``None`` when Nominatim
+        returned no match for the address (a legitimate non-error outcome).
+
+    Raises:
+        ValueError: If ``query_address`` is empty or None.
+        GeocodingError: If geocoding failed due to a network, service, or
+            parse error after retries (i.e., the geocoder could not even
+            attempt to match). Wraps the underlying geopy exception via
+            ``__cause__``.
     """
     log_debug(f'Geocoding address: {query_address}')
     if not query_address:
-        message = (
-            'query_address cannot be None, Empty address provided for geocoding'
-            )
-        log_warning(message)
-        return None
-    else:
-        message = f'Geocoding {query_address}'
-        log_info(message)
+        raise ValueError('query_address must be a non-empty string')
+    log_info(f'Geocoding {query_address}')
     if not country_codes:
         country_codes = GEOCODER_CONFIG.get('country_codes')
     # Build geocoder — use custom server domain if provided
@@ -460,13 +487,23 @@ def use_nominatim_geocoder(query_address, id=None, country_codes=None,
             if attempt == max_retries - 1:
                 message = f'All geocoding attempts failed for: {query_address}'
                 log_error(message)
-                return None
+                raise GeocodingError(
+                    f'Nominatim geocoding failed for {query_address!r} '
+                    f'after {max_retries} attempts'
+                ) from e
             time.sleep(2 ** attempt)
         except Exception as e:
             message = f'Unexpected error during geocoding: {str(e)}'
             log_error(message)
-            return None
-    return None
+            raise GeocodingError(
+                f'Unexpected error geocoding {query_address!r}'
+            ) from e
+    # Defensive: the loop only exits via return (success / no match) or
+    # raise (retries exhausted). Reaching here implies max_retries < 1.
+    raise GeocodingError(
+        f'Nominatim geocoder loop exited without result for '
+        f'{query_address!r} (max_retries={max_retries})'
+    )
 
 
 class NominatimGeoClassifier:
@@ -845,7 +882,14 @@ class SpatiaLiteCache:
         country_codes: Optional[str] = None,
         server_url: Optional[str] = None,
     ) -> Optional[Dict]:
-        """Look up cache, falling back to Nominatim if not cached."""
+        """Look up cache, falling back to Nominatim if not cached.
+
+        Returns ``None`` when the cache misses AND Nominatim has no match
+        for the address. Raises :class:`GeocodingError` when Nominatim
+        fails (network/service/parse) — callers that want fail-open
+        behavior must catch it explicitly. Raises :class:`ValueError`
+        for an empty/None ``address``.
+        """
         cached = self.get_geocode(address)
         if cached is not None:
             return cached
@@ -856,11 +900,18 @@ class SpatiaLiteCache:
         if result_json is None:
             return None
 
-        data = json.loads(result_json)
+        try:
+            data = json.loads(result_json)
+        except json.JSONDecodeError as e:
+            raise GeocodingError(
+                f"Could not parse Nominatim response for {address!r}"
+            ) from e
         lat = data.get("nominatim_lat")
         lon = data.get("nominatim_lng")
         if lat is None or lon is None:
-            return None
+            raise GeocodingError(
+                f"Nominatim response for {address!r} missing lat/lng fields"
+            )
 
         self.put_geocode(
             address, float(lat), float(lon),

--- a/tests/test_nominatim_geocoder_errors.py
+++ b/tests/test_nominatim_geocoder_errors.py
@@ -1,0 +1,150 @@
+"""Tests for the typed exception path in geo.geocoding (#800).
+
+Mirrors the test pattern from ``test_census_geocoder_errors.py`` so the
+two geocoders document and enforce the same SU-1 contract:
+
+* "No match" is a return-value outcome (``None``), not an exception.
+* Network, service, and parse failures raise ``GeocodingError`` with the
+  underlying cause attached via ``__cause__``.
+* Empty input is a precondition violation and raises ``ValueError``.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+geopy = pytest.importorskip("geopy")
+from geopy.exc import GeocoderServiceError, GeocoderTimedOut
+
+from siege_utilities.geo.geocoding import (
+    GeocodingError,
+    get_coordinates,
+    use_nominatim_geocoder,
+)
+
+
+def _fake_geocoder_returning(result):
+    """Build a Nominatim-like mock whose ``geocode`` returns ``result``."""
+    fake = MagicMock()
+    fake.geocode.return_value = result
+    return fake
+
+
+def _fake_geocoder_raising(exc):
+    """Build a Nominatim-like mock whose ``geocode`` raises ``exc`` every call."""
+    fake = MagicMock()
+    fake.geocode.side_effect = exc
+    return fake
+
+
+class TestExceptionHierarchy:
+    def test_is_runtime_error(self):
+        assert issubclass(GeocodingError, RuntimeError)
+
+
+class TestUseNominatimGeocoder:
+    def test_empty_address_raises_value_error(self):
+        with pytest.raises(ValueError):
+            use_nominatim_geocoder("")
+
+    def test_none_address_raises_value_error(self):
+        with pytest.raises(ValueError):
+            use_nominatim_geocoder(None)
+
+    def test_no_match_returns_none(self):
+        """A legitimate 'no result found' keeps the None return contract."""
+        fake = _fake_geocoder_returning(None)
+        with patch(
+            "siege_utilities.geo.geocoding.Nominatim", return_value=fake,
+        ), patch("siege_utilities.geo.geocoding.time.sleep"):
+            result = use_nominatim_geocoder(
+                "garbage address", server_url="http://x",
+            )
+        assert result is None
+
+    def test_timeout_after_retries_raises(self):
+        fake = _fake_geocoder_raising(GeocoderTimedOut("timeout"))
+        with patch(
+            "siege_utilities.geo.geocoding.Nominatim", return_value=fake,
+        ), patch("siege_utilities.geo.geocoding.time.sleep"):
+            with pytest.raises(GeocodingError) as exc_info:
+                use_nominatim_geocoder(
+                    "1600 Pennsylvania Ave", max_retries=2,
+                    server_url="http://x",
+                )
+        assert isinstance(exc_info.value.__cause__, GeocoderTimedOut)
+        assert "1600 Pennsylvania Ave" in str(exc_info.value)
+
+    def test_service_error_after_retries_raises(self):
+        fake = _fake_geocoder_raising(GeocoderServiceError("503"))
+        with patch(
+            "siege_utilities.geo.geocoding.Nominatim", return_value=fake,
+        ), patch("siege_utilities.geo.geocoding.time.sleep"):
+            with pytest.raises(GeocodingError) as exc_info:
+                use_nominatim_geocoder(
+                    "addr", max_retries=1, server_url="http://x",
+                )
+        assert isinstance(exc_info.value.__cause__, GeocoderServiceError)
+
+    def test_unexpected_exception_raises(self):
+        fake = _fake_geocoder_raising(RuntimeError("kaboom"))
+        with patch(
+            "siege_utilities.geo.geocoding.Nominatim", return_value=fake,
+        ), patch("siege_utilities.geo.geocoding.time.sleep"):
+            with pytest.raises(GeocodingError) as exc_info:
+                use_nominatim_geocoder("addr", server_url="http://x")
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+    def test_match_returns_json(self):
+        match = MagicMock()
+        match.raw = {"display_name": "1600 Pennsylvania Ave"}
+        match.latitude = 38.8977
+        match.longitude = -77.0365
+        fake = _fake_geocoder_returning(match)
+        with patch(
+            "siege_utilities.geo.geocoding.Nominatim", return_value=fake,
+        ), patch("siege_utilities.geo.geocoding.time.sleep"):
+            result = use_nominatim_geocoder(
+                "1600 Pennsylvania Ave", server_url="http://x",
+            )
+        assert result is not None
+        data = json.loads(result)
+        assert data["nominatim_lat"] == 38.8977
+        assert data["nominatim_lng"] == -77.0365
+
+
+class TestGetCoordinates:
+    def test_timeout_propagates_geocoding_error(self):
+        """Previously this swallowed every exception and returned None."""
+        fake = _fake_geocoder_raising(GeocoderTimedOut("timeout"))
+        with patch(
+            "siege_utilities.geo.geocoding.Nominatim", return_value=fake,
+        ), patch("siege_utilities.geo.geocoding.time.sleep"):
+            with pytest.raises(GeocodingError):
+                get_coordinates(
+                    "addr", max_retries=1, server_url="http://x",
+                )
+
+    def test_no_match_returns_none(self):
+        fake = _fake_geocoder_returning(None)
+        with patch(
+            "siege_utilities.geo.geocoding.Nominatim", return_value=fake,
+        ), patch("siege_utilities.geo.geocoding.time.sleep"):
+            assert get_coordinates("garbage", server_url="http://x") is None
+
+    def test_match_returns_tuple(self):
+        match = MagicMock()
+        match.raw = {}
+        match.latitude = 12.34
+        match.longitude = 56.78
+        fake = _fake_geocoder_returning(match)
+        with patch(
+            "siege_utilities.geo.geocoding.Nominatim", return_value=fake,
+        ), patch("siege_utilities.geo.geocoding.time.sleep"):
+            assert get_coordinates("addr", server_url="http://x") == (12.34, 56.78)
+
+    def test_empty_address_raises_value_error(self):
+        with pytest.raises(ValueError):
+            get_coordinates("")


### PR DESCRIPTION
## Summary

`use_nominatim_geocoder()`, `get_coordinates()`, and `SpatiaLiteCache.get_geocode_or_fetch()` returned `None` on every failure path — network timeout, service error, parse error, and "no results found" were all indistinguishable. Direct SU-1 violation (errors as data).

Introduce `GeocodingError(RuntimeError)` mirroring the existing `CensusGeocodeError` pattern in `siege_utilities.geo.providers.census_geocoder`. Raise it on real failures; reserve `None` for the legitimate "no match" outcome. Empty `query_address` now raises `ValueError` as a precondition violation.

## Changes

- `siege_utilities/geo/geocoding.py`
  - New `GeocodingError(RuntimeError)`.
  - `use_nominatim_geocoder`: raises `ValueError` on empty input; raises `GeocodingError` (with `__cause__`) when `GeocoderTimedOut` / `GeocoderServiceError` exhausts retries; raises `GeocodingError` on unexpected exceptions; preserves `None` return for "no match" and the JSON-string return for success (Spark UDF contract unchanged on the success path).
  - `get_coordinates`: drops the bare `except Exception` swallow; lets `GeocodingError` propagate; raises `GeocodingError` on malformed JSON or missing `lat`/`lng` (also fixes truthy-check bug that would swallow equator/prime-meridian coordinates).
  - `SpatiaLiteCache.get_geocode_or_fetch`: same — propagates `GeocodingError`, returns `None` only on true no-match.
- `siege_utilities/geo/__init__.py`, `siege_utilities/__init__.py`: export `GeocodingError`.
- `tests/test_nominatim_geocoder_errors.py` (new): 12 tests covering exception hierarchy, no-match, empty input, retry-exhausted timeout, service error, unexpected error, happy path, and the `get_coordinates` propagation contract.

## Behavior change

Callers that previously caught failures via `if result is None: # address not found` will now see `GeocodingError` surface on network failures. That is the intended SU-1 fix — callers can no longer mistake "geocoder broke" for "address doesn't exist." Repo-wide grep confirmed:

- The only production callers are the three functions in this PR.
- The `ga_geographic_analysis.py:50` import is F401-baselined (unused).
- No notebook calls these functions; `notebooks/spatial/02_geocoding.ipynb` uses the Census geocoder.

## Epic

#776 (Library Usability and Adversarial Quality)

## Test plan

- [x] Unit tests pass (`tests/test_nominatim_geocoder_errors.py` — 12/12)
- [x] No regression in adjacent geocoder suites (`test_nominatim_batch`, `test_composite_geocoder`, `test_batch_geocoder` — 66/66)
- [ ] Review `Raises:` docstring additions for `use_nominatim_geocoder`, `get_coordinates`, and `get_geocode_or_fetch`

Self-Review: Junior/Lead walkthrough; verified scoped callers, JSON-string UDF contract, retry backoff, ValueError vs GeocodingError selection, sibling sites
Self-Review-Source: plans/800-self-review.md