### PR TITLE
fix(#836): raise CredentialNotFoundError on GA service account miss (SU-1)

### DIFF
--- a/siege_utilities/config/credential_manager.py
+++ b/siege_utilities/config/credential_manager.py
@@ -1071,44 +1071,30 @@ def store_ga_service_account_from_file(credentials_file: Union[str, Path],
         return False
 
 
-def get_ga_service_account_credentials() -> Optional[Dict[str, str]]:
+def get_ga_service_account_credentials() -> Dict[str, str]:
     """
     Get Google Analytics service account credentials.
 
     Returns:
-        Dict with service account data or None
+        Dict with keys ``client_email``, ``project_id``, ``private_key``,
+        ``private_key_id``, ``type`` (always ``"service_account"``).
 
-    Note:
-        TODO(#801-followup): same SU-1 shape as the original #801 bug --
-        aggregate returns None on total miss. Kept None-returning until
-        a dedicated ticket audits the GA SA callers.
+    Raises:
+        CredentialNotFoundError: when any required field cannot be
+            retrieved from any configured backend. The error's ``field``
+            attribute names which field was missing; ``attempts`` carries
+            per-backend diagnostics so callers can surface an actionable
+            message instead of a generic "service account not configured."
     """
     manager = CredentialManager()
-
-    # get_credential now raises CredentialNotFoundError on total miss
-    # (#801); this helper documents "Returns Dict or None" so we catch
-    # explicitly and preserve the None contract. We catch around all four
-    # lookups together: if any one field is absent, the SA is incomplete
-    # and there's nothing to return.
-    try:
-        client_email = manager.get_credential('google-analytics-sa', 'service', 'client_email')
-        project_id = manager.get_credential('google-analytics-sa', 'service', 'project_id')
-        private_key = manager.get_credential('google-analytics-sa', 'service', 'private_key')
-        private_key_id = manager.get_credential('google-analytics-sa', 'service', 'private_key_id')
-    except CredentialNotFoundError as exc:
-        log_warning(f"Incomplete Google service account in credential store: {exc}")
-        return None
-
-    if all([client_email, project_id, private_key, private_key_id]):
-        return {
-            'client_email': client_email,
-            'project_id': project_id,
-            'private_key': private_key,
-            'private_key_id': private_key_id,
-            'type': 'service_account'
-        }
-
-    return None
+    service = 'google-analytics-sa'
+    return {
+        'client_email': manager.get_credential(service, 'service', 'client_email'),
+        'project_id': manager.get_credential(service, 'service', 'project_id'),
+        'private_key': manager.get_credential(service, 'service', 'private_key'),
+        'private_key_id': manager.get_credential(service, 'service', 'private_key_id'),
+        'type': 'service_account',
+    }
 
 
 def get_google_service_account_from_1password(item_title: str = "Google Analytics Service Account - Multi-Client Reporter",

--- a/tests/test_credential_manager.py
+++ b/tests/test_credential_manager.py
@@ -1510,36 +1510,51 @@ class TestStoreGAServiceAccountFromFile:
 # =============================================================================
 
 class TestGetGAServiceAccountCredentials:
-    """Tests for get_ga_service_account_credentials."""
+    """Tests for get_ga_service_account_credentials.
 
-    def test_returns_none_when_no_email(self, mock_op_available):
-        mock_op_available.return_value = Mock(returncode=1, stdout='', stderr='not found')
+    These patch ``CredentialManager.get_credential`` directly rather than
+    mocking the ``op`` subprocess. The previous subprocess-level mocks
+    only worked when 1Password happened to be the active backend in the
+    test env -- a fragility the old ``None or isinstance(result, dict)``
+    assertion was a tell for. Patching at the contract layer makes the
+    assertions deterministic regardless of which backends are configured.
+    """
+
+    @patch('siege_utilities.config.credential_manager.CredentialManager.get_credential')
+    def test_raises_when_first_field_missing(self, mock_get):
+        mock_get.side_effect = CredentialNotFoundError(
+            'google-analytics-sa', 'client_email', [('1password', 'no credential found')]
+        )
+        with pytest.raises(CredentialNotFoundError) as excinfo:
+            get_ga_service_account_credentials()
+        assert excinfo.value.field == 'client_email'
+        assert excinfo.value.service == 'google-analytics-sa'
+
+    @patch('siege_utilities.config.credential_manager.CredentialManager.get_credential')
+    def test_raises_when_partial_field_missing(self, mock_get):
+        def side_effect(service, username, field, *args, **kwargs):
+            if field == 'private_key':
+                raise CredentialNotFoundError(
+                    service, field, [('1password', 'no credential found')]
+                )
+            return f'value-for-{field}'
+
+        mock_get.side_effect = side_effect
+        with pytest.raises(CredentialNotFoundError) as excinfo:
+            get_ga_service_account_credentials()
+        assert excinfo.value.field == 'private_key'
+
+    @patch('siege_utilities.config.credential_manager.CredentialManager.get_credential')
+    def test_returns_dict_when_all_fields_found(self, mock_get):
+        mock_get.side_effect = lambda service, username, field, *a, **kw: f'value-for-{field}'
         result = get_ga_service_account_credentials()
-        assert result is None
-
-    def test_returns_dict_when_all_fields_found(self, mock_op_available):
-        mock_op_available.return_value = Mock(returncode=0, stdout='found_value\n', stderr='')
-        result = get_ga_service_account_credentials()
-        if result is not None:
-            assert 'type' in result
-            assert result['type'] == 'service_account'
-
-    def test_returns_none_when_partial_fields(self, mock_op_available):
-        """If some fields are found but not all, returns None."""
-        call_count = [0]
-
-        def side_effect(cmd, **kwargs):
-            call_count[0] += 1
-            # First call finds client_email, subsequent calls fail
-            if call_count[0] <= 5:  # enough for the initial get_credential call
-                return Mock(returncode=0, stdout='email@test.com\n', stderr='')
-            return Mock(returncode=1, stdout='', stderr='not found')
-
-        mock_op_available.side_effect = side_effect
-        # This test is complex because of the multi-backend fallthrough;
-        # just verify it doesn't crash
-        result = get_ga_service_account_credentials()
-        assert result is None or isinstance(result, dict)
+        assert result == {
+            'client_email': 'value-for-client_email',
+            'project_id': 'value-for-project_id',
+            'private_key': 'value-for-private_key',
+            'private_key_id': 'value-for-private_key_id',
+            'type': 'service_account',
+        }
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Closes #836.

Removes the SU-1 `try/except CredentialNotFoundError → return None` wrapper from `get_ga_service_account_credentials`. The wrapper collapsed "no SA configured" and "specific field missing" into one signal, so callers couldn't tell them apart — exactly the bug class #836 targets and the same shape as #800 / #801.

After this change the function either returns the dict or propagates `CredentialNotFoundError` from `get_credential`. The exception already carries `field` (which field was missing) and `attempts` (per-backend diagnostics), so callers can produce actionable error messages.

Tests rewritten to patch `CredentialManager.get_credential` directly rather than mocking the `op` subprocess. The previous subprocess-layer mocks were fragile across backend configurations (Tiger 4 in the pre-mortem) and the old `result is None or isinstance(result, dict)` assertion was a tell that the original author wasn't confident.

## Pipeline artifacts (all on #836)

- Design note: https://github.com/siege-analytics/siege_utilities/issues/836#issuecomment-4570634999
- Investigation Fact Sheet: https://github.com/siege-analytics/siege_utilities/issues/836#issuecomment-4570635567
- **Fact Sheet correction** (caught I'd been reading stale branch, not develop): https://github.com/siege-analytics/siege_utilities/issues/836#issuecomment-4570676137
- Pre-mortem: https://github.com/siege-analytics/siege_utilities/issues/836#issuecomment-4570690391
- Self-review: https://github.com/siege-analytics/siege_utilities/issues/836#issuecomment-4570708967

## Breaking change

`get_ga_service_account_credentials` return annotation changes from `Optional[Dict[str, str]]` to `Dict[str, str]`. Callers that did `if result is None:` must now catch `CredentialNotFoundError`. **Zero internal callers** — consistent with the #800 / #801 contract changes already on develop.

## Follow-ups

Sibling SU-1 violations remain in the same file (deferred per RESOLVER rule 10 — each ticket gets its own discipline):
- `get_ga_credentials` at `credential_manager.py:945`
- `get_google_service_account_from_1password` at `credential_manager.py:1114`

Also: no notebook coverage for this function (inherited gap, not added by this PR).

## Test plan
- [x] `pytest tests/test_credential_manager.py::TestGetGAServiceAccountCredentials` — 3 passed
- [x] `pytest tests/test_credential_manager.py` — 3 passed (new), 135 passed (existing), 3 pre-existing unrelated failures (`Flowable` reportlab import in `google_analytics_report_example.py`, not introduced by this PR)
- [x] No new `return None` paths in the function (`grep "return None"` on the modified function range → 0)