### PR TITLE
fix(#831): point statistics notebook at real [survey] extra

### DIFF
--- a/notebooks/engines/04_statistics_primitives.ipynb
+++ b/notebooks/engines/04_statistics_primitives.ipynb
@@ -3,23 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "# ElectInfo: MOE-aware aggregation + reference crosswalks + cross-tab primitive\n",
-    "\n",
-    "## What this shows\n",
-    "Three small statistical primitives ElectInfo relies on when working with ACS data and survey respondents: Margin-of-Error (MOE) propagation for reliable ACS aggregates, NAICS / SOC crosswalks for occupation / industry classification, and the `contingency_table` + `chi_square_test` primitive the survey pipeline delegates to.\n",
-    "\n",
-    "## Why it matters\n",
-    "Higher-level pipelines (the survey `WaveSet`, Census-joined reports) all sit on these primitives. Using them directly is the right tool when you're not inside a full survey workflow — e.g. \"is the Hispanic share in these tracts reliable enough to report?\" or \"classify ElectInfo's donor occupations into NAICS sectors.\"\n",
-    "\n",
-    "## Prereqs\n",
-    "- `pip install 'siege-utilities[stats]'`\n",
-    "- No credentials.\n",
-    "\n",
-    "## Next\n",
-    "- `reports/03_polling_survey_analysis.ipynb` wraps the cross-tab primitive inside the full survey pipeline.\n",
-    "- `spatial/01_boundaries.ipynb` is where you'd get ACS data in the first place.\n"
-   ]
+   "source": "# ElectInfo: MOE-aware aggregation + reference crosswalks + cross-tab primitive\n\n## What this shows\nThree small statistical primitives ElectInfo relies on when working with ACS data and survey respondents: Margin-of-Error (MOE) propagation for reliable ACS aggregates, NAICS / SOC crosswalks for occupation / industry classification, and the `contingency_table` + `chi_square_test` primitive the survey pipeline delegates to.\n\n## Why it matters\nHigher-level pipelines (the survey `WaveSet`, Census-joined reports) all sit on these primitives. Using them directly is the right tool when you're not inside a full survey workflow — e.g. \"is the Hispanic share in these tracts reliable enough to report?\" or \"classify ElectInfo's donor occupations into NAICS sectors.\"\n\n## Prereqs\n- `pip install 'siege-utilities[survey]'`\n- No credentials.\n\n## Next\n- `reports/03_polling_survey_analysis.ipynb` wraps the cross-tab primitive inside the full survey pipeline.\n- `spatial/01_boundaries.ipynb` is where you'd get ACS data in the first place.\n"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Closes #831 (epic #776).

## Problem
`notebooks/engines/04_statistics_primitives.ipynb` prereqs cell says `pip install 'siege-utilities[stats]'` but no `[stats]` extra exists in `pyproject.toml`. Users following the notebook get a silent no-op install that fails at import time when `scipy` is needed.

## Fix
Changed `[stats]` to `[survey]` in the notebook's markdown prereqs cell. The `[survey]` extra (pyproject.toml line 216) provides `scipy>=1.11.0` and `pandas>=2.0.0`, which are the two runtime dependencies the notebook needs:
- `cross_tabulation.py:192` lazy-imports `scipy.stats.chi2_contingency`
- `cross_tabulation.py:28` imports `pandas`

## Why `[survey]`
- The notebook itself describes these as "primitives the survey pipeline delegates to"
- `[survey]` is the minimal extra providing both scipy and pandas
- `[data]` and `[reporting]` also include scipy but pull heavy unneeded deps

## Precedent
Same shape as PR #830 (fixing #799), which changed `[engines]` to `[performance]` and `[config]` to `[config-extras]` in other notebooks.