### PR TITLE
fix(#832): add python-pptx to reporting extra, remove phantom [pptx]

### DIFF
--- a/notebooks/reports/02_slides_pptx_and_google.ipynb
+++ b/notebooks/reports/02_slides_pptx_and_google.ipynb
@@ -4,22 +4,7 @@
    "cell_type": "markdown",
    "id": "t",
    "metadata": {},
-   "source": [
-    "# Masai Interactive: Q1 deck from Arguments — PowerPoint + Google Slides\n",
-    "\n",
-    "## What this shows\n",
-    "Take the same `Argument` objects that drive PDFs in `reports/01_charts_and_pdf.ipynb` and render a 5-slide branded deck under Masai Interactive's colors. PowerPoint output runs inline; Google Slides output is shown as call shape (requires a Google service account).\n",
-    "\n",
-    "## Why it matters\n",
-    "Masai Interactive's client deliverables are decks, not PDFs. The `Argument` model means the same analysis flows into whichever surface a client wants — PDF, PPTX, or Google Slides — without rewriting the analysis layer. One upstream, many downstream.\n",
-    "\n",
-    "## Prereqs\n",
-    "- `pip install 'siege-utilities[reporting,pptx]'` (python-pptx + matplotlib).\n",
-    "- Optional: a Google service-account JSON for the live Slides path.\n",
-    "\n",
-    "## Next\n",
-    "- `analytics/02_ga_end_to_end.ipynb` — Masai's weekly GA digest, one-page PDF.\n"
-   ]
+   "source": "# Masai Interactive: Q1 deck from Arguments — PowerPoint + Google Slides\n\n## What this shows\nTake the same `Argument` objects that drive PDFs in `reports/01_charts_and_pdf.ipynb` and render a 5-slide branded deck under Masai Interactive's colors. PowerPoint output runs inline; Google Slides output is shown as call shape (requires a Google service account).\n\n## Why it matters\nMasai Interactive's client deliverables are decks, not PDFs. The `Argument` model means the same analysis flows into whichever surface a client wants — PDF, PPTX, or Google Slides — without rewriting the analysis layer. One upstream, many downstream.\n\n## Prereqs\n- `pip install 'siege-utilities[reporting]'` (python-pptx + matplotlib).\n- Optional: a Google service-account JSON for the live Slides path.\n\n## Next\n- `analytics/02_ga_end_to_end.ipynb` — Masai's weekly GA digest, one-page PDF.\n"
   },
   {
    "cell_type": "markdown",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ reporting = [
     "pypdf2>=3.0.1",
     "pillow>=10.0.0",
     "fonttools>=4.40.0",
+    "python-pptx>=1.0.0",
     "geopandas>=0.13.2",
     "pandas>=2.0.0",
     "scipy>=1.11.0",
@@ -259,6 +260,7 @@ all = [
     "pypdf2>=3.0.1",
     "pillow>=10.0.0",
     "fonttools>=4.40.0",
+    "python-pptx>=1.0.0",
     # analytics
     "google-auth>=2.40.3",
     "google-auth-oauthlib>=1.2.2",


### PR DESCRIPTION
## Summary

- Add `python-pptx>=1.0.0` to the `reporting` and `all` extras in `pyproject.toml`
- Update `notebooks/reports/02_slides_pptx_and_google.ipynb` install cell from `[reporting,pptx]` to `[reporting]`
- Follows the same pattern as #799/#830 (phantom extras in notebook install cells)

## Context

The notebook told users to `pip install 'siege-utilities[reporting,pptx]'` but no `[pptx]` extra exists, and `python-pptx` was not declared in any extra. Users following the notebook instructions would not get `python-pptx` installed, causing `PowerPointGenerator` to raise `ImportError` at init.

## Test plan

- [ ] `grep "python-pptx" pyproject.toml` returns 2 matches (reporting extra, all extra)
- [ ] `grep "reporting,pptx" notebooks/reports/02_slides_pptx_and_google.ipynb` returns 0 matches
- [ ] `pip install -e '.[reporting]'` installs python-pptx

Refs: #832