### PR TITLE
fix(#835): raise CredentialNotFoundError on GA OAuth credential miss (SU-1)

### DIFF
--- a/siege_utilities/config/credential_manager.py
+++ b/siege_utilities/config/credential_manager.py
@@ -671,47 +671,37 @@ class CredentialManager:
             log_error(f"Error storing Google Analytics credentials: {e}")
             return False
     
-    def get_google_analytics_credentials(self, item_title: str = "Google Analytics API") -> Optional[Tuple[str, str]]:
+    def get_google_analytics_credentials(self, item_title: str = "Google Analytics API") -> Tuple[str, str]:
         """
         Get Google Analytics credentials for GoogleAnalyticsConnector.
-        
+
         Args:
             item_title: Title of the credential item
-            
+
         Returns:
-            Tuple of (client_id, client_secret) or None if not found
+            Tuple of (client_id, client_secret).
+
+        Raises:
+            CredentialNotFoundError: when neither 1Password item lookup
+                nor the general credential backends yield both
+                ``client_id`` and ``client_secret``.  The error's
+                ``field`` attribute names which field was missing;
+                ``attempts`` carries per-backend diagnostics so callers
+                can surface an actionable message.
         """
-        # TODO(#801-followup): this aggregate has the same shape as the
-        # bug #801 fixed in get_credential -- it falls through two
-        # sources and returns None on total miss instead of raising. Keep
-        # the current None contract here until a dedicated ticket audits
-        # callers (GoogleAnalyticsConnector ergonomics).
-        try:
-            # Try to get from 1Password using item title
-            client_id = self._get_from_1password(item_title, 'client_id')
-            client_secret = self._get_from_1password(item_title, 'client_secret')
+        # Try to get from 1Password using item title
+        client_id = self._get_from_1password(item_title, 'client_id')
+        client_secret = self._get_from_1password(item_title, 'client_secret')
 
-            if client_id and client_secret:
-                return client_id, client_secret
+        if client_id and client_secret:
+            return client_id, client_secret
 
-            # Fallback to general credential retrieval. get_credential
-            # now raises CredentialNotFoundError on total miss; catch as
-            # part of the broad except below so the None contract holds.
-            client_id = self.get_credential('google-analytics', 'api', 'client_id')
-            client_secret = self.get_credential('google-analytics', 'api', 'client_secret')
+        # Fallback to general credential retrieval.  get_credential
+        # raises CredentialNotFoundError on total miss (#801).
+        client_id = self.get_credential('google-analytics', 'api', 'client_id')
+        client_secret = self.get_credential('google-analytics', 'api', 'client_secret')
 
-            if client_id and client_secret:
-                return client_id, client_secret
-
-            log_error("Could not retrieve Google Analytics credentials")
-            return None
-
-        except CredentialNotFoundError as e:
-            log_warning(f"Google Analytics credentials not found in any backend: {e}")
-            return None
-        except Exception as e:
-            log_error(f"Error retrieving Google Analytics credentials: {e}")
-            return None
+        return client_id, client_secret
     
     def list_stored_credentials(self, service_filter: Optional[str] = None,
                                 vault: Optional[str] = None,
@@ -964,12 +954,18 @@ def store_ga_credentials_from_file(credentials_file: Union[str, Path],
         return False
 
 
-def get_ga_credentials() -> Optional[Tuple[str, str]]:
+def get_ga_credentials() -> Tuple[str, str]:
     """
     Get Google Analytics credentials for connector.
-    
+
     Returns:
-        Tuple of (client_id, client_secret) or None
+        Tuple of (client_id, client_secret).
+
+    Raises:
+        CredentialNotFoundError: when no configured backend yields both
+            ``client_id`` and ``client_secret``.  See
+            ``CredentialManager.get_google_analytics_credentials`` for
+            details.
     """
     manager = _get_default_manager()
     return manager.get_google_analytics_credentials()

--- a/tests/test_credential_manager.py
+++ b/tests/test_credential_manager.py
@@ -880,30 +880,59 @@ class TestStoreGoogleAnalyticsCredentials:
 # =============================================================================
 
 class TestGetGoogleAnalyticsCredentials:
-    """Tests for get_google_analytics_credentials."""
+    """Tests for get_google_analytics_credentials.
 
-    def test_returns_tuple_from_1password(self, mock_op_available):
+    Mocks at CredentialManager.get_credential level (contract boundary)
+    rather than subprocess.  Mirrors the #836 test-relayering precedent.
+    """
+
+    def test_returns_tuple_when_get_credential_succeeds(self, mock_op_available):
         manager = CredentialManager()
-        mock_op_available.return_value = Mock(returncode=0, stdout='found_value\n', stderr='')
+        # 1Password item lookup returns nothing; fall through to get_credential
+        mock_op_available.return_value = Mock(returncode=1, stdout='', stderr='')
+
+        with patch.object(
+            CredentialManager, 'get_credential', side_effect=['cid', 'csec']
+        ):
+            result = manager.get_google_analytics_credentials()
+
+        assert result == ('cid', 'csec')
+
+    def test_returns_tuple_from_1password_item(self, mock_op_available):
+        """When _get_from_1password yields both fields, get_credential is not called."""
+        manager = CredentialManager()
+        mock_op_available.return_value = Mock(returncode=0, stdout='op_value\n', stderr='')
 
         result = manager.get_google_analytics_credentials()
-        assert result is not None
         assert isinstance(result, tuple)
         assert len(result) == 2
 
-    def test_returns_none_when_not_found(self, mock_op_available):
+    def test_raises_credential_not_found_on_total_miss(self, mock_op_available):
         manager = CredentialManager()
-        mock_op_available.return_value = Mock(returncode=1, stdout='', stderr='not found')
+        # 1Password item lookup returns nothing
+        mock_op_available.return_value = Mock(returncode=1, stdout='', stderr='')
 
-        result = manager.get_google_analytics_credentials()
-        assert result is None
+        with patch.object(
+            CredentialManager, 'get_credential',
+            side_effect=CredentialNotFoundError('google-analytics', 'client_id', [('env', 'not set')]),
+        ):
+            with pytest.raises(CredentialNotFoundError) as exc_info:
+                manager.get_google_analytics_credentials()
 
-    def test_returns_none_on_exception(self, mock_op_available):
+            assert exc_info.value.service == 'google-analytics'
+            assert exc_info.value.field == 'client_id'
+
+    def test_propagates_transport_errors(self, mock_op_available):
+        """Non-CredentialNotFoundError exceptions propagate to the caller."""
         manager = CredentialManager()
-        mock_op_available.side_effect = Exception("unexpected error")
+        mock_op_available.return_value = Mock(returncode=1, stdout='', stderr='')
 
-        result = manager.get_google_analytics_credentials()
-        assert result is None
+        with patch.object(
+            CredentialManager, 'get_credential',
+            side_effect=RuntimeError("1Password CLI timed out"),
+        ):
+            with pytest.raises(RuntimeError, match="timed out"):
+                manager.get_google_analytics_credentials()
 
 
 # =============================================================================
@@ -1072,11 +1101,21 @@ class TestConvenienceFunctions:
         assert isinstance(result, dict)
         assert 'env' in result
 
-    def test_get_ga_credentials_convenience(self, mock_op_available):
+    def test_get_ga_credentials_convenience_success(self, mock_op_available):
         mock_op_available.return_value = Mock(returncode=0, stdout='value\n', stderr='')
         result = get_ga_credentials()
-        # Either tuple or None
-        assert result is None or isinstance(result, tuple)
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+
+    def test_get_ga_credentials_convenience_raises(self, mock_op_available):
+        """Module-level get_ga_credentials propagates CredentialNotFoundError."""
+        mock_op_available.return_value = Mock(returncode=1, stdout='', stderr='')
+        with patch.object(
+            CredentialManager, 'get_credential',
+            side_effect=CredentialNotFoundError('google-analytics', 'client_id', []),
+        ):
+            with pytest.raises(CredentialNotFoundError):
+                get_ga_credentials()
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Removes the try/except wrapper in `get_google_analytics_credentials` that swallowed `CredentialNotFoundError` and returned `None` on total miss (SU-1 violation)
- Lets `CredentialNotFoundError` propagate from `get_credential` with field-level diagnostics (`field`, `attempts` attributes)
- Updates module-level `get_ga_credentials` wrapper with matching contract change
- Rewrites tests to mock at `CredentialManager.get_credential` contract boundary instead of subprocess layer (mirrors #836 precedent)

BREAKING: Return annotation changes from `Optional[Tuple[str, str]]` to `Tuple[str, str]`. Zero internal callers; consistent with #800/#801/#836 SU-1 contract changes on develop.

## Test plan

- [x] `test_returns_tuple_when_get_credential_succeeds` — fallback path returns tuple
- [x] `test_returns_tuple_from_1password_item` — 1Password happy path
- [x] `test_raises_credential_not_found_on_total_miss` — SU-1 fix verified
- [x] `test_propagates_transport_errors` — non-credential errors propagate
- [x] `test_get_ga_credentials_convenience_success` — module-level wrapper happy path
- [x] `test_get_ga_credentials_convenience_raises` — module-level wrapper propagates error
- [x] 137 tests pass (1 pre-existing yaml import failure unrelated)

Refs: #835