### PR TITLE
fix(#810): consolidate get_download_directory, deprecate verbose aliases

### DIFF
--- a/siege_utilities/analytics/datadotworld_connector.py
+++ b/siege_utilities/analytics/datadotworld_connector.py
@@ -236,7 +236,7 @@ class DataDotWorldConnector:
         try:
             if not output_path:
                 # Use default download directory
-                from siege_utilities.files import get_download_directory
+                from siege_utilities.config.user_config import get_download_directory
                 output_path = get_download_directory() / "datadotworld" / dataset_id.replace('/', '_') / file_name
             
             # Ensure output directory exists

--- a/siege_utilities/files/__init__.py
+++ b/siege_utilities/files/__init__.py
@@ -10,6 +10,7 @@ This module provides comprehensive file operations including:
 All functions are available at the top level for mutual availability across modules.
 """
 
+import warnings
 from pathlib import Path
 
 # Import all functions from submodules for mutual availability
@@ -71,31 +72,33 @@ from .hashing import (
 
 # Convenience function for getting download directory
 def get_download_directory() -> Path:
-    """
-    Get the default download directory for siege_utilities.
-    Uses the enhanced config system with profile-based directory resolution.
-    
+    """Get the default download directory for siege_utilities.
+
+    .. deprecated:: 3.19.0
+        Use :func:`siege_utilities.config.user_config.get_download_directory`
+        instead, or ``from siege_utilities import get_download_directory``.
+        Will be removed in v4.0.0.
+
     Returns:
         Path to the download directory
     """
-    from pathlib import Path
     import os
-    
-    # Try to get from environment variable first
-    download_dir = os.environ.get('SIEGE_DOWNLOAD_DIR', None)
+
+    warnings.warn(
+        "siege_utilities.files.get_download_directory is deprecated and will be "
+        "removed in v4.0.0. Use siege_utilities.config.user_config.get_download_directory "
+        "or import get_download_directory from siege_utilities directly.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    # Preserve SIEGE_DOWNLOAD_DIR env-var override during the deprecation window
+    download_dir = os.environ.get('SIEGE_DOWNLOAD_DIR')
     if download_dir:
         return Path(download_dir)
-    
-    # Use enhanced config system for profile-based directory resolution
-    try:
-        from ..config.enhanced_config import get_download_directory as enhanced_get_download_directory
-        username = os.environ.get('SIEGE_USERNAME', os.environ.get('USER', 'default'))
-        return enhanced_get_download_directory(username)
-    except (ImportError, TypeError):
-        # Fallback to default if enhanced config not available
-        downloads_dir = Path.home() / "Downloads" / "siege_utilities"
-        ensure_path_exists(downloads_dir)
-        return downloads_dir
+
+    from ..config.user_config import get_download_directory as _canonical
+    return _canonical()
 
 # Export all functions for mutual availability
 __all__ = [

--- a/siege_utilities/files/hashing.py
+++ b/siege_utilities/files/hashing.py
@@ -58,8 +58,11 @@ def _update_from_file(hash_obj, fp) -> None:
 
 
 def generate_sha256_hash_for_file(file_path) ->Optional[str]:
-    """
-    Generate SHA256 hash for a file - chunked reading for large files
+    """Generate SHA256 hash for a file - chunked reading for large files.
+
+    .. deprecated:: 3.19.0
+        Use :func:`calculate_file_hash` or :func:`get_file_hash` instead.
+        Will be removed in v4.0.0.
 
     SECURITY: This function validates paths to prevent path traversal attacks
     and access to sensitive system files.
@@ -78,11 +81,14 @@ def generate_sha256_hash_for_file(file_path) ->Optional[str]:
         >>>
         >>> # This will raise PathSecurityError
         >>> generate_sha256_hash_for_file("/etc/shadow")  # Sensitive file blocked
-
-    Security Changes:
-        - Now validates paths to block path traversal
-        - Blocks access to sensitive system files
     """
+    import warnings
+    warnings.warn(
+        "generate_sha256_hash_for_file is deprecated and will be removed in v4.0.0. "
+        "Use calculate_file_hash or get_file_hash instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     try:
         path_obj = _validated_path(file_path, must_exist=True)
         if not path_obj.exists() or not path_obj.is_file():

--- a/siege_utilities/files/operations.py
+++ b/siege_utilities/files/operations.py
@@ -597,11 +597,32 @@ def run_command(command: Union[str, List[str]],
 
 # Backward compatibility aliases
 rmtree = remove_tree
-check_if_file_exists_at_path = file_exists
+
+
+def check_if_file_exists_at_path(path: FilePath) -> bool:
+    """Check if a file exists at the specified path.
+
+    .. deprecated:: 3.19.0
+        Use :func:`file_exists` instead. Will be removed in v4.0.0.
+    """
+    import warnings
+    warnings.warn(
+        "check_if_file_exists_at_path is deprecated and will be removed in v4.0.0. "
+        "Use file_exists instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return file_exists(path)
+
 
 def delete_existing_file_and_replace_it_with_an_empty_file(file_path: FilePath, create_parents: bool = True) -> bool:
-    """
-    Backward compatibility function that deletes existing file and replaces it with empty file.
+    """Backward compatibility function that deletes existing file and replaces it with empty file.
+
+    .. deprecated:: 3.19.0
+        Use :func:`touch_file` for creating empty files. Note that ``touch_file``
+        does not delete the existing file first; if you need delete-then-create
+        semantics, call ``Path.unlink()`` before ``touch_file()``.
+        Will be removed in v4.0.0.
 
     SECURITY: Validates paths to prevent path traversal attacks.
 
@@ -615,6 +636,14 @@ def delete_existing_file_and_replace_it_with_an_empty_file(file_path: FilePath, 
     Raises:
         PathSecurityError: If path fails security validation
     """
+    import warnings
+    warnings.warn(
+        "delete_existing_file_and_replace_it_with_an_empty_file is deprecated and "
+        "will be removed in v4.0.0. Use touch_file instead (note: touch_file does "
+        "not delete the existing file first).",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     try:
         # Validate path
         try:


### PR DESCRIPTION
## Summary
- Consolidate two conflicting `get_download_directory()` implementations: `config.user_config` is now canonical, `files/__init__.py` becomes a deprecation wrapper
- Add `DeprecationWarning` (v4.0.0 removal) to three verbose legacy aliases: `check_if_file_exists_at_path`, `delete_existing_file_and_replace_it_with_an_empty_file`, `generate_sha256_hash_for_file`
- Update `datadotworld_connector.py` to import from the canonical path

## Design decisions
- The `files/__init__.py` wrapper preserves the `SIEGE_DOWNLOAD_DIR` env-var override during the deprecation window
- The deprecation warning for `delete_existing_file_and_replace_it_with_an_empty_file` explicitly notes the behavioral difference with `touch_file` (touch_file does not delete first)
- The `config/enhanced_config.py` third variant is out of scope (different interface — takes `username` param)

## Test plan
- [x] 244 existing tests pass (1 pre-existing failure in `test_version_is_semver` unrelated to this PR)
- [x] Deprecation warnings verified for all 4 deprecated functions
- [x] `check_if_file_exists_at_path` warning verified via manual invocation
- [x] Top-level import path (`from siege_utilities import get_download_directory`) unchanged (lazy registry points to config version)

Refs: #810