### PR TITLE
fix(#812): export create_ga_connector_with_service_account from analytics/

### DIFF
--- a/siege_utilities/analytics/__init__.py
+++ b/siege_utilities/analytics/__init__.py
@@ -20,6 +20,7 @@ def _register(names, module):
 _register([
     'GoogleAnalyticsConnector', 'create_ga_account_profile', 'save_ga_account_profile',
     'load_ga_account_profile', 'list_ga_accounts_for_client', 'batch_retrieve_ga_data',
+    'create_ga_connector_with_service_account',
 ], '.google_analytics')
 
 _register([


### PR DESCRIPTION
## Summary
- Add `create_ga_connector_with_service_account` to the `_register` call for `.google_analytics` in `analytics/__init__.py`
- The function existed at `google_analytics.py:666` but was not registered, causing `AttributeError` on import
- Unblocks `notebooks/analytics/01_connectors.ipynb` and `02_ga_end_to_end.ipynb`

## Test plan
- [x] Verified `from siege_utilities.analytics import create_ga_connector_with_service_account` resolves to `<class 'function'>`
- [x] Verified no sibling regressions (deprecated `create_ga_connector_from_1password` intentionally omitted; `create_ga_connector_with_oauth2` is separate scope)

Closes #812