### PR TITLE
fix(#820): warn when Census API key is not configured

### DIFF
--- a/siege_utilities/geo/census/api.py
+++ b/siege_utilities/geo/census/api.py
@@ -54,6 +54,14 @@ class CensusAPI:
         cache_ttl: int = CENSUS_API_CACHE_TIMEOUT,
     ):
         self.api_key = self._resolve_api_key(api_key)
+        if self.api_key is None:
+            log.warning(
+                "No Census API key configured. The Census Bureau API will "
+                "still work but enforces much lower rate limits "
+                "(500 requests/day vs 50,000 with a key). "
+                "Set the CENSUS_API_KEY environment variable or configure "
+                "a 'census' API key in your siege_utilities user profile."
+            )
         self.timeout = timeout or get_service_timeout('census_api') or CENSUS_API_DEFAULT_TIMEOUT
         self.base_url = CENSUS_API_BASE_URL
         self.cache_backend = cache_backend

--- a/tests/test_census_api_key_warning.py
+++ b/tests/test_census_api_key_warning.py
@@ -1,0 +1,47 @@
+"""Tests for Census API key missing warning (#820)."""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from siege_utilities.geo.census.api import CensusAPI
+
+
+@pytest.fixture
+def _no_census_key(monkeypatch, tmp_path):
+    """Ensure no Census API key is available from any source."""
+    monkeypatch.delenv("CENSUS_API_KEY", raising=False)
+    return tmp_path
+
+
+class TestCensusAPIKeyWarning:
+    """Verify that CensusAPI warns when no API key is configured."""
+
+    def test_warning_logged_when_api_key_missing(self, _no_census_key, caplog):
+        """CensusAPI.__init__ logs a warning when _resolve_api_key returns None."""
+        cache_dir = _no_census_key
+        with patch.object(CensusAPI, "_resolve_api_key", return_value=None):
+            with caplog.at_level(logging.WARNING, logger="siege_utilities.geo.census.api"):
+                CensusAPI(cache_dir=cache_dir)
+
+        warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("No Census API key configured" in msg for msg in warning_messages), (
+            f"Expected warning about missing Census API key, got: {warning_messages}"
+        )
+        # Verify the warning contains actionable remediation info
+        full_warning = next(m for m in warning_messages if "No Census API key configured" in m)
+        assert "CENSUS_API_KEY" in full_warning
+        assert "rate limit" in full_warning.lower()
+
+    def test_no_warning_when_api_key_present(self, _no_census_key, caplog):
+        """CensusAPI.__init__ does NOT warn when an API key is provided."""
+        cache_dir = _no_census_key
+        with patch.object(CensusAPI, "_resolve_api_key", return_value="test-key-123"):
+            with caplog.at_level(logging.WARNING, logger="siege_utilities.geo.census.api"):
+                CensusAPI(cache_dir=cache_dir)
+
+        warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert not any("No Census API key configured" in msg for msg in warning_messages), (
+            f"Warning should not appear when API key is present, got: {warning_messages}"
+        )


### PR DESCRIPTION
## Summary

- Adds a `log.warning()` in `CensusAPI.__init__()` when `_resolve_api_key()` returns None, explaining the rate-limit consequence (500 requests/day without a key vs 50,000 with) and pointing users to the `CENSUS_API_KEY` env var or profile config.
- Adds two tests verifying the warning fires when the key is absent and does not fire when present.

Closes #820

## Test plan

- [x] `test_warning_logged_when_api_key_missing` -- verifies warning is logged with actionable text
- [x] `test_no_warning_when_api_key_present` -- verifies no warning when key is provided
- [x] Both tests pass locally via `pytest tests/test_census_api_key_warning.py -v`