### PR TITLE
fix(#811): unify normalize_state_identifier namespace collision (SU-1)

### DIFF
--- a/siege_utilities/__init__.py
+++ b/siege_utilities/__init__.py
@@ -227,11 +227,11 @@ _register_lazy([
     'normalize_fips_code',
 ], '.geo.spatial_data', deps=['geopandas'])
 
-# normalize_state_identifier is an alias for normalize_state_identifier_standalone
+# normalize_state_identifier delegates to the canonical config version;
+# no geopandas dependency needed for pure FIPS lookup.
 _register_lazy(
     ['normalize_state_identifier'],
-    '.geo.spatial_data', deps=['geopandas'],
-    renames={'normalize_state_identifier': 'normalize_state_identifier_standalone'},
+    '.config.census_registry',
 )
 
 # ── Databricks helpers (requires databricks-sdk, pyspark) ────────────
@@ -502,7 +502,7 @@ def get_package_info() -> Dict[str, Any]:
         'get_state_by_abbreviation': 'geo', 'get_state_by_name': 'geo',
         'validate_state_fips': 'geo', 'get_state_name': 'geo',
         'get_state_abbreviation': 'geo', 'download_dataset': 'geo',
-        'get_unified_fips_data': 'geo', 'normalize_state_identifier': 'geo',
+        'get_unified_fips_data': 'geo', 'normalize_state_identifier': 'config',
         'generate_docstring_template': 'hygiene',
         'analyze_function_signature': 'hygiene',
         'generate_architecture_diagram': 'development',

--- a/siege_utilities/geo/spatial_data.py
+++ b/siege_utilities/geo/spatial_data.py
@@ -2149,8 +2149,27 @@ def get_unified_fips_data() -> Dict[str, Dict[str, Any]]:
     return census_source.get_comprehensive_state_info()
 
 def normalize_state_identifier_standalone(identifier: str) -> str:
-    """Normalize state identifier - standalone function."""
-    return census_source.normalize_state_identifier(identifier)
+    """Normalize a state identifier to its 2-digit FIPS code.
+
+    Delegates to :func:`siege_utilities.config.census_registry.normalize_state_identifier`,
+    the canonical implementation.
+
+    Parameters
+    ----------
+    identifier : str
+        Any of: 2-digit FIPS code, 2-letter abbreviation, or full state name.
+
+    Returns
+    -------
+    str
+        Zero-padded 2-digit FIPS code.
+
+    Raises
+    ------
+    ValueError
+        If *identifier* doesn't match any known state, territory, or DC.
+    """
+    return normalize_state_identifier(identifier)
 
 def normalize_state_input(raw_input: str) -> str:
     """


### PR DESCRIPTION
## Summary

- Resolves namespace collision where `siege_utilities.normalize_state_identifier` (geo standalone) returned `None` on failure while `siege_utilities.config.normalize_state_identifier` raised `ValueError`
- `normalize_state_identifier_standalone` in `geo/spatial_data.py` now delegates directly to the config canonical version instead of going through the deprecated `CensusDataSource` instance method that swallowed errors
- Top-level `__init__.py` registers `normalize_state_identifier` from `config.census_registry` directly, also removing the unnecessary geopandas dependency for pure FIPS lookup

## Test plan

- [x] `tests/test_states.py` — 27 tests pass (imports from config, tests ValueError on invalid input)
- [x] `tests/test_backward_compat.py` — 201 pass (1 pre-existing failure on version string format)
- [x] Verified `siege_utilities.normalize_state_identifier` resolves to `config.census_registry` module and raises `ValueError` on invalid input
- [x] All internal callers verified — none rely on None-return behavior

Refs: #811