### PR TITLE
fix(#818): remove import-time warnings for optional deps in sample_data

### DIFF
--- a/siege_utilities/reference/sample_data.py
+++ b/siege_utilities/reference/sample_data.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import pandas as pd
 import numpy as np
 from typing import Dict, Optional, Union, Any, Tuple, TYPE_CHECKING
-import warnings
 
 # Type checking imports for optional dependencies
 if TYPE_CHECKING:
@@ -32,7 +31,6 @@ try:
     FAKER_AVAILABLE = True
 except ImportError:
     FAKER_AVAILABLE = False
-    warnings.warn("Faker not available. Install with: pip install Faker")
 
 try:
     import geopandas as gpd
@@ -41,7 +39,6 @@ try:
 except ImportError:
     GEOPANDAS_AVAILABLE = False
     gpd = None  # type: ignore[assignment]
-    warnings.warn("GeoPandas not available. Install with: pip install geopandas")
 
 # Import existing Census utilities (kept as availability probe even though
 # the imported names are accessed lazily elsewhere)
@@ -51,7 +48,6 @@ try:
     CENSUS_AVAILABLE = True
 except ImportError:
     CENSUS_AVAILABLE = False
-    warnings.warn("Census utilities not available")
 
 # Initialize Faker instances for different locales
 if FAKER_AVAILABLE:


### PR DESCRIPTION
## Summary
- Removes three `warnings.warn()` calls that fired at import time in `reference/sample_data.py` when optional deps (Faker, GeoPandas, Census utilities) were missing
- Removes the now-unused `import warnings` statement
- All 11 call-time `ImportError` raises with install instructions remain intact — users get actionable errors when they actually call functions needing the missing dep

## Test plan
- [ ] Import `siege_utilities.reference.sample_data` without Faker/GeoPandas installed — no warnings should fire
- [ ] Call a function requiring Faker (e.g., `generate_synthetic_population`) without Faker installed — `ImportError` with install instructions should be raised
- [ ] Call a function requiring GeoPandas (e.g., `get_census_boundaries`) without GeoPandas — `ImportError` should be raised

Closes #818