### PR TITLE
fix(#819): remove PySpark re-export fallback from distributed

### DIFF
--- a/siege_utilities/distributed/__init__.py
+++ b/siege_utilities/distributed/__init__.py
@@ -9,8 +9,6 @@ import importlib
 import sys
 
 # Explicit map of public names to their source modules.
-# PySpark re-exports (col, lit, when, etc.) come through spark_utils
-# via its `from pyspark.sql.functions import *`.
 _LAZY_IMPORTS = {}
 
 
@@ -49,29 +47,11 @@ _register([
 
 __all__ = list(_LAZY_IMPORTS.keys())
 
-# Track whether spark_utils has been fully loaded (for PySpark re-exports)
-_spark_utils_module = None  # cached module or False (import failed)
-
 
 def __getattr__(name):
-    global _spark_utils_module
-
-    # 1. Check explicit registry
     if name in _LAZY_IMPORTS:
         mod = importlib.import_module(_LAZY_IMPORTS[name], __package__)
         val = getattr(mod, name)
-        setattr(sys.modules[__name__], name, val)
-        return val
-
-    # 2. Fallback: try spark_utils for PySpark re-exports (col, lit, when, etc.)
-    if _spark_utils_module is None:
-        try:
-            _spark_utils_module = importlib.import_module('.spark_utils', __package__)
-        except ImportError:
-            _spark_utils_module = False  # Don't retry import on failure
-
-    if _spark_utils_module and hasattr(_spark_utils_module, name):
-        val = getattr(_spark_utils_module, name)
         setattr(sys.modules[__name__], name, val)
         return val
 


### PR DESCRIPTION
## Summary

- Remove the `__getattr__` fallback in `distributed/__init__.py` that silently re-exported all of `pyspark.sql.functions` through `siege_utilities.distributed`
- Delete the `_spark_utils_module` sentinel and the fallback block (20 lines)
- The explicit `_LAZY_IMPORTS` registry is unchanged; all siege_utilities-defined names remain importable

## Context

The fallback meant that `from siege_utilities.distributed import col` (or any pyspark function name) silently succeeded, creating invisible coupling. Investigation confirmed zero internal callers depend on this path (4 grep strategies across library code, notebooks, docs, and tests — all returned 0 hits).

## Test plan

- [ ] Verify `from siege_utilities.distributed import sanitise_dataframe_column_names` still works (explicit registry path)
- [ ] Verify `from siege_utilities.distributed import col` raises `AttributeError` (fallback removed)
- [ ] Verify `from siege_utilities.distributed import HDFSConfig` still works (hdfs_config registry path)

Closes #819