### PR TITLE
fix(#809): add lazy re-exports for QCEWFiles and NCESFiles

### DIFF
--- a/siege_utilities/economic/__init__.py
+++ b/siege_utilities/economic/__init__.py
@@ -8,3 +8,13 @@ Future:
 - `bea`: BEA Regional Economic Accounts.
 - `irs.soi`: IRS Statistics of Income by ZIP/ZCTA.
 """
+
+__all__ = ["QCEWFiles"]
+
+
+def __getattr__(name: str):
+    if name == "QCEWFiles":
+        from .bls.qcew import QCEWFiles
+
+        return QCEWFiles
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/siege_utilities/education/__init__.py
+++ b/siege_utilities/education/__init__.py
@@ -9,3 +9,13 @@ Future:
 - `nces.api`: keyed NCES API (when available).
 - `state`: per-state DOE files (highly variable; on-demand basis).
 """
+
+__all__ = ["NCESFiles"]
+
+
+def __getattr__(name: str):
+    if name == "NCESFiles":
+        from .nces.files import NCESFiles
+
+        return NCESFiles
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary

- `economic/__init__.py` and `education/__init__.py` were docstring-only, making `QCEWFiles` and `NCESFiles` undiscoverable via top-level package imports
- Added PEP 562 `__getattr__` lazy imports so `from siege_utilities.economic import QCEWFiles` and `from siege_utilities.education import NCESFiles` work without eagerly pulling in heavy dependencies
- Both files also declare `__all__` for IDE autocompletion and `dir()` discoverability

## Test plan

- [x] `import siege_utilities.economic` succeeds without triggering pandas/requests import
- [x] `siege_utilities.economic.__all__` returns `["QCEWFiles"]`
- [x] `siege_utilities.economic.nonexistent` raises `AttributeError`
- [ ] `from siege_utilities.economic import QCEWFiles` returns the class (requires requests/pandas installed)
- [ ] `from siege_utilities.education import NCESFiles` returns the class (requires requests/pandas installed)

Closes #809