### PR TITLE
fix(#742): raise instead of returning magic values on error in files/ (SU-1)

### DIFF
--- a/siege_utilities/files/hashing.py
+++ b/siege_utilities/files/hashing.py
@@ -168,10 +168,12 @@ def get_quick_file_signature(file_path) ->str:
         file_path: Path to the file
 
     Returns:
-        Quick signature string ('missing', 'error', or hash)
+        Quick signature string ('missing', fallback stat string, or hash)
 
     Raises:
         PathSecurityError: If path fails security validation
+        Exception: If both primary and fallback signature generation fail
+            (logged before re-raise)
 
     Example:
         >>> sig = get_quick_file_signature("data.txt")
@@ -213,7 +215,7 @@ def get_quick_file_signature(file_path) ->str:
             return f'fallback_{stat.st_size}_{stat.st_mtime}'
         except Exception as fallback_exc:
             log_error(f'Fallback signature also failed for {file_path}: {fallback_exc}')
-            return 'error'
+            raise
 
 
 def verify_file_integrity(file_path, expected_hash, algorithm='sha256') ->bool:
@@ -229,10 +231,11 @@ def verify_file_integrity(file_path, expected_hash, algorithm='sha256') ->bool:
         algorithm: Hash algorithm used
 
     Returns:
-        True if file matches expected hash, False otherwise
+        True if file matches expected hash, False if hash does not match
 
     Raises:
         PathSecurityError: If path fails security validation
+        Exception: If hash computation fails (logged before re-raise)
 
     Example:
         >>> expected = "abc123..."
@@ -252,7 +255,7 @@ def verify_file_integrity(file_path, expected_hash, algorithm='sha256') ->bool:
             ) == expected_hash.lower()
     except Exception as exc:
         log_error(f"Failed to verify hash for {file_path}: {exc}")
-        return False
+        raise
 
 
 def test_hash_functions():

--- a/siege_utilities/files/remote.py
+++ b/siege_utilities/files/remote.py
@@ -363,7 +363,10 @@ def is_downloadable(url: str, timeout: int = 10) -> bool:
         
     Returns:
         True if the URL points to a downloadable file
-        
+
+    Raises:
+        Exception: If the network request fails (logged before re-raise)
+
     Example:
         >>> if is_downloadable("https://example.com/file.zip"):
         ...     print("URL is downloadable")
@@ -372,14 +375,14 @@ def is_downloadable(url: str, timeout: int = 10) -> bool:
         info = get_file_info(url, timeout)
         if info and info['size'] > 0:
             return True
-        
+
         # Try a GET request to see if we can access the content
         response = requests.get(url, stream=True, timeout=timeout)
         return response.ok
-        
+
     except Exception as exc:
         log.warning("Could not check if URL is downloadable %s: %s", url, exc)
-        return False
+        raise
 
 __all__ = [
     'download_file',


### PR DESCRIPTION
## Summary

- Replace `return False` / `return 'error'` with `raise` at 3 SU-1 violation sites in `files/remote.py` and `files/hashing.py`
- All 3 sites already had `log.warning()` / `log_error()` calls; only the `return` → `raise` changes
- Updated docstrings to document exception propagation behavior

## Details

Three functions swallowed exceptions and returned magic values indistinguishable from legitimate results:

| Function | File | Was returning | Now |
|---|---|---|---|
| `is_downloadable()` | `files/remote.py:380` | `False` (same as "not downloadable") | Raises (after logging) |
| `get_quick_file_signature()` | `files/hashing.py:216` | `'error'` (compares equal to itself) | Raises (after logging) |
| `verify_file_integrity()` | `files/hashing.py:255` | `False` (same as "hash mismatch") | Raises (after logging) |

## Blast radius

**LOW.** Investigation confirmed zero live callers depend on the swallowed-exception behavior:
- `nces_download._check_url_accessible` calls `is_downloadable` but is itself dead code (never called)
- All notebook references are in `archive/` (not actively maintained)
- Only other callers are the inline `test_hash_functions()` under `__main__`

## Test plan

- [ ] Verify `is_downloadable()` raises on network error instead of returning `False`
- [ ] Verify `get_quick_file_signature()` raises when both primary and fallback fail instead of returning `'error'`
- [ ] Verify `verify_file_integrity()` raises on hash computation failure instead of returning `False`
- [ ] Verify normal (non-error) paths still return correct values

Closes #742