### PR TITLE
fix(#745): replace silent error-dict returns with GitError raises (SU-1)

### DIFF
--- a/siege_utilities/git/git_operations.py
+++ b/siege_utilities/git/git_operations.py
@@ -7,7 +7,7 @@ from typing import Dict, Optional
 import re
 import subprocess
 
-from siege_utilities.core.logging import log_info, log_warning, log_error
+from siege_utilities.core.logging import log_info, log_warning
 from siege_utilities.exceptions import GitError
 from siege_utilities.git.validation import (
     GitSecurityError,
@@ -46,7 +46,7 @@ def create_feature_branch(
         try:
             run_git_command("pull", "origin", base_branch, repo_path=repo_path, check=False)
             log_info(f"Pulled latest changes from {base_branch}")
-        except Exception as exc:
+        except (RuntimeError, GitError) as exc:
             log_warning(f"Could not pull latest from {base_branch} (continuing anyway): {exc}")
 
     # Create and switch to new branch
@@ -58,7 +58,7 @@ def create_feature_branch(
         try:
             run_git_command("push", "-u", "origin", branch_name, repo_path=repo_path, check=False)
             log_info(f"Pushed branch to remote: origin/{branch_name}")
-        except Exception as exc:
+        except (RuntimeError, GitError) as exc:
             log_warning(f"Could not push to remote (continuing anyway): {exc}")
 
     return {
@@ -164,9 +164,7 @@ def merge_branch(
         merge_status = "success"
         log_info(f"Successfully merged {source_branch} into {target_branch}")
     except (RuntimeError, GitError) as e:
-        merge_status = "failed"
-        log_error(f"Merge failed: {e}")
-        return {"status": merge_status, "error": str(e)}
+        raise GitError(f"Merge of {source_branch} into {target_branch} failed: {e}") from e
 
     return {
         "source_branch": source_branch,
@@ -223,9 +221,7 @@ def rebase_branch(
         rebase_status = "success"
         log_info(f"Successfully rebased {source_branch} onto {base_branch}")
     except (RuntimeError, GitError) as e:
-        rebase_status = "failed"
-        log_error(f"Rebase failed: {e}")
-        return {"status": rebase_status, "error": str(e)}
+        raise GitError(f"Rebase of {source_branch} onto {base_branch} failed: {e}") from e
 
     return {
         "source_branch": source_branch,
@@ -285,9 +281,7 @@ def stash_changes(
             "include_untracked": include_untracked
         }
     except (RuntimeError, GitError) as e:
-        stash_status = "failed"
-        log_error(f"Stash failed: {e}")
-        return {"status": stash_status, "error": str(e)}
+        raise GitError(f"Stash failed: {e}") from e
 
 def apply_stash(
     stash_ref: str = "stash@{0}",
@@ -325,9 +319,7 @@ def apply_stash(
         action = "popped" if pop else "applied"
         log_info(f"Stash {stash_ref} {action} successfully")
     except (RuntimeError, GitError) as e:
-        apply_status = "failed"
-        log_error(f"Stash apply failed: {e}")
-        return {"status": apply_status, "error": str(e)}
+        raise GitError(f"Stash apply failed: {e}") from e
 
     return {
         "stash_ref": stash_ref,
@@ -386,9 +378,7 @@ def clean_working_directory(
         clean_status = "success"
         log_info("Working directory cleaned successfully")
     except (RuntimeError, GitError) as e:
-        clean_status = "failed"
-        log_error(f"Clean failed: {e}")
-        return {"status": clean_status, "error": str(e)}
+        raise GitError(f"Clean failed: {e}") from e
 
     return {
         "status": clean_status,
@@ -432,9 +422,7 @@ def reset_to_commit(
         reset_status = "success"
         log_info(f"Reset to commit {commit_hash} ({reset_type}) successful")
     except (RuntimeError, GitError) as e:
-        reset_status = "failed"
-        log_error(f"Reset failed: {e}")
-        return {"status": reset_status, "error": str(e)}
+        raise GitError(f"Reset to {commit_hash} ({reset_type}) failed: {e}") from e
 
     return {
         "commit_hash": commit_hash,
@@ -480,9 +468,7 @@ def cherry_pick_commit(
         action = "continued" if continue_on_conflict else "applied"
         log_info(f"Cherry-pick {action} successfully")
     except (RuntimeError, GitError) as e:
-        cherry_pick_status = "failed"
-        log_error(f"Cherry-pick failed: {e}")
-        return {"status": cherry_pick_status, "error": str(e)}
+        raise GitError(f"Cherry-pick failed: {e}") from e
 
     return {
         "commit_hash": commit_hash,
@@ -555,9 +541,7 @@ def create_tag(
             log_info(f"Tag {tag_name} pushed to remote")
             tag_status = "pushed"
     except (RuntimeError, GitError) as e:
-        tag_status = "failed"
-        log_error(f"Tag creation failed: {e}")
-        return {"status": tag_status, "error": str(e)}
+        raise GitError(f"Tag creation for {tag_name} failed: {e}") from e
 
     return {
         "tag_name": tag_name,
@@ -611,9 +595,7 @@ def push_branch(
         force_text = " (force)" if force else ""
         log_info(f"Branch pushed to {remote}{force_text} successfully")
     except (RuntimeError, GitError) as e:
-        push_status = "failed"
-        log_error(f"Push failed: {e}")
-        return {"status": push_status, "error": str(e)}
+        raise GitError(f"Push to {remote} failed: {e}") from e
 
     return {
         "branch_name": branch_name,
@@ -666,9 +648,7 @@ def pull_branch(
         rebase_text = " (rebase)" if rebase else ""
         log_info(f"Changes pulled from {remote}{rebase_text} successfully")
     except (RuntimeError, GitError) as e:
-        pull_status = "failed"
-        log_error(f"Pull failed: {e}")
-        return {"status": pull_status, "error": str(e)}
+        raise GitError(f"Pull from {remote} failed: {e}") from e
 
     return {
         "branch_name": branch_name,

--- a/siege_utilities/git/git_workflow.py
+++ b/siege_utilities/git/git_workflow.py
@@ -212,13 +212,8 @@ def start_feature_workflow(
             "workflow": "feature_started"
         }
 
-    except Exception as e:
-        return {
-            "status": "failed",
-            "error": str(e),
-            "branch_name": branch_name,
-            "base_branch": base_branch
-        }
+    except (RuntimeError, GitError) as e:
+        raise GitError(f"Feature workflow failed for {branch_name}: {e}") from e
 
 def complete_feature_workflow(
     feature_branch: str,
@@ -268,7 +263,7 @@ def complete_feature_workflow(
             try:
                 run_git_command("push", "origin", "--delete", feature_branch, repo_path=repo_path)
                 log_info(f"Deleted remote branch: origin/{feature_branch}")
-            except Exception as exc:
+            except (RuntimeError, GitError) as exc:
                 log_warning(f"Could not delete remote branch: origin/{feature_branch}: {exc}")
 
         return {
@@ -280,13 +275,8 @@ def complete_feature_workflow(
             "workflow": "feature_completed"
         }
 
-    except Exception as e:
-        return {
-            "status": "failed",
-            "error": str(e),
-            "feature_branch": feature_branch,
-            "target_branch": target_branch
-        }
+    except (RuntimeError, GitError) as e:
+        raise GitError(f"Feature completion failed for {feature_branch}: {e}") from e
 
 def hotfix_workflow(
     hotfix_name: str,
@@ -331,13 +321,8 @@ def hotfix_workflow(
             "workflow": "hotfix_started"
         }
 
-    except Exception as e:
-        return {
-            "status": "failed",
-            "error": str(e),
-            "branch_name": branch_name,
-            "base_branch": base_branch
-        }
+    except (RuntimeError, GitError) as e:
+        raise GitError(f"Hotfix workflow failed for {branch_name}: {e}") from e
 
 def release_workflow(
     version: str,
@@ -390,14 +375,8 @@ def release_workflow(
             "workflow": "release_started"
         }
 
-    except Exception as e:
-        return {
-            "status": "failed",
-            "error": str(e),
-            "branch_name": branch_name,
-            "version": version,
-            "base_branch": base_branch
-        }
+    except (RuntimeError, GitError) as e:
+        raise GitError(f"Release workflow failed for {version}: {e}") from e
 
 def _update_version_files(version: str, repo_path: str) -> None:
     """Update common version files."""
@@ -430,7 +409,7 @@ def _update_version_files(version: str, repo_path: str) -> None:
                     file_path.write_text(content)
 
                 log_info(f"Updated version in {filename}")
-            except Exception as e:
+            except (OSError, ValueError) as e:
                 log_warning(f"Could not update {filename}: {e}")
 
 def get_workflow_status(repo_path: str = ".") -> Dict[str, Union[str, List[str], Dict[str, str]]]:
@@ -474,7 +453,7 @@ def get_workflow_status(repo_path: str = ".") -> Dict[str, Union[str, List[str],
                     "commits_behind": int(behind),
                     "ready_for_merge": int(ahead) > 0 and int(behind) == 0
                 })
-            except Exception as exc:
+            except (RuntimeError, GitError) as exc:
                 log_warning(f"Could not determine ahead/behind counts: {exc}")
                 workflow_info.update({
                     "commits_ahead": None,
@@ -484,10 +463,5 @@ def get_workflow_status(repo_path: str = ".") -> Dict[str, Union[str, List[str],
 
         return workflow_info
 
-    except Exception as e:
-        return {
-            "status": "error",
-            "error": str(e),
-            "current_branch": "unknown",
-            "workflow_type": "unknown"
-        }
+    except (RuntimeError, GitError) as e:
+        raise GitError(f"Could not determine workflow status: {e}") from e

--- a/tests/test_git_operations.py
+++ b/tests/test_git_operations.py
@@ -304,11 +304,8 @@ class TestMergeBranch:
 
         assert ("checkout", "main") in call_log
 
-    def test_merge_failure_returns_error(self):
-        call_count = [0]
-
+    def test_merge_failure_raises_git_error(self):
         def fake_rgc(*args, **kwargs):
-            call_count[0] += 1
             if args[0] == "branch":
                 return "main"
             if args[0] == "pull":
@@ -318,9 +315,8 @@ class TestMergeBranch:
             return ""
 
         with patch(RGC, side_effect=fake_rgc):
-            result = merge_branch("feature/x")
-        assert result["status"] == "failed"
-        assert "error" in result
+            with pytest.raises(GitError, match="Merge of feature/x into main failed"):
+                merge_branch("feature/x")
 
 
 # ===================================================================
@@ -376,7 +372,7 @@ class TestRebaseBranch:
 
         assert ("checkout", "feature/x") in call_log
 
-    def test_rebase_failure(self):
+    def test_rebase_failure_raises_git_error(self):
         def fake_rgc(*args, **kwargs):
             if args[0] == "branch":
                 return "feature/x"
@@ -385,9 +381,8 @@ class TestRebaseBranch:
             return ""
 
         with patch(RGC, side_effect=fake_rgc):
-            result = rebase_branch("feature/x")
-        assert result["status"] == "failed"
-        assert "error" in result
+            with pytest.raises(GitError, match="Rebase of feature/x onto main failed"):
+                rebase_branch("feature/x")
 
 
 # ===================================================================
@@ -447,11 +442,10 @@ class TestStashChanges:
             result = stash_changes()
         assert result["stash_hash"] == "0"
 
-    def test_stash_failure(self):
+    def test_stash_failure_raises_git_error(self):
         with patch(RGC, side_effect=GitError("stash failed")):
-            result = stash_changes()
-        assert result["status"] == "failed"
-        assert "error" in result
+            with pytest.raises(GitError, match="Stash failed"):
+                stash_changes()
 
 
 # ===================================================================
@@ -500,11 +494,10 @@ class TestApplyStash:
         assert call_log[0] == ("stash", "apply", "stash@{2}")
         assert result["stash_ref"] == "stash@{2}"
 
-    def test_apply_failure(self):
+    def test_apply_failure_raises_git_error(self):
         with patch(RGC, side_effect=GitError("conflict")):
-            result = apply_stash()
-        assert result["status"] == "failed"
-        assert "error" in result
+            with pytest.raises(GitError, match="Stash apply failed"):
+                apply_stash()
 
 
 # ===================================================================
@@ -575,18 +568,15 @@ class TestCleanWorkingDirectory:
                 result = clean_working_directory(force=False)
         assert result["status"] == "success"
 
-    def test_clean_failure(self):
-        call_count = [0]
-
+    def test_clean_failure_raises_git_error(self):
         def fake_rgc(*args, **kwargs):
-            call_count[0] += 1
             if "-n" in args:
                 return "Would remove foo.txt"
             raise GitError("clean failed")
 
         with patch(RGC, side_effect=fake_rgc):
-            result = clean_working_directory(force=True)
-        assert result["status"] == "failed"
+            with pytest.raises(GitError, match="Clean failed"):
+                clean_working_directory(force=True)
 
 
 # ===================================================================
@@ -636,11 +626,10 @@ class TestResetToCommit:
         with pytest.raises(ValueError, match="Invalid reset type"):
             reset_to_commit("abc1234", reset_type="superhard")
 
-    def test_reset_failure(self):
+    def test_reset_failure_raises_git_error(self):
         with patch(RGC, side_effect=GitError("reset failed")):
-            result = reset_to_commit("abc1234")
-        assert result["status"] == "failed"
-        assert "error" in result
+            with pytest.raises(GitError, match="Reset to abc1234"):
+                reset_to_commit("abc1234")
 
     def test_return_dict_shape(self):
         with patch(RGC, return_value=""):
@@ -683,11 +672,10 @@ class TestCherryPickCommit:
         assert result["continue_on_conflict"] is True
         assert ("cherry-pick", "--continue") in call_log
 
-    def test_cherry_pick_failure(self):
+    def test_cherry_pick_failure_raises_git_error(self):
         with patch(RGC, side_effect=GitError("cherry-pick conflict")):
-            result = cherry_pick_commit("abc1234")
-        assert result["status"] == "failed"
-        assert "error" in result
+            with pytest.raises(GitError, match="Cherry-pick failed"):
+                cherry_pick_commit("abc1234")
 
 
 # ===================================================================
@@ -755,11 +743,10 @@ class TestCreateTag:
         assert len(push_calls) == 1
         assert "v1.0.0" in push_calls[0]
 
-    def test_tag_creation_failure(self):
+    def test_tag_creation_failure_raises_git_error(self):
         with patch(RGC, side_effect=GitError("tag exists")):
-            result = create_tag("v1.0.0")
-        assert result["status"] == "failed"
-        assert "error" in result
+            with pytest.raises(GitError, match="Tag creation for v1.0.0 failed"):
+                create_tag("v1.0.0")
 
     def test_empty_tag_name_fallback_validation(self):
         """When validation module is not importable, fallback checks empty name."""
@@ -834,11 +821,10 @@ class TestPushBranch:
         assert "upstream" in push_calls[0]
         assert result["remote"] == "upstream"
 
-    def test_push_failure(self):
+    def test_push_failure_raises_git_error(self):
         with patch(RGC, side_effect=GitError("push rejected")):
-            result = push_branch()
-        assert result["status"] == "failed"
-        assert "error" in result
+            with pytest.raises(GitError, match="Push to origin failed"):
+                push_branch()
 
 
 # ===================================================================
@@ -901,11 +887,10 @@ class TestPullBranch:
         pull_calls = [c for c in call_log if c[0] == "pull"]
         assert "upstream" in pull_calls[0]
 
-    def test_pull_failure(self):
+    def test_pull_failure_raises_git_error(self):
         with patch(RGC, side_effect=GitError("pull failed")):
-            result = pull_branch()
-        assert result["status"] == "failed"
-        assert "error" in result
+            with pytest.raises(GitError, match="Pull from origin failed"):
+                pull_branch()
 
     def test_return_dict_shape(self):
         with patch(RGC, return_value=""):


### PR DESCRIPTION
## Summary

- Replace 10 error-dict return patterns in `git_operations.py` with `raise GitError(...) from e` — callers can no longer confuse failure with success
- Replace 5 error-dict return patterns in `git_workflow.py` with `raise GitError(...) from e` and narrow `except Exception` to `except (RuntimeError, GitError)`
- Preserve warn-and-continue for genuinely non-fatal operations (pull/push in `create_feature_branch`, remote branch deletion, version file updates, ahead/behind counts)
- Update 10 tests from `assert result["status"] == "failed"` to `pytest.raises(GitError)`
- Remove unused `log_error` import from `git_operations.py`

## Test plan

- [x] All 80 tests in test_git_operations.py and test_git_workflow.py pass
- [x] Grep confirms zero remaining `"status": "failed"` returns in either file
- [x] Grep confirms zero remaining `except Exception` in either file
- [x] Non-fatal handlers (5 sites) preserved as warn-and-continue with narrowed exception types

Refs: #745