### PR TITLE
fix(#731): raise instead of returning fake signatures in hdfs_operations

### DIFF
--- a/siege_utilities/distributed/hdfs_operations.py
+++ b/siege_utilities/distributed/hdfs_operations.py
@@ -6,33 +6,56 @@ import hashlib
 import logging
 import pathlib
 import subprocess
-import time
 from typing import Optional, Tuple, Dict, List
 
 log = logging.getLogger(__name__)
 
 
-def _default_hash_function(file_path: str) ->str:
-    """Default hash function using built-in hashlib"""
-    try:
-        sha256_hash = hashlib.sha256()
-        with open(file_path, 'rb') as f:
-            for chunk in iter(lambda : f.read(65536), b''):
-                sha256_hash.update(chunk)
-        return sha256_hash.hexdigest()
-    except Exception as exc:
-        log.warning("Could not hash file %s, returning error signature: %s", file_path, exc)
-        return f'error_{int(time.time())}'
+def _default_hash_function(file_path: str) -> str:
+    """Default hash function using built-in hashlib.
+
+    Parameters
+    ----------
+    file_path : str
+        Path to the file to hash.
+
+    Returns
+    -------
+    str
+        SHA-256 hex digest of the file contents.
+
+    Raises
+    ------
+    OSError
+        If the file cannot be opened or read.
+    """
+    sha256_hash = hashlib.sha256()
+    with open(file_path, 'rb') as f:
+        for chunk in iter(lambda: f.read(65536), b''):
+            sha256_hash.update(chunk)
+    return sha256_hash.hexdigest()
 
 
-def _default_quick_signature(file_path: str) ->str:
-    """Default quick signature using file stats"""
-    try:
-        stat = pathlib.Path(file_path).stat()
-        return f'{stat.st_size}_{stat.st_mtime}'
-    except Exception as exc:
-        log.warning("Could not stat file %s for quick signature: %s", file_path, exc)
-        return 'error'
+def _default_quick_signature(file_path: str) -> str:
+    """Default quick signature using file stats.
+
+    Parameters
+    ----------
+    file_path : str
+        Path to the file to stat.
+
+    Returns
+    -------
+    str
+        String of ``{size}_{mtime}`` for the file.
+
+    Raises
+    ------
+    OSError
+        If the file cannot be stat'd.
+    """
+    stat = pathlib.Path(file_path).stat()
+    return f'{stat.st_size}_{stat.st_mtime}'
 
 
 def _ensure_directory_exists(path: str):

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -879,11 +879,11 @@ class TestDefaultHashFunction:
         assert len(result) == 64  # SHA256 hex length
         assert all(c in '0123456789abcdef' for c in result)
 
-    def test_returns_error_on_missing_file(self):
-        """Returns error string for missing file."""
+    def test_raises_on_missing_file(self):
+        """Raises OSError for missing file instead of returning fake signature."""
         from siege_utilities.distributed.hdfs_operations import _default_hash_function
-        result = _default_hash_function('/nonexistent/file.txt')
-        assert result.startswith('error_')
+        with pytest.raises(OSError):
+            _default_hash_function('/nonexistent/file.txt')
 
 
 class TestDefaultQuickSignature:
@@ -901,11 +901,11 @@ class TestDefaultQuickSignature:
         parts = result.split('_')
         assert len(parts) == 2
 
-    def test_returns_error_on_missing_file(self):
-        """Returns 'error' for missing file."""
+    def test_raises_on_missing_file(self):
+        """Raises OSError for missing file instead of returning fake signature."""
         from siege_utilities.distributed.hdfs_operations import _default_quick_signature
-        result = _default_quick_signature('/nonexistent/file.txt')
-        assert result == 'error'
+        with pytest.raises(OSError):
+            _default_quick_signature('/nonexistent/file.txt')
 
 
 class TestConvenienceFunction:


### PR DESCRIPTION
## Summary

- Remove SU-1 violations in `_default_hash_function` and `_default_quick_signature` where error paths returned fake signature strings instead of raising
- `_default_hash_function` returned `f'error_{int(time.time())}'` on failure (looks like a valid hash, changes every second, causes unnecessary reprocessing)
- `_default_quick_signature` returned literal `'error'` on failure (indistinguishable from valid data by callers)
- Both functions now let `OSError` propagate naturally; docstrings updated with `Raises` section; unused `time` import removed
- Tests updated to assert `pytest.raises(OSError)` instead of asserting the error-string returns

## Test plan

- [x] `TestDefaultHashFunction::test_hashes_file` passes (happy path unchanged)
- [x] `TestDefaultHashFunction::test_raises_on_missing_file` passes (now asserts OSError)
- [x] `TestDefaultQuickSignature::test_returns_signature` passes (happy path unchanged)
- [x] `TestDefaultQuickSignature::test_raises_on_missing_file` passes (now asserts OSError)

Refs: #731