### PR TITLE
fix(#729): replace silent error returns with GitError raises in git_status.py

### DIFF
--- a/siege_utilities/git/git_status.py
+++ b/siege_utilities/git/git_status.py
@@ -14,61 +14,62 @@ from ._utils import run_git_command
 log = logging.getLogger(__name__)
 
 def get_repository_status(repo_path: str = ".") -> Dict[str, Union[str, int, bool]]:
-    """Get comprehensive repository status information."""
-    
+    """Get comprehensive repository status information.
+
+    Raises
+    ------
+    ValueError
+        If *repo_path* is not a git repository.
+    GitError
+        If any git command fails while gathering status.
+    """
+
     repo_path = Path(repo_path).resolve()
-    
+
     if not (repo_path / ".git").exists():
         raise ValueError(f"Not a git repository: {repo_path}")
-    
+
     # Basic repository info
     current_branch = run_git_command("branch", "--show-current", repo_path=repo_path)
     is_detached = "HEAD" in current_branch
-    
+
     # Working directory status
     status_output = run_git_command("status", "--porcelain", repo_path=repo_path)
     status_lines = [line for line in status_output.split('\n') if line.strip()]
-    
+
     # Count different types of changes
     staged_files = len([line for line in status_lines if line[0] in 'AMDR'])
     unstaged_files = len([line for line in status_lines if line[1] in 'AMDR'])
     untracked_files = len([line for line in status_lines if line.startswith('??')])
-    
+
     # Get commit info
     try:
         last_commit_hash = run_git_command("rev-parse", "HEAD", repo_path=repo_path)[:7]
         last_commit_date = run_git_command("log", "-1", "--format=%cd", "--date=short", repo_path=repo_path)
         last_commit_author = run_git_command("log", "-1", "--format=%an", repo_path=repo_path)
         last_commit_message = run_git_command("log", "-1", "--format=%s", repo_path=repo_path)
-    except Exception as exc:
-        log.warning("Could not retrieve last commit info for %s: %s", repo_path, exc)
-        last_commit_hash = "unknown"
-        last_commit_date = "unknown"
-        last_commit_author = "unknown"
-        last_commit_message = "unknown"
-    
+    except (RuntimeError, GitError) as exc:
+        raise GitError(f"Could not retrieve last commit info for {repo_path}") from exc
+
     # Get remote info
     try:
         remote_url = run_git_command("config", "--get", "remote.origin.url", repo_path=repo_path)
         upstream_branch = run_git_command("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}", repo_path=repo_path, check=False)
         if upstream_branch == "":
             upstream_branch = None
-    except Exception as exc:
-        log.warning("Could not retrieve remote info for %s: %s", repo_path, exc)
-        remote_url = "unknown"
-        upstream_branch = None
-    
+    except (RuntimeError, GitError) as exc:
+        raise GitError(f"Could not retrieve remote info for {repo_path}") from exc
+
     # Get ahead/behind info
     ahead_behind = "0 0"
     if upstream_branch:
         try:
             ahead_behind = run_git_command("rev-list", "--count", "--left-right", f"{upstream_branch}...HEAD", repo_path=repo_path)
-        except Exception as exc:
-            log.warning("Could not determine ahead/behind for %s: %s", upstream_branch, exc)
-            ahead_behind = "0 0"
-    
+        except (RuntimeError, GitError) as exc:
+            raise GitError(f"Could not determine ahead/behind for {upstream_branch}") from exc
+
     behind, ahead = ahead_behind.split()
-    
+
     return {
         "repository_path": str(repo_path),
         "current_branch": current_branch,
@@ -94,11 +95,17 @@ def get_repository_status(repo_path: str = ".") -> Dict[str, Union[str, int, boo
     }
 
 def get_branch_info(repo_path: str = ".") -> Dict[str, Union[str, List[str], int]]:
-    """Get detailed information about all branches."""
-    
+    """Get detailed information about all branches.
+
+    Raises
+    ------
+    GitError
+        If any git command fails while gathering branch info.
+    """
+
     # Local branches
     local_branches = run_git_command("branch", "--list", "--format=%(refname:short)|%(upstream:short)|%(upstream:track)", repo_path=repo_path)
-    
+
     branches = []
     for line in local_branches.split('\n'):
         if line.strip():
@@ -106,7 +113,7 @@ def get_branch_info(repo_path: str = ".") -> Dict[str, Union[str, List[str], int
             branch_name = parts[0]
             upstream = parts[1] if len(parts) > 1 and parts[1] else None
             tracking = parts[2] if len(parts) > 2 and parts[2] else None
-            
+
             # Get branch details
             try:
                 last_commit = run_git_command("log", "-1", "--format=%H|%cd|%an|%s", "--date=short", branch_name, repo_path=repo_path)
@@ -123,22 +130,18 @@ def get_branch_info(repo_path: str = ".") -> Dict[str, Union[str, List[str], int
                             "message": message
                         }
                     })
-            except Exception as exc:
-                log.warning("Could not retrieve commit info for branch %s: %s", branch_name, exc)
-                branches.append({
-                    "name": branch_name,
-                    "upstream": upstream,
-                    "tracking": tracking,
-                    "last_commit": None
-                })
-    
+            except (RuntimeError, GitError) as exc:
+                raise GitError(
+                    f"Could not retrieve commit info for branch {branch_name}"
+                ) from exc
+
     # Remote branches
     remote_branches = run_git_command("branch", "-r", "--format=%(refname:short)", repo_path=repo_path)
     remote_branch_list = [branch.strip() for branch in remote_branches.split('\n') if branch.strip()]
-    
+
     # Current branch
     current_branch = run_git_command("branch", "--show-current", repo_path=repo_path)
-    
+
     return {
         "current_branch": current_branch,
         "local_branches": branches,
@@ -148,36 +151,38 @@ def get_branch_info(repo_path: str = ".") -> Dict[str, Union[str, List[str], int
     }
 
 def get_remote_info(repo_path: str = ".") -> Dict[str, Union[str, List[Dict[str, str]]]]:
-    """Get information about remote repositories."""
-    
+    """Get information about remote repositories.
+
+    Raises
+    ------
+    GitError
+        If any git command fails while gathering remote info.
+    """
+
     # Get remote names
     remotes = run_git_command("remote", repo_path=repo_path)
     remote_list = [remote.strip() for remote in remotes.split('\n') if remote.strip()]
-    
+
     remote_info = []
     for remote_name in remote_list:
         try:
             url = run_git_command("config", "--get", f"remote.{remote_name}.url", repo_path=repo_path)
-            
+
             # Get fetch and push URLs if different
             fetch_url = run_git_command("config", "--get", f"remote.{remote_name}.fetch", repo_path=repo_path, check=False)
             push_url = run_git_command("config", "--get", f"remote.{remote_name}.push", repo_path=repo_path, check=False)
-            
+
             remote_info.append({
                 "name": remote_name,
                 "url": url,
                 "fetch_url": fetch_url if fetch_url else url,
                 "push_url": push_url if push_url else url
             })
-        except Exception as exc:
-            log.warning("Could not retrieve URL for remote %s: %s", remote_name, exc)
-            remote_info.append({
-                "name": remote_name,
-                "url": "unknown",
-                "fetch_url": "unknown",
-                "push_url": "unknown"
-            })
-    
+        except (RuntimeError, GitError) as exc:
+            raise GitError(
+                f"Could not retrieve URL for remote {remote_name}"
+            ) from exc
+
     return {
         "remotes": remote_info,
         "total_remotes": len(remote_info),
@@ -185,50 +190,58 @@ def get_remote_info(repo_path: str = ".") -> Dict[str, Union[str, List[Dict[str,
     }
 
 def get_stash_list(repo_path: str = ".") -> List[Dict[str, str]]:
-    """Get list of stashed changes."""
-    
+    """Get list of stashed changes.
+
+    Raises
+    ------
+    GitError
+        If the git stash list command fails.
+    """
     try:
         stash_output = run_git_command("stash", "list", "--format=%gd|%cd|%s", "--date=short", repo_path=repo_path)
-        
-        stashes = []
-        for line in stash_output.split('\n'):
-            if line.strip():
-                parts = line.split('|', 2)
-                if len(parts) == 3:
-                    stash_ref, date, message = parts
-                    stashes.append({
-                        "ref": stash_ref,
-                        "date": date,
-                        "message": message
-                    })
-        
-        return stashes
-    except Exception as exc:
-        log.warning("Could not retrieve stash list: %s", exc)
-        return []
+    except (RuntimeError, GitError) as exc:
+        raise GitError("Could not retrieve stash list") from exc
+
+    stashes = []
+    for line in stash_output.split('\n'):
+        if line.strip():
+            parts = line.split('|', 2)
+            if len(parts) == 3:
+                stash_ref, date, message = parts
+                stashes.append({
+                    "ref": stash_ref,
+                    "date": date,
+                    "message": message
+                })
+
+    return stashes
 
 def get_tag_list(repo_path: str = ".") -> List[Dict[str, str]]:
-    """Get list of tags with details."""
-    
+    """Get list of tags with details.
+
+    Raises
+    ------
+    GitError
+        If the git tag list command fails.
+    """
     try:
         tag_output = run_git_command("tag", "--format=%(refname:short)|%(creatordate:short)|%(creator)", repo_path=repo_path)
-        
-        tags = []
-        for line in tag_output.split('\n'):
-            if line.strip():
-                parts = line.split('|', 2)
-                if len(parts) == 3:
-                    tag_name, date, author = parts
-                    tags.append({
-                        "name": tag_name,
-                        "date": date,
-                        "author": author
-                    })
-        
-        return tags
-    except Exception as exc:
-        log.warning("Could not retrieve tag list: %s", exc)
-        return []
+    except (RuntimeError, GitError) as exc:
+        raise GitError("Could not retrieve tag list") from exc
+
+    tags = []
+    for line in tag_output.split('\n'):
+        if line.strip():
+            parts = line.split('|', 2)
+            if len(parts) == 3:
+                tag_name, date, author = parts
+                tags.append({
+                    "name": tag_name,
+                    "date": date,
+                    "author": author
+                })
+
+    return tags
 
 def get_log_summary(
     since: Optional[str] = None,
@@ -237,118 +250,118 @@ def get_log_summary(
     repo_path: str = ".",
     max_count: int = 100
 ) -> Dict[str, Union[int, List[Dict[str, str]]]]:
-    """Get a summary of commit logs with filtering options."""
-    
+    """Get a summary of commit logs with filtering options.
+
+    Raises
+    ------
+    GitError
+        If the git log command fails.
+    """
+
     log_args = ["log", f"--max-count={max_count}", "--format=%H|%cd|%an|%s", "--date=short"]
-    
+
     if since:
         log_args.extend(["--since", since])
     if until:
         log_args.extend(["--until", until])
     if author:
         log_args.extend(["--author", author])
-    
+
     try:
         log_output = run_git_command(*log_args, repo_path=repo_path)
-        
-        commits = []
-        for line in log_output.split('\n'):
-            if line.strip():
-                parts = line.split('|', 3)
-                if len(parts) == 4:
-                    hash_full, date, author_name, message = parts
-                    commits.append({
-                        "hash": hash_full[:7],
-                        "hash_full": hash_full,
-                        "date": date,
-                        "author": author_name,
-                        "message": message
-                    })
-        
-        return {
-            "total_commits": len(commits),
-            "commits": commits,
-            "filters": {
-                "since": since,
-                "until": until,
-                "author": author,
-                "max_count": max_count
-            }
+    except (RuntimeError, GitError) as exc:
+        raise GitError("Could not retrieve commit log") from exc
+
+    commits = []
+    for line in log_output.split('\n'):
+        if line.strip():
+            parts = line.split('|', 3)
+            if len(parts) == 4:
+                hash_full, date, author_name, message = parts
+                commits.append({
+                    "hash": hash_full[:7],
+                    "hash_full": hash_full,
+                    "date": date,
+                    "author": author_name,
+                    "message": message
+                })
+
+    return {
+        "total_commits": len(commits),
+        "commits": commits,
+        "filters": {
+            "since": since,
+            "until": until,
+            "author": author,
+            "max_count": max_count
         }
-    except Exception as exc:
-        log.warning("Could not retrieve commit log: %s", exc)
-        return {
-            "total_commits": 0,
-            "commits": [],
-            "filters": {
-                "since": since,
-                "until": until,
-                "author": author,
-                "max_count": max_count
-            }
-        }
+    }
 
 def get_file_status(repo_path: str = ".") -> Dict[str, List[str]]:
-    """Get detailed status of all files in the repository."""
-    
+    """Get detailed status of all files in the repository.
+
+    Raises
+    ------
+    GitError
+        If the git status command fails.
+    """
     try:
         status_output = run_git_command("status", "--porcelain", repo_path=repo_path)
-        
-        files = {
-            "staged": [],
-            "unstaged": [],
-            "untracked": [],
-            "renamed": [],
-            "deleted": []
-        }
-        
-        for line in status_output.split('\n'):
-            if line.strip():
-                status = line[:2]
-                filepath = line[3:]
-                
-                if status[0] == 'A':  # Added
-                    files["staged"].append(filepath)
-                elif status[0] == 'M':  # Modified
-                    files["staged"].append(filepath)
-                elif status[0] == 'D':  # Deleted
-                    files["staged"].append(filepath)
-                elif status[0] == 'R':  # Renamed
-                    files["renamed"].append(filepath)
-                elif status[1] == 'M':  # Modified (unstaged)
-                    files["unstaged"].append(filepath)
-                elif status[1] == 'D':  # Deleted (unstaged)
-                    files["unstaged"].append(filepath)
-                elif status == '??':  # Untracked
-                    files["untracked"].append(filepath)
-        
-        return files
-    except Exception as exc:
-        log.warning("Could not retrieve file status: %s", exc)
-        return {
-            "staged": [],
-            "unstaged": [],
-            "untracked": [],
-            "renamed": [],
-            "deleted": []
-        }
+    except (RuntimeError, GitError) as exc:
+        raise GitError("Could not retrieve file status") from exc
+
+    files = {
+        "staged": [],
+        "unstaged": [],
+        "untracked": [],
+        "renamed": [],
+        "deleted": []
+    }
+
+    for line in status_output.split('\n'):
+        if line.strip():
+            status = line[:2]
+            filepath = line[3:]
+
+            if status[0] == 'A':  # Added
+                files["staged"].append(filepath)
+            elif status[0] == 'M':  # Modified
+                files["staged"].append(filepath)
+            elif status[0] == 'D':  # Deleted
+                files["staged"].append(filepath)
+            elif status[0] == 'R':  # Renamed
+                files["renamed"].append(filepath)
+            elif status[1] == 'M':  # Modified (unstaged)
+                files["unstaged"].append(filepath)
+            elif status[1] == 'D':  # Deleted (unstaged)
+                files["unstaged"].append(filepath)
+            elif status == '??':  # Untracked
+                files["untracked"].append(filepath)
+
+    return files
 
 def get_repository_size(repo_path: str = ".") -> Dict[str, Union[int, str]]:
-    """Get repository size information."""
-    
+    """Get repository size information.
+
+    Raises
+    ------
+    GitError
+        If repository size cannot be calculated.
+    """
+
     repo_path = Path(repo_path).resolve()
-    
+
     try:
         # Get .git directory size
         git_dir = repo_path / ".git"
         git_size = sum(f.stat().st_size for f in git_dir.rglob('*') if f.is_file())
-        
+
         # Get working directory size (excluding .git)
         working_size = 0
         for f in repo_path.rglob('*'):
             if f.is_file() and '.git' not in f.parts:
                 working_size += f.stat().st_size
-        
+
         return {
             "git_directory_size_bytes": git_size,
             "git_directory_size_mb": round(git_size / (1024 * 1024), 2),
@@ -357,13 +370,5 @@ def get_repository_size(repo_path: str = ".") -> Dict[str, Union[int, str]]:
             "total_size_bytes": git_size + working_size,
             "total_size_mb": round((git_size + working_size) / (1024 * 1024), 2)
         }
-    except Exception as exc:
-        log.warning("Could not calculate repository size for %s: %s", repo_path, exc)
-        return {
-            "git_directory_size_bytes": 0,
-            "git_directory_size_mb": 0,
-            "working_directory_size_bytes": 0,
-            "working_directory_size_mb": 0,
-            "total_size_bytes": 0,
-            "total_size_mb": 0
-        }
+    except (OSError, PermissionError) as exc:
+        raise GitError(f"Could not calculate repository size for {repo_path}") from exc

--- a/tests/test_git_status.py
+++ b/tests/test_git_status.py
@@ -1,6 +1,6 @@
 """Tests for siege_utilities.git.git_status module.
 
-All git commands are mocked via subprocess — no real repository needed.
+All git commands are mocked via run_git_command -- no real repository needed.
 """
 
 from unittest import mock
@@ -10,13 +10,15 @@ import pytest
 from siege_utilities.exceptions import GitError
 from siege_utilities.git.git_status import (
     get_branch_info,
+    get_file_status,
     get_log_summary,
     get_remote_info,
+    get_repository_size,
     get_repository_status,
     get_stash_list,
     get_tag_list,
-    run_git_command,
 )
+from siege_utilities.git._utils import run_git_command
 
 
 # ---------------------------------------------------------------------------
@@ -38,13 +40,13 @@ def _mock_run(stdout: str = "", returncode: int = 0, stderr: str = ""):
 
 class TestRunGitCommand:
 
-    @mock.patch("siege_utilities.git.git_status.subprocess.run")
+    @mock.patch("siege_utilities.git._utils.subprocess.run")
     def test_success(self, mock_run):
         mock_run.return_value = _mock_run(stdout="main\n")
         result = run_git_command("branch", "--show-current")
         assert result == "main"
 
-    @mock.patch("siege_utilities.git.git_status.subprocess.run")
+    @mock.patch("siege_utilities.git._utils.subprocess.run")
     def test_failure_raises_git_error(self, mock_run):
         mock_run.side_effect = __import__("subprocess").CalledProcessError(
             1, "git", stderr="fatal: not a repo"
@@ -52,7 +54,7 @@ class TestRunGitCommand:
         with pytest.raises(GitError, match="Git command failed"):
             run_git_command("status")
 
-    @mock.patch("siege_utilities.git.git_status.subprocess.run")
+    @mock.patch("siege_utilities.git._utils.subprocess.run")
     def test_failure_check_false_returns_empty(self, mock_run):
         mock_run.side_effect = __import__("subprocess").CalledProcessError(
             1, "git", stderr="error"
@@ -99,6 +101,47 @@ class TestGetRepositoryStatus:
         assert "working_directory_clean" in result
         assert result["working_directory_clean"] is True
 
+    @mock.patch("siege_utilities.git.git_status.run_git_command")
+    def test_commit_info_failure_raises_git_error(self, mock_cmd, tmp_path):
+        (tmp_path / ".git").mkdir()
+
+        def _side_effect(*args, **kwargs):
+            cmd = args[0] if args else ""
+            if cmd == "branch":
+                return "main"
+            if cmd == "status":
+                return ""
+            # Fail on rev-parse (commit info)
+            raise GitError("rev-parse failed")
+
+        mock_cmd.side_effect = _side_effect
+        with pytest.raises(GitError, match="Could not retrieve last commit info"):
+            get_repository_status(str(tmp_path))
+
+    @mock.patch("siege_utilities.git.git_status.run_git_command")
+    def test_remote_info_failure_raises_git_error(self, mock_cmd, tmp_path):
+        (tmp_path / ".git").mkdir()
+
+        def _side_effect(*args, **kwargs):
+            cmd = args[0] if args else ""
+            if cmd == "branch":
+                return "main"
+            if cmd == "status":
+                return ""
+            if cmd == "rev-parse":
+                if "--abbrev-ref" in args:
+                    raise GitError("no upstream")
+                return "abc1234def"
+            if cmd == "log":
+                return "test"
+            if cmd == "config":
+                raise GitError("config failed")
+            return ""
+
+        mock_cmd.side_effect = _side_effect
+        with pytest.raises(GitError, match="Could not retrieve remote info"):
+            get_repository_status(str(tmp_path))
+
 
 # ---------------------------------------------------------------------------
 # get_branch_info
@@ -108,10 +151,45 @@ class TestGetBranchInfo:
 
     @mock.patch("siege_utilities.git.git_status.run_git_command")
     def test_returns_dict(self, mock_cmd):
-        mock_cmd.return_value = "main"
+        call_count = [0]
+
+        def _side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                # branch --list: one branch with no upstream/tracking
+                return "main||"
+            if call_count[0] == 2:
+                # log for "main" branch commit
+                return "abc1234def5678|2026-05-29|Test Author|Initial commit"
+            if call_count[0] == 3:
+                # branch -r (remote branches)
+                return ""
+            # branch --show-current
+            return "main"
+
+        mock_cmd.side_effect = _side_effect
         result = get_branch_info()
         assert isinstance(result, dict)
         assert "current_branch" in result
+        assert result["current_branch"] == "main"
+        assert len(result["local_branches"]) == 1
+        assert result["local_branches"][0]["name"] == "main"
+
+    @mock.patch("siege_utilities.git.git_status.run_git_command")
+    def test_branch_commit_failure_raises_git_error(self, mock_cmd):
+        call_count = [0]
+
+        def _side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                # First call: branch --list
+                return "main||"
+            # Second call: log for branch commit -- fail
+            raise GitError("log failed")
+
+        mock_cmd.side_effect = _side_effect
+        with pytest.raises(GitError, match="Could not retrieve commit info for branch main"):
+            get_branch_info()
 
 
 # ---------------------------------------------------------------------------
@@ -125,6 +203,20 @@ class TestGetRemoteInfo:
         mock_cmd.return_value = "origin"
         result = get_remote_info()
         assert isinstance(result, dict)
+
+    @mock.patch("siege_utilities.git.git_status.run_git_command")
+    def test_remote_url_failure_raises_git_error(self, mock_cmd):
+        call_count = [0]
+
+        def _side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return "origin"  # remote list
+            raise GitError("config failed")
+
+        mock_cmd.side_effect = _side_effect
+        with pytest.raises(GitError, match="Could not retrieve URL for remote origin"):
+            get_remote_info()
 
 
 # ---------------------------------------------------------------------------
@@ -150,6 +242,12 @@ class TestGetStashList:
         assert result[0]["ref"] == "stash@{0}"
         assert result[1]["message"] == "WIP on dev"
 
+    @mock.patch("siege_utilities.git.git_status.run_git_command")
+    def test_failure_raises_git_error(self, mock_cmd):
+        mock_cmd.side_effect = GitError("stash failed")
+        with pytest.raises(GitError, match="Could not retrieve stash list"):
+            get_stash_list()
+
 
 # ---------------------------------------------------------------------------
 # get_tag_list
@@ -173,6 +271,12 @@ class TestGetTagList:
         assert len(result) == 2
         assert result[0]["name"] == "v1.0.0"
 
+    @mock.patch("siege_utilities.git.git_status.run_git_command")
+    def test_failure_raises_git_error(self, mock_cmd):
+        mock_cmd.side_effect = GitError("tag failed")
+        with pytest.raises(GitError, match="Could not retrieve tag list"):
+            get_tag_list()
+
 
 # ---------------------------------------------------------------------------
 # get_log_summary
@@ -186,3 +290,48 @@ class TestGetLogSummary:
         result = get_log_summary()
         assert isinstance(result, dict)
         assert "total_commits" in result
+
+    @mock.patch("siege_utilities.git.git_status.run_git_command")
+    def test_failure_raises_git_error(self, mock_cmd):
+        mock_cmd.side_effect = GitError("log failed")
+        with pytest.raises(GitError, match="Could not retrieve commit log"):
+            get_log_summary()
+
+
+# ---------------------------------------------------------------------------
+# get_file_status
+# ---------------------------------------------------------------------------
+
+class TestGetFileStatus:
+
+    @mock.patch("siege_utilities.git.git_status.run_git_command")
+    def test_returns_dict(self, mock_cmd):
+        mock_cmd.return_value = ""
+        result = get_file_status()
+        assert isinstance(result, dict)
+        assert "staged" in result
+
+    @mock.patch("siege_utilities.git.git_status.run_git_command")
+    def test_failure_raises_git_error(self, mock_cmd):
+        mock_cmd.side_effect = GitError("status failed")
+        with pytest.raises(GitError, match="Could not retrieve file status"):
+            get_file_status()
+
+
+# ---------------------------------------------------------------------------
+# get_repository_size
+# ---------------------------------------------------------------------------
+
+class TestGetRepositorySize:
+
+    @mock.patch("siege_utilities.git.git_status.Path.resolve")
+    def test_failure_raises_git_error(self, mock_resolve, tmp_path):
+        """OSError during size calculation raises GitError."""
+        mock_path = mock.MagicMock()
+        mock_resolve.return_value = mock_path
+        git_dir = mock.MagicMock()
+        mock_path.__truediv__ = mock.MagicMock(return_value=git_dir)
+        git_dir.rglob.side_effect = OSError("Permission denied")
+
+        with pytest.raises(GitError, match="Could not calculate repository size"):
+            get_repository_size("/fake/path")


### PR DESCRIPTION
## Summary

- Replaces 10 `except Exception` blocks in `git_status.py` that silently returned fake empty data ("unknown" strings, empty lists, zero counts) with `raise GitError(...)` with exception chaining
- Narrows catches from bare `Exception` to `(RuntimeError, GitError)` for git commands and `(OSError, PermissionError)` for filesystem operations
- Adds `Raises: GitError` to docstrings for all 8 public functions
- Adds 10 error-path tests; fixes 3 pre-existing test mock paths; 22 tests pass

Follows the pattern established in #745 (git_operations.py, git_workflow.py) and #730 (branch_analyzer.py). This is the last file in `siege_utilities/git/` with SU-1 violations.

## Test plan

- [x] All 22 tests in `test_git_status.py` pass
- [x] Zero `except Exception` blocks remain in `git_status.py`
- [x] 10 `raise GitError` statements present
- [x] Each error-path test fails on revert (asserts `pytest.raises(GitError)`)

Refs: #729