### PR TITLE
feat(#813): add geocode_results_to_dataframe() helper

### DIFF
--- a/notebooks/spatial/02_geocoding.ipynb
+++ b/notebooks/spatial/02_geocoding.ipynb
@@ -11,11 +11,11 @@
     "How to batch-geocode addresses through the Census Bureau's free geocoder, attach tract-level FIPS / GEOID to each record, and handle the mix of clean + messy inputs ElectInfo sees in practice. A second run against the same batch demonstrates the per-session cache hit without going back to the network.\n",
     "\n",
     "## Why it matters\n",
-    "Address → tract is the first step in joining individual-level data (donors, voters, survey respondents) to Census demographics or TIGER boundaries. The primitives here are what `spatial/03_choropleth_maps` and the survey pipeline end up consuming.\n",
+    "Address \u2192 tract is the first step in joining individual-level data (donors, voters, survey respondents) to Census demographics or TIGER boundaries. The primitives here are what `spatial/03_choropleth_maps` and the survey pipeline end up consuming.\n",
     "\n",
     "## Prereqs\n",
     "- `pip install 'siege-utilities[geo]'`\n",
-    "- No credentials — the Census geocoder is public.\n",
+    "- No credentials \u2014 the Census geocoder is public.\n",
     "\n",
     "## Next\n",
     "- `spatial/03_choropleth_maps.ipynb` renders tract-keyed values on a map.\n",
@@ -29,7 +29,7 @@
    "source": [
     "## 1. ElectInfo's synthetic donor batch\n",
     "\n",
-    "A realistic-shaped CSV — three clean addresses for the TX-32 engagement, plus two messy ones (missing ZIP, wrong state) to show how unmatched rows come back."
+    "A realistic-shaped CSV \u2014 three clean addresses for the TX-32 engagement, plus two messy ones (missing ZIP, wrong state) to show how unmatched rows come back."
    ]
   },
   {
@@ -207,14 +207,14 @@
    "id": "s3",
    "metadata": {},
    "source": [
-    "## 3. Attach tract GEOID back to the donor DataFrame\n",
+    "## 3. Convert results to a DataFrame with `geocode_results_to_dataframe`\n",
     "\n",
-    "The standard pattern downstream consumers expect: one new `tract_geoid` column, blank for unmatched rows. `CensusGeocodeResult.tract_geoid` is composed from state + county + tract FIPS so it can be joined against TIGER tracts (from `spatial/01`) or ACS tables directly."
+    "`geocode_results_to_dataframe()` converts the list of `CensusGeocodeResult` objects into a flat DataFrame with standard columns (`matched`, `latitude`, `longitude`, `tract_geoid`, `block_geoid`, etc.). This replaces the per-field list-comprehension boilerplate that every caller otherwise has to write."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "c3",
    "metadata": {
     "execution": {
@@ -224,112 +224,18 @@
      "shell.execute_reply": "2026-04-24T22:18:56.277930Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>id</th>\n",
-       "      <th>street</th>\n",
-       "      <th>city</th>\n",
-       "      <th>tract_geoid</th>\n",
-       "      <th>county_geoid</th>\n",
-       "      <th>lat</th>\n",
-       "      <th>lon</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>1501 Matamoros Ave</td>\n",
-       "      <td>Austin</td>\n",
-       "      <td></td>\n",
-       "      <td></td>\n",
-       "      <td>None</td>\n",
-       "      <td>None</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>2</td>\n",
-       "      <td>2929 Main Street</td>\n",
-       "      <td>Dallas</td>\n",
-       "      <td></td>\n",
-       "      <td></td>\n",
-       "      <td>None</td>\n",
-       "      <td>None</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>3</td>\n",
-       "      <td>1201 Louisiana St</td>\n",
-       "      <td>Houston</td>\n",
-       "      <td></td>\n",
-       "      <td></td>\n",
-       "      <td>None</td>\n",
-       "      <td>None</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>4</td>\n",
-       "      <td>1 Legit Sounding Ave</td>\n",
-       "      <td>Plano</td>\n",
-       "      <td></td>\n",
-       "      <td></td>\n",
-       "      <td>None</td>\n",
-       "      <td>None</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>5</td>\n",
-       "      <td>742 Evergreen Terr</td>\n",
-       "      <td>Springfield</td>\n",
-       "      <td></td>\n",
-       "      <td></td>\n",
-       "      <td>None</td>\n",
-       "      <td>None</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "  id                street         city tract_geoid county_geoid   lat   lon\n",
-       "0  1    1501 Matamoros Ave       Austin                           None  None\n",
-       "1  2      2929 Main Street       Dallas                           None  None\n",
-       "2  3     1201 Louisiana St      Houston                           None  None\n",
-       "3  4  1 Legit Sounding Ave        Plano                           None  None\n",
-       "4  5    742 Evergreen Terr  Springfield                           None  None"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "donors['tract_geoid'] = [r.tract_geoid if r.matched else '' for r in results]\n",
-    "donors['county_geoid'] = [r.county_geoid if r.matched else '' for r in results]\n",
-    "donors['lat']          = [r.lat if r.matched else None for r in results]\n",
-    "donors['lon']          = [r.lon if r.matched else None for r in results]\n",
-    "donors[['id', 'street', 'city', 'tract_geoid', 'county_geoid', 'lat', 'lon']]\n"
+    "from siege_utilities.geo.providers.census_geocoder import geocode_results_to_dataframe\n",
+    "\n",
+    "geo_df = geocode_results_to_dataframe(results)\n",
+    "\n",
+    "# Merge selected columns back onto the donor DataFrame\n",
+    "donors = donors.merge(\n",
+    "    geo_df[['input_id', 'tract_geoid', 'county_geoid', 'latitude', 'longitude']],\n",
+    "    left_on='id', right_on='input_id', how='left',\n",
+    ").drop(columns='input_id')\n",
+    "donors[['id', 'street', 'city', 'tract_geoid', 'county_geoid', 'latitude', 'longitude']]\n"
    ]
   },
   {
@@ -337,7 +243,7 @@
    "id": "s4",
    "metadata": {},
    "source": [
-    "## 4. Quality check — what stayed unmatched and why\n",
+    "## 4. Quality check \u2014 what stayed unmatched and why\n",
     "\n",
     "Row 4 is missing a ZIP; row 5 uses a nonexistent state. Both should come back unmatched. In production this is the point at which ElectInfo would re-queue them for a fallback geocoder or hand-review."
    ]
@@ -460,7 +366,7 @@
    "id": "s5",
    "metadata": {},
    "source": [
-    "## 5. Rerun — within one run the results dict is the cache\n",
+    "## 5. Rerun \u2014 within one run the results dict is the cache\n",
     "\n",
     "The batch endpoint's own persistent cache is an enhancement we'd layer on top (e.g. via `siege_utilities.cache`); what matters for the demo is that a second pass over the same results is instantaneous."
    ]
@@ -503,8 +409,8 @@
    "source": [
     "## Related\n",
     "\n",
-    "- **Source**: `siege_utilities/geo/providers/census_geocoder.py` (`geocode_batch`, `geocode_single`, `CensusGeocodeResult`, `CensusGeocodeError`).\n",
-    "- **Tests**: `tests/test_census_geocoder.py`, `tests/test_census_geocoder_errors.py`.\n",
+    "- **Source**: `siege_utilities/geo/providers/census_geocoder.py` (`geocode_batch`, `geocode_single`, `geocode_results_to_dataframe`, `CensusGeocodeResult`, `CensusGeocodeError`).\n",
+    "- **Tests**: `tests/test_census_geocoder.py`, `tests/test_census_geocoder_errors.py`, `tests/test_geocode_results_to_dataframe.py`.\n",
     "- **Next**: `spatial/03_choropleth_maps.ipynb` uses the `tract_geoid` column emitted above to join per-donor counts onto the tract polygons from `spatial/01`.\n"
    ]
   }

--- a/siege_utilities/geo/__init__.py
+++ b/siege_utilities/geo/__init__.py
@@ -113,7 +113,7 @@ _register([
     'CensusGeocodeError',
     'CensusVintage', 'CensusGeocodeResult',
     'select_vintage_for_cycle', 'geocode_single', 'geocode_batch',
-    'geocode_batch_chunked',
+    'geocode_batch_chunked', 'geocode_results_to_dataframe',
 ], '.providers.census_geocoder')
 
 # --- census_api_client ---

--- a/siege_utilities/geo/census_geocoder.py
+++ b/siege_utilities/geo/census_geocoder.py
@@ -22,6 +22,7 @@ from .providers.census_geocoder import (  # noqa: F401, E402
     _safe_float,
     geocode_batch,
     geocode_batch_chunked,
+    geocode_results_to_dataframe,
     geocode_single,
     select_vintage_for_cycle,
 )

--- a/siege_utilities/geo/providers/census_geocoder.py
+++ b/siege_utilities/geo/providers/census_geocoder.py
@@ -409,3 +409,94 @@ def _safe_float(val) -> Optional[float]:
         return float(val)
     except (ValueError, TypeError):
         return None
+
+
+def geocode_results_to_dataframe(
+    results: list[CensusGeocodeResult],
+) -> "pd.DataFrame":
+    """Convert a list of CensusGeocodeResult to a pandas DataFrame.
+
+    Extracts all dataclass fields and computed GEOID properties into a
+    flat DataFrame with standard column names. This eliminates the
+    per-field list-comprehension boilerplate that every caller of
+    :func:`geocode_batch` otherwise has to write.
+
+    Args:
+        results: List of :class:`CensusGeocodeResult` objects, typically
+            returned by :func:`geocode_batch` or :func:`geocode_batch_chunked`.
+
+    Returns:
+        DataFrame with columns: ``input_id``, ``input_address``, ``matched``,
+        ``match_type``, ``matched_address``, ``latitude``, ``longitude``,
+        ``state_geoid``, ``county_geoid``, ``tract_geoid``, ``block_geoid``,
+        ``block_group_geoid``, ``state_fips``, ``county_fips``, ``tract``,
+        ``block``, ``side``, ``tiger_line_id``.
+        For unmatched rows, latitude/longitude are ``None`` and GEOID
+        columns are empty strings.
+
+    Raises:
+        TypeError: If *results* is not a list.
+
+    Example::
+
+        results = geocode_batch(addresses)
+        df = geocode_results_to_dataframe(results)
+        # df now has tract_geoid, block_geoid, lat/lon, etc.
+    """
+    import pandas as pd
+
+    if not isinstance(results, list):
+        raise TypeError(
+            f"results must be a list of CensusGeocodeResult, got {type(results).__name__}"
+        )
+
+    _COLUMNS = [
+        "input_id",
+        "input_address",
+        "matched",
+        "match_type",
+        "matched_address",
+        "latitude",
+        "longitude",
+        "state_geoid",
+        "county_geoid",
+        "tract_geoid",
+        "block_geoid",
+        "block_group_geoid",
+        "state_fips",
+        "county_fips",
+        "tract",
+        "block",
+        "side",
+        "tiger_line_id",
+    ]
+
+    if not results:
+        return pd.DataFrame(columns=_COLUMNS)
+
+    rows = []
+    for r in results:
+        rows.append(
+            {
+                "input_id": r.input_id,
+                "input_address": r.input_address,
+                "matched": r.matched,
+                "match_type": r.match_type,
+                "matched_address": r.matched_address,
+                "latitude": r.lat,
+                "longitude": r.lon,
+                "state_geoid": r.state_geoid,
+                "county_geoid": r.county_geoid,
+                "tract_geoid": r.tract_geoid,
+                "block_geoid": r.block_geoid,
+                "block_group_geoid": r.block_group_geoid,
+                "state_fips": r.state_fips,
+                "county_fips": r.county_fips,
+                "tract": r.tract,
+                "block": r.block,
+                "side": r.side,
+                "tiger_line_id": r.tiger_line_id,
+            }
+        )
+
+    return pd.DataFrame(rows, columns=_COLUMNS)

--- a/tests/test_geocode_results_to_dataframe.py
+++ b/tests/test_geocode_results_to_dataframe.py
@@ -1,0 +1,131 @@
+"""Tests for geocode_results_to_dataframe() helper.
+
+Verifies the conversion from list[CensusGeocodeResult] to pandas DataFrame
+with correct columns, types, and edge-case handling.
+"""
+
+import pytest
+import pandas as pd
+
+from siege_utilities.geo.providers.census_geocoder import (
+    CensusGeocodeResult,
+    geocode_results_to_dataframe,
+)
+
+EXPECTED_COLUMNS = [
+    "input_id",
+    "input_address",
+    "matched",
+    "match_type",
+    "matched_address",
+    "latitude",
+    "longitude",
+    "state_geoid",
+    "county_geoid",
+    "tract_geoid",
+    "block_geoid",
+    "block_group_geoid",
+    "state_fips",
+    "county_fips",
+    "tract",
+    "block",
+    "side",
+    "tiger_line_id",
+]
+
+
+class TestGeocodeResultsToDataframe:
+    """Tests for geocode_results_to_dataframe()."""
+
+    def test_empty_list_returns_empty_dataframe_with_columns(self):
+        df = geocode_results_to_dataframe([])
+        assert isinstance(df, pd.DataFrame)
+        assert list(df.columns) == EXPECTED_COLUMNS
+        assert len(df) == 0
+
+    def test_single_matched_result(self):
+        result = CensusGeocodeResult(
+            matched=True,
+            input_id="1",
+            input_address="123 Main St, Austin, TX 78741",
+            matched_address="123 MAIN ST, AUSTIN, TX, 78741",
+            lat=30.25,
+            lon=-97.75,
+            state_fips="48",
+            county_fips="453",
+            tract="001234",
+            block="1001",
+            match_type="Exact",
+            side="L",
+            tiger_line_id="12345",
+        )
+        df = geocode_results_to_dataframe([result])
+        assert len(df) == 1
+        row = df.iloc[0]
+        assert row["matched"] == True
+        assert row["latitude"] == 30.25
+        assert row["longitude"] == -97.75
+        assert row["tract_geoid"] == "48453001234"
+        assert row["block_geoid"] == "484530012341001"
+        assert row["county_geoid"] == "48453"
+        assert row["state_geoid"] == "48"
+        assert row["block_group_geoid"] == "484530012341"
+        assert row["input_id"] == "1"
+
+    def test_single_unmatched_result(self):
+        result = CensusGeocodeResult(
+            input_id="5",
+            input_address="742 Evergreen Terr, Springfield, XX 00000",
+        )
+        df = geocode_results_to_dataframe([result])
+        assert len(df) == 1
+        row = df.iloc[0]
+        assert row["matched"] == False
+        assert pd.isna(row["latitude"])
+        assert pd.isna(row["longitude"])
+        assert row["tract_geoid"] == ""
+        assert row["block_geoid"] == ""
+
+    def test_mixed_matched_and_unmatched(self):
+        matched = CensusGeocodeResult(
+            matched=True,
+            input_id="1",
+            input_address="123 Main St",
+            lat=30.0,
+            lon=-97.0,
+            state_fips="48",
+            county_fips="453",
+            tract="001234",
+            block="1001",
+        )
+        unmatched = CensusGeocodeResult(
+            input_id="2",
+            input_address="Bad Address",
+        )
+        df = geocode_results_to_dataframe([matched, unmatched])
+        assert len(df) == 2
+        assert df.iloc[0]["matched"] == True
+        assert df.iloc[1]["matched"] == False
+        assert df.iloc[0]["tract_geoid"] == "48453001234"
+        assert df.iloc[1]["tract_geoid"] == ""
+
+    def test_column_order_matches_expected(self):
+        df = geocode_results_to_dataframe([CensusGeocodeResult()])
+        assert list(df.columns) == EXPECTED_COLUMNS
+
+    def test_raises_type_error_for_non_list(self):
+        with pytest.raises(TypeError, match="results must be a list"):
+            geocode_results_to_dataframe("not a list")
+
+    def test_lat_lon_renamed_to_latitude_longitude(self):
+        result = CensusGeocodeResult(matched=True, lat=40.0, lon=-74.0)
+        df = geocode_results_to_dataframe([result])
+        assert "latitude" in df.columns
+        assert "longitude" in df.columns
+        assert "lat" not in df.columns
+        assert "lon" not in df.columns
+
+    def test_importable_from_geo_init(self):
+        """Verify the function is exported via geo/__init__.py."""
+        from siege_utilities.geo import geocode_results_to_dataframe as fn
+        assert callable(fn)


### PR DESCRIPTION
## Summary

- Add `geocode_results_to_dataframe()` to `siege_utilities/geo/providers/census_geocoder.py` that converts `list[CensusGeocodeResult]` to a pandas DataFrame with 18 standard columns (matched, latitude, longitude, tract_geoid, block_geoid, etc.)
- Export via `geo/__init__.py` lazy registration and deprecation shim
- Update `notebooks/spatial/02_geocoding.ipynb` (cells s3, c3, related) to use the helper instead of manual list comprehensions

## Test plan

- [x] 8 unit tests passing: empty input, matched result, unmatched result, mixed, column order, TypeError, lat/lon renaming, import path
- [ ] Run notebook `spatial/02_geocoding.ipynb` end-to-end (requires network access to Census API)

Refs: #813