### PR TITLE
fix(#815): add library API demo cells to choropleth notebook

### DIFF
--- a/notebooks/spatial/03_choropleth_maps.ipynb
+++ b/notebooks/spatial/03_choropleth_maps.ipynb
@@ -415,15 +415,51 @@
   },
   {
    "cell_type": "markdown",
+   "id": "97afb410",
+   "source": "## 4. The same map via the library API\n\nThe manual approach above is useful for understanding the mechanics. In production, use `siege_utilities.geo.choropleth` — it handles quantile binning, color-scheme resolution, breakpoint-labeled legends, and verification in a single call.\n\nNote: the library uses `pd.qcut` for classification (slightly different boundary assignment than the hand-rolled `tertile()` above), so bin assignments may differ at the margins. The library approach is more robust for production use.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "095004c5",
+   "source": "from siege_utilities.geo import (\n    create_bivariate_choropleth,\n    create_bivariate_analysis,\n    verify_bivariate_classification,\n    BIVARIATE_COLOR_SCHEMES,\n)\n\n# One-call bivariate choropleth with labeled legend\nfig, axes = create_bivariate_choropleth(\n    gdf, 'dem_pct', 'turnout_pct',\n    title='TX-32: Dem share × turnout (library API)',\n    color_scheme='purple_blue',\n    figsize=(14, 8),\n)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ec4e93a",
+   "source": "### Verify the classification\n\n`verify_bivariate_classification()` is a pure-data check: it confirms that all units are classified, breakpoints are monotonic, and counts sum correctly. Use it as a sanity check before publishing.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "e7988bac",
+   "source": "verification = verify_bivariate_classification(gdf, 'dem_pct', 'turnout_pct')\nprint(f\"Valid: {verification['valid']}\")\nprint(f\"Total units: {verification['total_units']}\")\nprint(f\"Classified: {verification['classified_units']}\")\nprint(f\"Errors: {verification['errors']}\")\nprint(f\"\\nVar1 breaks: {verification['var1_breaks']}\")\nprint(f\"Var2 breaks: {verification['var2_breaks']}\")\nprint(f\"\\nCrosstab:\\n{verification['crosstab']}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10be15e9",
+   "source": "### Full analysis orchestrator\n\n`create_bivariate_analysis()` produces all artifacts in one call: the bivariate map, a rendered crosstab, companion monovariate maps, and verification results.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "2e897192",
+   "source": "result = create_bivariate_analysis(\n    gdf, 'dem_pct', 'turnout_pct',\n    title='TX-32: Full bivariate analysis',\n    color_scheme='purple_blue',\n)\n\n# The result bundles every artifact\nprint(f\"Verification valid: {result.verification['valid']}\")\nprint(f\"Var1 breaks: {result.var1_breaks}\")\nprint(f\"Var2 breaks: {result.var2_breaks}\")\nprint(f\"\\nCrosstab:\\n{result.crosstab}\")\n\n# Show the companion monovariate maps\nresult.companion_fig",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "r",
    "metadata": {},
-   "source": [
-    "## Related\n",
-    "\n",
-    "- **Source**: `siege_utilities/reporting/chart_generator.py` for the full bivariate helpers (this notebook builds one by hand for clarity).\n",
-    "- **Tests**: `tests/test_chart_types*.py`.\n",
-    "- **Next**: `reports/01_charts_and_pdf.ipynb` embeds this map into ElectInfo's Q1 PDF deliverable.\n"
-   ]
+   "source": "## Related\n\n- **Source**: `siege_utilities/geo/choropleth.py` — `create_choropleth()`, `create_bivariate_choropleth()`, `create_bivariate_analysis()`, and supporting functions.\n- **Tests**: `tests/test_chart_types*.py`.\n- **Next**: `reports/01_charts_and_pdf.ipynb` embeds this map into ElectInfo's Q1 PDF deliverable."
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

- Add Section 4 to `notebooks/spatial/03_choropleth_maps.ipynb` demonstrating the library's `create_bivariate_choropleth()`, `verify_bivariate_classification()`, and `create_bivariate_analysis()` functions from `siege_utilities.geo.choropleth`
- Update the Related section to point at `geo/choropleth.py` instead of the stale `reporting/chart_generator.py` reference
- Preserve the existing manual matplotlib approach (Sections 1-3) as a pedagogical walkthrough

## Test plan

- [ ] Run the notebook end-to-end with `siege-utilities[geo,reporting]` installed
- [ ] Verify Section 4 cells produce bivariate choropleth, verification output, and companion maps
- [ ] Confirm no regressions in existing Sections 1-3

Refs: #815