### PR TITLE
fix(#814): correct Census geocoder API params and field mappings

### DIFF
--- a/notebooks/spatial/02_geocoding.ipynb
+++ b/notebooks/spatial/02_geocoding.ipynb
@@ -11,11 +11,11 @@
     "How to batch-geocode addresses through the Census Bureau's free geocoder, attach tract-level FIPS / GEOID to each record, and handle the mix of clean + messy inputs ElectInfo sees in practice. A second run against the same batch demonstrates the per-session cache hit without going back to the network.\n",
     "\n",
     "## Why it matters\n",
-    "Address \u2192 tract is the first step in joining individual-level data (donors, voters, survey respondents) to Census demographics or TIGER boundaries. The primitives here are what `spatial/03_choropleth_maps` and the survey pipeline end up consuming.\n",
+    "Address → tract is the first step in joining individual-level data (donors, voters, survey respondents) to Census demographics or TIGER boundaries. The primitives here are what `spatial/03_choropleth_maps` and the survey pipeline end up consuming.\n",
     "\n",
     "## Prereqs\n",
     "- `pip install 'siege-utilities[geo]'`\n",
-    "- No credentials \u2014 the Census geocoder is public.\n",
+    "- No credentials — the Census geocoder is public.\n",
     "\n",
     "## Next\n",
     "- `spatial/03_choropleth_maps.ipynb` renders tract-keyed values on a map.\n",
@@ -26,15 +26,11 @@
    "cell_type": "markdown",
    "id": "s1",
    "metadata": {},
-   "source": [
-    "## 1. ElectInfo's synthetic donor batch\n",
-    "\n",
-    "A realistic-shaped CSV \u2014 three clean addresses for the TX-32 engagement, plus two messy ones (missing ZIP, wrong state) to show how unmatched rows come back."
-   ]
+   "source": "## 1. ElectInfo's synthetic donor batch\n\nA realistic-shaped CSV — three clean addresses for the TX-32 engagement, plus two messy ones (missing ZIP, wrong state) to show how unmatched rows come back. The three valid addresses (Austin, Dallas, Houston) should all match; rows 4 and 5 are intentionally bad."
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "c1",
    "metadata": {
     "execution": {
@@ -44,106 +40,8 @@
      "shell.execute_reply": "2026-04-24T22:18:55.841878Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>id</th>\n",
-       "      <th>street</th>\n",
-       "      <th>city</th>\n",
-       "      <th>state</th>\n",
-       "      <th>zipcode</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>1501 Matamoros Ave</td>\n",
-       "      <td>Austin</td>\n",
-       "      <td>TX</td>\n",
-       "      <td>78741</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>2</td>\n",
-       "      <td>2929 Main Street</td>\n",
-       "      <td>Dallas</td>\n",
-       "      <td>TX</td>\n",
-       "      <td>75226</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>3</td>\n",
-       "      <td>1201 Louisiana St</td>\n",
-       "      <td>Houston</td>\n",
-       "      <td>TX</td>\n",
-       "      <td>77002</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>4</td>\n",
-       "      <td>1 Legit Sounding Ave</td>\n",
-       "      <td>Plano</td>\n",
-       "      <td>TX</td>\n",
-       "      <td></td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>5</td>\n",
-       "      <td>742 Evergreen Terr</td>\n",
-       "      <td>Springfield</td>\n",
-       "      <td>XX</td>\n",
-       "      <td>00000</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "  id                street         city state zipcode\n",
-       "0  1    1501 Matamoros Ave       Austin    TX   78741\n",
-       "1  2      2929 Main Street       Dallas    TX   75226\n",
-       "2  3     1201 Louisiana St      Houston    TX   77002\n",
-       "3  4  1 Legit Sounding Ave        Plano    TX        \n",
-       "4  5    742 Evergreen Terr  Springfield    XX   00000"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "import pandas as pd\n",
-    "\n",
-    "donors = pd.DataFrame([\n",
-    "    {'id': '1', 'street': '1501 Matamoros Ave',  'city': 'Austin',      'state': 'TX', 'zipcode': '78741'},\n",
-    "    {'id': '2', 'street': '2929 Main Street',    'city': 'Dallas',      'state': 'TX', 'zipcode': '75226'},\n",
-    "    {'id': '3', 'street': '1201 Louisiana St',   'city': 'Houston',     'state': 'TX', 'zipcode': '77002'},\n",
-    "    {'id': '4', 'street': '1 Legit Sounding Ave','city': 'Plano',       'state': 'TX', 'zipcode': ''},\n",
-    "    {'id': '5', 'street': '742 Evergreen Terr',  'city': 'Springfield', 'state': 'XX', 'zipcode': '00000'},\n",
-    "])\n",
-    "donors\n"
-   ]
+   "outputs": [],
+   "source": "import pandas as pd\n\ndonors = pd.DataFrame([\n    {'id': '1', 'street': '301 W 2nd St',       'city': 'Austin',      'state': 'TX', 'zipcode': '78701'},\n    {'id': '2', 'street': '2929 Main Street',    'city': 'Dallas',      'state': 'TX', 'zipcode': '75226'},\n    {'id': '3', 'street': '1201 Louisiana St',   'city': 'Houston',     'state': 'TX', 'zipcode': '77002'},\n    {'id': '4', 'street': '1 Legit Sounding Ave','city': 'Plano',       'state': 'TX', 'zipcode': ''},\n    {'id': '5', 'street': '742 Evergreen Terr',  'city': 'Springfield', 'state': 'XX', 'zipcode': '00000'},\n])\ndonors"
   },
   {
    "cell_type": "markdown",
@@ -157,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "c2",
    "metadata": {
     "execution": {
@@ -167,26 +65,7 @@
      "shell.execute_reply": "2026-04-24T22:18:56.265188Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[siege_utilities] 2026-04-24 17:18:56,260 INFO: Census batch: 0/5 matched\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "id=1   no match  tract_geoid=(none)\n",
-      "id=2   no match  tract_geoid=(none)\n",
-      "id=3   no match  tract_geoid=(none)\n",
-      "id=4   no match  tract_geoid=(none)\n",
-      "id=5   no match  tract_geoid=(none)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from siege_utilities.geo.providers.census_geocoder import (\n",
     "    geocode_batch, CensusGeocodeError,\n",
@@ -242,15 +121,11 @@
    "cell_type": "markdown",
    "id": "s4",
    "metadata": {},
-   "source": [
-    "## 4. Quality check \u2014 what stayed unmatched and why\n",
-    "\n",
-    "Row 4 is missing a ZIP; row 5 uses a nonexistent state. Both should come back unmatched. In production this is the point at which ElectInfo would re-queue them for a fallback geocoder or hand-review."
-   ]
+   "source": "## 4. Quality check — what stayed unmatched and why\n\nRow 4 is missing a ZIP; row 5 uses a nonexistent state. Both should come back unmatched — the Census geocoder requires a valid state abbreviation and works best with a ZIP code. In production this is the point at which ElectInfo would re-queue them for a fallback geocoder or hand-review."
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "c4",
    "metadata": {
     "execution": {
@@ -260,101 +135,7 @@
      "shell.execute_reply": "2026-04-24T22:18:56.284765Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "5 of 5 unmatched\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>id</th>\n",
-       "      <th>street</th>\n",
-       "      <th>city</th>\n",
-       "      <th>state</th>\n",
-       "      <th>zipcode</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>1501 Matamoros Ave</td>\n",
-       "      <td>Austin</td>\n",
-       "      <td>TX</td>\n",
-       "      <td>78741</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>2</td>\n",
-       "      <td>2929 Main Street</td>\n",
-       "      <td>Dallas</td>\n",
-       "      <td>TX</td>\n",
-       "      <td>75226</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>3</td>\n",
-       "      <td>1201 Louisiana St</td>\n",
-       "      <td>Houston</td>\n",
-       "      <td>TX</td>\n",
-       "      <td>77002</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>4</td>\n",
-       "      <td>1 Legit Sounding Ave</td>\n",
-       "      <td>Plano</td>\n",
-       "      <td>TX</td>\n",
-       "      <td></td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>5</td>\n",
-       "      <td>742 Evergreen Terr</td>\n",
-       "      <td>Springfield</td>\n",
-       "      <td>XX</td>\n",
-       "      <td>00000</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "  id                street         city state zipcode\n",
-       "0  1    1501 Matamoros Ave       Austin    TX   78741\n",
-       "1  2      2929 Main Street       Dallas    TX   75226\n",
-       "2  3     1201 Louisiana St      Houston    TX   77002\n",
-       "3  4  1 Legit Sounding Ave        Plano    TX        \n",
-       "4  5    742 Evergreen Terr  Springfield    XX   00000"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "unmatched = donors[donors['tract_geoid'] == '']\n",
     "print(f'{len(unmatched)} of {len(donors)} unmatched')\n",
@@ -366,14 +147,14 @@
    "id": "s5",
    "metadata": {},
    "source": [
-    "## 5. Rerun \u2014 within one run the results dict is the cache\n",
+    "## 5. Rerun — within one run the results dict is the cache\n",
     "\n",
     "The batch endpoint's own persistent cache is an enhancement we'd layer on top (e.g. via `siege_utilities.cache`); what matters for the demo is that a second pass over the same results is instantaneous."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "c5",
    "metadata": {
     "execution": {
@@ -383,16 +164,7 @@
      "shell.execute_reply": "2026-04-24T22:18:56.288690Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "in-memory scan of 5 results : 0.0 ms\n",
-      "matched ids                            : []\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import time\n",
     "start = time.perf_counter()\n",

--- a/siege_utilities/geo/providers/census_geocoder.py
+++ b/siege_utilities/geo/providers/census_geocoder.py
@@ -61,25 +61,30 @@ class CensusGeocodeError(RuntimeError):
 class CensusVintage(str, Enum):
     """Census geocoder benchmark/vintage pairs.
 
-    Each value is the benchmark string accepted by the Census Geocoder API.
-    The vintage determines which geographic boundaries are used for matching.
+    Each member's value encodes ``<benchmark>|<vintage>`` where both halves
+    are the exact strings the Census Geocoder API expects.  Use the
+    ``.benchmark`` and ``.vintage`` properties to extract them.
+
+    The benchmark names follow the ``Public_AR_<label>`` pattern used by
+    ``https://geocoding.geo.census.gov/geocoder/benchmarks``.  The vintage
+    names follow the ``<label>_<benchmark-label>`` pattern returned by
+    ``https://geocoding.geo.census.gov/geocoder/vintages?benchmark=…``.
     """
-    CENSUS_2010 = "Census2010_Census2010"
-    CENSUS_2020 = "Census2020_Census2020"
-    CURRENT = "Public_Current"
-    ACS_2022 = "Public_ACS2022"
-    ACS_2023 = "Public_ACS2023"
+    CENSUS_2010 = "Public_AR_Census2020|Census2010_Census2020"
+    CENSUS_2020 = "Public_AR_Census2020|Census2020_Census2020"
+    CURRENT = "Public_AR_Current|Current_Current"
+    ACS_2022 = "Public_AR_Current|ACS2022_Current"
+    ACS_2023 = "Public_AR_Current|ACS2023_Current"
 
     @property
     def benchmark(self) -> str:
-        """Extract the benchmark portion (before underscore)."""
-        return self.value.split("_")[0]
+        """The benchmark string accepted by the Census Geocoder API."""
+        return self.value.split("|")[0]
 
     @property
     def vintage(self) -> str:
-        """Extract the vintage portion (after underscore)."""
-        parts = self.value.split("_", 1)
-        return parts[1] if len(parts) > 1 else parts[0]
+        """The vintage string accepted by the Census Geocoder API."""
+        return self.value.split("|")[1]
 
 
 # Year boundaries for vintage selection
@@ -101,11 +106,11 @@ def select_vintage_for_cycle(year: int) -> CensusVintage:
 
     Examples:
         >>> select_vintage_for_cycle(2024)
-        <CensusVintage.CURRENT: 'Public_Current'>
+        <CensusVintage.CURRENT: 'Public_AR_Current|Current_Current'>
         >>> select_vintage_for_cycle(2016)
-        <CensusVintage.CENSUS_2020: 'Census2020_Census2020'>
+        <CensusVintage.CENSUS_2020: 'Public_AR_Census2020|Census2020_Census2020'>
         >>> select_vintage_for_cycle(2008)
-        <CensusVintage.CENSUS_2010: 'Census2010_Census2010'>
+        <CensusVintage.CENSUS_2010: 'Public_AR_Census2020|Census2010_Census2020'>
     """
     for threshold, vintage in _VINTAGE_THRESHOLDS:
         if year >= threshold:
@@ -202,7 +207,7 @@ def _parse_single_result(result: dict) -> CensusGeocodeResult:
     matched_address = result.get("matchedAddress", "")
     coords = result.get("coordinates", {})
     geographies = result.get("geographies", {})
-    tiger = result.get("addressComponents", {})
+    tiger = result.get("tigerLine", {})
 
     # Census Blocks is the most detailed geography; extract FIPS from there
     blocks = geographies.get("Census Blocks", geographies.get("2020 Census Blocks", []))
@@ -253,13 +258,15 @@ def geocode_single(
     input_addr = f"{street}, {city}, {state} {zipcode}"
 
     try:
+        # censusgeocode v0.5+ returns an AddressResult (list-like) of
+        # match dicts, not a nested {"result": {"addressMatches": [...]}}
+        # structure.
         result = cg.onelineaddress(input_addr, returntype="geographies")
-        matches = result.get("result", {}).get("addressMatches", [])
-        if not matches:
+        if not result or len(result) == 0:
             log_info(f"No match for: {input_addr}")
             return CensusGeocodeResult(input_address=input_addr)
 
-        parsed = _parse_single_result(matches[0])
+        parsed = _parse_single_result(result[0])
         parsed.input_address = input_addr
         log_debug(f"Matched: {input_addr} -> {parsed.matched_address}")
         return parsed
@@ -324,27 +331,33 @@ def geocode_batch(
             f"Census batch geocode failed for {len(addresses)} addresses: {e}"
         ) from e
 
-    # Parse batch results
+    # Parse batch results.
+    #
+    # censusgeocode v0.5+ returns dicts with these keys (after its own
+    # internal parsing):
+    #   id, address, match (bool), matchtype, parsed (matched address),
+    #   tigerlineid, side, statefp, countyfp, tract, block, lat (float),
+    #   lon (float)
     results_by_id = {}
     if isinstance(result, list):
         for row in result:
             row_id = str(row.get("id", ""))
-            matched = row.get("is_match", "").strip().lower() == "match"
+            matched = row.get("match", False) is True
             if matched:
                 parsed = CensusGeocodeResult(
                     matched=True,
                     input_id=row_id,
                     input_address=row.get("address", ""),
-                    matched_address=row.get("match_address", ""),
+                    matched_address=row.get("parsed", ""),
                     lat=_safe_float(row.get("lat")),
                     lon=_safe_float(row.get("lon")),
-                    state_fips=row.get("statefp", ""),
-                    county_fips=row.get("countyfp", ""),
-                    tract=row.get("tract", ""),
-                    block=row.get("block", ""),
-                    match_type=row.get("match_type", ""),
-                    tiger_line_id=row.get("tigerlineid", ""),
-                    side=row.get("side", ""),
+                    state_fips=row.get("statefp", "") or "",
+                    county_fips=row.get("countyfp", "") or "",
+                    tract=row.get("tract", "") or "",
+                    block=row.get("block", "") or "",
+                    match_type=row.get("matchtype", "") or "",
+                    tiger_line_id=row.get("tigerlineid", "") or "",
+                    side=row.get("side", "") or "",
                 )
             else:
                 parsed = CensusGeocodeResult(

--- a/tests/test_census_geocoder.py
+++ b/tests/test_census_geocoder.py
@@ -20,19 +20,19 @@ from siege_utilities.geo.providers.census_geocoder import (
 
 class TestCensusVintage:
     def test_enum_values(self):
-        assert CensusVintage.CENSUS_2010.value == "Census2010_Census2010"
-        assert CensusVintage.CENSUS_2020.value == "Census2020_Census2020"
-        assert CensusVintage.CURRENT.value == "Public_Current"
+        assert CensusVintage.CENSUS_2010.value == "Public_AR_Census2020|Census2010_Census2020"
+        assert CensusVintage.CENSUS_2020.value == "Public_AR_Census2020|Census2020_Census2020"
+        assert CensusVintage.CURRENT.value == "Public_AR_Current|Current_Current"
 
     def test_benchmark_property(self):
-        assert CensusVintage.CENSUS_2010.benchmark == "Census2010"
-        assert CensusVintage.CENSUS_2020.benchmark == "Census2020"
-        assert CensusVintage.CURRENT.benchmark == "Public"
+        assert CensusVintage.CENSUS_2010.benchmark == "Public_AR_Census2020"
+        assert CensusVintage.CENSUS_2020.benchmark == "Public_AR_Census2020"
+        assert CensusVintage.CURRENT.benchmark == "Public_AR_Current"
 
     def test_vintage_property(self):
-        assert CensusVintage.CENSUS_2010.vintage == "Census2010"
-        assert CensusVintage.CENSUS_2020.vintage == "Census2020"
-        assert CensusVintage.CURRENT.vintage == "Current"
+        assert CensusVintage.CENSUS_2010.vintage == "Census2010_Census2020"
+        assert CensusVintage.CENSUS_2020.vintage == "Census2020_Census2020"
+        assert CensusVintage.CURRENT.vintage == "Current_Current"
 
     def test_is_string_enum(self):
         assert isinstance(CensusVintage.CURRENT, str)
@@ -107,24 +107,26 @@ class TestCensusGeocodeResult:
 class TestGeocodeSingle:
     @patch("siege_utilities.geo.providers.census_geocoder._get_geocoder")
     def test_successful_match(self, mock_get_geocoder):
+        """Mock data mirrors censusgeocode v0.5+ return: ``onelineaddress``
+        returns a list-like ``AddressResult`` of match dicts, not a nested
+        ``{"result": {"addressMatches": [...]}}`` structure."""
         mock_cg = MagicMock()
-        mock_cg.onelineaddress.return_value = {
-            "result": {
-                "addressMatches": [{
-                    "matchedAddress": "1600 PENNSYLVANIA AVE NW, WASHINGTON, DC, 20500",
-                    "coordinates": {"x": -77.0365, "y": 38.8977},
-                    "geographies": {
-                        "Census Blocks": [{
-                            "STATE": "11",
-                            "COUNTY": "001",
-                            "TRACT": "006202",
-                            "BLOCK": "1031",
-                        }]
-                    },
-                    "addressComponents": {"side": "L", "tigerLineId": "12345"},
-                }]
+        # censusgeocode returns an AddressResult (list-like) of match dicts
+        mock_cg.onelineaddress.return_value = [
+            {
+                "matchedAddress": "1600 PENNSYLVANIA AVE NW, WASHINGTON, DC, 20500",
+                "coordinates": {"x": -77.0365, "y": 38.8977},
+                "geographies": {
+                    "2020 Census Blocks": [{
+                        "STATE": "11",
+                        "COUNTY": "001",
+                        "TRACT": "006202",
+                        "BLOCK": "1031",
+                    }]
+                },
+                "tigerLine": {"side": "L", "tigerLineId": "12345"},
             }
-        }
+        ]
         mock_get_geocoder.return_value = mock_cg
 
         result = geocode_single(
@@ -145,9 +147,8 @@ class TestGeocodeSingle:
     @patch("siege_utilities.geo.providers.census_geocoder._get_geocoder")
     def test_no_match(self, mock_get_geocoder):
         mock_cg = MagicMock()
-        mock_cg.onelineaddress.return_value = {
-            "result": {"addressMatches": []}
-        }
+        # censusgeocode returns an empty list-like result for no match
+        mock_cg.onelineaddress.return_value = []
         mock_get_geocoder.return_value = mock_cg
 
         result = geocode_single("123 Fake St", "Nowhere", "XX", "00000")
@@ -179,16 +180,19 @@ class TestGeocodeBatch:
 
     @patch("siege_utilities.geo.providers.census_geocoder._get_geocoder")
     def test_batch_results(self, mock_get_geocoder):
+        """Mock data mirrors censusgeocode v0.5+ return format: ``match``
+        is a boolean, the matched address is ``parsed``, and lat/lon are
+        already floats after the library's own parsing step."""
         mock_cg = MagicMock()
         mock_cg.addressbatch.return_value = [
             {
                 "id": "1",
-                "is_match": "Match",
-                "match_type": "Exact",
+                "match": True,
+                "matchtype": "Exact",
                 "address": "1600 Pennsylvania Ave, Washington, DC 20500",
-                "match_address": "1600 PENNSYLVANIA AVE NW, WASHINGTON, DC, 20500",
-                "lat": "38.8977",
-                "lon": "-77.0365",
+                "parsed": "1600 PENNSYLVANIA AVE NW, WASHINGTON, DC, 20500",
+                "lat": 38.8977,
+                "lon": -77.0365,
                 "statefp": "11",
                 "countyfp": "001",
                 "tract": "006202",
@@ -198,8 +202,18 @@ class TestGeocodeBatch:
             },
             {
                 "id": "2",
-                "is_match": "No_Match",
+                "match": False,
+                "matchtype": None,
                 "address": "123 Fake St, Nowhere, XX 00000",
+                "parsed": None,
+                "tigerlineid": None,
+                "side": None,
+                "statefp": None,
+                "countyfp": None,
+                "tract": None,
+                "block": None,
+                "lat": None,
+                "lon": None,
             },
         ]
         mock_get_geocoder.return_value = mock_cg
@@ -213,6 +227,7 @@ class TestGeocodeBatch:
         assert len(results) == 2
         assert results[0].matched
         assert results[0].state_fips == "11"
+        assert results[0].matched_address == "1600 PENNSYLVANIA AVE NW, WASHINGTON, DC, 20500"
         assert results[0].lat == pytest.approx(38.8977)
         assert not results[1].matched
 

--- a/tests/test_census_geocoder_errors.py
+++ b/tests/test_census_geocoder_errors.py
@@ -34,7 +34,8 @@ class TestGeocodeSingle:
     def test_no_match_returns_unmatched_result_not_error(self):
         """No match is a return-value concern, not an exception."""
         fake = MagicMock()
-        fake.onelineaddress.return_value = {"result": {"addressMatches": []}}
+        # censusgeocode v0.5+ returns empty list-like for no match
+        fake.onelineaddress.return_value = []
         with patch(
             "siege_utilities.geo.providers.census_geocoder._get_geocoder",
             return_value=fake,


### PR DESCRIPTION
## Summary

- Fixed three bugs that caused 0% match rate in the Census batch geocoder:
  1. `CensusVintage` enum produced invalid API benchmark/vintage strings (`"Public"` instead of `"Public_AR_Current"`)
  2. `geocode_batch()` parsed result dicts with wrong field names (`"is_match"` instead of `"match"`, `"match_address"` instead of `"parsed"`)
  3. `geocode_single()` assumed a nested dict return but censusgeocode v0.5+ returns a list-like `AddressResult`
- Updated all test mocks to mirror actual censusgeocode library return shapes
- Replaced non-geocodable notebook address with 301 W 2nd St, Austin; cleared stale 0/5 outputs

## Test plan

- [x] All 37 geocoder tests pass (`test_census_geocoder.py`, `test_census_geocoder_errors.py`, `test_geocode_results_to_dataframe.py`)
- [x] Live API test confirms 3/5 addresses match (Austin, Dallas, Houston) and 2/5 don't (missing ZIP, fake state)
- [x] `geocode_single()` works against live Census API
- [x] `geocode_results_to_dataframe()` correctly converts results (no changes needed, consumes dataclass interface)

Refs: #814