### PR TITLE
fix(#692): raise ValueError on unsupported DB type in Spark session builder

### DIFF
--- a/siege_utilities/config/databases.py
+++ b/siege_utilities/config/databases.py
@@ -319,6 +319,12 @@ def create_spark_session_with_databases(app_name: str = "SiegeAnalytics",
     Returns:
         Configured Spark session or None if PySpark not available
 
+    Raises:
+        ValueError: If a database config declares a ``connection_type`` for which
+            no JDBC driver is registered. Supported types: ``postgres``, ``mysql``,
+            ``oracle``. The error names the offending type so callers can either
+            add a supported config or extend the dispatch.
+
     Example:
         >>> spark = siege_utilities.create_spark_session_with_databases(
         ...     "Analytics App",
@@ -337,6 +343,7 @@ def create_spark_session_with_databases(app_name: str = "SiegeAnalytics",
 
     # Add database drivers based on configured databases
     packages = []
+    supported_connection_types = ('postgres', 'mysql', 'oracle')
 
     if database_names:
         for db_name in database_names:
@@ -351,10 +358,13 @@ def create_spark_session_with_databases(app_name: str = "SiegeAnalytics",
                 elif connection_type == 'oracle':
                     packages.append("com.oracle.database.jdbc:ojdbc8:21.1.0.0")
                 else:
-                    logger.warning(
-                        "No JDBC driver for connection type %r (database %r); "
-                        "Spark session may not connect to this database",
-                        connection_type, db_name,
+                    raise ValueError(
+                        f"Unsupported connection_type {connection_type!r} for "
+                        f"database {db_name!r}. Supported types: "
+                        f"{', '.join(supported_connection_types)}. "
+                        f"Previously this case silently loaded the PostgreSQL "
+                        f"JDBC driver, which produced misleading connection "
+                        f"errors at runtime."
                     )
 
     # Add common packages if none specified


### PR DESCRIPTION
## Summary

Closes the silent-PostgreSQL-default failure shape in `create_spark_session_with_databases`. The else-branch of the connection-type dispatch previously warned and continued; execution then fell through to the post-loop default at line 362 and silently installed the PostgreSQL JDBC driver. A DuckDB or SQLite config got a PostgreSQL driver and produced a misleading "connection refused" or "wrong protocol" error at runtime.

This PR replaces the warning with `raise ValueError`. The message names:
- the offending `connection_type`,
- the offending database name,
- the supported set (`postgres`, `mysql`, `oracle`),
- the prior silent-default behavior (so debuggers don't have to re-derive it).

Also adds a `Raises:` clause to the docstring.

## Pipeline artifacts (all posted on #692)

- Design note: https://github.com/siege-analytics/siege_utilities/issues/692#issuecomment-4579141169
- Investigation Fact Sheet (Focused tier): https://github.com/siege-analytics/siege_utilities/issues/692#issuecomment-4579143204
- Pre-mortem: https://github.com/siege-analytics/siege_utilities/issues/692#issuecomment-4579146297
- Self-review: https://github.com/siege-analytics/siege_utilities/issues/692#issuecomment-4579176563

## Out of scope

The post-loop default at `databases.py:371-372` still silently installs PostgreSQL when `database_names` is `None` or empty. This is a separate failure mode (legal call with no DB list, not unsupported-type dispatch) and is captured as Elephant 1 in the pre-mortem. Follow-up ticket to be filed.

## Test plan

- [ ] Pull the branch and call `create_spark_session_with_databases(database_names=["some_sqlite_db"])` against a config with `connection_type: "sqlite"`; expect `ValueError` whose message contains `'sqlite'` and lists `postgres, mysql, oracle`.
- [ ] Call with `database_names=["pg_db"]` against a `connection_type: "postgres"` config; expect a Spark session with `org.postgresql:postgresql:42.3.1` in `spark.jars.packages` (unchanged behavior).
- [ ] Call with `database_names=None`; expect a Spark session built without entering the dispatch loop (existing default path, unchanged).

## Refs
- #711 (preceding partial fix that added the warning)
- #692 (this completion)