### PR TITLE
fix(SU-1): stop returning valid-shaped empty results on failure

### DIFF
--- a/siege_utilities/analytics/facebook_business.py
+++ b/siege_utilities/analytics/facebook_business.py
@@ -108,7 +108,7 @@ class FacebookBusinessConnector:
 
         except (*_FB_API_ERRORS, AttributeError) as e:
             logger.error("Failed to retrieve ad accounts: %s", e, exc_info=True)
-            return []
+            raise
 
     def get_ad_insights(self, ad_account_id: str, start_date: str, end_date: str,
                         fields: List[str] = None, breakdowns: List[str] = None) -> pd.DataFrame:

--- a/siege_utilities/config/directories.py
+++ b/siege_utilities/config/directories.py
@@ -468,7 +468,7 @@ def clean_empty_directories(base_path: str, keep_gitkeep: bool = True) -> int:
 
     except OSError as e:
         log_error(f"Error cleaning directories: {e}")
-        return 0
+        raise
 
 
 def list_directory_configs(config_directory: str = "config") -> List[Dict[str, Any]]:

--- a/siege_utilities/config/enhanced_config.py
+++ b/siege_utilities/config/enhanced_config.py
@@ -643,7 +643,7 @@ def list_client_profiles(config_dir: Optional[Path] = None) -> List[str]:
         
     except OSError as e:
         logger.error(f"Failed to list client profiles: {e}")
-        return []
+        raise
 
 
 def export_config_yaml(config_data: Dict[str, Any], output_file: Path) -> bool:

--- a/siege_utilities/geo/providers/boundary_providers.py
+++ b/siege_utilities/geo/providers/boundary_providers.py
@@ -136,8 +136,10 @@ class CensusTIGERProvider(BoundaryProvider):
     def list_available_vintages(self, timeout: int = 30) -> list[int]:
         """Fetch the Census TIGER listing and parse out published TIGER{YYYY} years.
 
-        Returns a sorted list of int years. Empty list on network failure
-        (logged at WARNING).
+        Returns a sorted list of int years.
+
+        Raises:
+            requests.RequestException: On network failure.
         """
         import re
         import requests
@@ -147,14 +149,19 @@ class CensusTIGERProvider(BoundaryProvider):
             resp.raise_for_status()
         except requests.RequestException as exc:
             logger.warning('TIGER listing fetch failed: %s', exc)
-            return []
+            raise
 
         years = {int(m) for m in re.findall(r'TIGER(\d{4})/', resp.text)}
         return sorted(years)
 
     def latest_vintage(self, timeout: int = 30) -> Optional[int]:
         """Return the newest published TIGER vintage year, or None on failure."""
-        vintages = self.list_available_vintages(timeout=timeout)
+        import requests
+
+        try:
+            vintages = self.list_available_vintages(timeout=timeout)
+        except requests.RequestException:
+            return None
         return max(vintages) if vintages else None
 
 

--- a/siege_utilities/hygiene/generate_docstrings.py
+++ b/siege_utilities/hygiene/generate_docstrings.py
@@ -43,7 +43,7 @@ def analyze_function_signature(func):
         return params, return_desc
     except (ValueError, TypeError, AttributeError) as e:
         log_warning(f'Could not analyze signature: {e}')
-        return [], 'Any: Description needed'
+        raise
 
 
 def categorize_function(func_name):


### PR DESCRIPTION
## Summary
- Five functions across analytics, config, geo, and hygiene modules were returning `[]`, `0`, or default tuples on error, masking failures as valid empty results (SU-1 violation)
- Each except block now re-raises so callers can distinguish errors from legitimately empty results
- Updated `latest_vintage()` caller to catch `RequestException` and preserve its `Optional[int]` contract

## Files changed
- `siege_utilities/analytics/facebook_business.py` — `get_ad_accounts()`
- `siege_utilities/config/enhanced_config.py` — `list_client_profiles()`
- `siege_utilities/config/directories.py` — `clean_empty_directories()`
- `siege_utilities/geo/providers/boundary_providers.py` — `list_available_vintages()`
- `siege_utilities/hygiene/generate_docstrings.py` — `analyze_function_signature()`

## Test plan
- [ ] Verify modules import cleanly (done locally)
- [ ] Confirm callers handle the new exceptions (grep verified, `latest_vintage` updated)

Partial fix for #864.