### PR TITLE
fix(SU-1): raise on failure in git and files modules

### DIFF
--- a/siege_utilities/files/operations.py
+++ b/siege_utilities/files/operations.py
@@ -808,17 +808,17 @@ def get_file_size_mb(file_path: Union[str, Path]) -> float:
         file_path: Path to file
 
     Returns:
-        File size in MB (0.0 if file doesn't exist)
+        File size in MB.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+        OSError: If the file size cannot be determined.
     """
-    try:
-        file_path = Path(file_path)
-        if not file_path.exists():
-            return 0.0
-        size_bytes = file_path.stat().st_size
-        return round(size_bytes / (1024 * 1024), 2)
-    except OSError as e:
-        log.error(f"Error getting file size for {file_path}: {e}")
-        return 0.0
+    file_path = Path(file_path)
+    if not file_path.exists():
+        raise FileNotFoundError(f"File does not exist: {file_path}")
+    size_bytes = file_path.stat().st_size
+    return round(size_bytes / (1024 * 1024), 2)
 
 
 def list_files_recursive(
@@ -836,18 +836,18 @@ def list_files_recursive(
 
     Returns:
         List of Path objects
+
+    Raises:
+        FileNotFoundError: If the directory does not exist.
+        OSError: If the directory cannot be read.
     """
-    try:
-        directory = Path(directory)
-        if not directory.exists():
-            return []
-        if exclude_dirs:
-            return [p for p in directory.rglob(pattern) if p.is_file()]
-        else:
-            return list(directory.rglob(pattern))
-    except OSError as e:
-        log.error(f"Error listing files in {directory}: {e}")
-        return []
+    directory = Path(directory)
+    if not directory.exists():
+        raise FileNotFoundError(f"Directory does not exist: {directory}")
+    if exclude_dirs:
+        return [p for p in directory.rglob(pattern) if p.is_file()]
+    else:
+        return list(directory.rglob(pattern))
 
 
 __all__ = [

--- a/siege_utilities/files/paths.py
+++ b/siege_utilities/files/paths.py
@@ -325,6 +325,7 @@ def find_files_by_pattern(directory: FilePath,
 
     Raises:
         PathSecurityError: If path fails security validation
+        OSError: If the directory cannot be read
 
     Example:
         >>> files = find_files_by_pattern("data", "*.csv", recursive=True)
@@ -358,8 +359,7 @@ def find_files_by_pattern(directory: FilePath,
     except PathSecurityError:
         raise
     except OSError as e:
-        log.error(f"Failed to find files in {directory}: {e}")
-        return []
+        raise OSError(f"Failed to find files in {directory}: {e}") from e
 
 def create_backup_path(original_path: FilePath,
                       backup_suffix: str = ".backup",

--- a/siege_utilities/git/_utils.py
+++ b/siege_utilities/git/_utils.py
@@ -9,8 +9,14 @@ def run_git_command(*args, repo_path: str = ".", check: bool = True) -> str:
     """Run a git command and return stdout.
 
     When ``check=True`` (default), raises ``GitError`` on non-zero exit.
-    When ``check=False``, returns ``""`` on failure — callers must treat
-    empty string as a potential error signal, not as valid empty output.
+    When ``check=False``, returns ``""`` on failure.
+
+    .. note::
+        # SU-1: intentional — check=False callers (upstream detection,
+        # optional config reads, best-effort push/pull) explicitly expect
+        # empty-string as a "not available" sentinel and handle it at the
+        # call site. Do not remove this path without converting all callers
+        # to try/except.
     """
     try:
         result = subprocess.run(
@@ -25,4 +31,4 @@ def run_git_command(*args, repo_path: str = ".", check: bool = True) -> str:
     except subprocess.CalledProcessError as e:
         if check:
             raise GitError(f"Git command failed: {' '.join(args)} - {e.stderr}") from e
-        return ""
+        return ""  # SU-1: intentional — callers must handle

--- a/siege_utilities/git/git_status.py
+++ b/siege_utilities/git/git_status.py
@@ -229,8 +229,7 @@ def get_stash_list(repo_path: str = ".") -> List[Dict[str, str]]:
         
         return stashes
     except (GitError, RuntimeError) as exc:
-        log.warning("Could not retrieve stash list: %s", exc)
-        return []
+        raise GitError(f"Could not retrieve stash list: {exc}") from exc
 
 def get_tag_list(repo_path: str = ".") -> List[Dict[str, str]]:
     """Get list of tags with details.
@@ -257,8 +256,7 @@ def get_tag_list(repo_path: str = ".") -> List[Dict[str, str]]:
         
         return tags
     except (GitError, RuntimeError) as exc:
-        log.warning("Could not retrieve tag list: %s", exc)
-        return []
+        raise GitError(f"Could not retrieve tag list: {exc}") from exc
 
 def get_log_summary(
     since: Optional[str] = None,
@@ -323,7 +321,6 @@ def get_log_summary(
                 "max_count": max_count
             }
         }
-    }
 
 def get_file_status(repo_path: str = ".") -> Dict[str, List[str]]:
     """Get detailed status of all files in the repository.


### PR DESCRIPTION
## Summary

- `get_stash_list()` and `get_tag_list()` now raise `GitError` on failure instead of returning `[]` (docstrings already documented this contract — code now matches)
- `get_file_size_mb()` raises `FileNotFoundError`/`OSError` instead of returning `0.0`
- `list_files_recursive()` raises `FileNotFoundError` instead of returning `[]`
- `find_files_by_pattern()` re-raises `OSError` instead of returning `[]`
- `run_git_command(check=False)` path preserved with SU-1 annotation (intentional sentinel for optional git queries)
- Fixes pre-existing stray brace syntax error in `get_log_summary`

## Test plan

- [x] All 33 relevant tests pass (TestGetStashList, TestGetTagList, TestRunGitCommand, TestGetFileSizeMb, TestListFilesRecursive)
- [x] Module imports verified clean
- [ ] Pre-existing test failures on develop (6 tests for other functions) are unrelated

Closes #864