### PR TITLE
fix(geo): restore get_coordinates — SyntaxError from SU-1 sweep

### DIFF
--- a/siege_utilities/geo/geocoding.py
+++ b/siege_utilities/geo/geocoding.py
@@ -411,16 +411,7 @@ def get_coordinates(query_address, country_codes=None, max_retries=3, server_url
         raise GeocodingError(
             f"Nominatim response for {query_address!r} missing lat/lng fields"
         )
-        if result_json:
-            data = json.loads(result_json)
-            lat = data.get('nominatim_lat')
-            lng = data.get('nominatim_lng')
-            if lat and lng:
-                return (float(lat), float(lng))
-        return None
-    except (ValueError, TypeError, KeyError, AttributeError) as e:
-        log_error(f"Geocoding failed for {query_address}: {e}")
-        return None
+    return (float(lat), float(lng))
 
 
 def use_nominatim_geocoder(query_address, id=None, country_codes=None,


### PR DESCRIPTION
## Summary

The SU-1 broad-except sweep (commit 31286bf) broke `get_coordinates()` in `geo/geocoding.py`:
- Replaced `return (float(lat), float(lng))` with dead code after a `raise` statement
- Added an orphaned `except` clause with no matching `try`
- **Result: `geocoding.py` cannot be imported — crashes with SyntaxError at line 421**

This restores the original return path. The sweep's replacement was both unreachable (after a `raise`) and an SU-1 violation itself (returning `None` to hide `ValueError`).

## Impact

**Module-level import failure** — any code importing `siege_utilities.geo.geocoding` crashes. This includes geocoding notebooks, batch geocoding scripts, and any downstream module that imports the geo package.

## Test plan

- [x] `ast.parse()` succeeds on the fixed file
- [ ] `python -c "import siege_utilities.geo.geocoding"` succeeds
- [ ] `get_coordinates("1600 Pennsylvania Ave, Washington DC")` returns a tuple