### PR TITLE
fix(geo): set CRS on DuckDB GeoDataFrames, warn on missing CRS (#866)

### DIFF
--- a/siege_utilities/geo/crs.py
+++ b/siege_utilities/geo/crs.py
@@ -70,13 +70,26 @@ def reproject_if_needed(gdf, crs: str | None = None):
 
     If *crs* is ``None``, uses :func:`get_default_crs`.
     Returns the GeoDataFrame unchanged if it is already in *crs* or is empty.
+
+    When the GeoDataFrame has no CRS (``gdf.crs is None``) and a target is
+    specified, the target CRS is **set** (not reprojected) on the assumption
+    that the data is already in the target CRS. A warning is logged because
+    this assumption may be wrong.
     """
     if gdf is None:
         return None
     target = crs or get_default_crs()
     if not target or len(gdf) == 0:
         return gdf
-    if gdf.crs and str(gdf.crs).upper() != target.upper():
+    if gdf.crs is None:
+        log.warning(
+            "GeoDataFrame has no CRS; setting to %s without reprojection. "
+            "If the data is in a different CRS, results will be incorrect.",
+            target,
+        )
+        gdf = gdf.set_crs(target)
+        return gdf
+    if str(gdf.crs).upper() != target.upper():
         return gdf.to_crs(target)
     return gdf
 

--- a/siege_utilities/geo/spatial_transformations.py
+++ b/siege_utilities/geo/spatial_transformations.py
@@ -709,8 +709,8 @@ class DuckDBConnector:
                 df['geometry'] = df['geometry_wkt'].apply(wkt.loads)
                 df = df.drop(columns=['geometry_wkt'])
 
-            # Create GeoDataFrame
-            gdf = gpd.GeoDataFrame(df, geometry='geometry')
+            # Create GeoDataFrame — default to WGS84 since WKT lacks SRID
+            gdf = gpd.GeoDataFrame(df, geometry='geometry', crs="EPSG:4326")
 
             log.info(f"Successfully downloaded from DuckDB: {table_name}")
             return reproject_if_needed(gdf, crs)
@@ -756,7 +756,8 @@ class DuckDBConnector:
                     df['geometry'] = df['geometry_wkt'].apply(wkt.loads)
                     df = df.drop(columns=['geometry_wkt'])
 
-                gdf = gpd.GeoDataFrame(df, geometry='geometry')
+                # Default to WGS84 since WKT lacks SRID metadata
+                gdf = gpd.GeoDataFrame(df, geometry='geometry', crs="EPSG:4326")
 
                 log.info("Successfully executed DuckDB query")
                 return reproject_if_needed(gdf, crs)


### PR DESCRIPTION
## Summary

Fixes #866 — DuckDB spatial queries produced GeoDataFrames with `crs=None` because WKT deserialization carries no SRID metadata. `reproject_if_needed` then silently returned data without CRS, ignoring the caller's `crs` parameter.

**Changes:**
- DuckDB connector sets `crs="EPSG:4326"` (WGS84 convention for untagged WKT) on GeoDataFrame construction
- `reproject_if_needed` now handles `gdf.crs is None`: logs a warning and sets the target CRS (assumes data is already in target CRS)

## Test plan

- [ ] `execute_duckdb_query("SELECT ...", crs="EPSG:4326")` returns GeoDataFrame with `gdf.crs` set
- [ ] `reproject_if_needed(gdf_with_no_crs, "EPSG:3857")` logs warning and sets CRS
- [ ] Existing PostGIS paths unaffected (they get CRS from gpd.read_postgis)