### PR TITLE
fix(SU-2): return type annotations match actual behavior

### DIFF
--- a/siege_utilities/config/credential_manager.py
+++ b/siege_utilities/config/credential_manager.py
@@ -689,27 +689,26 @@ class CredentialManager:
                 ``attempts`` carries per-backend diagnostics so callers
                 can surface an actionable message.
         """
-        try:
-            # Try to get from 1Password using item title
-            client_id = self._get_from_1password(item_title, 'client_id')
-            client_secret = self._get_from_1password(item_title, 'client_secret')
-            
-            if client_id and client_secret:
-                return client_id, client_secret
-            
-            # Fallback to general credential retrieval
-            client_id = self.get_credential('google-analytics', 'api', 'client_id')
-            client_secret = self.get_credential('google-analytics', 'api', 'client_secret')
-            
-            if client_id and client_secret:
-                return client_id, client_secret
-            
-            log_error("Could not retrieve Google Analytics credentials")
-            return None
-            
-        except (subprocess.SubprocessError, OSError, json.JSONDecodeError) as e:
-            log_error(f"Error retrieving Google Analytics credentials: {e}")
-            return None
+        # Try to get from 1Password using item title
+        client_id = self._get_from_1password(item_title, 'client_id')
+        client_secret = self._get_from_1password(item_title, 'client_secret')
+
+        if client_id and client_secret:
+            return client_id, client_secret
+
+        # Fallback to general credential retrieval
+        client_id = self.get_credential('google-analytics', 'api', 'client_id')
+        client_secret = self.get_credential('google-analytics', 'api', 'client_secret')
+
+        if client_id and client_secret:
+            return client_id, client_secret
+
+        missing_field = 'client_id' if not client_id else 'client_secret'
+        raise CredentialNotFoundError(
+            'google-analytics', missing_field,
+            [('1password', f'item {item_title!r} missing field'),
+             ('general', 'get_credential returned falsy')],
+        )
     
     def list_stored_credentials(self, service_filter: Optional[str] = None,
                                 vault: Optional[str] = None,

--- a/siege_utilities/geo/django/management/commands/populate_boundaries.py
+++ b/siege_utilities/geo/django/management/commands/populate_boundaries.py
@@ -8,6 +8,8 @@ Usage:
     python manage.py populate_boundaries --year 2020 --type all --state 06
 """
 
+from typing import Optional
+
 from django.core.management.base import BaseCommand, CommandError
 
 from siege_utilities.geo.django.services import BoundaryPopulationService
@@ -73,7 +75,7 @@ class Command(BaseCommand):
             help="Link child boundaries to parent boundaries after population",
         )
 
-    def _normalize_state(self, state_input: str) -> str:
+    def _normalize_state(self, state_input: str) -> Optional[str]:
         """Convert state input to FIPS code."""
         if not state_input:
             return None

--- a/siege_utilities/geo/django/management/commands/populate_crosswalks.py
+++ b/siege_utilities/geo/django/management/commands/populate_crosswalks.py
@@ -6,6 +6,8 @@ Usage:
     python manage.py populate_crosswalks --source-year 2010 --target-year 2020 --type tract --state 06
 """
 
+from typing import Optional
+
 from django.core.management.base import BaseCommand, CommandError
 
 from siege_utilities.geo.django.services import CrosswalkPopulationService
@@ -62,7 +64,7 @@ class Command(BaseCommand):
             help="Batch size for database operations",
         )
 
-    def _normalize_state(self, state_input: str) -> str:
+    def _normalize_state(self, state_input: str) -> Optional[str]:
         """Convert state input to FIPS code."""
         if not state_input:
             return None

--- a/siege_utilities/reference/sample_data.py
+++ b/siege_utilities/reference/sample_data.py
@@ -458,8 +458,9 @@ def get_census_county_sample(state_fips: str = "06",
             all_tracts.append(tract_data)
 
     if not all_tracts:
-        log_error("No tract data generated")
-        return None
+        raise ValueError(
+            f"No tract data generated for state={state_fips}, county={county_fips}"
+        )
 
     # Combine all tracts
     county_data = pd.concat(all_tracts, ignore_index=True)

--- a/tests/test_credential_manager.py
+++ b/tests/test_credential_manager.py
@@ -927,12 +927,8 @@ class TestGetGoogleAnalyticsCredentials:
         manager = CredentialManager()
         mock_op_available.side_effect = OSError("unexpected error")
 
-        with patch.object(
-            CredentialManager, 'get_credential',
-            side_effect=RuntimeError("1Password CLI timed out"),
-        ):
-            with pytest.raises(RuntimeError, match="timed out"):
-                manager.get_google_analytics_credentials()
+        with pytest.raises(OSError, match="unexpected error"):
+            manager.get_google_analytics_credentials()
 
 
 # =============================================================================


### PR DESCRIPTION
Closes #876

## Summary

- **credential_manager**: `get_google_analytics_credentials()` now raises `CredentialNotFoundError` instead of returning `None` — matches its own docstring, its type annotation (`-> Tuple[str, str]`), and existing test expectations. Transport errors (OSError etc.) propagate directly per the class's error philosophy.
- **sample_data**: `get_census_county_sample()` raises `ValueError` instead of returning `None`. The downstream caller `get_metropolitan_sample()` immediately indexes into the return value without a None check, so this was a latent crash.
- **populate_boundaries/crosswalks**: `_normalize_state() -> Optional[str]` — annotation corrected to reflect the existing `return None` on empty input. Callers already handle None.

## Test plan

- [x] `test_credential_manager.py` — 137 passed (deselecting unrelated yaml-dep test)
- [x] `test_propagates_transport_errors` updated to assert OSError (the actual first transport error) instead of RuntimeError from a never-reached fallback
- [x] All 4 modified files pass `ast.parse()`