### PR TITLE
fix(geo): close resource leaks in geocoding modules

### DIFF
--- a/siege_utilities/geo/geocoding.py
+++ b/siege_utilities/geo/geocoding.py
@@ -753,70 +753,72 @@ class SpatiaLiteCache:
     def _init_db(self):
         conn = self._get_conn()
         cur = conn.cursor()
-
-        # Check if SpatiaLite is available
         try:
-            cur.execute("SELECT spatialite_version()")
-            version = cur.fetchone()
-            logger.debug("SpatiaLite version: %s", version[0] if version else "unknown")
-        except sqlite3.OperationalError:
-            logger.debug("SpatiaLite not loaded; spatial features unavailable for geocode cache")
+            # Check if SpatiaLite is available
+            try:
+                cur.execute("SELECT spatialite_version()")
+                version = cur.fetchone()
+                logger.debug("SpatiaLite version: %s", version[0] if version else "unknown")
+            except sqlite3.OperationalError:
+                logger.debug("SpatiaLite not loaded; spatial features unavailable for geocode cache")
 
-        # Geocode results table
-        cur.execute("""
-            CREATE TABLE IF NOT EXISTS geocode_cache (
-                address_hash TEXT PRIMARY KEY,
-                address_raw TEXT NOT NULL,
-                latitude REAL NOT NULL,
-                longitude REAL NOT NULL,
-                point_wkt TEXT NOT NULL,
-                source TEXT NOT NULL DEFAULT 'nominatim',
-                raw_response TEXT,
-                created_at TEXT NOT NULL DEFAULT (datetime('now')),
-                updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-            )
-        """)
+            # Geocode results table
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS geocode_cache (
+                    address_hash TEXT PRIMARY KEY,
+                    address_raw TEXT NOT NULL,
+                    latitude REAL NOT NULL,
+                    longitude REAL NOT NULL,
+                    point_wkt TEXT NOT NULL,
+                    source TEXT NOT NULL DEFAULT 'nominatim',
+                    raw_response TEXT,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+                )
+            """)
 
-        # Boundary lookup table
-        cur.execute("""
-            CREATE TABLE IF NOT EXISTS boundary_cache (
-                geoid TEXT NOT NULL,
-                vintage_year INTEGER NOT NULL,
-                point_wkt TEXT,
-                boundary_wkt TEXT,
-                source TEXT NOT NULL DEFAULT 'tiger',
-                created_at TEXT NOT NULL DEFAULT (datetime('now')),
-                PRIMARY KEY (geoid, vintage_year)
-            )
-        """)
+            # Boundary lookup table
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS boundary_cache (
+                    geoid TEXT NOT NULL,
+                    vintage_year INTEGER NOT NULL,
+                    point_wkt TEXT,
+                    boundary_wkt TEXT,
+                    source TEXT NOT NULL DEFAULT 'tiger',
+                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    PRIMARY KEY (geoid, vintage_year)
+                )
+            """)
 
-        # Crosswalk mapping table
-        cur.execute("""
-            CREATE TABLE IF NOT EXISTS crosswalk_cache (
-                source_geoid TEXT NOT NULL,
-                target_geoid TEXT NOT NULL,
-                weight REAL NOT NULL DEFAULT 1.0,
-                source TEXT NOT NULL DEFAULT 'census',
-                created_at TEXT NOT NULL DEFAULT (datetime('now')),
-                PRIMARY KEY (source_geoid, target_geoid)
-            )
-        """)
+            # Crosswalk mapping table
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS crosswalk_cache (
+                    source_geoid TEXT NOT NULL,
+                    target_geoid TEXT NOT NULL,
+                    weight REAL NOT NULL DEFAULT 1.0,
+                    source TEXT NOT NULL DEFAULT 'census',
+                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    PRIMARY KEY (source_geoid, target_geoid)
+                )
+            """)
 
-        # Indexes
-        cur.execute("""
-            CREATE INDEX IF NOT EXISTS idx_geocode_source
-            ON geocode_cache(source)
-        """)
-        cur.execute("""
-            CREATE INDEX IF NOT EXISTS idx_geocode_lat_lon
-            ON geocode_cache(latitude, longitude)
-        """)
-        cur.execute("""
-            CREATE INDEX IF NOT EXISTS idx_boundary_vintage
-            ON boundary_cache(vintage_year)
-        """)
+            # Indexes
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_geocode_source
+                ON geocode_cache(source)
+            """)
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_geocode_lat_lon
+                ON geocode_cache(latitude, longitude)
+            """)
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_boundary_vintage
+                ON boundary_cache(vintage_year)
+            """)
 
-        conn.commit()
+            conn.commit()
+        finally:
+            cur.close()
 
     # ------------------------------------------------------------------
     # Geocode cache operations

--- a/siege_utilities/geo/providers/census_geocoder.py
+++ b/siege_utilities/geo/providers/census_geocoder.py
@@ -24,6 +24,7 @@ Usage:
 import csv
 import io
 import logging
+import os
 import tempfile
 from dataclasses import dataclass
 from enum import Enum
@@ -330,6 +331,8 @@ def geocode_batch(
         raise CensusGeocodeError(
             f"Census batch geocode failed for {len(addresses)} addresses: {e}"
         ) from e
+    finally:
+        os.unlink(csv_path)
 
     # Parse batch results.
     #


### PR DESCRIPTION
## Summary

- **census_geocoder**: Batch geocoding writes addresses to a temp CSV with `delete=False` but never cleans up the file. On repeated batch jobs, these accumulate indefinitely. Added `finally: os.unlink(csv_path)`.
- **geocoding**: `_init_db()` creates a SQLite cursor for schema setup but never closes it. Wrapped in `try/finally` to ensure `cur.close()`.

## Test plan

- [x] Both files pass `ast.parse()`
- [x] `test_census_geocoder.py` — 30/31 pass (1 pre-existing failure on develop unrelated to this change)
- [x] `test_geocode_results_to_dataframe.py` — all pass