### PR TITLE
fix(geo): Census geocoder catches all API exceptions per contract

### DIFF
--- a/siege_utilities/geo/providers/census_geocoder.py
+++ b/siege_utilities/geo/providers/census_geocoder.py
@@ -272,7 +272,7 @@ def geocode_single(
         log_debug(f"Matched: {input_addr} -> {parsed.matched_address}")
         return parsed
 
-    except (OSError, ValueError, TypeError, KeyError, AttributeError, RuntimeError) as e:
+    except Exception as e:
         raise CensusGeocodeError(
             f"Census geocode failed for {input_addr}: {e}"
         ) from e
@@ -327,7 +327,7 @@ def geocode_batch(
 
     try:
         result = cg.addressbatch(csv_path, returntype="geographies")
-    except (OSError, ValueError, TypeError, KeyError, AttributeError, RuntimeError) as e:
+    except Exception as e:
         raise CensusGeocodeError(
             f"Census batch geocode failed for {len(addresses)} addresses: {e}"
         ) from e


### PR DESCRIPTION
## Summary

- `geocode_single` and `geocode_batch` promise `CensusGeocodeError` on any API failure, but the except clause only caught 6 specific exception types
- The `censusgeocode` library doesn't document its exception surface — HTTP library errors, JSON decode errors from unexpected responses, etc. could propagate unhandled
- Broadened to `except Exception` with `raise ... from e` chain preservation
- This is the correct pattern at third-party API boundaries (distinct from the SU-1 anti-pattern of swallowing exceptions)

## Test plan

- [x] `test_census_geocoder.py` �� 23 passed (was 22 passed + 1 failed; the previously-failing test now passes)
- [x] `test_census_geocoder_errors.py` — 6 passed
- [x] File passes `ast.parse()`