### PR TITLE
fix(SU-1): resolve 11 test failures from errors-as-data violations

### DIFF
--- a/siege_utilities/distributed/hdfs_operations.py
+++ b/siege_utilities/distributed/hdfs_operations.py
@@ -11,27 +11,19 @@ from typing import Optional, Tuple, Dict, List
 log = logging.getLogger(__name__)
 
 
-def _default_hash_function(file_path: str) ->str:
-    """Default hash function using built-in hashlib"""
-    try:
-        sha256_hash = hashlib.sha256()
-        with open(file_path, 'rb') as f:
-            for chunk in iter(lambda : f.read(65536), b''):
-                sha256_hash.update(chunk)
-        return sha256_hash.hexdigest()
-    except (OSError, ValueError) as exc:
-        log.warning("Could not hash file %s, returning error signature: %s", file_path, exc)
-        return f'error_{int(time.time())}'
+def _default_hash_function(file_path: str) -> str:
+    """Default hash function using built-in hashlib."""
+    sha256_hash = hashlib.sha256()
+    with open(file_path, 'rb') as f:
+        for chunk in iter(lambda: f.read(65536), b''):
+            sha256_hash.update(chunk)
+    return sha256_hash.hexdigest()
 
 
-def _default_quick_signature(file_path: str) ->str:
-    """Default quick signature using file stats"""
-    try:
-        stat = pathlib.Path(file_path).stat()
-        return f'{stat.st_size}_{stat.st_mtime}'
-    except OSError as exc:
-        log.warning("Could not stat file %s for quick signature: %s", file_path, exc)
-        return 'error'
+def _default_quick_signature(file_path: str) -> str:
+    """Default quick signature using file stats."""
+    stat = pathlib.Path(file_path).stat()
+    return f'{stat.st_size}_{stat.st_mtime}'
 
 
 def _ensure_directory_exists(path: str):

--- a/siege_utilities/geo/geocoding.py
+++ b/siege_utilities/geo/geocoding.py
@@ -492,9 +492,8 @@ def use_nominatim_geocoder(query_address, id=None, country_codes=None,
                     f'after {max_retries} attempts'
                 ) from e
             time.sleep(2 ** attempt)
-        except (ValueError, TypeError, KeyError, AttributeError) as e:
-            message = f'Unexpected error during geocoding: {str(e)}'
-            log_error(message)
+        except Exception as e:
+            log_error(f'Unexpected error during geocoding: {e}')
             raise GeocodingError(
                 f'Unexpected error geocoding {query_address!r}'
             ) from e

--- a/siege_utilities/git/git_status.py
+++ b/siege_utilities/git/git_status.py
@@ -49,12 +49,10 @@ def get_repository_status(repo_path: str = ".") -> Dict[str, Union[str, int, boo
         last_commit_author = run_git_command("log", "-1", "--format=%an", repo_path=repo_path)
         last_commit_message = run_git_command("log", "-1", "--format=%s", repo_path=repo_path)
     except (GitError, RuntimeError) as exc:
-        log.warning("Could not retrieve last commit info for %s: %s", repo_path, exc)
-        last_commit_hash = "unknown"
-        last_commit_date = "unknown"
-        last_commit_author = "unknown"
-        last_commit_message = "unknown"
-    
+        raise GitError(
+            f"Could not retrieve last commit info for {repo_path}: {exc}"
+        ) from exc
+
     # Get remote info
     try:
         remote_url = run_git_command("config", "--get", "remote.origin.url", repo_path=repo_path)
@@ -62,9 +60,9 @@ def get_repository_status(repo_path: str = ".") -> Dict[str, Union[str, int, boo
         if upstream_branch == "":
             upstream_branch = None
     except (GitError, RuntimeError) as exc:
-        log.warning("Could not retrieve remote info for %s: %s", repo_path, exc)
-        remote_url = "unknown"
-        upstream_branch = None
+        raise GitError(
+            f"Could not retrieve remote info for {repo_path}: {exc}"
+        ) from exc
     
     # Get ahead/behind info
     ahead_behind = "0 0"
@@ -124,26 +122,22 @@ def get_branch_info(repo_path: str = ".") -> Dict[str, Union[str, List[str], int
             # Get branch details
             try:
                 last_commit = run_git_command("log", "-1", "--format=%H|%cd|%an|%s", "--date=short", branch_name, repo_path=repo_path)
-                if last_commit:
-                    hash_part, date, author, message = last_commit.split('|', 3)
-                    branches.append({
-                        "name": branch_name,
-                        "upstream": upstream,
-                        "tracking": tracking,
-                        "last_commit": {
-                            "hash": hash_part[:7],
-                            "date": date,
-                            "author": author,
-                            "message": message
-                        }
-                    })
-            except (GitError, RuntimeError, ValueError) as exc:
-                log.warning("Could not retrieve commit info for branch %s: %s", branch_name, exc)
+            except (GitError, RuntimeError) as exc:
+                raise GitError(
+                    f"Could not retrieve commit info for branch {branch_name}: {exc}"
+                ) from exc
+            if last_commit:
+                hash_part, date, author, message = last_commit.split('|', 3)
                 branches.append({
                     "name": branch_name,
                     "upstream": upstream,
                     "tracking": tracking,
-                    "last_commit": None
+                    "last_commit": {
+                        "hash": hash_part[:7],
+                        "date": date,
+                        "author": author,
+                        "message": message
+                    }
                 })
     
     # Remote branches
@@ -178,25 +172,21 @@ def get_remote_info(repo_path: str = ".") -> Dict[str, Union[str, List[Dict[str,
     for remote_name in remote_list:
         try:
             url = run_git_command("config", "--get", f"remote.{remote_name}.url", repo_path=repo_path)
-
-            # Get fetch and push URLs if different
-            fetch_url = run_git_command("config", "--get", f"remote.{remote_name}.fetch", repo_path=repo_path, check=False)
-            push_url = run_git_command("config", "--get", f"remote.{remote_name}.push", repo_path=repo_path, check=False)
-
-            remote_info.append({
-                "name": remote_name,
-                "url": url,
-                "fetch_url": fetch_url if fetch_url else url,
-                "push_url": push_url if push_url else url
-            })
         except (GitError, RuntimeError) as exc:
-            log.warning("Could not retrieve URL for remote %s: %s", remote_name, exc)
-            remote_info.append({
-                "name": remote_name,
-                "url": "unknown",
-                "fetch_url": "unknown",
-                "push_url": "unknown"
-            })
+            raise GitError(
+                f"Could not retrieve URL for remote {remote_name}: {exc}"
+            ) from exc
+
+        # Get fetch and push URLs if different
+        fetch_url = run_git_command("config", "--get", f"remote.{remote_name}.fetch", repo_path=repo_path, check=False)
+        push_url = run_git_command("config", "--get", f"remote.{remote_name}.push", repo_path=repo_path, check=False)
+
+        remote_info.append({
+            "name": remote_name,
+            "url": url,
+            "fetch_url": fetch_url if fetch_url else url,
+            "push_url": push_url if push_url else url
+        })
     
     return {
         "remotes": remote_info,
@@ -284,43 +274,33 @@ def get_log_summary(
 
     try:
         log_output = run_git_command(*log_args, repo_path=repo_path)
-        
-        commits = []
-        for line in log_output.split('\n'):
-            if line.strip():
-                parts = line.split('|', 3)
-                if len(parts) == 4:
-                    hash_full, date, author_name, message = parts
-                    commits.append({
-                        "hash": hash_full[:7],
-                        "hash_full": hash_full,
-                        "date": date,
-                        "author": author_name,
-                        "message": message
-                    })
-        
-        return {
-            "total_commits": len(commits),
-            "commits": commits,
-            "filters": {
-                "since": since,
-                "until": until,
-                "author": author,
-                "max_count": max_count
-            }
-        }
     except (GitError, RuntimeError) as exc:
-        log.warning("Could not retrieve commit log: %s", exc)
-        return {
-            "total_commits": 0,
-            "commits": [],
-            "filters": {
-                "since": since,
-                "until": until,
-                "author": author,
-                "max_count": max_count
-            }
+        raise GitError(f"Could not retrieve commit log: {exc}") from exc
+
+    commits = []
+    for line in log_output.split('\n'):
+        if line.strip():
+            parts = line.split('|', 3)
+            if len(parts) == 4:
+                hash_full, date, author_name, message = parts
+                commits.append({
+                    "hash": hash_full[:7],
+                    "hash_full": hash_full,
+                    "date": date,
+                    "author": author_name,
+                    "message": message
+                })
+
+    return {
+        "total_commits": len(commits),
+        "commits": commits,
+        "filters": {
+            "since": since,
+            "until": until,
+            "author": author,
+            "max_count": max_count
         }
+    }
 
 def get_file_status(repo_path: str = ".") -> Dict[str, List[str]]:
     """Get detailed status of all files in the repository.
@@ -332,45 +312,38 @@ def get_file_status(repo_path: str = ".") -> Dict[str, List[str]]:
     """
     try:
         status_output = run_git_command("status", "--porcelain", repo_path=repo_path)
-        
-        files = {
-            "staged": [],
-            "unstaged": [],
-            "untracked": [],
-            "renamed": [],
-            "deleted": []
-        }
-        
-        for line in status_output.split('\n'):
-            if line.strip():
-                status = line[:2]
-                filepath = line[3:]
-                
-                if status[0] == 'A':  # Added
-                    files["staged"].append(filepath)
-                elif status[0] == 'M':  # Modified
-                    files["staged"].append(filepath)
-                elif status[0] == 'D':  # Deleted
-                    files["staged"].append(filepath)
-                elif status[0] == 'R':  # Renamed
-                    files["renamed"].append(filepath)
-                elif status[1] == 'M':  # Modified (unstaged)
-                    files["unstaged"].append(filepath)
-                elif status[1] == 'D':  # Deleted (unstaged)
-                    files["unstaged"].append(filepath)
-                elif status == '??':  # Untracked
-                    files["untracked"].append(filepath)
-        
-        return files
     except (GitError, RuntimeError) as exc:
-        log.warning("Could not retrieve file status: %s", exc)
-        return {
-            "staged": [],
-            "unstaged": [],
-            "untracked": [],
-            "renamed": [],
-            "deleted": []
-        }
+        raise GitError(f"Could not retrieve file status: {exc}") from exc
+
+    files = {
+        "staged": [],
+        "unstaged": [],
+        "untracked": [],
+        "renamed": [],
+        "deleted": []
+    }
+
+    for line in status_output.split('\n'):
+        if line.strip():
+            status = line[:2]
+            filepath = line[3:]
+
+            if status[0] == 'A':  # Added
+                files["staged"].append(filepath)
+            elif status[0] == 'M':  # Modified
+                files["staged"].append(filepath)
+            elif status[0] == 'D':  # Deleted
+                files["staged"].append(filepath)
+            elif status[0] == 'R':  # Renamed
+                files["renamed"].append(filepath)
+            elif status[1] == 'M':  # Modified (unstaged)
+                files["unstaged"].append(filepath)
+            elif status[1] == 'D':  # Deleted (unstaged)
+                files["unstaged"].append(filepath)
+            elif status == '??':  # Untracked
+                files["untracked"].append(filepath)
+
+    return files
 
 def get_repository_size(repo_path: str = ".") -> Dict[str, Union[int, str]]:
     """Get repository size information.
@@ -403,12 +376,6 @@ def get_repository_size(repo_path: str = ".") -> Dict[str, Union[int, str]]:
             "total_size_mb": round((git_size + working_size) / (1024 * 1024), 2)
         }
     except OSError as exc:
-        log.warning("Could not calculate repository size for %s: %s", repo_path, exc)
-        return {
-            "git_directory_size_bytes": 0,
-            "git_directory_size_mb": 0,
-            "working_directory_size_bytes": 0,
-            "working_directory_size_mb": 0,
-            "total_size_bytes": 0,
-            "total_size_mb": 0
-        }
+        raise GitError(
+            f"Could not calculate repository size for {repo_path}: {exc}"
+        ) from exc

--- a/tests/test_snowflake_connector.py
+++ b/tests/test_snowflake_connector.py
@@ -88,7 +88,7 @@ def test_connect_passes_only_non_none_params(_patch_snowflake):
     from siege_utilities.analytics.snowflake_connector import SnowflakeConnector
 
     c = SnowflakeConnector(account="acc", user="u", password="p", warehouse=None)
-    assert c.connect() is True
+    c.connect()
 
     _patch_snowflake.connector.connect.assert_called_once()
     kwargs = _patch_snowflake.connector.connect.call_args.kwargs


### PR DESCRIPTION
## Summary

Fixes 11 test failures on develop caused by errors-as-data patterns where implementations returned defaults/fakes instead of raising as documented:

- **git_status** (7 tests): `get_repository_status`, `get_branch_info`, `get_remote_info`, `get_log_summary`, `get_file_status`, `get_repository_size` all caught `GitError` and returned defaults with `log.warning()`. Docstrings and tests say they raise `GitError`. Now they catch-and-re-raise with descriptive messages.
- **hdfs_operations** (2 tests): `_default_hash_function` returned `f'error_{int(time.time())}'` (which also had a missing `import time` NameError) and `_default_quick_signature` returned `'error'`. Both now let `OSError`/`FileNotFoundError` propagate.
- **geocoding** (1 test): `use_nominatim_geocoder` narrow except clause missed `RuntimeError` from geopy. Broadened to `except Exception` at the API boundary (same fix as census_geocoder in PR #879).
- **snowflake_connector** (1 test): `assert c.connect() is True` stale from PR #875's `connect() -> None` change. Updated to just call `c.connect()`.

## Test plan

- [x] 127 tests pass, 0 failures (was 11 failures)
- [x] All modified files pass `ast.parse()`
- [x] 1 test error remains: `test_snowflake_live_connect_disconnect` (requires live Snowflake creds, pre-existing)