### PR TITLE
fix(SU-1): division-by-zero, empty-DataFrame, and type coercion guards

### DIFF
--- a/siege_utilities/geo/locale.py
+++ b/siege_utilities/geo/locale.py
@@ -704,7 +704,10 @@ class NCESLocaleClassifier:
         ua_populations: Dict[str, int] = {}
         if uac_pop_col and uac_id_col:
             for _, row in urbanized_areas.iterrows():
-                ua_populations[str(row[uac_id_col])] = int(row[uac_pop_col])
+                try:
+                    ua_populations[str(row[uac_id_col])] = int(row[uac_pop_col])
+                except (ValueError, TypeError):
+                    continue
 
         # Download Place boundaries
         try:

--- a/siege_utilities/geo/temporal/services.py
+++ b/siege_utilities/geo/temporal/services.py
@@ -133,7 +133,10 @@ class TemporalTimeseriesBuilder:
                 moe_by_year: dict[int, float | int] = {}
 
                 for _, row in bid_rows.iterrows():
-                    yr = int(row["year"])
+                    raw_yr = row["year"]
+                    if raw_yr is None or (isinstance(raw_yr, float) and raw_yr != raw_yr):
+                        continue
+                    yr = int(raw_yr)
                     if yr not in years_sorted:
                         continue
                     vals = row.get("values", {})

--- a/siege_utilities/geo/temporal/store.py
+++ b/siege_utilities/geo/temporal/store.py
@@ -158,10 +158,10 @@ class TemporalDataStore:
     ) -> Path:
         """Persist demographic snapshot data as Parquet."""
         if year is None:
-            if "year" in snapshots.columns:
+            if "year" in snapshots.columns and not snapshots.empty:
                 year = int(snapshots["year"].iloc[0])
             else:
-                raise ValueError("year must be provided or present in DataFrame")
+                raise ValueError("year must be provided or present in a non-empty DataFrame")
 
         dest = self._demographics_path(geography_type, dataset, year)
         dest.parent.mkdir(parents=True, exist_ok=True)
@@ -216,11 +216,11 @@ class TemporalDataStore:
     ) -> Path:
         """Persist pre-computed time-series data as Parquet."""
         if variable_code is None:
-            if "variable_code" in series.columns:
+            if "variable_code" in series.columns and not series.empty:
                 variable_code = str(series["variable_code"].iloc[0])
             else:
                 raise ValueError(
-                    "variable_code must be provided or present in DataFrame"
+                    "variable_code must be provided or present in a non-empty DataFrame"
                 )
 
         dest = self._timeseries_path(geography_type, variable_code, dataset)

--- a/siege_utilities/reporting/analytics_reports.py
+++ b/siege_utilities/reporting/analytics_reports.py
@@ -445,9 +445,9 @@ class AnalyticsReportGenerator:
         if 'total_users' in ga_data and 'total_sessions' in ga_data:
             users = ga_data['total_users']
             sessions = ga_data['total_sessions']
-            if sessions > users:
+            if users > 0 and sessions > users:
                 insights.append(f"High engagement: {sessions/users:.1f} sessions per user on average")
-            elif sessions < users:
+            elif users > 0 and sessions < users:
                 insights.append(f"Low engagement: Only {sessions/users:.1f} sessions per user on average")
         
         # Bounce rate insights

--- a/siege_utilities/reporting/examples/google_analytics_report_example.py
+++ b/siege_utilities/reporting/examples/google_analytics_report_example.py
@@ -59,6 +59,18 @@ from siege_utilities.reporting.report_generator import ReportGenerator
 log = logging.getLogger(__name__)
 
 
+def _safe_int(value, default: int = 0) -> int:
+    """Coerce a value to int, returning *default* for None/NaN/non-numeric."""
+    if value is None:
+        return default
+    if isinstance(value, float) and (value != value or value in (float("inf"), float("-inf"))):
+        return default
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return default
+
+
 class KPICard(Flowable):
     """A custom flowable for displaying KPI metrics in a card format."""
 
@@ -428,12 +440,12 @@ def generate_sample_ga_data(start_date: datetime, end_date: datetime) -> Dict[st
             'users': daily_users[worst_day_idx],
         },
         'best_week': {
-            'week': int(weekly_agg.loc[best_week_idx, 'week']),
-            'sessions': int(weekly_agg.loc[best_week_idx, 'sessions']),
+            'week': _safe_int(weekly_agg.loc[best_week_idx, 'week']),
+            'sessions': _safe_int(weekly_agg.loc[best_week_idx, 'sessions']),
         },
         'worst_week': {
-            'week': int(weekly_agg.loc[worst_week_idx, 'week']),
-            'sessions': int(weekly_agg.loc[worst_week_idx, 'sessions']),
+            'week': _safe_int(weekly_agg.loc[worst_week_idx, 'week']),
+            'sessions': _safe_int(weekly_agg.loc[worst_week_idx, 'sessions']),
         },
         'weekly_data': weekly_agg.to_dict('records'),
         'longitudinal': longitudinal_data,
@@ -592,10 +604,10 @@ def fetch_real_ga4_data(property_id: str, start_date: str, end_date: str,
                 traffic_sources.append({
                     'source': row.get('sessionDefaultChannelGrouping', 'unknown'),
                     'medium': 'channel',
-                    'sessions': int(row['sessions']),
-                    'users': int(row.get('totalUsers', 0)),
-                    'bounce_rate': float(row.get('bounceRate', 0)),
-                    'avg_duration': float(row.get('averageSessionDuration', 0)),
+                    'sessions': _safe_int(row.get('sessions', 0)),
+                    'users': _safe_int(row.get('totalUsers', 0)),
+                    'bounce_rate': float(row.get('bounceRate', 0) or 0),
+                    'avg_duration': float(row.get('averageSessionDuration', 0) or 0),
                 })
 
         # Devices
@@ -604,8 +616,8 @@ def fetch_real_ga4_data(property_id: str, start_date: str, end_date: str,
             for _, row in device_df.iterrows():
                 devices.append({
                     'device': row.get('deviceCategory', 'unknown'),
-                    'sessions': int(row['sessions']),
-                    'bounce_rate': float(row.get('bounceRate', 0)),
+                    'sessions': _safe_int(row.get('sessions', 0)),
+                    'bounce_rate': float(row.get('bounceRate', 0) or 0),
                 })
 
         # Geographic data (top 5 cities)
@@ -616,21 +628,22 @@ def fetch_real_ga4_data(property_id: str, start_date: str, end_date: str,
                     'country': row.get('country', 'Unknown'),
                     'region': row.get('region', 'Unknown'),
                     'city': row.get('city', 'Unknown'),
-                    'sessions': int(row['sessions']),
-                    'users': int(row.get('totalUsers', 0)),
+                    'sessions': _safe_int(row.get('sessions', 0)),
+                    'users': _safe_int(row.get('totalUsers', 0)),
                 })
 
         # Top pages
         top_pages = []
         if pages_df is not None and not pages_df.empty:
             for _, row in pages_df.nlargest(5, 'screenPageViews').iterrows():
+                pv = _safe_int(row.get('screenPageViews', 0))
                 top_pages.append({
                     'page': row.get('pagePath', '/'),
-                    'pageviews': int(row['screenPageViews']),
-                    'unique_views': int(row['screenPageViews'] * 0.85),
-                    'avg_time': float(row.get('averageSessionDuration', 0)),
-                    'bounce_rate': float(row.get('bounceRate', 0)),
-                    'exit_rate': float(row.get('bounceRate', 0)) * 0.8,
+                    'pageviews': pv,
+                    'unique_views': int(pv * 0.85),
+                    'avg_time': float(row.get('averageSessionDuration', 0) or 0),
+                    'bounce_rate': float(row.get('bounceRate', 0) or 0),
+                    'exit_rate': float(row.get('bounceRate', 0) or 0) * 0.8,
                 })
 
         # Best/worst day
@@ -2602,9 +2615,9 @@ def export_design_kit(ga_data: Dict[str, Any], output_dir: str,
             'branding_key': branding_key,
             'date_range': {'start': date_range['start'], 'end': date_range['end']},
             'totals': {
-                'sessions': int(totals['sessions']),
-                'users': int(totals['users']),
-                'pageviews': int(totals['pageviews']),
+                'sessions': _safe_int(totals.get('sessions', 0)),
+                'users': _safe_int(totals.get('users', 0)),
+                'pageviews': _safe_int(totals.get('pageviews', 0)),
                 'avg_bounce_rate': float(round(totals['avg_bounce_rate'], 1)),
                 'avg_session_duration': float(round(totals['avg_session_duration'], 0)),
                 'pages_per_session': float(round(totals['pages_per_session'], 2)),


### PR DESCRIPTION
## Summary

- **analytics_reports.py**: `sessions/users` division when `users==0` produces ZeroDivisionError — add `users > 0` precondition.
- **geo/temporal/store.py**: `save_demographics` and `save_timeseries` call `.iloc[0]` after checking column existence but NOT row existence — add `not df.empty` guard.
- **geo/temporal/services.py**: `int(row["year"])` without NaN guard crashes on missing values — add None/NaN check.
- **geo/locale.py**: `int(row[uac_pop_col])` lacked try/except while the identical pattern 20 lines later had it — add matching guard.
- **reporting/examples/google_analytics_report_example.py** (SU-3): 6+ bare `int(row[col])` calls on GA4 DataFrame values crash on NaN — add `_safe_int()` helper.

## Rules exercised

- SU-1: Errors are not data (division-by-zero produces exception instead of result)
- SU-3: No demo exemptions (example file held to library standard)

## Test plan

- [ ] `python -m pytest tests/test_git_status.py tests/test_credential_manager.py tests/test_snowflake_connector.py` — no regressions on core tests
- [ ] `python -c "import ast; ast.parse(open(f).read())"` — all modified files parse cleanly
- [ ] Manual: pass `{'total_users': 0, 'total_sessions': 5}` to `_generate_ga_insights` — no crash