### PR TITLE
fix: NameError on PathSecurityError + narrow conf exception catch

### DIFF
--- a/siege_utilities/conf/__init__.py
+++ b/siege_utilities/conf/__init__.py
@@ -63,7 +63,12 @@ class Settings:
 
             if hasattr(django_settings, name):
                 return getattr(django_settings, name)
-        except (ImportError, Exception):
+        except ImportError:
+            pass
+        except Exception:
+            # django.core.exceptions.ImproperlyConfigured when
+            # DJANGO_SETTINGS_MODULE is unset; can't narrow further
+            # without importing from Django itself.
             pass
 
         # 4. YAML file

--- a/siege_utilities/files/remote.py
+++ b/siege_utilities/files/remote.py
@@ -24,6 +24,12 @@ except ImportError:
     TQDM_AVAILABLE = False
     tqdm = None
 
+try:
+    from siege_utilities.files.validation import PathSecurityError
+except ImportError:
+    class PathSecurityError(Exception):
+        """Stub for when validation module is unavailable."""
+
 # Get logger for this module
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

- **files/remote.py**: `PathSecurityError` imported inside a `try` block (lines 116, 260) but referenced in outer `except` handlers (lines 159, 276). If the inner import fails, the outer `except PathSecurityError:` raises `NameError` — masking the security check and causing it to fail open. Fix: import at module level with a stub fallback class.
- **conf/__init__.py**: Split redundant `except (ImportError, Exception): pass` into two clauses documenting the distinct failure modes (Django not installed vs Django misconfigured).

## Test plan

- [ ] `python -c "import ast; ast.parse(open('siege_utilities/files/remote.py').read())"` — parses cleanly
- [ ] `python -c "from siege_utilities.files.remote import PathSecurityError"` — importable at module level
- [ ] Existing download tests pass