### PR TITLE
fix: TypeError on naive/aware datetime comparison in connections and cache

### DIFF
--- a/siege_utilities/config/connections.py
+++ b/siege_utilities/config/connections.py
@@ -470,7 +470,8 @@ def get_connection_status(
     # Determine connection health
     if last_connected:
         last_connected_dt = datetime.fromisoformat(last_connected)
-        time_since_connection = datetime.now() - last_connected_dt
+        now = datetime.now(last_connected_dt.tzinfo)
+        time_since_connection = now - last_connected_dt
         
         if time_since_connection < timedelta(hours=1):
             health = 'excellent'
@@ -523,19 +524,19 @@ def cleanup_old_connections(
     if not connections_dir.exists():
         return 0
     
-    cutoff_date = datetime.now() - timedelta(days=days_old)
     removed_count = 0
-    
+
     for config_file in connections_dir.glob("connection_*.json"):
         try:
             with open(config_file, 'r') as f:
                 profile = json.load(f)
-            
+
             created_date = datetime.fromisoformat(profile['metadata']['created_date'])
             last_used = datetime.fromisoformat(profile['metadata']['last_used'])
-            
+            cutoff_date = datetime.now(created_date.tzinfo) - timedelta(days=days_old)
+
             # Remove if old and unused
-            if (created_date < cutoff_date and 
+            if (created_date < cutoff_date and
                 last_used < cutoff_date and 
                 profile['metadata']['connection_count'] == 0):
                 

--- a/siege_utilities/geo/providers/nlrb_cache.py
+++ b/siege_utilities/geo/providers/nlrb_cache.py
@@ -178,7 +178,7 @@ class NLRBCache:
         if fetched_at:
             try:
                 cached_time = datetime.fromisoformat(fetched_at)
-                if datetime.now() - cached_time > self._ttl:
+                if datetime.now(cached_time.tzinfo) - cached_time > self._ttl:
                     log.info("Cache expired for %s", key)
                     return None
             except (ValueError, TypeError):


### PR DESCRIPTION
## Summary

- **connections.py**: `datetime.fromisoformat()` returns timezone-aware datetimes when the ISO string has offset info (e.g., `+00:00`), but `datetime.now()` returns naive. Subtracting them raises `TypeError: can't subtract offset-naive and offset-aware datetimes`. Fix: pass the parsed datetime's `tzinfo` to `datetime.now()` so both operands match.
- **nlrb_cache.py**: Same pattern — `fromisoformat()` on cached `fetched_at` vs `datetime.now()`.

Affected functions: `get_connection_status()`, `cleanup_old_connections()`, `NLRBFileCache.get()`.

## Test plan

- [ ] `python -c "import ast; ast.parse(open(f).read())"` for both files
- [ ] Manual: `datetime.now(datetime.fromisoformat('2024-01-01T00:00:00+00:00').tzinfo)` produces aware datetime
- [ ] Manual: `datetime.now(None)` produces naive datetime (backward compatible when ISO strings lack offset)