### PR TITLE
fix: misleading error messages in stash and SRID validation

### DIFF
--- a/siege_utilities/geo/spatial_transformations.py
+++ b/siege_utilities/geo/spatial_transformations.py
@@ -576,7 +576,7 @@ class PostGISConnector:
                     srid = None
             srid = srid or settings.STORAGE_CRS
             if not isinstance(srid, int):
-                raise ValueError(f"SRID must be an integer, got {type(srid)}")
+                raise TypeError(f"SRID must be an integer, got {type(srid)}")
 
             create_sql = f"""
             CREATE TABLE IF NOT EXISTS {table_name} (

--- a/siege_utilities/git/git_operations.py
+++ b/siege_utilities/git/git_operations.py
@@ -319,7 +319,8 @@ def apply_stash(
         action = "popped" if pop else "applied"
         log_info(f"Stash {stash_ref} {action} successfully")
     except (RuntimeError, GitError) as e:
-        raise GitError(f"Stash apply failed: {e}") from e
+        action = "pop" if pop else "apply"
+        raise GitError(f"Stash {action} failed: {e}") from e
 
     return {
         "stash_ref": stash_ref,


### PR DESCRIPTION
## Summary

- **git/git_operations.py**: `apply_stash()` error message hardcodes "Stash apply failed" even when `pop=True`. The success log correctly uses the action variable but the error path doesn't.
- **geo/spatial_transformations.py**: `_create_spatial_table` raises `ValueError` for a type check ("SRID must be an integer, got \<type\>"). `TypeError` is the correct exception for wrong-type errors.

## Test plan

- [ ] `python -c "import ast; ast.parse(open(f).read())"` for both files
- [ ] `pytest tests/test_git_status.py` — no regressions