### PR TITLE
fix: double-checked locking for all lazy singletons

### DIFF
--- a/siege_utilities/geo/census_api_client.py
+++ b/siege_utilities/geo/census_api_client.py
@@ -33,6 +33,7 @@ This file provides the backward-compatible ``CensusAPIClient`` facade.
 """
 
 import logging
+import threading
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Union, Any, TYPE_CHECKING
@@ -428,13 +429,16 @@ def get_housing_data(
 
 # Module-level client for convenience
 _default_client: Optional[CensusAPIClient] = None
+_default_client_lock = threading.Lock()
 
 
 def get_census_api_client() -> CensusAPIClient:
     """Get or create the default Census API client."""
     global _default_client
     if _default_client is None:
-        _default_client = CensusAPIClient()
+        with _default_client_lock:
+            if _default_client is None:
+                _default_client = CensusAPIClient()
     return _default_client
 
 

--- a/siege_utilities/geo/census_files/pl_downloader.py
+++ b/siege_utilities/geo/census_files/pl_downloader.py
@@ -21,6 +21,7 @@ Example usage:
 """
 
 import logging
+import threading
 import zipfile
 from datetime import datetime, timedelta
 from io import StringIO
@@ -583,13 +584,16 @@ class PLFileDownloader:
 # =============================================================================
 
 _default_downloader: Optional[PLFileDownloader] = None
+_default_downloader_lock = threading.Lock()
 
 
 def _get_downloader() -> PLFileDownloader:
     """Get or create default downloader."""
     global _default_downloader
     if _default_downloader is None:
-        _default_downloader = PLFileDownloader()
+        with _default_downloader_lock:
+            if _default_downloader is None:
+                _default_downloader = PLFileDownloader()
     return _default_downloader
 
 

--- a/siege_utilities/geo/crosswalk/crosswalk_client.py
+++ b/siege_utilities/geo/crosswalk/crosswalk_client.py
@@ -26,6 +26,7 @@ Example usage:
 """
 
 import logging
+import threading
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, List, Optional, Union
@@ -440,13 +441,16 @@ class CrosswalkClient:
 
 # Module-level client instance
 _default_client: Optional[CrosswalkClient] = None
+_default_client_lock = threading.Lock()
 
 
 def get_crosswalk_client() -> CrosswalkClient:
     """Get or create the default crosswalk client."""
     global _default_client
     if _default_client is None:
-        _default_client = CrosswalkClient()
+        with _default_client_lock:
+            if _default_client is None:
+                _default_client = CrosswalkClient()
     return _default_client
 
 

--- a/siege_utilities/geo/spatial_data.py
+++ b/siege_utilities/geo/spatial_data.py
@@ -6,6 +6,7 @@ Provides clean, type-safe access to Census, Government, and OpenStreetMap data.
 import logging
 import os
 import re
+import threading
 import time
 import warnings
 import warnings as _warnings_mod
@@ -2303,26 +2304,33 @@ def download_dataset(
 _census_source = None
 _government_source = None
 _osm_source = None
+_source_lock = threading.Lock()
 
 
 def _get_census_source() -> "CensusDataSource":
     global _census_source
     if _census_source is None:
-        _census_source = CensusDataSource()
+        with _source_lock:
+            if _census_source is None:
+                _census_source = CensusDataSource()
     return _census_source
 
 
 def _get_government_source() -> "GovernmentDataSource":
     global _government_source
     if _government_source is None:
-        _government_source = GovernmentDataSource("https://data.gov")
+        with _source_lock:
+            if _government_source is None:
+                _government_source = GovernmentDataSource("https://data.gov")
     return _government_source
 
 
 def _get_osm_source() -> "OpenStreetMapDataSource":
     global _osm_source
     if _osm_source is None:
-        _osm_source = OpenStreetMapDataSource()
+        with _source_lock:
+            if _osm_source is None:
+                _osm_source = OpenStreetMapDataSource()
     return _osm_source
 
 

--- a/siege_utilities/geo/temporal/store.py
+++ b/siege_utilities/geo/temporal/store.py
@@ -12,6 +12,7 @@ GeoPackage is available as an alternative via format="gpkg" (boundaries only).
 from __future__ import annotations
 
 import logging
+import threading
 from datetime import date
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
@@ -24,6 +25,7 @@ log = logging.getLogger(__name__)
 
 _DEFAULT_ROOT = Path.home() / ".siege_utilities" / "store" / "temporal"
 _SINGLETON: Optional["TemporalDataStore"] = None
+_SINGLETON_LOCK = threading.Lock()
 
 
 class TemporalDataStore:
@@ -281,7 +283,9 @@ def get_temporal_store(
     """Get or create the singleton TemporalDataStore."""
     global _SINGLETON
     if _SINGLETON is None or (root_dir is not None):
-        _SINGLETON = TemporalDataStore(root_dir=root_dir, format=format)
+        with _SINGLETON_LOCK:
+            if _SINGLETON is None or (root_dir is not None):
+                _SINGLETON = TemporalDataStore(root_dir=root_dir, format=format)
     return _SINGLETON
 
 


### PR DESCRIPTION
## Summary

- Applied double-checked locking pattern to 5 lazy-singleton getters that previously used unsynchronized check-then-set
- Matches the correct pattern already in `geo/plans/registry.py`
- Prevents duplicate network I/O (e.g., `CensusDataSource.__init__` hits the Census API) and duplicate object creation under concurrent access

**Files changed:** `spatial_data.py`, `census_api_client.py`, `crosswalk_client.py`, `pl_downloader.py`, `temporal/store.py`

## Test plan

- [x] `ast.parse()` on all 5 modified files
- [x] 229 tests pass, zero regressions
- [ ] Verify under concurrent access (threading stress test)