### PR TITLE
fix(geo): guard int(NaN) on population iloc[0] in locale

### DIFF
--- a/siege_utilities/geo/locale.py
+++ b/siege_utilities/geo/locale.py
@@ -431,7 +431,10 @@ class NCESLocaleClassifier:
         # Fallback: check for an inline population column
         for col in ("POP", "POPULATION", "pop", "population", "POP20", "POP10"):
             if col in pc_match.columns:
-                return int(pc_match[col].iloc[0])
+                try:
+                    return int(pc_match[col].iloc[0])
+                except (ValueError, TypeError):
+                    continue
         # Default to small city if no population data available
         log.warning("No population data found for principal city match; defaulting to small city")
         return 0
@@ -448,7 +451,10 @@ class NCESLocaleClassifier:
         # Fallback: inline population column
         for col in ("POP", "POPULATION", "POP20", "POP10", "pop"):
             if col in ua_match.columns:
-                return int(ua_match[col].iloc[0])
+                try:
+                    return int(ua_match[col].iloc[0])
+                except (ValueError, TypeError):
+                    continue
         log.warning("No population data found for UA match; defaulting to small suburb")
         return 0
 


### PR DESCRIPTION
## Summary

- `_get_place_population` and `_get_ua_population` call `int(df[col].iloc[0])` on population columns that may contain NaN
- `int(NaN)` raises `ValueError`, crashing locale classification when Census shapefiles have missing population data
- Added try/except guards matching the pattern already used at lines 707-710 and 727-732 (fixed in PR #882 but these two methods were missed)

## Test plan

- [x] `ast.parse()` verification
- [x] 229 tests pass, zero regressions
- [ ] Verify with Census shapefile containing NaN population values