### PR TITLE
fix: guard 6 division-by-zero paths

### DIFF
--- a/siege_utilities/geo/providers/redistricting_data_hub.py
+++ b/siege_utilities/geo/providers/redistricting_data_hub.py
@@ -763,8 +763,14 @@ def compare_plans(
         raise ImportError("pandas is required")
 
     def _plan_stats(gdf, label):
+        if gdf.empty:
+            raise ValueError(f"Cannot compute plan stats: '{label}' has no districts")
         pops = gdf[population_col]
         ideal = pops.sum() / len(pops)
+        if ideal == 0:
+            raise ValueError(
+                f"Cannot compute plan stats: '{label}' has zero total population"
+            )
         return {
             "label": label,
             "num_districts": len(gdf),

--- a/siege_utilities/reporting/engines/map_engine.py
+++ b/siege_utilities/reporting/engines/map_engine.py
@@ -488,9 +488,10 @@ class MapChartMixin:
 
                 # Determine marker size based on value
                 if value_column and value_column in row:
-                    # Normalize values to marker sizes (10-50 pixels)
                     value = row[value_column]
-                    marker_size = max(10, min(50, int(10 + (value / df[value_column].max()) * 40)))
+                    col_max = df[value_column].max()
+                    normalized = (value / col_max) if col_max else 0
+                    marker_size = max(10, min(50, int(10 + normalized * 40)))
                 else:
                     marker_size = 15
 
@@ -800,7 +801,9 @@ class MapChartMixin:
             else:
                 df = data.copy()
 
-            # Calculate center point for map
+            if df.empty:
+                raise ValueError("Cannot create flow map from empty DataFrame")
+
             all_lats = df[origin_lat_column].tolist() + df[dest_lat_column].tolist()
             all_lons = df[origin_lon_column].tolist() + df[dest_lon_column].tolist()
             center_lat = sum(all_lats) / len(all_lats)
@@ -820,7 +823,9 @@ class MapChartMixin:
 
                 # Determine line weight based on flow value
                 if flow_value_column and flow_value_column in row:
-                    weight = max(1, min(10, int(row[flow_value_column] / df[flow_value_column].max() * 10)))
+                    flow_max = df[flow_value_column].max()
+                    normalized = (row[flow_value_column] / flow_max) if flow_max else 0
+                    weight = max(1, min(10, int(normalized * 10)))
                 else:
                     weight = 3
 

--- a/siege_utilities/reporting/examples/ga_geographic_analysis.py
+++ b/siege_utilities/reporting/examples/ga_geographic_analysis.py
@@ -257,7 +257,8 @@ def create_city_heatmap(ga_city_df: pd.DataFrame, value_column: str = 'sessions'
         # Prepare heatmap data
         heat_data = []
         for _, row in valid.iterrows():
-            weight = row[value_column] / valid[value_column].max()  # Normalize
+            col_max = valid[value_column].max()
+            weight = (row[value_column] / col_max) if col_max else 0
             heat_data.append([row['latitude'], row['longitude'], weight])
 
         # Add heatmap layer

--- a/siege_utilities/reporting/examples/google_analytics_report_example.py
+++ b/siege_utilities/reporting/examples/google_analytics_report_example.py
@@ -406,7 +406,7 @@ def generate_sample_ga_data(start_date: datetime, end_date: datetime) -> Dict[st
             'pageviews': total_pageviews,
             'avg_bounce_rate': avg_bounce_rate,
             'avg_session_duration': avg_session_duration,
-            'pages_per_session': total_pageviews / total_sessions,
+            'pages_per_session': (total_pageviews / total_sessions) if total_sessions else 0,
         },
         'prior_period': {
             'users': prior_users,
@@ -420,10 +420,10 @@ def generate_sample_ga_data(start_date: datetime, end_date: datetime) -> Dict[st
             'users': prior_daily_users,
         },
         'changes': {
-            'users': ((total_users - prior_users) / prior_users) * 100,
-            'sessions': ((total_sessions - prior_sessions) / prior_sessions) * 100,
+            'users': (((total_users - prior_users) / prior_users) * 100) if prior_users else 0,
+            'sessions': (((total_sessions - prior_sessions) / prior_sessions) * 100) if prior_sessions else 0,
             'bounce_rate': avg_bounce_rate - prior_bounce,
-            'duration': ((avg_session_duration - prior_duration) / prior_duration) * 100,
+            'duration': (((avg_session_duration - prior_duration) / prior_duration) * 100) if prior_duration else 0,
         },
         'traffic_sources': traffic_sources,
         'top_pages': top_pages,


### PR DESCRIPTION
## Summary
- **redistricting_data_hub**: `_plan_stats()` raises `ValueError` on empty GeoDataFrame or zero total population instead of dividing by zero in deviation/range calculations
- **map_engine**: guards marker-size and flow-weight normalization against zero `.max()`; raises on empty DataFrame in `create_flow_map`
- **ga_geographic_analysis**: guards heatmap weight normalization against zero `.max()`
- **google_analytics_report_example**: guards `pages_per_session` and 3 growth-percentage calculations against zero denominators

## Test plan
- [ ] `python -m pytest tests/test_redistricting_data_hub.py` passes
- [ ] Verify empty-plan input raises `ValueError` (not `ZeroDivisionError`)
- [ ] Verify zero-max columns produce 0 weight (not crash)