### PR TITLE
fix: guard unguarded .iloc[0] and data-URI split

### DIFF
--- a/siege_utilities/reporting/analytics/polling_analyzer.py
+++ b/siege_utilities/reporting/analytics/polling_analyzer.py
@@ -370,7 +370,10 @@ class PollingAnalyzer:
                         f"frame for {data_type!r} has no non-metric column to label; "
                         f"pass name_column= explicitly"
                     )
-                top_item = df.nlargest(1, metric).iloc[0]
+                top_df = df.nlargest(1, metric)
+                if top_df.empty:
+                    continue
+                top_item = top_df.iloc[0]
                 value = float(top_item[metric])
                 top_performers[data_type] = {
                     "name": top_item[label_col],

--- a/siege_utilities/reporting/image_utils.py
+++ b/siege_utilities/reporting/image_utils.py
@@ -24,7 +24,8 @@ def decode_rl_image(rl_img) -> Optional[bytes]:
     """
     if (hasattr(rl_img, 'filename')
             and isinstance(rl_img.filename, str)
-            and rl_img.filename.startswith('data:image')):
+            and rl_img.filename.startswith('data:image')
+            and ',' in rl_img.filename):
         b64_data = rl_img.filename.split(',', 1)[1]
         return base64.b64decode(b64_data)
     return None


### PR DESCRIPTION
## Summary
- **polling_analyzer**: `nlargest(1).iloc[0]` crashes with IndexError on empty DataFrame — now checks `.empty` first
- **image_utils**: `split(',', 1)[1]` crashes if data URI is malformed (no comma) — now verifies comma exists

## Test plan
- [ ] `python -m pytest tests/ -k polling` passes
- [ ] Manually verify image_utils handles `"data:image"` (no comma) gracefully