### PR TITLE
fix(geo): correct return type annotation on _add_geometry

### DIFF
--- a/siege_utilities/geo/timeseries/longitudinal_data.py
+++ b/siege_utilities/geo/timeseries/longitudinal_data.py
@@ -363,7 +363,7 @@ def _add_geometry(
     state_fips: Optional[str],
     year: int,
     county_fips: Optional[str] = None,
-) -> 'gpd.GeoDataFrame':
+) -> "Union['gpd.GeoDataFrame', pd.DataFrame]":
     """
     Add geometry to the DataFrame.
 
@@ -376,7 +376,8 @@ def _add_geometry(
             demographics scope (prevents state-wide geometry with county-filtered data)
 
     Returns:
-        GeoDataFrame with geometry, preserving canonical GEOID from demographics
+        GeoDataFrame with geometry if boundaries are available, otherwise the
+        original DataFrame unchanged.
     """
     import geopandas as gpd
     from ..spatial_data import get_census_boundaries


### PR DESCRIPTION
## Summary
- `_add_geometry()` in `longitudinal_data.py` was typed `-> gpd.GeoDataFrame` but returns plain `pd.DataFrame` when boundaries are unavailable
- Updated to `Union[GeoDataFrame, DataFrame]` with docstring documenting the fallback
- SU-2 violation: type signature must match implementation

## Test plan
- [ ] `python -c "import ast; ast.parse(open('siege_utilities/geo/timeseries/longitudinal_data.py').read())"` passes
- [ ] mypy/pyright check passes on the file