### PR TITLE
fix(geo): log warnings on connection close failures

### DIFF
--- a/siege_utilities/geo/spatial_transformations.py
+++ b/siege_utilities/geo/spatial_transformations.py
@@ -340,8 +340,8 @@ class PostGISConnector:
         if self.connection is not None:
             try:
                 self.connection.close()
-            except Exception:
-                pass
+            except Exception as exc:
+                log.warning("Failed to close PostGIS connection: %s", exc)
             self.connection = None
 
     def __enter__(self):
@@ -634,8 +634,8 @@ class DuckDBConnector:
         if self.connection is not None:
             try:
                 self.connection.close()
-            except Exception:
-                pass
+            except Exception as exc:
+                log.warning("Failed to close DuckDB connection: %s", exc)
             self.connection = None
 
     def __enter__(self):


### PR DESCRIPTION
## Summary
- PostGISConnector.close() and DuckDBConnector.close() had `except Exception: pass` — completely silent failures
- Now log a warning so connection issues surface during debugging

## Test plan
- [ ] `python -c "import ast; ast.parse(open('siege_utilities/geo/spatial_transformations.py').read())"` passes
- [ ] Connection close failures now appear in log output