### PR TITLE
fix: guard 3 path traversal vulnerabilities

### DIFF
--- a/siege_utilities/config/databases.py
+++ b/siege_utilities/config/databases.py
@@ -117,6 +117,8 @@ def save_database_config(config: Dict[str, Any], config_directory: str = "config
     config_dir.mkdir(parents=True, exist_ok=True)
 
     db_name = config['name']
+    if not db_name or '/' in db_name or '\\' in db_name or '..' in db_name:
+        raise ValueError(f"Invalid database name for filename: {db_name!r}")
     config_file = config_dir / f"database_{db_name}.json"
 
     # Warning about password storage

--- a/siege_utilities/config/google_account_registry.py
+++ b/siege_utilities/config/google_account_registry.py
@@ -156,6 +156,9 @@ def save_google_account_profile(
     """Save a single GoogleAccount to a per-owner JSON file. Returns the path."""
     directory = Path(config_directory)
     directory.mkdir(parents=True, exist_ok=True)
+    for part_name, part_val in [("owner_id", owner_id), ("google_account_id", account.google_account_id)]:
+        if not part_val or '/' in part_val or '\\' in part_val or '..' in part_val:
+            raise ValueError(f"Invalid {part_name} for filename: {part_val!r}")
     filename = f"{owner_id}_google_account_{account.google_account_id}.json"
     path = directory / filename
     path.write_text(json.dumps(account.model_dump(mode="json"), indent=2, default=str))
@@ -168,6 +171,9 @@ def load_google_account_profile(
     config_directory: str = "config",
 ) -> Optional[GoogleAccount]:
     """Load a single GoogleAccount from a per-owner JSON file."""
+    for part_name, part_val in [("owner_id", owner_id), ("google_account_id", google_account_id)]:
+        if not part_val or '/' in part_val or '\\' in part_val or '..' in part_val:
+            raise ValueError(f"Invalid {part_name} for filename: {part_val!r}")
     filename = f"{owner_id}_google_account_{google_account_id}.json"
     path = Path(config_directory) / filename
     if not path.exists():

--- a/siege_utilities/distributed/hdfs_config.py
+++ b/siege_utilities/distributed/hdfs_config.py
@@ -84,9 +84,13 @@ class HDFSConfig:
         if self.log_error_func is None:
             self.log_error_func = lambda msg: log_error(msg)
 
-    def get_cache_path(self, filename: str) ->pathlib.Path:
-        """Get path for cache files"""
-        return pathlib.Path(self.cache_directory) / filename
+    def get_cache_path(self, filename: str) -> pathlib.Path:
+        """Get path for cache files."""
+        base = pathlib.Path(self.cache_directory)
+        result = (base / filename).resolve()
+        if not str(result).startswith(str(base.resolve())):
+            raise ValueError(f"filename {filename!r} escapes cache directory")
+        return result
 
     def get_optimal_partitions(self) ->int:
         """Calculate optimal partitions for I/O heavy workloads"""


### PR DESCRIPTION
## Summary
- **hdfs_config.get_cache_path()**: resolves path and verifies it stays within cache directory
- **databases.save_database_config()**: rejects `db_name` containing path separators or `..`
- **google_account_registry**: validates `owner_id` and `google_account_id` before use in filenames (both save and load)

## Test plan
- [ ] `get_cache_path("../etc/passwd")` raises ValueError
- [ ] `save_database_config({"name": "../etc/cron"})` raises ValueError
- [ ] `save_google_account_profile(account, "../escape")` raises ValueError