### PR TITLE
fix: guard unsafe int/float casts on external input

### DIFF
--- a/siege_utilities/conf/__init__.py
+++ b/siege_utilities/conf/__init__.py
@@ -88,9 +88,15 @@ class Settings:
         if isinstance(default, bool):
             return val.lower() in ("true", "1", "yes")
         if isinstance(default, int):
-            return int(val)
+            try:
+                return int(val)
+            except (ValueError, TypeError):
+                return default
         if isinstance(default, float):
-            return float(val)
+            try:
+                return float(val)
+            except (ValueError, TypeError):
+                return default
         return val
 
     def _load_yaml(self) -> dict | None:

--- a/siege_utilities/distributed/hdfs_config.py
+++ b/siege_utilities/distributed/hdfs_config.py
@@ -66,11 +66,17 @@ class HDFSConfig:
             self.cache_directory = str(pathlib.Path.home() /
                 '.spark_hdfs_cache')
         if self.num_executors is None:
-            self.num_executors = int(os.environ.get(
-                'SPARK_EXECUTOR_INSTANCES', '4'))
+            try:
+                self.num_executors = int(os.environ.get(
+                    'SPARK_EXECUTOR_INSTANCES', '4'))
+            except (ValueError, TypeError):
+                self.num_executors = 4
         if self.executor_cores is None:
-            self.executor_cores = int(os.environ.get('SPARK_EXECUTOR_CORES',
-                '2'))
+            try:
+                self.executor_cores = int(os.environ.get(
+                    'SPARK_EXECUTOR_CORES', '2'))
+            except (ValueError, TypeError):
+                self.executor_cores = 2
         if 'SPARK_EXECUTOR_MEMORY' in os.environ:
             self.executor_memory = os.environ['SPARK_EXECUTOR_MEMORY']
         if 'SPARK_DRIVER_MEMORY' in os.environ:

--- a/siege_utilities/files/remote.py
+++ b/siege_utilities/files/remote.py
@@ -36,6 +36,17 @@ log = logging.getLogger(__name__)
 # Type aliases
 FilePath = Union[str, Path]
 
+
+def _safe_content_length(response) -> int:
+    """Parse Content-Length header, returning 0 on missing or malformed values."""
+    raw = response.headers.get('content-length')
+    if raw is None:
+        return 0
+    try:
+        return int(raw)
+    except (ValueError, TypeError):
+        return 0
+
 def _get_ssl_verify_path():
     """Get the appropriate SSL certificate verification path for the current platform."""
     # macOS system CA bundle path (works better than certifi for some sites)
@@ -138,7 +149,7 @@ def download_file(url: str, local_filename: FilePath,
                 return False
             
             # Get total size for progress bar
-            total_size = int(response.headers.get('content-length', 0))
+            total_size = _safe_content_length(response)
             
             if total_size > 0:
                 log.info(f'Download started, file size: {total_size} bytes')
@@ -178,7 +189,7 @@ def download_file(url: str, local_filename: FilePath,
                     return False
                 
                 # Get total size for progress bar
-                total_size = int(response.headers.get('content-length', 0))
+                total_size = _safe_content_length(response)
                 
                 if total_size > 0:
                     log.info(f'Download started without SSL, file size: {total_size} bytes')
@@ -346,7 +357,7 @@ def get_file_info(url: str, timeout: int = 10) -> Optional[dict]:
         
         info = {
             'url': url,
-            'size': int(response.headers.get('content-length', 0)),
+            'size': _safe_content_length(response),
             'content_type': response.headers.get('content-type', 'unknown'),
             'last_modified': response.headers.get('last-modified'),
             'etag': response.headers.get('etag')


### PR DESCRIPTION
## Summary
- **hdfs_config**: `SPARK_EXECUTOR_INSTANCES` / `SPARK_EXECUTOR_CORES` env vars fall back to defaults on non-numeric values
- **files/remote.py**: New `_safe_content_length()` helper prevents ValueError on malformed Content-Length headers (3 call sites)
- **conf/__init__**: `_coerce()` returns the declared default instead of crashing when env var is non-numeric

## Test plan
- [ ] Set `SPARK_EXECUTOR_INSTANCES=abc` — should not crash, uses default 4
- [ ] Mocked response with `Content-Length: invalid` — should return 0
- [ ] Set non-numeric env var for int config — should use default