### PR TITLE
fix: eliminate TOCTOU races and fragile is-True comparison

### DIFF
--- a/siege_utilities/analytics/google_slides.py
+++ b/siege_utilities/analytics/google_slides.py
@@ -348,8 +348,10 @@ def upload_figure_to_drive(
         log.info("Uploaded figure %r → Drive %s", filename, file_id)
         return url
     finally:
-        if os.path.exists(tmp_path):
+        try:
             os.unlink(tmp_path)
+        except FileNotFoundError:
+            pass
 
 
 def create_argument_slide(

--- a/siege_utilities/geo/census/catalog_cache.py
+++ b/siege_utilities/geo/census/catalog_cache.py
@@ -216,13 +216,17 @@ class CatalogCache:
             return 0
         if dataset and year:
             path = self._cache_path(dataset, year)
-            if path.exists():
+            try:
                 path.unlink()
                 return 1
-            return 0
+            except FileNotFoundError:
+                return 0
         count = 0
         for path in self.cache_dir.glob("*.json"):
-            path.unlink()
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                continue
             count += 1
         return count
 

--- a/siege_utilities/geo/providers/census_geocoder.py
+++ b/siege_utilities/geo/providers/census_geocoder.py
@@ -345,7 +345,7 @@ def geocode_batch(
     if isinstance(result, list):
         for row in result:
             row_id = str(row.get("id", ""))
-            matched = row.get("match", False) is True
+            matched = bool(row.get("match", False))
             if matched:
                 parsed = CensusGeocodeResult(
                     matched=True,


### PR DESCRIPTION
## Summary
- **census_geocoder**: `is True` identity comparison replaced with `bool()` — prevents silent match drops
- **google_slides**: check-then-unlink in finally block replaced with try/except FileNotFoundError
- **catalog_cache**: exists()-then-unlink() replaced with try/except pattern for safe concurrent operation

## Test plan
- [ ] Census geocoder: verify API responses with value `1` or `"True"` still match
- [ ] google_slides: tmp file cleanup doesn't crash if file already deleted
- [ ] catalog_cache: concurrent clear_cache calls don't crash