### PR TITLE
fix(config): add explicit encoding='utf-8' to all config file I/O

### DIFF
--- a/siege_utilities/conf/__init__.py
+++ b/siege_utilities/conf/__init__.py
@@ -110,7 +110,7 @@ class Settings:
                 try:
                     import yaml
 
-                    with open(candidate) as f:
+                    with open(candidate, encoding="utf-8") as f:
                         self._yaml_cache = yaml.safe_load(f) or {}
                         self._yaml_path = candidate
                 except ImportError:
@@ -131,7 +131,7 @@ class Settings:
                 try:
                     import yaml
 
-                    with open(candidate) as f:
+                    with open(candidate, encoding="utf-8") as f:
                         self._yaml_cache = yaml.safe_load(f) or {}
                         self._yaml_path = candidate
                 except ImportError:

--- a/siege_utilities/config/clients.py
+++ b/siege_utilities/config/clients.py
@@ -150,7 +150,7 @@ def save_client_profile(
         dir=str(config_dir),
     )
     try:
-        with os.fdopen(fd, 'w') as f:
+        with os.fdopen(fd, 'w', encoding='utf-8') as f:
             json.dump(profile, f, indent=2)
             f.flush()
             os.fsync(f.fileno())
@@ -195,7 +195,7 @@ def load_client_profile(
         return None
     
     try:
-        with open(config_file, 'r') as f:
+        with open(config_file, 'r', encoding='utf-8') as f:
             profile = json.load(f)
         
         log_info(f"Loaded client profile: {client_code}")
@@ -287,7 +287,7 @@ def list_client_profiles(
     
     for config_file in config_dir.glob("client_*.json"):
         try:
-            with open(config_file, 'r') as f:
+            with open(config_file, 'r', encoding='utf-8') as f:
                 profile = json.load(f)
             
             clients.append({
@@ -338,7 +338,7 @@ def search_client_profiles(
     # Load all profiles
     for config_file in pathlib.Path(config_directory).glob("client_*.json"):
         try:
-            with open(config_file, 'r') as f:
+            with open(config_file, 'r', encoding='utf-8') as f:
                 profile = json.load(f)
             all_profiles.append(profile)
         except (OSError, json.JSONDecodeError):

--- a/siege_utilities/config/databases.py
+++ b/siege_utilities/config/databases.py
@@ -125,7 +125,7 @@ def save_database_config(config: Dict[str, Any], config_directory: str = "config
     log_warning(f"Saving database config with password in plain text to {config_file}")
     log_warning("In production, consider using environment variables or encryption")
 
-    with open(config_file, 'w') as f:
+    with open(config_file, 'w', encoding='utf-8') as f:
         json.dump(config, f, indent=2)
 
     log_info(f"Saved database config to: {config_file}")
@@ -156,7 +156,7 @@ def load_database_config(db_name: str, config_directory: str = "config") -> Opti
         return None
 
     try:
-        with open(config_file, 'r') as f:
+        with open(config_file, 'r', encoding='utf-8') as f:
             config = json.load(f)
 
         log_info(f"Loaded database config: {db_name}")
@@ -289,7 +289,7 @@ def list_database_configs(config_directory: str = "config") -> list:
 
     for config_file in config_dir.glob("database_*.json"):
         try:
-            with open(config_file, 'r') as f:
+            with open(config_file, 'r', encoding='utf-8') as f:
                 config = json.load(f)
 
             databases.append({

--- a/siege_utilities/config/user_config.py
+++ b/siege_utilities/config/user_config.py
@@ -117,7 +117,7 @@ class UserConfigManager:
         """Load user profile from configuration file."""
         if self.user_config_file.exists():
             try:
-                with open(self.user_config_file, 'r') as f:
+                with open(self.user_config_file, 'r', encoding='utf-8') as f:
                     config_data = yaml.safe_load(f)
                     if config_data:
                         # Convert lists back to tuples for specific fields
@@ -136,7 +136,7 @@ class UserConfigManager:
             config_dict = asdict(self.user_profile)
             # Convert tuples to lists for YAML compatibility
             config_dict = self._convert_to_yaml_safe(config_dict)
-            with open(self.user_config_file, 'w') as f:
+            with open(self.user_config_file, 'w', encoding='utf-8') as f:
                 yaml.dump(config_dict, f, default_flow_style=False)
         except (OSError, yaml.YAMLError, TypeError) as e:
             log.error(f"Failed to save user config: {e}")


### PR DESCRIPTION
## Summary
- Added explicit `encoding='utf-8'` to all `open()` calls in core config modules
- Files affected: `conf/__init__.py`, `config/user_config.py`, `config/databases.py`, `config/clients.py`
- Prevents silent data corruption on systems with non-UTF-8 default encoding (Windows, minimal CI containers)

## Test plan
- [ ] Config files with unicode content (e.g., client name "Café") load correctly
- [ ] `python -m pytest tests/test_config.py` passes
- [ ] Verify on a system with `LANG=C` locale