### PR TITLE
fix(config): encoding='utf-8' batch 2 — enhanced_config, credentials, branding

### DIFF
--- a/siege_utilities/config/credential_manager.py
+++ b/siege_utilities/config/credential_manager.py
@@ -350,7 +350,7 @@ class CredentialManager:
         """Extract credential from a specific file."""
         try:
             if file_path.suffix.lower() == '.json':
-                with open(file_path, 'r') as f:
+                with open(file_path, 'r', encoding='utf-8') as f:
                     data = json.load(f)
                 
                 # Handle different JSON structures
@@ -369,7 +369,7 @@ class CredentialManager:
                     return self._find_field_in_dict(data, field)
             
             else:  # Plain text file
-                with open(file_path, 'r') as f:
+                with open(file_path, 'r', encoding='utf-8') as f:
                     content = f.read().strip()
                     return content if content else None
                     
@@ -942,9 +942,9 @@ def store_ga_credentials_from_file(credentials_file: Union[str, Path],
             log_error(f"Credentials file not found: {credentials_file}")
             return False
         
-        with open(credentials_file, 'r') as f:
+        with open(credentials_file, 'r', encoding='utf-8') as f:
             credentials_data = json.load(f)
-        
+
         manager = CredentialManager(default_vault=vault)
         success = manager.store_google_analytics_credentials(
             credentials_data, item_title, vault
@@ -1008,7 +1008,7 @@ def store_ga_service_account_from_file(credentials_file: Union[str, Path],
             return False
         
         # Read service account JSON
-        with open(credentials_file, 'r') as f:
+        with open(credentials_file, 'r', encoding='utf-8') as f:
             service_account_data = json.load(f)
         
         # Validate service account format

--- a/siege_utilities/config/enhanced_config.py
+++ b/siege_utilities/config/enhanced_config.py
@@ -61,7 +61,7 @@ class ConfigurationMigrator:
             return self._create_default_user_profile()
         
         try:
-            with open(legacy_file, 'r') as f:
+            with open(legacy_file, 'r', encoding='utf-8') as f:
                 legacy_data = yaml.safe_load(f)
 
             # safe_load returns None for empty docs, lists/scalars for
@@ -105,7 +105,7 @@ class ConfigurationMigrator:
             # json.load on .toml/.cfg/anything-else and silently raising
             # JSONDecodeError hides the real cause.
             suffix = legacy_file.suffix.lower()
-            with open(legacy_file, 'r') as f:
+            with open(legacy_file, 'r', encoding='utf-8') as f:
                 if suffix in ('.yaml', '.yml'):
                     legacy_data = yaml.safe_load(f)
                 elif suffix == '.json':
@@ -418,7 +418,7 @@ def load_user_profile(username: str, config_dir: Optional[Path] = None) -> Optio
             logger.warning(f"User profile not found: {config_file}")
             return None
             
-        with open(config_file, 'r') as f:
+        with open(config_file, 'r', encoding='utf-8') as f:
             data = yaml.safe_load(f)
 
         if not isinstance(data, dict):
@@ -479,7 +479,7 @@ def save_user_profile(profile: UserProfile, username: str, config_dir: Optional[
         profile_data = profile.model_dump()
         profile_data = _convert_to_yaml_safe(profile_data)
 
-        with open(config_file, 'w') as f:
+        with open(config_file, 'w', encoding='utf-8') as f:
             yaml.dump(profile_data, f, default_flow_style=False)
 
         logger.info(f"Saved user profile: {config_file}")
@@ -537,7 +537,7 @@ def load_client_profile(client_code: str, config_dir: Optional[Path] = None) -> 
             logger.warning(f"Client profile not found: {config_file}")
             return None
             
-        with open(config_file, 'r') as f:
+        with open(config_file, 'r', encoding='utf-8') as f:
             data = yaml.safe_load(f)
 
         if not isinstance(data, dict):
@@ -581,7 +581,7 @@ def save_client_profile(profile: ClientProfile, config_dir: Optional[Path] = Non
         profile_data = profile.model_dump()
         profile_data = _convert_to_yaml_safe(profile_data)
 
-        with open(config_file, 'w') as f:
+        with open(config_file, 'w', encoding='utf-8') as f:
             yaml.dump(profile_data, f, default_flow_style=False)
 
         logger.info(f"Saved client profile: {config_file}")
@@ -660,7 +660,7 @@ def export_config_yaml(config_data: Dict[str, Any], output_file: Path) -> bool:
     try:
         output_file.parent.mkdir(parents=True, exist_ok=True)
         
-        with open(output_file, 'w') as f:
+        with open(output_file, 'w', encoding='utf-8') as f:
             yaml.dump(config_data, f, default_flow_style=False)
             
         logger.info(f"Exported configuration to: {output_file}")
@@ -686,7 +686,7 @@ def import_config_yaml(input_file: Path) -> Optional[Dict[str, Any]]:
             logger.warning(f"Configuration file not found: {input_file}")
             return None
             
-        with open(input_file, 'r') as f:
+        with open(input_file, 'r', encoding='utf-8') as f:
             config_data = yaml.safe_load(f)
             
         logger.info(f"Imported configuration from: {input_file}")

--- a/siege_utilities/reporting/client_branding.py
+++ b/siege_utilities/reporting/client_branding.py
@@ -265,9 +265,9 @@ class ClientBrandingManager:
             # Create branding config file
             config_file = client_dir / f"{_slugify_client_name(client_name)}_branding.yaml"
             
-            with open(config_file, 'w') as f:
+            with open(config_file, 'w', encoding='utf-8') as f:
                 yaml.dump(branding_config, f, default_flow_style=False, indent=2)
-            
+
             log.info(f"Created branding configuration for {client_name}: {config_file}")
             return config_file
             
@@ -295,7 +295,7 @@ class ClientBrandingManager:
             if client_dir.exists():
                 # Look for branding config files
                 for config_file in client_dir.glob("*_branding.yaml"):
-                    with open(config_file, 'r') as f:
+                    with open(config_file, 'r', encoding='utf-8') as f:
                         config = yaml.safe_load(f)
                         log.info(f"Loaded branding configuration from {config_file}")
                         return config
@@ -337,7 +337,7 @@ class ClientBrandingManager:
             client_dir = self.config_dir / _slugify_client_name(client_name)
             config_file = client_dir / f"{_slugify_client_name(client_name)}_branding.yaml"
 
-            with open(config_file, 'w') as f:
+            with open(config_file, 'w', encoding='utf-8') as f:
                 yaml.dump(current_config, f, default_flow_style=False, indent=2)
 
             log.info(f"Updated branding configuration for {client_name}")
@@ -492,16 +492,16 @@ class ClientBrandingManager:
         try:
             # Export as YAML
             if export_path.suffix.lower() in ['.yaml', '.yml']:
-                with open(export_path, 'w') as f:
+                with open(export_path, 'w', encoding='utf-8') as f:
                     yaml.dump(branding_config, f, default_flow_style=False, indent=2)
             # Export as JSON
             elif export_path.suffix.lower() == '.json':
-                with open(export_path, 'w') as f:
+                with open(export_path, 'w', encoding='utf-8') as f:
                     json.dump(branding_config, f, indent=2)
             else:
                 # Default to YAML
                 export_path = export_path.with_suffix('.yaml')
-                with open(export_path, 'w') as f:
+                with open(export_path, 'w', encoding='utf-8') as f:
                     yaml.dump(branding_config, f, default_flow_style=False, indent=2)
 
             log.info(f"Exported branding configuration for {client_name} to {export_path}")
@@ -526,10 +526,10 @@ class ClientBrandingManager:
         try:
             # Load configuration
             if import_path.suffix.lower() in ['.yaml', '.yml']:
-                with open(import_path, 'r') as f:
+                with open(import_path, 'r', encoding='utf-8') as f:
                     branding_config = yaml.safe_load(f)
             elif import_path.suffix.lower() == '.json':
-                with open(import_path, 'r') as f:
+                with open(import_path, 'r', encoding='utf-8') as f:
                     branding_config = json.load(f)
             else:
                 log.error(f"Unsupported file format: {import_path.suffix}")


### PR DESCRIPTION
## Summary
- Added explicit `encoding='utf-8'` to 20 more `open()` calls across 3 files
- **enhanced_config.py** (8 calls): user/client profile load/save, migration, import/export
- **credential_manager.py** (4 calls): Google OAuth + service account JSON reads
- **client_branding.py** (8 calls): branding config YAML/JSON read/write

## Test plan
- [ ] Config files with unicode (e.g. client "José's Café") load/save correctly
- [ ] Credential files load on systems with `LANG=C` locale