### PR TITLE
fix: defer 3 module-level singletons that create dirs on import

### DIFF
--- a/siege_utilities/config/user_config.py
+++ b/siege_utilities/config/user_config.py
@@ -5,6 +5,7 @@ Enhanced with Pydantic validation while maintaining backward compatibility.
 """
 
 import logging
+import threading
 import warnings
 import yaml
 from pathlib import Path
@@ -344,12 +345,18 @@ class UserConfigManager:
         except (OSError, yaml.YAMLError, AttributeError) as e:
             log.error(f"Failed to import configuration: {e}")
 
-# Global instance
-user_config = UserConfigManager()
+_user_config = None
+_user_config_lock = threading.Lock()
+
 
 def get_user_config() -> UserConfigManager:
-    """Get the global user configuration manager."""
-    return user_config
+    """Get or create the global user configuration manager."""
+    global _user_config
+    if _user_config is None:
+        with _user_config_lock:
+            if _user_config is None:
+                _user_config = UserConfigManager()
+    return _user_config
 
 def get_download_directory(specific_path: Optional[str] = None, client_code: Optional[str] = None, config_dir: Optional[Path] = None) -> Path:
     """
@@ -391,13 +398,13 @@ def get_download_directory(specific_path: Optional[str] = None, client_code: Opt
             if client_profile:
                 # Client profiles don't have download_directory anymore,
                 # use a client-specific subdirectory instead
-                download_dir = user_config.get_download_directory() / "clients" / client_code.lower()
+                download_dir = get_user_config().get_download_directory() / "clients" / client_code.lower()
         except (ImportError, OSError, yaml.YAMLError, ValueError) as e:
             log.debug(f"Could not load client profile for {client_code}: {e}")
 
     # Priority 3 & 4: User's preferred directory or default
     if download_dir is None:
-        download_dir = user_config.get_download_directory()
+        download_dir = get_user_config().get_download_directory()
 
     # Ensure the directory exists and is writable
     try:

--- a/siege_utilities/reporting/chart_types.py
+++ b/siege_utilities/reporting/chart_types.py
@@ -5,6 +5,7 @@ Provides base chart types and easy extension capabilities.
 from __future__ import annotations
 
 import logging
+import threading
 from typing import TYPE_CHECKING, Dict, Any, Optional, List, Callable
 from dataclasses import dataclass, field
 import yaml
@@ -513,17 +514,23 @@ class ChartTypeRegistry:
         except (OSError, yaml.YAMLError, AttributeError) as e:
             log.error(f"Failed to export chart type configuration: {e}")
 
-# Global instance
-chart_registry = ChartTypeRegistry()
+_chart_registry = None
+_chart_registry_lock = threading.Lock()
+
 
 def get_chart_registry() -> ChartTypeRegistry:
-    """Get the global chart type registry."""
-    return chart_registry
+    """Get or create the global chart type registry."""
+    global _chart_registry
+    if _chart_registry is None:
+        with _chart_registry_lock:
+            if _chart_registry is None:
+                _chart_registry = ChartTypeRegistry()
+    return _chart_registry
 
 def register_chart_type(chart_type: ChartType):
     """Register a new chart type."""
-    chart_registry.register_chart_type(chart_type)
+    get_chart_registry().register_chart_type(chart_type)
 
 def create_chart(chart_type_name: str, **kwargs) -> Optional[Figure]:
     """Create a chart using the specified chart type."""
-    return chart_registry.create_chart(chart_type_name, **kwargs)
+    return get_chart_registry().create_chart(chart_type_name, **kwargs)

--- a/siege_utilities/reporting/templates/page_templates.py
+++ b/siege_utilities/reporting/templates/page_templates.py
@@ -4,6 +4,7 @@ Provides base templates and customization capabilities for different page types.
 """
 
 import logging
+import threading
 from pathlib import Path
 from typing import Dict, Any, Optional, List, Union, Callable
 from dataclasses import dataclass, field
@@ -383,13 +384,19 @@ class PageTemplateManager:
             'custom_elements': template.custom_elements
         }
 
-# Global instance
-template_manager = PageTemplateManager()
+_template_manager = None
+_template_manager_lock = threading.Lock()
+
 
 def get_template_manager() -> PageTemplateManager:
-    """Get the global template manager."""
-    return template_manager
+    """Get or create the global template manager."""
+    global _template_manager
+    if _template_manager is None:
+        with _template_manager_lock:
+            if _template_manager is None:
+                _template_manager = PageTemplateManager()
+    return _template_manager
 
 def get_template(template_name: str) -> Optional[PageTemplate]:
     """Get a template by name."""
-    return template_manager.get_template(template_name)
+    return get_template_manager().get_template(template_name)


### PR DESCRIPTION
## Summary
- **user_config.py**: `UserConfigManager()` was instantiated at module level, creating `~/.siege_utilities/config/` on every import — now lazy with double-checked locking
- **page_templates.py**: `PageTemplateManager()` created templates directory on import — now lazy
- **chart_types.py**: `ChartTypeRegistry()` registered all default chart types on import — now lazy

All follow the same pattern established in PR #888 for thread-safe lazy singletons.

## Test plan
- [ ] `from siege_utilities.config.user_config import get_user_config` doesn't create dirs
- [ ] `get_user_config()` still works correctly on first call
- [ ] `get_template_manager()` creates templates dir on first access
- [ ] `get_chart_registry()` registers chart types on first access