### PR TITLE
fix(geo): guard slug_to_geoid against IndexError on malformed slugs

### DIFF
--- a/siege_utilities/geo/geoid_utils.py
+++ b/siege_utilities/geo/geoid_utils.py
@@ -744,43 +744,42 @@ def slug_to_geoid(slug: str) -> str:
 
     geography_lower = _SLUG_LABEL_TO_LEVEL[level_label]
 
-    if geography_lower == 'county':
-        # "ca-county-037"
-        county = parts[level_idx + 1]
-        return state_fips + county
-    elif geography_lower == 'tract':
-        # "ca-037-tract-101100"
-        county = parts[level_idx - 1]
-        tract = parts[level_idx + 1]
-        return state_fips + county + tract
-    elif geography_lower == 'block_group':
-        # "ca-037-101100-bg-1"
-        county = parts[1]
-        tract = parts[2]
-        bg = parts[level_idx + 1]
-        return state_fips + county + tract + bg
-    elif geography_lower == 'block':
-        # "ca-037-101100-block-1001"
-        county = parts[1]
-        tract = parts[2]
-        block = parts[level_idx + 1]
-        return state_fips + county + tract + block
-    elif geography_lower == 'place':
-        # "ca-place-44000"
-        place = parts[level_idx + 1]
-        return state_fips + place
-    elif geography_lower in ('cd', 'sldu', 'sldl'):
-        # "ca-cd-14"
-        district = parts[level_idx + 1]
-        return state_fips + district
-    elif geography_lower == 'vtd':
-        # "ca-037-vtd-001"
-        county = parts[level_idx - 1]
-        vtd = parts[level_idx + 1]
-        return state_fips + county + vtd
-    else:
-        remainder = "".join(parts[level_idx + 1:])
-        return state_fips + remainder
+    try:
+        if geography_lower == 'county':
+            county = parts[level_idx + 1]
+            return state_fips + county
+        elif geography_lower == 'tract':
+            county = parts[level_idx - 1]
+            tract = parts[level_idx + 1]
+            return state_fips + county + tract
+        elif geography_lower == 'block_group':
+            county = parts[1]
+            tract = parts[2]
+            bg = parts[level_idx + 1]
+            return state_fips + county + tract + bg
+        elif geography_lower == 'block':
+            county = parts[1]
+            tract = parts[2]
+            block = parts[level_idx + 1]
+            return state_fips + county + tract + block
+        elif geography_lower == 'place':
+            place = parts[level_idx + 1]
+            return state_fips + place
+        elif geography_lower in ('cd', 'sldu', 'sldl'):
+            district = parts[level_idx + 1]
+            return state_fips + district
+        elif geography_lower == 'vtd':
+            county = parts[level_idx - 1]
+            vtd = parts[level_idx + 1]
+            return state_fips + county + vtd
+        else:
+            remainder = "".join(parts[level_idx + 1:])
+            return state_fips + remainder
+    except IndexError:
+        raise ValueError(
+            f"Malformed slug '{slug}': not enough components for "
+            f"{geography_lower}-level GEOID"
+        ) from None
 
 
 def find_geoid_column(df: pd.DataFrame) -> Optional[str]:


### PR DESCRIPTION
## Summary
- `slug_to_geoid()` had 12 unguarded `parts[level_idx + 1]` / `parts[level_idx - 1]` accesses
- Malformed slugs (e.g., "ca-tract" without tract code) raised cryptic IndexError
- Now wraps parsing in try/except IndexError → raises ValueError with helpful message

## Test plan
- [ ] `slug_to_geoid("ca-county-037")` still returns "06037"
- [ ] `slug_to_geoid("ca-tract")` raises ValueError (not IndexError)
- [ ] `slug_to_geoid("ca-bg")` raises ValueError with "block_group" in message