### PR TITLE
fix: add encoding='utf-8' to 64 open() calls across 19 files

### DIFF
--- a/siege_utilities/analytics/datadotworld_connector.py
+++ b/siege_utilities/analytics/datadotworld_connector.py
@@ -67,9 +67,9 @@ class DataDotWorldConnector:
             raise FileNotFoundError(f"Configuration file not found: {config_path}")
         
         try:
-            with open(config_path, 'r') as f:
+            with open(config_path, 'r', encoding='utf-8') as f:
                 config = json.load(f)
-            
+
             # Update instance variables with config values
             if 'api_token' in config and config['api_token']:
                 self.api_token = config['api_token']

--- a/siege_utilities/analytics/facebook_business.py
+++ b/siege_utilities/analytics/facebook_business.py
@@ -393,7 +393,7 @@ def save_facebook_account_profile(profile: Dict[str, Any],
     account_id = profile['fb_account_id']
     config_file = config_dir / f"fb_account_{account_id}.json"
 
-    with open(config_file, 'w') as f:
+    with open(config_file, 'w', encoding='utf-8') as f:
         json.dump(profile, f, indent=2)
 
     log_info(f"Saved Facebook account profile to: {config_file}")
@@ -419,7 +419,7 @@ def load_facebook_account_profile(account_id: str,
         return None
 
     try:
-        with open(config_file, 'r') as f:
+        with open(config_file, 'r', encoding='utf-8') as f:
             profile = json.load(f)
 
         log_info(f"Loaded Facebook account profile: {account_id}")
@@ -450,7 +450,7 @@ def list_facebook_accounts_for_client(client_id: str,
     accounts = []
     for config_file in config_dir.glob("fb_account_*.json"):
         try:
-            with open(config_file, 'r') as f:
+            with open(config_file, 'r', encoding='utf-8') as f:
                 profile = json.load(f)
 
             if profile.get('client_id') == client_id:

--- a/siege_utilities/analytics/google_analytics.py
+++ b/siege_utilities/analytics/google_analytics.py
@@ -171,7 +171,7 @@ class GoogleAnalyticsConnector:
 
     def _save_credentials(self, token_path: pathlib.Path):
         """Save OAuth credentials to file."""
-        with open(token_path, 'w') as token:
+        with open(token_path, 'w', encoding='utf-8') as token:
             token.write(self.credentials.to_json())
         log_info(f"Saved credentials to: {token_path}")
 
@@ -489,7 +489,7 @@ def save_ga_account_profile(profile: Dict[str, Any],
     account_id = profile['ga_account_id']
     config_file = config_dir / f"ga_account_{account_id}.json"
 
-    with open(config_file, 'w') as f:
+    with open(config_file, 'w', encoding='utf-8') as f:
         json.dump(profile, f, indent=2)
 
     log_info(f"Saved GA account profile to: {config_file}")
@@ -515,7 +515,7 @@ def load_ga_account_profile(account_id: str,
         return None
 
     try:
-        with open(config_file, 'r') as f:
+        with open(config_file, 'r', encoding='utf-8') as f:
             profile = json.load(f)
 
         log_info(f"Loaded GA account profile: {account_id}")
@@ -546,7 +546,7 @@ def list_ga_accounts_for_client(client_id: str,
     accounts = []
     for config_file in config_dir.glob("ga_account_*.json"):
         try:
-            with open(config_file, 'r') as f:
+            with open(config_file, 'r', encoding='utf-8') as f:
                 profile = json.load(f)
 
             if profile.get('client_id') == client_id:
@@ -617,7 +617,7 @@ def batch_retrieve_ga_data(client_id: str, start_date: str, end_date: str,
                 if not creds_path.exists():
                     results['errors'].append(f"Credentials file not found: {creds_path}")
                     continue
-                with open(creds_path, 'r') as creds_f:
+                with open(creds_path, 'r', encoding='utf-8') as creds_f:
                     service_account_data = json.load(creds_f)
                 connector = GoogleAnalyticsConnector(
                     auth_method="service_account",

--- a/siege_utilities/analytics/snowflake_connector.py
+++ b/siege_utilities/analytics/snowflake_connector.py
@@ -89,9 +89,9 @@ class SnowflakeConnector:
             raise FileNotFoundError(f"Configuration file not found: {config_path}")
         
         try:
-            with open(config_path, 'r') as f:
+            with open(config_path, 'r', encoding='utf-8') as f:
                 config = json.load(f)
-            
+
             _ALLOWED_CONFIG_KEYS = frozenset({
                 "account", "user", "password", "warehouse",
                 "database", "schema", "role",

--- a/siege_utilities/config/connections.py
+++ b/siege_utilities/config/connections.py
@@ -137,9 +137,9 @@ def save_connection_profile(
     # Update last_used timestamp
     profile['metadata']['last_used'] = datetime.now().isoformat()
     
-    with open(config_file, 'w') as f:
+    with open(config_file, 'w', encoding='utf-8') as f:
         json.dump(profile, f, indent=2)
-    
+
     log_info(f"Saved connection profile to: {config_file}")
     return str(config_file)
 
@@ -172,9 +172,9 @@ def load_connection_profile(
         return None
     
     try:
-        with open(config_file, 'r') as f:
+        with open(config_file, 'r', encoding='utf-8') as f:
             profile = json.load(f)
-        
+
         log_info(f"Loaded connection profile: {connection_id}")
         return profile
         
@@ -210,9 +210,9 @@ def find_connection_by_name(
     
     for config_file in connections_dir.glob("connection_*.json"):
         try:
-            with open(config_file, 'r') as f:
+            with open(config_file, 'r', encoding='utf-8') as f:
                 profile = json.load(f)
-            
+
             if profile['name'] == name:
                 return profile
                 
@@ -253,9 +253,9 @@ def list_connection_profiles(
     
     for config_file in connections_dir.glob("connection_*.json"):
         try:
-            with open(config_file, 'r') as f:
+            with open(config_file, 'r', encoding='utf-8') as f:
                 profile = json.load(f)
-            
+
             # Filter by type if specified
             if connection_type and profile['connection_type'] != connection_type:
                 continue
@@ -528,7 +528,7 @@ def cleanup_old_connections(
 
     for config_file in connections_dir.glob("connection_*.json"):
         try:
-            with open(config_file, 'r') as f:
+            with open(config_file, 'r', encoding='utf-8') as f:
                 profile = json.load(f)
 
             created_date = datetime.fromisoformat(profile['metadata']['created_date'])

--- a/siege_utilities/config/directories.py
+++ b/siege_utilities/config/directories.py
@@ -214,7 +214,7 @@ def save_directory_config(paths: Dict[str, str], config_name: str,
         'created_date': str(pathlib.Path().stat().st_mtime)
     }
 
-    with open(config_file, 'w') as f:
+    with open(config_file, 'w', encoding='utf-8') as f:
         json.dump(config, f, indent=2)
 
     log_info(f"Saved directory config to: {config_file}")
@@ -263,7 +263,7 @@ def load_directory_config(config_name: str, config_directory: str = "config") ->
         return None
 
     try:
-        with open(config_file, 'r') as f:
+        with open(config_file, 'r', encoding='utf-8') as f:
             config = json.load(f)
 
         log_info(f"Loaded directory config: {config_name}")
@@ -513,7 +513,7 @@ def list_directory_configs(config_directory: str = "config") -> List[Dict[str, A
 
     for config_file in config_dir.glob("directories_*.json"):
         try:
-            with open(config_file, 'r') as f:
+            with open(config_file, 'r', encoding='utf-8') as f:
                 config = json.load(f)
 
             configs.append({

--- a/siege_utilities/config/migration.py
+++ b/siege_utilities/config/migration.py
@@ -56,9 +56,9 @@ class ConfigurationMigrator:
             return self._create_default_user_profile()
         
         try:
-            with open(legacy_file, 'r') as f:
+            with open(legacy_file, 'r', encoding='utf-8') as f:
                 legacy_data = yaml.safe_load(f)
-            
+
             logger.info(f"Loading legacy user profile from: {legacy_file}")
             
             # Map legacy fields to new UserProfile fields
@@ -90,7 +90,7 @@ class ConfigurationMigrator:
             return self._create_default_client_profile(client_code)
         
         try:
-            with open(legacy_file, 'r') as f:
+            with open(legacy_file, 'r', encoding='utf-8') as f:
                 legacy_data = yaml.safe_load(f) if legacy_file.suffix in ['.yaml', '.yml'] else json.load(f)
             
             logger.info(f"Loading legacy client profile from: {legacy_file}")

--- a/siege_utilities/config/projects.py
+++ b/siege_utilities/config/projects.py
@@ -143,7 +143,7 @@ def save_project_config(config: Dict[str, Any], config_directory: str = "config"
     project_code = config['project_code']
     config_file = config_dir / f"project_{project_code}.json"
 
-    with open(config_file, 'w') as f:
+    with open(config_file, 'w', encoding='utf-8') as f:
         json.dump(config, f, indent=2)
 
     log_info(f"Saved project config to: {config_file}")
@@ -196,7 +196,7 @@ def load_project_config(project_code: str, config_directory: str = "config") -> 
         return None
 
     try:
-        with open(config_file, 'r') as f:
+        with open(config_file, 'r', encoding='utf-8') as f:
             config = json.load(f)
 
         log_info(f"Loaded project config: {project_code}")
@@ -339,7 +339,7 @@ def list_projects(config_directory: str = "config") -> list:
 
     for config_file in config_dir.glob("project_*.json"):
         try:
-            with open(config_file, 'r') as f:
+            with open(config_file, 'r', encoding='utf-8') as f:
                 config = json.load(f)
 
             projects.append({

--- a/siege_utilities/config/user_config.py
+++ b/siege_utilities/config/user_config.py
@@ -317,9 +317,9 @@ class UserConfigManager:
             config_data.pop('facebook_business_key', None)
             config_data.pop('census_api_key', None)
             
-            with open(output_path, 'w') as f:
+            with open(output_path, 'w', encoding='utf-8') as f:
                 yaml.dump(config_data, f, default_flow_style=False)
-            
+
             log.info(f"Configuration exported to: {output_path}")
         except (OSError, yaml.YAMLError) as e:
             log.error(f"Failed to export configuration: {e}")
@@ -332,9 +332,9 @@ class UserConfigManager:
             input_path: Path to import configuration from
         """
         try:
-            with open(input_path, 'r') as f:
+            with open(input_path, 'r', encoding='utf-8') as f:
                 config_data = yaml.safe_load(f)
-            
+
             # Update profile with imported data
             for key, value in config_data.items():
                 if hasattr(self.user_profile, key):

--- a/siege_utilities/development/architecture.py
+++ b/siege_utilities/development/architecture.py
@@ -412,7 +412,7 @@ def generate_requirements_txt(setup_py_path: str = "setup.py", output_path: str 
             return False
 
         # Read and parse setup.py
-        with open(setup_path, 'r') as f:
+        with open(setup_path, 'r', encoding='utf-8') as f:
             content = f.read()
 
         # Parse AST to extract dependencies
@@ -428,7 +428,7 @@ def generate_requirements_txt(setup_py_path: str = "setup.py", output_path: str 
                                 dependencies.append(elt.value)
 
         # Write requirements.txt
-        with open(output_path, 'w') as f:
+        with open(output_path, 'w', encoding='utf-8') as f:
             for dep in dependencies:
                 f.write(f"{dep}\n")
 
@@ -488,7 +488,7 @@ def generate_pyproject_toml(setup_py_path: str = "setup.py", output_path: str = 
             return False
 
         # Read and parse setup.py
-        with open(setup_path, 'r') as f:
+        with open(setup_path, 'r', encoding='utf-8') as f:
             content = f.read()
 
         # Parse AST to extract package info
@@ -557,7 +557,7 @@ dependencies = [
         toml_content += '\n[tool.setuptools.packages.find]\nwhere = ["."]\ninclude = ["*"]\n'
 
         # Write pyproject.toml
-        with open(output_path, 'w') as f:
+        with open(output_path, 'w', encoding='utf-8') as f:
             f.write(toml_content)
 
         log_info(f"Generated {output_path} from {setup_py_path}")
@@ -616,7 +616,7 @@ def generate_poetry_toml(setup_py_path: str = "setup.py", output_path: str = "py
             return False
 
         # Read and parse setup.py
-        with open(setup_path, 'r') as f:
+        with open(setup_path, 'r', encoding='utf-8') as f:
             content = f.read()
 
         # Parse AST to extract package info
@@ -677,7 +677,7 @@ python = "{package_info.get('python_requires', '>=3.8')}"
         toml_content += '\n[build-system]\nrequires = ["poetry-core"]\nbuild-backend = "poetry.core.masonry.api"\n'
 
         # Write pyproject.toml
-        with open(output_path, 'w') as f:
+        with open(output_path, 'w', encoding='utf-8') as f:
             f.write(toml_content)
 
         log_info(f"Generated Poetry-compatible {output_path} from {setup_py_path}")

--- a/siege_utilities/geo/census_dataset_mapper.py
+++ b/siege_utilities/geo/census_dataset_mapper.py
@@ -583,7 +583,7 @@ class CensusDatasetMapper:
             }
         }
         
-        with open(filepath, 'w') as f:
+        with open(filepath, 'w', encoding='utf-8') as f:
             json.dump(catalog, f, indent=2)
 
         log_info(f"Dataset catalog exported to {filepath}")

--- a/siege_utilities/geo/django/services/timezone_service.py
+++ b/siege_utilities/geo/django/services/timezone_service.py
@@ -107,7 +107,7 @@ class TimezonePopulationService:
                     return result
                 data = json.loads(zf.read(geojson_names[0]))
         else:
-            with open(geojson_path) as f:
+            with open(geojson_path, encoding='utf-8') as f:
                 data = json.load(f)
 
         features = data.get("features", [])

--- a/siege_utilities/geo/spatial_data.py
+++ b/siege_utilities/geo/spatial_data.py
@@ -315,7 +315,7 @@ def update_census_inventory(
 
     save_path = Path(save_path or _DEFAULT_INVENTORY_PATH)
     save_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(save_path, "w") as fh:
+    with open(save_path, "w", encoding="utf-8") as fh:
         json.dump(inventory, fh, indent=2)
     log.info("census inventory saved to %s", save_path)
     return inventory
@@ -328,7 +328,7 @@ def load_census_inventory(path: Optional[Path] = None) -> Optional[dict]:
     if not p.exists():
         return None
     try:
-        with open(p) as fh:
+        with open(p, encoding="utf-8") as fh:
             return json.load(fh)
     except (OSError, ValueError, UnicodeDecodeError) as exc:
         log.warning("could not load census inventory from %s: %s", p, exc)

--- a/siege_utilities/geo/spatial_transformations.py
+++ b/siege_utilities/geo/spatial_transformations.py
@@ -234,7 +234,7 @@ class SpatialDataTransformer:
                 + "'));"
             )
 
-            with open(output_path, 'w') as f:
+            with open(output_path, 'w', encoding='utf-8') as f:
                 f.write('\n'.join(sql_lines))
             
             log.info(f"Successfully generated PostGIS SQL: {output_path}")

--- a/siege_utilities/reporting/chart_types.py
+++ b/siege_utilities/reporting/chart_types.py
@@ -507,7 +507,7 @@ class ChartTypeRegistry:
                 'custom_options': chart_type.custom_options
             }
             
-            with open(output_path, 'w') as f:
+            with open(output_path, 'w', encoding='utf-8') as f:
                 yaml.dump(config_data, f, default_flow_style=False)
             
             log.info(f"Exported chart type configuration to: {output_path}")

--- a/siege_utilities/reporting/examples/google_analytics_report_example.py
+++ b/siege_utilities/reporting/examples/google_analytics_report_example.py
@@ -2469,7 +2469,7 @@ def export_design_kit(ga_data: Dict[str, Any], output_dir: str,
         # ── 2. Tables (CSV) ──
         # Daily performance
         daily = ga_data['daily_data']
-        with open(tables_dir / 'daily_performance.csv', 'w', newline='') as f:
+        with open(tables_dir / 'daily_performance.csv', 'w', newline='', encoding='utf-8') as f:
             w = csv.writer(f)
             w.writerow(['Date', 'Sessions', 'Users', 'Pageviews', 'Bounce Rate (%)', 'Avg Duration (s)'])
             for i in range(len(daily['dates'])):
@@ -2478,7 +2478,7 @@ def export_design_kit(ga_data: Dict[str, Any], output_dir: str,
                             f"{daily['avg_duration'][i]:.0f}"])
 
         # Traffic sources
-        with open(tables_dir / 'traffic_sources.csv', 'w', newline='') as f:
+        with open(tables_dir / 'traffic_sources.csv', 'w', newline='', encoding='utf-8') as f:
             w = csv.writer(f)
             w.writerow(['Source', 'Medium', 'Sessions', 'Users', 'Bounce Rate (%)', 'Avg Duration (s)'])
             for src in sorted(ga_data['traffic_sources'], key=lambda x: x['sessions'], reverse=True):
@@ -2486,7 +2486,7 @@ def export_design_kit(ga_data: Dict[str, Any], output_dir: str,
                             f"{src['bounce_rate']:.1f}", f"{src['avg_duration']:.1f}"])
 
         # Top pages
-        with open(tables_dir / 'top_pages.csv', 'w', newline='') as f:
+        with open(tables_dir / 'top_pages.csv', 'w', newline='', encoding='utf-8') as f:
             w = csv.writer(f)
             w.writerow(['Page', 'Pageviews', 'Unique Views', 'Avg Time (s)', 'Bounce Rate (%)', 'Exit Rate (%)'])
             for p in ga_data['top_pages']:
@@ -2494,7 +2494,7 @@ def export_design_kit(ga_data: Dict[str, Any], output_dir: str,
                             f"{p['avg_time']:.1f}", f"{p['bounce_rate']:.1f}", f"{p['exit_rate']:.1f}"])
 
         # Geographic data
-        with open(tables_dir / 'geographic.csv', 'w', newline='') as f:
+        with open(tables_dir / 'geographic.csv', 'w', newline='', encoding='utf-8') as f:
             w = csv.writer(f)
             w.writerow(['Country', 'Region', 'City', 'Continent', 'Sessions', 'Users'])
             for loc in sorted(ga_data['geo_data'], key=lambda x: x.get('sessions', 0), reverse=True):
@@ -2502,14 +2502,14 @@ def export_design_kit(ga_data: Dict[str, Any], output_dir: str,
                             loc.get('continent', ''), loc.get('sessions', 0), loc.get('users', 0)])
 
         # Device breakdown
-        with open(tables_dir / 'devices.csv', 'w', newline='') as f:
+        with open(tables_dir / 'devices.csv', 'w', newline='', encoding='utf-8') as f:
             w = csv.writer(f)
             w.writerow(['Device', 'Sessions', 'Bounce Rate (%)'])
             for d in ga_data['devices']:
                 w.writerow([d['device'], d['sessions'], f"{d['bounce_rate']:.1f}"])
 
         # KPI summary
-        with open(tables_dir / 'kpi_summary.csv', 'w', newline='') as f:
+        with open(tables_dir / 'kpi_summary.csv', 'w', newline='', encoding='utf-8') as f:
             w = csv.writer(f)
             w.writerow(['Metric', 'Value', 'Change vs Prior (%)'])
             w.writerow(['Sessions', totals['sessions'], f"{changes['sessions']:+.1f}"])
@@ -2522,7 +2522,7 @@ def export_design_kit(ga_data: Dict[str, Any], output_dir: str,
         # Period comparison (if available)
         prior = ga_data.get('prior_period')
         if prior:
-            with open(tables_dir / 'period_comparison.csv', 'w', newline='') as f:
+            with open(tables_dir / 'period_comparison.csv', 'w', newline='', encoding='utf-8') as f:
                 w = csv.writer(f)
                 w.writerow(['Metric', 'Current Period', 'Prior Period', 'Change'])
                 w.writerow(['Sessions', totals['sessions'], prior.get('sessions', 0), f"{changes['sessions']:+.1f}%"])
@@ -2535,7 +2535,7 @@ def export_design_kit(ga_data: Dict[str, Any], output_dir: str,
         # Longitudinal / YoY
         longitudinal = ga_data.get('longitudinal', {})
         if longitudinal:
-            with open(tables_dir / 'year_over_year.csv', 'w', newline='') as f:
+            with open(tables_dir / 'year_over_year.csv', 'w', newline='', encoding='utf-8') as f:
                 w = csv.writer(f)
                 w.writerow(['Year', 'Sessions', 'Users', 'Pageviews'])
                 for year in sorted(longitudinal.keys()):
@@ -2606,7 +2606,7 @@ def export_design_kit(ga_data: Dict[str, Any], output_dir: str,
         lines.append("")
         lines.append("Charts are available as SVG (vector, editable) in `charts/` and PNG (raster, 300 DPI) in `charts-png/`.")
 
-        with open(text_dir / 'report_text.md', 'w') as f:
+        with open(text_dir / 'report_text.md', 'w', encoding='utf-8') as f:
             f.write('\n'.join(lines))
 
         # ── 4. Metadata (YAML or plain text) ──
@@ -2635,11 +2635,11 @@ def export_design_kit(ga_data: Dict[str, Any], output_dir: str,
         }
 
         if _has_yaml:
-            with open(kit / 'metadata.yaml', 'w') as f:
+            with open(kit / 'metadata.yaml', 'w', encoding='utf-8') as f:
                 yaml.dump(metadata, f, default_flow_style=False, sort_keys=False)
         else:
             # Fallback: write as readable text
-            with open(kit / 'metadata.txt', 'w') as f:
+            with open(kit / 'metadata.txt', 'w', encoding='utf-8') as f:
                 for k, v in metadata.items():
                     if isinstance(v, dict):
                         f.write(f"\n{k}:\n")

--- a/siege_utilities/reporting/templates/base_template.py
+++ b/siege_utilities/reporting/templates/base_template.py
@@ -98,7 +98,7 @@ class BaseReportTemplate:
             FileNotFoundError: If the branding config file does not exist.
             yaml.YAMLError: If the YAML is malformed.
         """
-        with open(self.branding_config_path, 'r') as f:
+        with open(self.branding_config_path, 'r', encoding='utf-8') as f:
             config = yaml.safe_load(f)
         log.info(f"Configuration loaded successfully from {self.branding_config_path}")
         return config

--- a/siege_utilities/reporting/templates/page_templates.py
+++ b/siege_utilities/reporting/templates/page_templates.py
@@ -223,7 +223,7 @@ class PageTemplateManager:
         
         for template_file in custom_templates_dir.glob("*.yaml"):
             try:
-                with open(template_file, 'r') as f:
+                with open(template_file, 'r', encoding='utf-8') as f:
                     template_data = yaml.safe_load(f)
                     template = PageTemplate(**template_data)
                     self.templates[template.name] = template
@@ -275,7 +275,7 @@ class PageTemplateManager:
         
         template_file = custom_templates_dir / f"{template.name}.yaml"
         try:
-            with open(template_file, 'w') as f:
+            with open(template_file, 'w', encoding='utf-8') as f:
                 yaml.dump(template.__dict__, f, default_flow_style=False)
         except (OSError, yaml.YAMLError) as e:
             log.error(f"Failed to save custom template: {e}")
@@ -334,7 +334,7 @@ class PageTemplateManager:
             return
         
         try:
-            with open(output_path, 'w') as f:
+            with open(output_path, 'w', encoding='utf-8') as f:
                 yaml.dump(template.__dict__, f, default_flow_style=False)
             log.info(f"Exported template to: {output_path}")
         except (OSError, yaml.YAMLError) as e:
@@ -349,7 +349,7 @@ class PageTemplateManager:
             template_name: Custom name for the imported template
         """
         try:
-            with open(input_path, 'r') as f:
+            with open(input_path, 'r', encoding='utf-8') as f:
                 template_data = yaml.safe_load(f)
             
             if template_name:

--- a/siege_utilities/testing/runner.py
+++ b/siege_utilities/testing/runner.py
@@ -43,7 +43,7 @@ def run_command(cmd: List[str], description: str, log_file: Optional[str] = None
     log_info("-" * 60)
 
     if log_file:
-        with open(log_file, "w") as f:
+        with open(log_file, "w", encoding="utf-8") as f:
             process = subprocess.Popen(
                 cmd,
                 stdout=subprocess.PIPE,


### PR DESCRIPTION
On non-UTF-8 locales (Windows cp1252, macOS LANG=C), open() without explicit encoding silently corrupts any file containing non-ASCII characters. This fixes 64 instances across config/, analytics/, reporting/, geo/, testing/, and development/ modules.

Binary-mode opens (rb/wb) were correctly excluded — only text-mode opens were fixed.