### PR TITLE
fix: narrow bare except and guard unvalidated config keys

### DIFF
--- a/siege_utilities/conf/__init__.py
+++ b/siege_utilities/conf/__init__.py
@@ -59,16 +59,14 @@ class Settings:
 
         # 3. Django settings
         try:
+            from django.core.exceptions import ImproperlyConfigured
             from django.conf import settings as django_settings
 
             if hasattr(django_settings, name):
                 return getattr(django_settings, name)
         except ImportError:
             pass
-        except Exception:
-            # django.core.exceptions.ImproperlyConfigured when
-            # DJANGO_SETTINGS_MODULE is unset; can't narrow further
-            # without importing from Django itself.
+        except ImproperlyConfigured:
             pass
 
         # 4. YAML file

--- a/siege_utilities/config/databases.py
+++ b/siege_utilities/config/databases.py
@@ -189,6 +189,12 @@ def get_spark_database_options(db_name: str, config_directory: str = "config") -
     if config is None:
         return None
 
+    required_keys = ('jdbc_url', 'jdbc_driver', 'username', 'password')
+    missing = [k for k in required_keys if k not in config]
+    if missing:
+        log_error(f"Database config {db_name!r} missing required keys: {missing}")
+        return None
+
     spark_options = {
         'url': config['jdbc_url'],
         'driver': config['jdbc_driver'],
@@ -351,6 +357,10 @@ def create_spark_session_with_databases(app_name: str = "SiegeAnalytics",
         for db_name in database_names:
             config = load_database_config(db_name, config_directory)
             if config:
+                if 'connection_type' not in config:
+                    raise ValueError(
+                        f"Database config {db_name!r} missing 'connection_type' key"
+                    )
                 connection_type = config['connection_type'].lower()
 
                 if connection_type == 'postgres':


### PR DESCRIPTION
Two SU-1/SU-2 violations:

1. `conf/__init__.py`: `except Exception: pass` replaced with specific `except ImproperlyConfigured: pass`. Programming errors (AttributeError, TypeError) were being silently swallowed.

2. `config/databases.py`: `get_spark_database_options()` now validates required keys before bracket access. Previously a malformed config JSON would crash with unhelpful KeyError instead of returning None as the return type promises. Also added key validation to `create_spark_session_with_databases()`.