### PR TITLE
fix(files): convert list to string before shell=True Popen

### DIFF
--- a/siege_utilities/files/shell.py
+++ b/siege_utilities/files/shell.py
@@ -234,8 +234,9 @@ def _run_subprocess_unrestricted(command_list: Union[str, List[str]],
         "This is dangerous and will be removed in future versions."
     )
 
+    cmd = shlex.join(command_list) if isinstance(command_list, list) else command_list
     p = subprocess.Popen(
-        command_list,
+        cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         shell=True  # DANGER: No validation


### PR DESCRIPTION
When `subprocess.Popen` receives a list with `shell=True` on Unix, only the first element is the shell command — remaining elements become positional parameters ($0, $1...) to the shell, not arguments to the command. This means `['ls', '-la']` with shell=True actually runs `ls` without `-la`.

Fix: `shlex.join()` the list before passing to the shell, matching caller intent. The function already declares `Union[str, List[str]]` input.