### PR TITLE
fix: guard division-by-zero in zscore outlier detection and GA example

### DIFF
--- a/siege_utilities/geo/timeseries/trend_classifier.py
+++ b/siege_utilities/geo/timeseries/trend_classifier.py
@@ -402,6 +402,10 @@ def identify_outliers(
     elif method == 'zscore':
         mean = values.mean()
         std = values.std()
+        if std == 0 or pd.isna(std):
+            df['is_outlier'] = False
+            df['outlier_type'] = 'normal'
+            return df
         zscores = (values - mean) / std
 
         df['is_outlier'] = abs(zscores) > threshold

--- a/siege_utilities/reporting/examples/google_analytics_report_example.py
+++ b/siege_utilities/reporting/examples/google_analytics_report_example.py
@@ -1577,14 +1577,16 @@ def generate_insights(ga_data: Dict[str, Any]) -> List[str]:
                        "Consider improving page load times and content relevance.")
 
     # Traffic source insight
-    top_source = max(sources, key=lambda x: x['sessions'])
-    insights.append(f"'{top_source['source'].title()}' is the primary traffic driver, "
-                   f"contributing {top_source['sessions']:,} sessions ({top_source['sessions']/totals['sessions']*100:.1f}% of total).")
+    total_sessions = totals['sessions']
+    if sources and total_sessions > 0:
+        top_source = max(sources, key=lambda x: x['sessions'])
+        insights.append(f"'{top_source['source'].title()}' is the primary traffic driver, "
+                       f"contributing {top_source['sessions']:,} sessions ({top_source['sessions']/total_sessions*100:.1f}% of total).")
 
     # Device insight
     mobile = next((d for d in devices if d['device'] == 'mobile'), None)
-    if mobile:
-        mobile_pct = mobile['sessions'] / totals['sessions'] * 100
+    if mobile and total_sessions > 0:
+        mobile_pct = mobile['sessions'] / total_sessions * 100
         if mobile_pct > 50:
             insights.append(f"Mobile traffic accounts for {mobile_pct:.1f}% of sessions. "
                            "Ensure your site provides an excellent mobile experience.")
@@ -1613,7 +1615,7 @@ def generate_recommendations(ga_data: Dict[str, Any]) -> List[str]:
 
     # Traffic source recommendations
     organic = next((s for s in sources if s['source'] == 'organic'), None)
-    if organic and organic['sessions'] / totals['sessions'] < 0.40:
+    if organic and totals['sessions'] > 0 and organic['sessions'] / totals['sessions'] < 0.40:
         recommendations.append("Invest in SEO to increase organic traffic share. "
                               "Focus on keyword research and content optimization.")
 


### PR DESCRIPTION
Two unguarded division-by-zero cases:

1. `trend_classifier.py` `detect_outliers()` zscore method: divides by `std` without checking for zero. All-identical values produce inf/nan arrays. Early return added matching existing pattern in `classify_changes()`.

2. `google_analytics_report_example.py`: `generate_insights()` and `generate_recommendations()` divide by `totals['sessions']` without guard. Zero-traffic period crashes with ZeroDivisionError.