### PR TITLE
fix(geo): prevent input DataFrame mutation in Census API helpers

### DIFF
--- a/siege_utilities/geo/census/api.py
+++ b/siege_utilities/geo/census/api.py
@@ -270,6 +270,7 @@ class CensusAPI:
 
     @staticmethod
     def _construct_geoid(df: pd.DataFrame, geography: str) -> pd.DataFrame:
+        df = df.copy()
         if geography == 'state':
             df['GEOID'] = df['state']
         elif geography == 'county':
@@ -299,6 +300,7 @@ class CensusAPI:
 
     @staticmethod
     def _convert_numeric_columns(df: pd.DataFrame) -> pd.DataFrame:
+        df = df.copy()
         skip_cols = {'GEOID', 'NAME'}
         for col in df.columns:
             if col in skip_cols:


### PR DESCRIPTION
`_construct_geoid()` and `_convert_numeric_columns()` in the Census API client modified their input DataFrame in-place while their `-> pd.DataFrame` return type implies producing a new DataFrame.

Added `df = df.copy()` at the top of both methods, matching the defensive pattern used elsewhere in the codebase (`pl_downloader._construct_geoid()`, `crosswalk_client._calculate_weights()`).