### PR TITLE
fix(reporting): remove AttributeError from chart engine catch clauses

### DIFF
--- a/siege_utilities/reporting/engines/bar_engine.py
+++ b/siege_utilities/reporting/engines/bar_engine.py
@@ -130,7 +130,7 @@ class BarChartMixin:
             # Convert to ReportLab Image
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
+        except (ValueError, TypeError, KeyError, IndexError) as e:
             log.error(f"Error creating bar chart: {e}")
             return self._create_placeholder_chart(width, height, f"Chart Error: {str(e)}")
 
@@ -215,7 +215,7 @@ class BarChartMixin:
             # Convert to ReportLab Image
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
+        except (ValueError, TypeError, KeyError, IndexError) as e:
             log.error(f"Error creating line chart: {e}")
             return self._create_placeholder_chart(width, height, f"Chart Error: {str(e)}")
 
@@ -324,7 +324,7 @@ class BarChartMixin:
             # Convert to ReportLab Image
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
+        except (ValueError, TypeError, KeyError, IndexError) as e:
             log.error(f"Error creating pie chart: {e}")
             return self._create_placeholder_chart(width, height, f"Chart Error: {str(e)}")
 
@@ -388,6 +388,6 @@ class BarChartMixin:
 
             return "<br/>".join(chart_lines)
 
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
+        except (ValueError, TypeError, KeyError, IndexError) as e:
             log.error(f"Error creating proportional text bar chart: {e}")
             return f"<i>Error creating text bar chart: {str(e)}</i>"

--- a/siege_utilities/reporting/engines/base_engine.py
+++ b/siege_utilities/reporting/engines/base_engine.py
@@ -314,7 +314,7 @@ class BaseChartEngine:
 
             return rl_image
 
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
+        except (ValueError, TypeError, KeyError, IndexError, OSError) as e:
             log.error(f"Error converting matplotlib figure to ReportLab Image: {e}")
             return self._create_placeholder_chart(width, height, "Image Conversion Error")
 
@@ -348,7 +348,7 @@ class BaseChartEngine:
                 sw, sh = self._scale_dimensions(width, height)
                 return Image("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
                            width=sw*inch, height=sh*inch)
-        except (ValueError, TypeError, AttributeError, OSError) as e:
+        except (ValueError, TypeError, OSError) as e:
             log.error(f"Error creating placeholder chart: {e}")
             # Return a minimal image — still honour auto-scaling
             sw, sh = self._scale_dimensions(width, height)
@@ -446,7 +446,7 @@ class BaseChartEngine:
             else:
                 return self.create_bar_chart(df, x_column, y_columns[0] if y_columns else None, title, width, height)
 
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
+        except (ValueError, TypeError, KeyError, IndexError) as e:
             log.error(f"Error generating chart from DataFrame: {e}")
             return self._create_placeholder_chart(width, height, "DataFrame Chart Error")
 
@@ -500,6 +500,6 @@ class BaseChartEngine:
             else:
                 return self.create_bar_chart(chart_config['data'], title=chart_config.get('title', ''), width=width, height=height)
 
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
+        except (ValueError, TypeError, KeyError, IndexError) as e:
             log.error(f"Error creating custom chart: {e}")
             return self._create_placeholder_chart(width, height, "Custom Chart Error")

--- a/siege_utilities/reporting/engines/composite_engine.py
+++ b/siege_utilities/reporting/engines/composite_engine.py
@@ -189,7 +189,7 @@ class CompositeChartMixin:
             ax.set_title(title, fontsize=13, fontweight='bold')
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
+        except (ValueError, TypeError, KeyError, IndexError) as e:
             log.error(f"Error creating convergence diagram: {e}")
             return self._create_placeholder_chart(width, height, f"Convergence Diagram Error: {str(e)}")
 
@@ -256,7 +256,7 @@ class CompositeChartMixin:
             # Convert to ReportLab Image
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
+        except (ValueError, TypeError, KeyError, IndexError) as e:
             log.error(f"Error creating dashboard: {e}")
             return self._create_placeholder_chart(width, height, f"Dashboard Error: {str(e)}")
 
@@ -308,7 +308,7 @@ class CompositeChartMixin:
             # Convert to ReportLab Image
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
+        except (ValueError, TypeError, KeyError, IndexError) as e:
             log.error(f"Error creating DataFrame summary charts: {e}")
             return self._create_placeholder_chart(width, height, f"Summary Charts Error: {str(e)}")
 
@@ -324,7 +324,7 @@ class CompositeChartMixin:
                 ax.bar(labels, values, color=self.default_colors['primary'])
                 ax.set_title(title)
                 ax.grid(True, alpha=0.3)
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
+        except (ValueError, TypeError, KeyError, IndexError) as e:
             log.error(f"Error creating bar subplot: {e}")
 
     def _create_line_subplot(self, ax, chart_config: Dict[str, Any], title: str):
@@ -341,7 +341,7 @@ class CompositeChartMixin:
 
             ax.set_title(title)
             ax.grid(True, alpha=0.3)
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
+        except (ValueError, TypeError, KeyError, IndexError) as e:
             log.error(f"Error creating line subplot: {e}")
 
     def _create_pie_subplot(self, ax, chart_config: Dict[str, Any], title: str):
@@ -353,7 +353,7 @@ class CompositeChartMixin:
 
             ax.pie(values, labels=labels, autopct='%1.1f%%', colors=self.color_palette[:len(values)])
             ax.set_title(title)
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
+        except (ValueError, TypeError, KeyError, IndexError) as e:
             log.error(f"Error creating pie subplot: {e}")
 
     def _create_scatter_subplot(self, ax, chart_config: Dict[str, Any], title: str):
@@ -366,5 +366,5 @@ class CompositeChartMixin:
             ax.scatter(x_values, y_values, alpha=0.6, color=self.default_colors['primary'])
             ax.set_title(title)
             ax.grid(True, alpha=0.3)
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
+        except (ValueError, TypeError, KeyError, IndexError) as e:
             log.error(f"Error creating scatter subplot: {e}")

--- a/siege_utilities/reporting/engines/map_engine.py
+++ b/siege_utilities/reporting/engines/map_engine.py
@@ -140,7 +140,7 @@ class MapChartMixin:
             return self._save_folium_map(m, "temp_choropleth_map.html",
                                         "Choropleth Map", width, height)
 
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
+        except (ValueError, TypeError, KeyError, IndexError, OSError) as e:
             log.error(f"Error creating choropleth map: {e}")
             return self._create_placeholder_chart(width, height, f"Map Error: {str(e)}")
 
@@ -231,7 +231,7 @@ class MapChartMixin:
             # Convert to ReportLab Image
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
+        except (ValueError, TypeError, KeyError, IndexError) as e:
             log.error(f"Error creating bivariate choropleth with matplotlib: {e}")
             return self._create_placeholder_chart(width, height, f"Bivariate Choropleth Error: {str(e)}")
 
@@ -335,7 +335,7 @@ class MapChartMixin:
             legend_ax.set_ylabel(var2, fontsize=9, fontweight='bold')
             legend_ax.tick_params(length=0, labelsize=8)
 
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
+        except (ValueError, TypeError, KeyError, IndexError) as e:
             log.warning(f"Could not add bivariate legend: {e}")
 
     def create_advanced_choropleth(self, data: Union[pd.DataFrame, Dict[str, Any]],
@@ -423,7 +423,7 @@ class MapChartMixin:
             # Convert to ReportLab Image
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
+        except (ValueError, TypeError, KeyError, IndexError) as e:
             log.error(f"Error creating advanced choropleth: {e}")
             return self._create_placeholder_chart(width, height, f"Advanced Choropleth Error: {str(e)}")
 
@@ -523,7 +523,7 @@ class MapChartMixin:
             return self._save_folium_map(m, "temp_marker_map.html",
                                         "Marker Map", width, height)
 
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
+        except (ValueError, TypeError, KeyError, IndexError, OSError) as e:
             log.error(f"Error creating marker map: {e}")
             return self._create_placeholder_chart(width, height, f"Marker Map Error: {str(e)}")
 
@@ -596,7 +596,7 @@ class MapChartMixin:
             # Convert to ReportLab Image
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
+        except (ValueError, TypeError, KeyError, IndexError) as e:
             log.error(f"Error creating 3D map: {e}")
             return self._create_placeholder_chart(width, height, f"3D Map Error: {str(e)}")
 
@@ -669,7 +669,7 @@ class MapChartMixin:
             return self._save_folium_map(m, "temp_heatmap.html",
                                         "Heatmap", width, height)
 
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
+        except (ValueError, TypeError, KeyError, IndexError, OSError) as e:
             log.error(f"Error creating heatmap: {e}")
             return self._create_placeholder_chart(width, height, f"Heatmap Error: {str(e)}")
 
@@ -765,7 +765,7 @@ class MapChartMixin:
             return self._save_folium_map(m, "temp_cluster_map.html",
                                         "Cluster Map", width, height)
 
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
+        except (ValueError, TypeError, KeyError, IndexError, OSError) as e:
             log.error(f"Error creating cluster map: {e}")
             return self._create_placeholder_chart(width, height, f"Cluster Map Error: {str(e)}")
 
@@ -868,7 +868,7 @@ class MapChartMixin:
             return self._save_folium_map(m, "temp_flow_map.html",
                                         "Flow Map", width, height)
 
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
+        except (ValueError, TypeError, KeyError, IndexError, OSError) as e:
             log.error(f"Error creating flow map: {e}")
             return self._create_placeholder_chart(width, height, f"Flow Map Error: {str(e)}")
 
@@ -971,6 +971,6 @@ class MapChartMixin:
             return self._save_folium_map(m, "temp_bivariate_choropleth.html",
                                         "Bivariate Choropleth", width, height)
 
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
+        except (ValueError, TypeError, KeyError, IndexError, OSError) as e:
             log.error(f"Error creating bivariate choropleth map: {e}")
             return self._create_placeholder_chart(width, height, f"Bivariate Choropleth Error: {str(e)}")

--- a/siege_utilities/reporting/engines/stats_engine.py
+++ b/siege_utilities/reporting/engines/stats_engine.py
@@ -94,7 +94,7 @@ class StatsChartMixin:
             # Convert to ReportLab Image
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
+        except (ValueError, TypeError, KeyError, IndexError) as e:
             log.error(f"Error creating heatmap: {e}")
             return self._create_placeholder_chart(width, height, f"Heatmap Error: {str(e)}")
 
@@ -148,7 +148,7 @@ class StatsChartMixin:
             # Convert to ReportLab Image
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
+        except (ValueError, TypeError, KeyError, IndexError) as e:
             log.error(f"Error creating scatter plot: {e}")
             return self._create_placeholder_chart(width, height, f"Scatter Plot Error: {str(e)}")
 
@@ -222,6 +222,6 @@ class StatsChartMixin:
 
             return "<br/>".join(chart_lines)
 
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
+        except (ValueError, TypeError, KeyError, IndexError) as e:
             log.error(f"Error creating text heatmap: {e}")
             return f"<i>Error creating text heatmap: {str(e)}</i>"


### PR DESCRIPTION
Removes `AttributeError` from all 28 broad exception handlers across 5
reporting engine files (map, bar, composite, stats, base).

**Problem:** Catching `AttributeError` alongside data errors
(ValueError, KeyError, etc.) silently swallows programming errors —
typos like `self.defualt_dpi`, calls to nonexistent methods, or missing
attributes — returning a placeholder chart instead of crashing. This
violates SU-1 (errors are not data) and makes bugs invisible.

**Fix:** Remove `AttributeError` from all catch tuples. Data errors
(ValueError, TypeError, KeyError, IndexError, OSError) are still caught
and reported as placeholder charts with descriptive messages.

**Files changed:**
- `reporting/engines/map_engine.py` (10 handlers)
- `reporting/engines/bar_engine.py` (4 handlers)
- `reporting/engines/composite_engine.py` (7 handlers)
- `reporting/engines/stats_engine.py` (3 handlers)
- `reporting/engines/base_engine.py` (4 handlers)