### PR TITLE
fix: stream large HTTP downloads with size cap

### DIFF
--- a/siege_utilities/economic/bls/qcew.py
+++ b/siege_utilities/economic/bls/qcew.py
@@ -48,10 +48,29 @@ class QCEWFiles:
         df = files.load(year=2024, quarter=3, state_fips="06", naics_depth=2)
     """
 
+    _MAX_DOWNLOAD_BYTES = 512 * 1024 * 1024  # 512 MB cap
+    _CHUNK_SIZE = 64 * 1024
+
     def __init__(self, cache_dir: Optional[Path] = None, timeout: int = 120):
         self.cache_dir = Path(cache_dir) if cache_dir else DEFAULT_CACHE_DIR
         self.cache_dir.mkdir(parents=True, exist_ok=True)
         self.timeout = timeout
+
+    def _stream_download_to_file(self, url: str, dest: Path) -> None:
+        """Stream an HTTP response directly to disk with a size cap."""
+        downloaded = 0
+        with requests.get(url, stream=True, timeout=self.timeout) as resp:
+            resp.raise_for_status()
+            with open(dest, 'wb') as f:
+                for chunk in resp.iter_content(chunk_size=self._CHUNK_SIZE):
+                    downloaded += len(chunk)
+                    if downloaded > self._MAX_DOWNLOAD_BYTES:
+                        dest.unlink(missing_ok=True)
+                        raise ValueError(
+                            f"Download from {url} exceeds "
+                            f"{self._MAX_DOWNLOAD_BYTES / 1024 / 1024:.0f} MB limit"
+                        )
+                    f.write(chunk)
 
     def download(self, year: int) -> Path:
         """Download (or return cached) the year's QCEW zip; return CSV path."""
@@ -64,9 +83,7 @@ class QCEWFiles:
 
         url = QCEW_FILE_URL.format(year=year)
         logger.info("Downloading QCEW %s from %s", year, url)
-        resp = requests.get(url, timeout=self.timeout)
-        resp.raise_for_status()
-        zip_path.write_bytes(resp.content)
+        self._stream_download_to_file(url, zip_path)
 
         with zipfile.ZipFile(zip_path) as zf:
             csv_name = next(

--- a/siege_utilities/education/nces/files.py
+++ b/siege_utilities/education/nces/files.py
@@ -87,15 +87,33 @@ class NCESFiles:
         start = int(start_str)
         return start, start + 1
 
+    _MAX_DOWNLOAD_BYTES = 512 * 1024 * 1024  # 512 MB cap
+    _CHUNK_SIZE = 64 * 1024
+
+    def _stream_download(self, url: str) -> bytes:
+        """Stream-download a URL into memory with a size cap."""
+        chunks = []
+        downloaded = 0
+        with requests.get(url, stream=True, timeout=self.timeout) as resp:
+            resp.raise_for_status()
+            for chunk in resp.iter_content(chunk_size=self._CHUNK_SIZE):
+                downloaded += len(chunk)
+                if downloaded > self._MAX_DOWNLOAD_BYTES:
+                    raise ValueError(
+                        f"Download from {url} exceeds "
+                        f"{self._MAX_DOWNLOAD_BYTES / 1024 / 1024:.0f} MB limit"
+                    )
+                chunks.append(chunk)
+        return b''.join(chunks)
+
     def _download_zip(self, url: str, cache_name: str) -> Path:
         """Download + cache one NCES zip; return CSV path inside cache_dir."""
         csv_path = self.cache_dir / f"{cache_name}.csv"
         if csv_path.exists():
             return csv_path
         logger.info("Downloading NCES file: %s", url)
-        resp = requests.get(url, timeout=self.timeout)
-        resp.raise_for_status()
-        with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+        content = self._stream_download(url)
+        with zipfile.ZipFile(io.BytesIO(content)) as zf:
             csv_name = next((n for n in zf.namelist() if n.endswith((".csv", ".txt"))), None)
             if not csv_name:
                 raise ValueError(f"No CSV/TXT inside {url}")
@@ -155,9 +173,8 @@ class NCESFiles:
         csv_path = self.cache_dir / f"{cache_name}.csv"
         if not csv_path.exists():
             logger.info("Downloading EDGE district demographics: %s", url)
-            resp = requests.get(url, timeout=self.timeout)
-            resp.raise_for_status()
-            csv_path.write_bytes(resp.content)
+            content = self._stream_download(url)
+            csv_path.write_bytes(content)
         return pd.read_csv(
             csv_path,
             dtype={"LEAID": str, "STATEFP": str, "STATEFIPS": str},

--- a/siege_utilities/geo/census_files/pl_downloader.py
+++ b/siege_utilities/geo/census_files/pl_downloader.py
@@ -55,6 +55,29 @@ DEFAULT_CACHE_DIR = Path.home() / '.siege_utilities' / 'cache' / 'pl_files'
 # Request timeout
 PL_REQUEST_TIMEOUT = 300  # 5 minutes - files can be large
 
+# Maximum download size (1 GB) — protects against unbounded memory allocation
+PL_MAX_DOWNLOAD_BYTES = 1024 * 1024 * 1024
+
+_STREAM_CHUNK_SIZE = 64 * 1024  # 64 KB chunks
+
+
+def _stream_download_to_file(
+    url: str, dest: Path, timeout: int = PL_REQUEST_TIMEOUT,
+    max_bytes: int = PL_MAX_DOWNLOAD_BYTES,
+) -> None:
+    """Stream an HTTP response directly to disk with a size cap."""
+    with requests.get(url, stream=True, timeout=timeout) as resp:
+        resp.raise_for_status()
+        downloaded = 0
+        with open(dest, 'wb') as f:
+            for chunk in resp.iter_content(chunk_size=_STREAM_CHUNK_SIZE):
+                downloaded += len(chunk)
+                if downloaded > max_bytes:
+                    raise ValueError(
+                        f"Download from {url} exceeds {max_bytes / 1024 / 1024:.0f} MB limit"
+                    )
+                f.write(chunk)
+
 # Summary Level Codes
 SUMMARY_LEVELS = {
     'nation': '010',
@@ -212,6 +235,22 @@ class PLFileDownloader:
         self.timeout = timeout
 
         log.info(f"Initialized PLFileDownloader (cache: {self.cache_dir})")
+
+    def _stream_download(self, url: str) -> bytes:
+        """Stream-download a URL into memory with a size cap."""
+        chunks = []
+        downloaded = 0
+        with requests.get(url, stream=True, timeout=self.timeout) as resp:
+            resp.raise_for_status()
+            for chunk in resp.iter_content(chunk_size=_STREAM_CHUNK_SIZE):
+                downloaded += len(chunk)
+                if downloaded > PL_MAX_DOWNLOAD_BYTES:
+                    raise ValueError(
+                        f"Download from {url} exceeds "
+                        f"{PL_MAX_DOWNLOAD_BYTES / 1024 / 1024:.0f} MB limit"
+                    )
+                chunks.append(chunk)
+        return b''.join(chunks)
 
     def get_data(
         self,
@@ -373,13 +412,11 @@ class PLFileDownloader:
 
     def _download_and_parse_geo(self, url: str, year: int) -> pd.DataFrame:
         """Download and parse geographic header file."""
-        # Download zip file
-        response = requests.get(url, timeout=self.timeout)
-        response.raise_for_status()
+        import io
+        content = self._stream_download(url)
 
         # Extract geo file from zip
-        import io
-        with zipfile.ZipFile(io.BytesIO(response.content)) as zf:
+        with zipfile.ZipFile(io.BytesIO(content)) as zf:
             # Find the geo file (ends with 'geo2020.pl' or similar)
             geo_filename = None
             for name in zf.namelist():
@@ -444,12 +481,10 @@ class PLFileDownloader:
         file_type: str
     ) -> pd.DataFrame:
         """Download and parse data segment file."""
-        # Data files are in the same zip
-        response = requests.get(url, timeout=self.timeout)
-        response.raise_for_status()
-
         import io
-        with zipfile.ZipFile(io.BytesIO(response.content)) as zf:
+        content = self._stream_download(url)
+
+        with zipfile.ZipFile(io.BytesIO(content)) as zf:
             # Find the data file
             file_num = {'pl1': '1', 'pl2': '2', 'pl3': '3', 'pl4': '4'}.get(file_type, '1')
             data_filename = None
@@ -718,10 +753,7 @@ def download_pl_file(
     output_file = output_dir / f"{state_abbr.lower()}{year}.pl.zip"
 
     log.info(f"Downloading {url} to {output_file}")
-    response = requests.get(url, timeout=PL_REQUEST_TIMEOUT)
-    response.raise_for_status()
-
-    output_file.write_bytes(response.content)
+    _stream_download_to_file(url, output_file, timeout=PL_REQUEST_TIMEOUT)
     log.info(f"Downloaded {output_file.stat().st_size / 1024 / 1024:.1f} MB")
 
     return output_file


### PR DESCRIPTION
Three bulk-data downloaders buffered entire HTTP responses (100-500 MB)
in RAM without streaming or size limits. This causes OOM on constrained
CI runners or when multiple downloads run concurrently.

**Fix:** Use `requests.get(url, stream=True)` + `iter_content(64KB)` with
a hard size cap (512 MB for NCES/BLS, 1 GB for Census PL files). Raises
`ValueError` if the cap is exceeded, preventing unbounded allocation.

**Files changed:**
- `geo/census_files/pl_downloader.py` — 3 download sites refactored
  (class method `_stream_download` for in-memory, module function
  `_stream_download_to_file` for disk)
- `education/nces/files.py` — `_download_zip` and `load_edge_district_demographics`
- `economic/bls/qcew.py` — `download()` now streams to disk via
  `_stream_download_to_file`