### PR TITLE
fix: replace 110 naive datetime.now() with timezone-aware UTC

### DIFF
--- a/siege_utilities/analytics/facebook_business.py
+++ b/siege_utilities/analytics/facebook_business.py
@@ -361,7 +361,7 @@ def create_facebook_account_profile(client_id: str, fb_account_id: str,
         'fb_account_id_raw': fb_account_id,
         'account_type': account_type,
         'access_token': access_token,
-        'created_date': datetime.now().isoformat(),
+        'created_date': datetime.now(tz=timezone.utc).isoformat(),
         'last_accessed': None,
         'status': 'active',
         'metadata': {

--- a/siege_utilities/analytics/google_analytics.py
+++ b/siege_utilities/analytics/google_analytics.py
@@ -457,7 +457,7 @@ def create_ga_account_profile(client_id: str, ga_property_id: str,
         'ga_property_id': ga_property_id,
         'account_type': account_type,
         'credentials_file': credentials_file,
-        'created_date': datetime.now().isoformat(),
+        'created_date': datetime.now(tz=timezone.utc).isoformat(),
         'last_accessed': None,
         'status': 'active',
         'metadata': {

--- a/siege_utilities/config/census_registry.py
+++ b/siege_utilities/config/census_registry.py
@@ -10,14 +10,14 @@ Other modules should import from here (or from the backward-compatible
 shim in ``census_constants.py``).
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Dict, List
 
 # ============================================================================
 # INTERNAL: current year for dynamic range calculation
 # ============================================================================
-_CURRENT_YEAR = datetime.now().year
+_CURRENT_YEAR = datetime.now(tz=timezone.utc).year
 
 
 # ============================================================================

--- a/siege_utilities/config/clients.py
+++ b/siege_utilities/config/clients.py
@@ -10,7 +10,7 @@ import re
 import logging
 import tempfile
 from typing import Dict, Any, Optional, List
-from datetime import datetime
+from datetime import datetime, timezone
 import uuid
 
 logger = logging.getLogger(__name__)
@@ -81,8 +81,8 @@ def create_client_profile(
         'client_code': client_code,
         'contact_info': contact_info,
         'metadata': {
-            'created_date': datetime.now().isoformat(),
-            'last_updated': datetime.now().isoformat(),
+            'created_date': datetime.now(tz=timezone.utc).isoformat(),
+            'last_updated': datetime.now(tz=timezone.utc).isoformat(),
             'status': kwargs.get('status', 'active'),
             'industry': kwargs.get('industry', ''),
             'project_count': kwargs.get('project_count', 0),
@@ -139,7 +139,7 @@ def save_client_profile(
     config_file = config_dir / f"client_{client_code}.json"
 
     # Update last_updated timestamp
-    profile['metadata']['last_updated'] = datetime.now().isoformat()
+    profile['metadata']['last_updated'] = datetime.now(tz=timezone.utc).isoformat()
 
     # Atomic write: serialize to a temp file in the same directory,
     # fsync, then os.replace into place. Without this, two concurrent

--- a/siege_utilities/config/connections.py
+++ b/siege_utilities/config/connections.py
@@ -7,7 +7,7 @@ import json
 import pathlib
 import logging
 from typing import Dict, Any, Optional, List
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import uuid
 
 logger = logging.getLogger(__name__)
@@ -58,8 +58,8 @@ def create_connection_profile(
         'connection_type': connection_type,
         'connection_params': connection_params,
         'metadata': {
-            'created_date': datetime.now().isoformat(),
-            'last_used': datetime.now().isoformat(),
+            'created_date': datetime.now(tz=timezone.utc).isoformat(),
+            'last_used': datetime.now(tz=timezone.utc).isoformat(),
             'last_connected': None,
             'connection_count': 0,
             'status': kwargs.get('status', 'active'),
@@ -135,7 +135,7 @@ def save_connection_profile(
     config_file = connections_dir / f"connection_{connection_id}.json"
     
     # Update last_used timestamp
-    profile['metadata']['last_used'] = datetime.now().isoformat()
+    profile['metadata']['last_used'] = datetime.now(tz=timezone.utc).isoformat()
     
     with open(config_file, 'w', encoding='utf-8') as f:
         json.dump(profile, f, indent=2)
@@ -353,20 +353,20 @@ def verify_connection_profile(
         return {
             'success': False,
             'error': 'Connection profile not found',
-            'timestamp': datetime.now().isoformat()
+            'timestamp': datetime.now(tz=timezone.utc).isoformat()
         }
     
     connection_type = profile['connection_type']
     test_result = {
         'success': False,
         'connection_type': connection_type,
-        'timestamp': datetime.now().isoformat(),
+        'timestamp': datetime.now(tz=timezone.utc).isoformat(),
         'error': None,
         'response_time_ms': None
     }
     
     try:
-        start_time = datetime.now()
+        start_time = datetime.now(tz=timezone.utc)
         
         if connection_type == 'notebook':
             # Test notebook connection
@@ -419,12 +419,12 @@ def verify_connection_profile(
             test_result['error'] = f'Connection testing not implemented for {connection_type}'
         
         # Calculate response time
-        end_time = datetime.now()
+        end_time = datetime.now(tz=timezone.utc)
         test_result['response_time_ms'] = (end_time - start_time).total_seconds() * 1000
         
         # Update connection profile with test results
         if test_result['success']:
-            profile['metadata']['last_connected'] = datetime.now().isoformat()
+            profile['metadata']['last_connected'] = datetime.now(tz=timezone.utc).isoformat()
             profile['metadata']['connection_count'] += 1
             save_connection_profile(profile, config_directory)
         

--- a/siege_utilities/config/enhanced_config.py
+++ b/siege_utilities/config/enhanced_config.py
@@ -10,7 +10,7 @@ import warnings
 import yaml
 from pathlib import Path
 from typing import Dict, Any, Optional, List
-from datetime import datetime
+from datetime import datetime, timezone
 import logging
 
 from .models import UserProfile, ClientProfile
@@ -336,7 +336,7 @@ class ConfigurationMigrator:
             Path to backup directory
         """
         if backup_dir is None:
-            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
             backup_dir = self.legacy_config_dir.parent / f"config_backup_{timestamp}"
         
         backup_dir.mkdir(parents=True, exist_ok=True)

--- a/siege_utilities/config/migration.py
+++ b/siege_utilities/config/migration.py
@@ -9,7 +9,7 @@ import json
 import yaml
 from pathlib import Path
 from typing import Dict, Any, Optional
-from datetime import datetime
+from datetime import datetime, timezone
 import logging
 
 from .models import UserProfile, ClientProfile
@@ -305,7 +305,7 @@ class ConfigurationMigrator:
             Path to backup directory
         """
         if backup_dir is None:
-            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
             backup_dir = self.legacy_config_dir.parent / f"config_backup_{timestamp}"
         
         backup_dir.mkdir(parents=True, exist_ok=True)

--- a/siege_utilities/config/models/actor_types.py
+++ b/siege_utilities/config/models/actor_types.py
@@ -4,7 +4,7 @@ Specific actor types that extend the base Person model.
 
 from pydantic import BaseModel, Field, field_validator, ConfigDict
 from typing import List, Optional, Dict, Any, Union
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import re
 
@@ -186,13 +186,13 @@ class User(Person):
         """Add a permission to this user."""
         if permission not in self.permissions:
             self.permissions.append(permission)
-            self.last_updated = datetime.now()
+            self.last_updated = datetime.now(tz=timezone.utc)
     
     def remove_permission(self, permission: str) -> None:
         """Remove a permission from this user."""
         if permission in self.permissions:
             self.permissions.remove(permission)
-            self.last_updated = datetime.now()
+            self.last_updated = datetime.now(tz=timezone.utc)
 
     # Source credential helpers
     def get_source_credential(self, source_id: str) -> Optional[str]:
@@ -202,7 +202,7 @@ class User(Person):
     def set_source_credential(self, source_id: str, credential_ref: str) -> None:
         """Set a credential reference for a data source."""
         self.source_credentials[source_id] = credential_ref
-        self.last_updated = datetime.now()
+        self.last_updated = datetime.now(tz=timezone.utc)
 
     def has_jurisdiction_access(self, jurisdiction_name: str) -> bool:
         """Check if user is authorized for a jurisdiction (empty list = all)."""
@@ -215,7 +215,7 @@ class User(Person):
         """Assign a client to this user."""
         if client_code not in self.assigned_clients:
             self.assigned_clients.append(client_code)
-            self.last_updated = datetime.now()
+            self.last_updated = datetime.now(tz=timezone.utc)
 
     def unassign_client(self, client_code: str) -> bool:
         """Unassign a client from this user. Returns True if removed."""
@@ -223,7 +223,7 @@ class User(Person):
             self.assigned_clients.remove(client_code)
             if self.primary_client == client_code:
                 self.primary_client = None
-            self.last_updated = datetime.now()
+            self.last_updated = datetime.now(tz=timezone.utc)
             return True
         return False
 
@@ -232,7 +232,7 @@ class User(Person):
         if client_code not in self.assigned_clients:
             self.assigned_clients.append(client_code)
         self.primary_client = client_code
-        self.last_updated = datetime.now()
+        self.last_updated = datetime.now(tz=timezone.utc)
 
     def get_assigned_clients(self) -> List[str]:
         """Get list of assigned client codes."""
@@ -358,13 +358,13 @@ class Client(Person):
     def increment_project_count(self) -> None:
         """Increment the project count."""
         self.project_count += 1
-        self.last_updated = datetime.now()
+        self.last_updated = datetime.now(tz=timezone.utc)
     
     def decrement_project_count(self) -> None:
         """Decrement the project count."""
         if self.project_count > 0:
             self.project_count -= 1
-            self.last_updated = datetime.now()
+            self.last_updated = datetime.now(tz=timezone.utc)
     
     def is_active_client(self) -> bool:
         """Check if client is active."""
@@ -388,7 +388,7 @@ class Client(Person):
         """Assign a user to this client."""
         if person_id not in self.assigned_users:
             self.assigned_users.append(person_id)
-            self.last_updated = datetime.now()
+            self.last_updated = datetime.now(tz=timezone.utc)
 
     def unassign_user(self, person_id: str) -> bool:
         """Unassign a user from this client. Returns True if removed."""
@@ -396,7 +396,7 @@ class Client(Person):
             self.assigned_users.remove(person_id)
             if self.primary_user == person_id:
                 self.primary_user = None
-            self.last_updated = datetime.now()
+            self.last_updated = datetime.now(tz=timezone.utc)
             return True
         return False
 
@@ -405,7 +405,7 @@ class Client(Person):
         if person_id not in self.assigned_users:
             self.assigned_users.append(person_id)
         self.primary_user = person_id
-        self.last_updated = datetime.now()
+        self.last_updated = datetime.now(tz=timezone.utc)
 
     def get_assigned_users(self) -> List[str]:
         """Get list of assigned user person_ids."""
@@ -490,7 +490,7 @@ class Collaborator(Person):
     @classmethod
     def validate_access_expires(cls, v):
         """Validate access expiration date."""
-        if v and v <= datetime.now():
+        if v and v <= datetime.now(tz=timezone.utc):
             raise ValueError('Access expiration must be in the future')
         return v
     
@@ -518,7 +518,7 @@ class Collaborator(Person):
         """Check if collaboration access has expired."""
         if not self.access_expires:
             return False
-        return datetime.now() > self.access_expires
+        return datetime.now(tz=timezone.utc) > self.access_expires
     
     def is_collaboration_active(self) -> bool:
         """Check if collaboration is active (not expired and person is active)."""
@@ -546,16 +546,16 @@ class Collaborator(Person):
     
     def accept_invitation(self) -> None:
         """Accept collaboration invitation."""
-        self.invitation_accepted = datetime.now()
-        self.last_updated = datetime.now()
+        self.invitation_accepted = datetime.now(tz=timezone.utc)
+        self.last_updated = datetime.now(tz=timezone.utc)
     
     def extend_access(self, days: int) -> None:
         """Extend collaboration access by specified days."""
         if self.access_expires:
             self.access_expires = self.access_expires + timedelta(days=days)
         else:
-            self.access_expires = datetime.now() + timedelta(days=days)
-        self.last_updated = datetime.now()
+            self.access_expires = datetime.now(tz=timezone.utc) + timedelta(days=days)
+        self.last_updated = datetime.now(tz=timezone.utc)
 
 
 class Organization(BaseModel):
@@ -653,7 +653,7 @@ class Organization(BaseModel):
         """Add a member to this organization."""
         if person_id not in self.members:
             self.members.append(person_id)
-            self.last_updated = datetime.now()
+            self.last_updated = datetime.now(tz=timezone.utc)
     
     def remove_member(self, person_id: str) -> None:
         """Remove a member from this organization."""
@@ -661,14 +661,14 @@ class Organization(BaseModel):
             self.members.remove(person_id)
             if self.primary_contact == person_id:
                 self.primary_contact = None
-            self.last_updated = datetime.now()
+            self.last_updated = datetime.now(tz=timezone.utc)
     
     def set_primary_contact(self, person_id: str) -> None:
         """Set the primary contact for this organization."""
         if person_id not in self.members:
             self.members.append(person_id)
         self.primary_contact = person_id
-        self.last_updated = datetime.now()
+        self.last_updated = datetime.now(tz=timezone.utc)
 
     def get_summary(self) -> Dict[str, Any]:
         """Get organization summary information."""
@@ -802,7 +802,7 @@ class Collaboration(BaseModel):
     @classmethod
     def validate_end_date(cls, v):
         """Validate end date."""
-        if v and v <= datetime.now():
+        if v and v <= datetime.now(tz=timezone.utc):
             raise ValueError('End date must be in the future')
         return v
     
@@ -810,24 +810,24 @@ class Collaboration(BaseModel):
         """Add an organization to this collaboration."""
         if org_id not in self.organizations:
             self.organizations.append(org_id)
-            self.last_updated = datetime.now()
+            self.last_updated = datetime.now(tz=timezone.utc)
     
     def add_client(self, client_id: str) -> None:
         """Add a client to this collaboration."""
         if client_id not in self.clients:
             self.clients.append(client_id)
-            self.last_updated = datetime.now()
+            self.last_updated = datetime.now(tz=timezone.utc)
     
     def add_participant(self, person_id: str) -> None:
         """Add a participant to this collaboration."""
         if person_id not in self.participants:
             self.participants.append(person_id)
-            self.last_updated = datetime.now()
+            self.last_updated = datetime.now(tz=timezone.utc)
     
     def is_active(self) -> bool:
         """Check if collaboration is active."""
         return (self.status == "active" and 
-                (not self.end_date or datetime.now() < self.end_date))
+                (not self.end_date or datetime.now(tz=timezone.utc) < self.end_date))
     
     def get_summary(self) -> Dict[str, Any]:
         """Get collaboration summary information."""

--- a/siege_utilities/config/models/client_profile.py
+++ b/siege_utilities/config/models/client_profile.py
@@ -4,7 +4,7 @@ Enhanced client profile model with comprehensive validation.
 
 from pydantic import BaseModel, Field, field_validator
 from typing import List, Optional
-from datetime import datetime
+from datetime import datetime, timezone
 
 from .database_connection import DatabaseConnection
 from .social_media_account import SocialMediaAccount
@@ -225,7 +225,7 @@ class ClientProfile(BaseModel):
             raise ValueError(f'Database connection "{connection.name}" already exists')
         
         self.database_connections.append(connection)
-        self.last_updated = datetime.now()
+        self.last_updated = datetime.now(tz=timezone.utc)
     
     def add_social_media_account(self, account: SocialMediaAccount) -> None:
         """Add a new social media account."""
@@ -234,17 +234,17 @@ class ClientProfile(BaseModel):
             raise ValueError(f'Social media account for "{account.platform}" already exists')
         
         self.social_media_accounts.append(account)
-        self.last_updated = datetime.now()
+        self.last_updated = datetime.now(tz=timezone.utc)
     
     def update_branding_config(self, branding: BrandingConfig) -> None:
         """Update branding configuration."""
         self.branding_config = branding
-        self.last_updated = datetime.now()
+        self.last_updated = datetime.now(tz=timezone.utc)
     
     def update_report_preferences(self, preferences: ReportPreferences) -> None:
         """Update report preferences."""
         self.report_preferences = preferences
-        self.last_updated = datetime.now()
+        self.last_updated = datetime.now(tz=timezone.utc)
     
     def get_summary(self) -> dict:
         """Get client profile summary."""

--- a/siege_utilities/config/models/credential.py
+++ b/siege_utilities/config/models/credential.py
@@ -4,7 +4,7 @@ Credential management model with comprehensive validation.
 
 from pydantic import BaseModel, Field, field_validator, ConfigDict
 from typing import Optional, Dict, Any
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 import re
 
@@ -144,7 +144,7 @@ class Credential(BaseModel):
     @classmethod
     def validate_expires_at(cls, v):
         """Validate expiration date."""
-        if v and v <= datetime.now():
+        if v and v <= datetime.now(tz=timezone.utc):
             raise ValueError('Expiration date must be in the future')
         return v
     
@@ -152,7 +152,7 @@ class Credential(BaseModel):
         """Check if credential is expired."""
         if not self.expires_at:
             return False
-        return datetime.now() > self.expires_at
+        return datetime.now(tz=timezone.utc) > self.expires_at
     
     def is_valid(self) -> bool:
         """Check if credential is valid (active and not expired)."""
@@ -161,7 +161,7 @@ class Credential(BaseModel):
     
     def update_last_used(self) -> None:
         """Update the last used timestamp."""
-        self.last_used = datetime.now()
+        self.last_used = datetime.now(tz=timezone.utc)
     
     def get_credential_data(self) -> Dict[str, Any]:
         """Get credential data as dictionary (excluding sensitive fields for logging)."""

--- a/siege_utilities/config/models/export.py
+++ b/siege_utilities/config/models/export.py
@@ -6,7 +6,7 @@ organizations, collaborations) to a single YAML document and deserialize back.
 """
 
 from typing import List, Optional, Dict, Any, Union
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import yaml
@@ -44,7 +44,7 @@ def export_entities(
     """
     document = {
         'version': EXPORT_FORMAT_VERSION,
-        'exported_at': datetime.now().isoformat(),
+        'exported_at': datetime.now(tz=timezone.utc).isoformat(),
         'entities': {}
     }
 

--- a/siege_utilities/config/models/google_account.py
+++ b/siege_utilities/config/models/google_account.py
@@ -7,7 +7,7 @@ for credential resolution, scope tracking, and default selection.
 
 from pydantic import BaseModel, Field, field_validator, model_validator, ConfigDict
 from typing import Optional, List, Dict, Any
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 import re
 
@@ -150,7 +150,7 @@ class GoogleAccount(BaseModel):
 
     def update_last_used(self) -> None:
         """Update the last-used timestamp."""
-        self.last_used = datetime.now()
+        self.last_used = datetime.now(tz=timezone.utc)
 
     def get_info(self) -> Dict[str, Any]:
         """Get account info (excluding sensitive credential data)."""

--- a/siege_utilities/config/models/oauth_integration.py
+++ b/siege_utilities/config/models/oauth_integration.py
@@ -4,7 +4,7 @@ OAuth integration model with comprehensive validation.
 
 from pydantic import BaseModel, Field, field_validator, ConfigDict
 from typing import Optional, Dict, Any, List
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 import re
 
@@ -175,7 +175,7 @@ class OAuthIntegration(BaseModel):
     @classmethod
     def validate_expires_at(cls, v):
         """Validate token expiration date."""
-        if v and v <= datetime.now():
+        if v and v <= datetime.now(tz=timezone.utc):
             raise ValueError('Token expiration must be in the future')
         return v
     
@@ -183,7 +183,7 @@ class OAuthIntegration(BaseModel):
         """Check if access token is expired."""
         if not self.expires_at:
             return False
-        return datetime.now() >= self.expires_at
+        return datetime.now(tz=timezone.utc) >= self.expires_at
     
     def needs_refresh(self) -> bool:
         """Check if token needs refresh based on threshold."""
@@ -191,7 +191,7 @@ class OAuthIntegration(BaseModel):
             return False
         
         threshold_time = self.expires_at - timedelta(seconds=self.refresh_threshold)
-        return datetime.now() >= threshold_time
+        return datetime.now(tz=timezone.utc) >= threshold_time
     
     def is_valid(self) -> bool:
         """Check if integration is valid (active and has valid token)."""
@@ -201,7 +201,7 @@ class OAuthIntegration(BaseModel):
     
     def update_last_used(self) -> None:
         """Update the last used timestamp."""
-        self.last_used = datetime.now()
+        self.last_used = datetime.now(tz=timezone.utc)
     
     def update_tokens(self, access_token: str, refresh_token: Optional[str] = None, 
                      expires_in: Optional[int] = None) -> None:
@@ -211,9 +211,9 @@ class OAuthIntegration(BaseModel):
             self.refresh_token = refresh_token
         
         if expires_in:
-            self.expires_at = datetime.now() + timedelta(seconds=expires_in)
+            self.expires_at = datetime.now(tz=timezone.utc) + timedelta(seconds=expires_in)
         
-        self.last_refreshed = datetime.now()
+        self.last_refreshed = datetime.now(tz=timezone.utc)
         self.update_last_used()
     
     def get_authorization_url(self, state: Optional[str] = None) -> str:

--- a/siege_utilities/config/models/person.py
+++ b/siege_utilities/config/models/person.py
@@ -4,7 +4,7 @@ Base Person model with comprehensive validation and credential management.
 
 from pydantic import BaseModel, Field, field_validator, ConfigDict
 from typing import List, Optional, Dict, Any, Union
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 import re
 
@@ -183,14 +183,14 @@ class Person(BaseModel):
             raise ValueError(f'Credential "{credential.name}" already exists')
         
         self.credentials.append(credential)
-        self.last_updated = datetime.now()
+        self.last_updated = datetime.now(tz=timezone.utc)
     
     def remove_credential(self, credential_name: str) -> bool:
         """Remove a credential by name."""
         for i, cred in enumerate(self.credentials):
             if cred.name == credential_name:
                 del self.credentials[i]
-                self.last_updated = datetime.now()
+                self.last_updated = datetime.now(tz=timezone.utc)
                 return True
         return False
     
@@ -217,14 +217,14 @@ class Person(BaseModel):
             raise ValueError(f'OAuth integration "{integration.name}" already exists')
         
         self.oauth_integrations.append(integration)
-        self.last_updated = datetime.now()
+        self.last_updated = datetime.now(tz=timezone.utc)
     
     def remove_oauth_integration(self, integration_name: str) -> bool:
         """Remove an OAuth integration by name."""
         for i, oauth in enumerate(self.oauth_integrations):
             if oauth.name == integration_name:
                 del self.oauth_integrations[i]
-                self.last_updated = datetime.now()
+                self.last_updated = datetime.now(tz=timezone.utc)
                 return True
         return False
     
@@ -247,14 +247,14 @@ class Person(BaseModel):
             raise ValueError(f'Database connection "{connection.name}" already exists')
         
         self.database_connections.append(connection)
-        self.last_updated = datetime.now()
+        self.last_updated = datetime.now(tz=timezone.utc)
     
     def remove_database_connection(self, connection_name: str) -> bool:
         """Remove a database connection by name."""
         for i, conn in enumerate(self.database_connections):
             if conn.name == connection_name:
                 del self.database_connections[i]
-                self.last_updated = datetime.now()
+                self.last_updated = datetime.now(tz=timezone.utc)
                 return True
         return False
     
@@ -274,14 +274,14 @@ class Person(BaseModel):
             raise ValueError(f'1Password credential "{credential.credential_name}" already exists in vault {credential.vault_id}')
         
         self.onepassword_credentials.append(credential)
-        self.last_updated = datetime.now()
+        self.last_updated = datetime.now(tz=timezone.utc)
     
     def remove_onepassword_credential(self, credential_name: str, vault_id: str) -> bool:
         """Remove a 1Password credential reference."""
         for i, cred in enumerate(self.onepassword_credentials):
             if cred.credential_name == credential_name and cred.vault_id == vault_id:
                 del self.onepassword_credentials[i]
-                self.last_updated = datetime.now()
+                self.last_updated = datetime.now(tz=timezone.utc)
                 return True
         return False
     
@@ -302,7 +302,7 @@ class Person(BaseModel):
         # Ensure we always have a default if any account exists.
         if not any(a.is_default for a in self.google_accounts):
             self.google_accounts[0].is_default = True
-        self.last_updated = datetime.now()
+        self.last_updated = datetime.now(tz=timezone.utc)
 
     def remove_google_account(self, google_account_id: str) -> bool:
         """Remove a Google account by ID."""
@@ -313,7 +313,7 @@ class Person(BaseModel):
                 if removed_default and self.google_accounts:
                     # Promote first remaining account as default.
                     self.google_accounts[0].is_default = True
-                self.last_updated = datetime.now()
+                self.last_updated = datetime.now(tz=timezone.utc)
                 return True
         return False
 
@@ -349,7 +349,7 @@ class Person(BaseModel):
                 a.is_default = False
         if not found:
             raise ValueError(f'Google account "{google_account_id}" not found')
-        self.last_updated = datetime.now()
+        self.last_updated = datetime.now(tz=timezone.utc)
 
     def list_google_accounts(self, active_only: bool = False) -> List[GoogleAccount]:
         """List Google accounts, optionally filtering to active only."""
@@ -362,7 +362,7 @@ class Person(BaseModel):
         """Add an organization to this person."""
         if org_id not in self.organizations:
             self.organizations.append(org_id)
-            self.last_updated = datetime.now()
+            self.last_updated = datetime.now(tz=timezone.utc)
     
     def remove_organization(self, org_id: str) -> None:
         """Remove an organization from this person."""
@@ -370,27 +370,27 @@ class Person(BaseModel):
             self.organizations.remove(org_id)
             if self.primary_organization == org_id:
                 self.primary_organization = None
-            self.last_updated = datetime.now()
+            self.last_updated = datetime.now(tz=timezone.utc)
     
     def set_primary_organization(self, org_id: str) -> None:
         """Set the primary organization for this person."""
         if org_id not in self.organizations:
             self.organizations.append(org_id)
         self.primary_organization = org_id
-        self.last_updated = datetime.now()
+        self.last_updated = datetime.now(tz=timezone.utc)
     
     # Collaboration Management Methods
     def add_collaboration(self, collab_id: str) -> None:
         """Add a collaboration to this person."""
         if collab_id not in self.collaborations:
             self.collaborations.append(collab_id)
-            self.last_updated = datetime.now()
+            self.last_updated = datetime.now(tz=timezone.utc)
     
     def remove_collaboration(self, collab_id: str) -> None:
         """Remove a collaboration from this person."""
         if collab_id in self.collaborations:
             self.collaborations.remove(collab_id)
-            self.last_updated = datetime.now()
+            self.last_updated = datetime.now(tz=timezone.utc)
     
     # Utility Methods
     def get_summary(self) -> Dict[str, Any]:

--- a/siege_utilities/core/logging.py
+++ b/siege_utilities/core/logging.py
@@ -10,7 +10,7 @@ from typing import Optional, Dict, Union, Generator
 from dataclasses import dataclass, field
 from contextlib import contextmanager
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 
 # Type aliases for better readability
 LogLevel = Union[str, int]
@@ -178,7 +178,7 @@ class LoggerManager:
                 )
             else:
                 # Individual file handler
-                log_file = config.log_dir / f"{logger.name}_{datetime.now():%Y%m%d_%H%M%S}.log"
+                log_file = config.log_dir / f"{logger.name}_{datetime.now(tz=timezone.utc):%Y%m%d_%H%M%S}.log"
                 config.log_dir.mkdir(parents=True, exist_ok=True)
                 
                 file_handler = self._create_rotating_file_handler(

--- a/siege_utilities/geo/census/api.py
+++ b/siege_utilities/geo/census/api.py
@@ -9,7 +9,7 @@ import hashlib
 import logging
 import os
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Union, Any
 
@@ -350,8 +350,8 @@ class CensusAPI:
         if not cache_file.exists():
             return None
 
-        file_mtime = datetime.fromtimestamp(cache_file.stat().st_mtime)
-        if datetime.now() - file_mtime > timedelta(seconds=self.cache_ttl):
+        file_mtime = datetime.fromtimestamp(cache_file.stat().st_mtime, tz=timezone.utc)
+        if datetime.now(tz=timezone.utc) - file_mtime > timedelta(seconds=self.cache_ttl):
             log.debug(f"Cache expired for {cache_key}")
             cache_file.unlink()
             return None

--- a/siege_utilities/geo/census/catalog_cache.py
+++ b/siege_utilities/geo/census/catalog_cache.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -183,8 +183,8 @@ class CatalogCache:
         if not path.exists():
             return None
 
-        mtime = datetime.fromtimestamp(path.stat().st_mtime)
-        if datetime.now() - mtime > timedelta(days=self.ttl_days):
+        mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+        if datetime.now(tz=timezone.utc) - mtime > timedelta(days=self.ttl_days):
             log.debug("Cache expired for %s/%d", dataset, year)
             path.unlink()
             return None

--- a/siege_utilities/geo/census_api_client.py
+++ b/siege_utilities/geo/census_api_client.py
@@ -34,7 +34,7 @@ This file provides the backward-compatible ``CensusAPIClient`` facade.
 
 import logging
 import threading
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Union, Any, TYPE_CHECKING
 
@@ -317,7 +317,7 @@ def get_demographics(
         DataFrame with demographic data
     """
     if year is None:
-        year = datetime.now().year - 1
+        year = datetime.now(tz=timezone.utc).year - 1
 
     state_fips = normalize_state_identifier(state)
 
@@ -340,7 +340,7 @@ def get_population(
 ) -> pd.DataFrame:
     """Convenience function to get population data."""
     if year is None:
-        year = datetime.now().year - 1
+        year = datetime.now(tz=timezone.utc).year - 1
 
     state_fips = normalize_state_identifier(state)
 
@@ -364,7 +364,7 @@ def get_income_data(
 ) -> pd.DataFrame:
     """Convenience function to get income data."""
     if year is None:
-        year = datetime.now().year - 1
+        year = datetime.now(tz=timezone.utc).year - 1
 
     state_fips = normalize_state_identifier(state)
 
@@ -388,7 +388,7 @@ def get_education_data(
 ) -> pd.DataFrame:
     """Convenience function to get educational attainment data."""
     if year is None:
-        year = datetime.now().year - 1
+        year = datetime.now(tz=timezone.utc).year - 1
 
     state_fips = normalize_state_identifier(state)
 
@@ -412,7 +412,7 @@ def get_housing_data(
 ) -> pd.DataFrame:
     """Convenience function to get housing data."""
     if year is None:
-        year = datetime.now().year - 1
+        year = datetime.now(tz=timezone.utc).year - 1
 
     state_fips = normalize_state_identifier(state)
 

--- a/siege_utilities/geo/census_dataset_mapper.py
+++ b/siege_utilities/geo/census_dataset_mapper.py
@@ -7,7 +7,7 @@ making it easier to understand which datasets to use for different analysis need
 
 import json
 from typing import Dict, List, Optional, Any
-from datetime import datetime
+from datetime import datetime, timezone
 from dataclasses import dataclass
 
 from siege_utilities.core.logging import log_info
@@ -577,7 +577,7 @@ class CensusDatasetMapper:
                 for rel in self.relationships
             ],
             "metadata": {
-                "last_updated": datetime.now().isoformat(),
+                "last_updated": datetime.now(tz=timezone.utc).isoformat(),
                 "total_datasets": len(self.datasets),
                 "total_relationships": len(self.relationships)
             }

--- a/siege_utilities/geo/census_files/pl_downloader.py
+++ b/siege_utilities/geo/census_files/pl_downloader.py
@@ -23,7 +23,7 @@ Example usage:
 import logging
 import threading
 import zipfile
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from io import StringIO
 from pathlib import Path
 from typing import Dict, List, Optional, Union
@@ -561,8 +561,8 @@ class PLFileDownloader:
         if not cache_file.exists():
             return False
 
-        file_mtime = datetime.fromtimestamp(cache_file.stat().st_mtime)
-        age = datetime.now() - file_mtime
+        file_mtime = datetime.fromtimestamp(cache_file.stat().st_mtime, tz=timezone.utc)
+        age = datetime.now(tz=timezone.utc) - file_mtime
 
         if age > timedelta(days=PL_CACHE_TIMEOUT_DAYS):
             return False

--- a/siege_utilities/geo/crosswalk/crosswalk_client.py
+++ b/siege_utilities/geo/crosswalk/crosswalk_client.py
@@ -27,7 +27,7 @@ Example usage:
 
 import logging
 import threading
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 from io import StringIO
@@ -293,11 +293,11 @@ class CrosswalkClient:
         deleted = 0
         cutoff = None
         if older_than_days is not None:
-            cutoff = datetime.now() - timedelta(days=older_than_days)
+            cutoff = datetime.now(tz=timezone.utc) - timedelta(days=older_than_days)
 
         for cache_file in self.cache_dir.glob('*.parquet'):
             if cutoff is not None:
-                file_mtime = datetime.fromtimestamp(cache_file.stat().st_mtime)
+                file_mtime = datetime.fromtimestamp(cache_file.stat().st_mtime, tz=timezone.utc)
                 if file_mtime > cutoff:
                     continue
 
@@ -333,8 +333,8 @@ class CrosswalkClient:
         if not cache_file.exists():
             return False
 
-        file_mtime = datetime.fromtimestamp(cache_file.stat().st_mtime)
-        age = datetime.now() - file_mtime
+        file_mtime = datetime.fromtimestamp(cache_file.stat().st_mtime, tz=timezone.utc)
+        age = datetime.now(tz=timezone.utc) - file_mtime
 
         if age > CROSSWALK_CACHE_TIMEOUT:
             log.debug(f"Cache expired: {cache_file.name} ({age.days} days old)")

--- a/siege_utilities/geo/django/services/isochrone_service.py
+++ b/siege_utilities/geo/django/services/isochrone_service.py
@@ -81,7 +81,7 @@ class IsochroneComputeService:
         from siege_utilities.geo.django.models import IsochroneResult
 
         result = IsochroneComputeResult()
-        vintage = vintage_year or datetime.now().year
+        vintage = vintage_year or datetime.now(tz=timezone.utc).year
 
         # Check cache first
         if max_age_days is not None:

--- a/siege_utilities/geo/providers/nlrb_cache.py
+++ b/siege_utilities/geo/providers/nlrb_cache.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -41,7 +41,7 @@ def _str_to_date(s: Optional[str]) -> Optional[date]:
 def _result_to_dict(result: NLRBFetchResult) -> dict:
     return {
         "source": result.source,
-        "fetched_at": datetime.now().isoformat(),
+        "fetched_at": datetime.now(tz=timezone.utc).isoformat(),
         "cases": [
             {
                 "case_number": c.case_number,

--- a/siege_utilities/geo/spatial_data.py
+++ b/siege_utilities/geo/spatial_data.py
@@ -257,7 +257,7 @@ def update_census_inventory(
     import json
 
     if years is None:
-        years = list(range(2010, datetime.now().year + 1))
+        years = list(range(2010, datetime.now(tz=timezone.utc).year + 1))
 
     def _parse_dir_links(html: bytes) -> List[str]:
         soup = BeautifulSoup(html, "html.parser")
@@ -445,7 +445,7 @@ class CensusDirectoryDiscovery:
                         year = 2000 + int(match.group(1))
                     else:
                         year = int(match.group(1))
-                    if 1990 <= year <= datetime.now().year + 1:
+                    if 1990 <= year <= datetime.now(tz=timezone.utc).year + 1:
                         years.append(year)
                     break
 
@@ -517,7 +517,7 @@ class CensusDirectoryDiscovery:
 
         log.error(f"Failed to discover available years after {CENSUS_RETRY_ATTEMPTS} attempts: {last_exception}")
         log.info("Using fallback years (2010-present)")
-        return list(range(2010, datetime.now().year + 1))
+        return list(range(2010, datetime.now(tz=timezone.utc).year + 1))
     
     def get_year_directory_contents(
         self, year: int, force_refresh: bool = False, on_error: str = "skip",
@@ -1509,8 +1509,8 @@ class CensusDataSource(SpatialDataSource):
     def _validate_census_parameters(self, year: int, geographic_level: str, 
                                   state_fips: Optional[str]) -> None:
         """Validate Census API parameters."""
-        if year < 1990 or year > datetime.now().year + 1:
-            raise ValueError(f"Year {year} is outside valid range (1990-{datetime.now().year + 1})")
+        if year < 1990 or year > datetime.now(tz=timezone.utc).year + 1:
+            raise ValueError(f"Year {year} is outside valid range (1990-{datetime.now(tz=timezone.utc).year + 1})")
         
         if geographic_level in self.state_required_levels and not state_fips:
             raise ValueError(f"State FIPS required for {geographic_level}-level data")
@@ -2044,7 +2044,7 @@ def get_optimal_year(geographic_level: str, preferred_year: Optional[int] = None
         Best available year for the requested boundary type
     """
     from datetime import datetime
-    year = preferred_year if preferred_year is not None else datetime.now().year
+    year = preferred_year if preferred_year is not None else datetime.now(tz=timezone.utc).year
     return _get_census_source().get_optimal_year(year, geographic_level)
 
 def download_data(

--- a/siege_utilities/git/branch_analyzer.py
+++ b/siege_utilities/git/branch_analyzer.py
@@ -5,7 +5,7 @@ Based on the Change-Agent-AI branch status generator.
 
 import logging
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Dict, Optional
 
@@ -184,7 +184,7 @@ def generate_branch_report(
     file_stats = get_file_stats(repo_path)
 
     # Generate the report
-    current_date = datetime.now().strftime("%B %d, %Y")
+    current_date = datetime.now(tz=timezone.utc).strftime("%B %d, %Y")
 
     # Determine status text (emojis removed)
     if int(status["ahead"]) > 0:
@@ -297,7 +297,7 @@ This branch represents ongoing development work with **{status['ahead']} commits
 ---
 
 **Branch Maintainer**: Development Team
-**Last Generated**: {datetime.now().strftime("%B %d, %Y at %I:%M %p")}
+**Last Generated**: {datetime.now(tz=timezone.utc).strftime("%B %d, %Y at %I:%M %p")}
 **Status**: {'IN DEVELOPMENT' if int(status['ahead']) > 0 else 'READY FOR MERGE'}"""
 
     # Save to file if specified

--- a/siege_utilities/git/git_status.py
+++ b/siege_utilities/git/git_status.py
@@ -6,7 +6,7 @@ Comprehensive repository state analysis and monitoring.
 import logging
 from pathlib import Path
 from typing import List, Dict, Optional, Union
-from datetime import datetime
+from datetime import datetime, timezone
 
 from siege_utilities.exceptions import GitError
 from ._utils import run_git_command
@@ -96,7 +96,7 @@ def get_repository_status(repo_path: str = ".") -> Dict[str, Union[str, int, boo
             "behind": int(behind)
         },
         "working_directory_clean": staged_files + unstaged_files + untracked_files == 0,
-        "last_updated": datetime.now().isoformat()
+        "last_updated": datetime.now(tz=timezone.utc).isoformat()
     }
 
 def get_branch_info(repo_path: str = ".") -> Dict[str, Union[str, List[str], int]]:

--- a/siege_utilities/reporting/examples/google_analytics_report_example.py
+++ b/siege_utilities/reporting/examples/google_analytics_report_example.py
@@ -18,7 +18,7 @@ Requirements:
 import pandas as pd
 import numpy as np
 from pathlib import Path
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Any, Optional, Tuple
 import logging
 import io
@@ -1814,7 +1814,7 @@ def generate_ga_report_pdf(ga_data: Dict[str, Any], output_path: str,
             fontSize=20, alignment=TA_CENTER, fontName='Helvetica-Bold'
         )))
         story.append(Spacer(1, 0.5*inch))
-        story.append(Paragraph(f"<b>Report Date:</b> {datetime.now().strftime('%B %d, %Y')}", details_style))
+        story.append(Paragraph(f"<b>Report Date:</b> {datetime.now(tz=timezone.utc).strftime('%B %d, %Y')}", details_style))
         story.append(Paragraph(f"<b>Period Covered:</b> {date_range['start']} to {date_range['end']}", details_style))
         story.append(Paragraph(f"<b>Prepared By:</b> {prepared_by}", details_style))
         data_source = ga_data.get('data_source', 'sample')
@@ -2671,7 +2671,7 @@ def main():
     print("=" * 80)
 
     # Generate sample data for last 30 days
-    end_date = datetime.now()
+    end_date = datetime.now(tz=timezone.utc)
     start_date = end_date - timedelta(days=30)
 
     print(f"\nGenerating sample data for {start_date.strftime('%Y-%m-%d')} to {end_date.strftime('%Y-%m-%d')}...")

--- a/siege_utilities/reporting/pages/page_models.py
+++ b/siege_utilities/reporting/pages/page_models.py
@@ -185,7 +185,7 @@ class TitlePage(Page):
 
     def build(self, start_date, end_date):
         """Build the complete title page"""
-        from datetime import datetime
+        from datetime import datetime, timezone
 
         # Blue header bar
         blue_bar_style = self.create_blue_bar_style()
@@ -206,7 +206,7 @@ class TitlePage(Page):
 
         # Report details
         details_style = self.create_details_style()
-        self.add_paragraph("<b>Report Date:</b><br/>" + datetime.now().strftime('%B %d, %Y'), details_style)
+        self.add_paragraph("<b>Report Date:</b><br/>" + datetime.now(tz=timezone.utc).strftime('%B %d, %Y'), details_style)
         self.add_spacer(self.DETAILS_INTERNAL)
         self.add_paragraph(f"<b>Period Covered:</b><br/>{start_date} to {end_date}", details_style)
         self.add_spacer(self.DETAILS_INTERNAL)

--- a/siege_utilities/reporting/powerpoint_generator.py
+++ b/siege_utilities/reporting/powerpoint_generator.py
@@ -7,7 +7,7 @@ import logging
 import uuid
 from pathlib import Path
 from typing import Dict, List, Any, Optional, Union
-from datetime import datetime
+from datetime import datetime, timezone
 import pandas as pd
 
 try:
@@ -85,7 +85,7 @@ class PowerPointGenerator:
             # the first. Append a short uuid4 fragment to make the path
             # unique even at sub-second cadence; the timestamp still
             # provides human-readable sortability.
-            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
             suffix = uuid.uuid4().hex[:8]
             filename = (
                 f"{self.client_name.lower().replace(' ', '_')}"
@@ -145,7 +145,7 @@ class PowerPointGenerator:
         """
         try:
             # Generate filename
-            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
             suffix = uuid.uuid4().hex[:8]
             filename = f"{self.client_name.lower().replace(' ', '_')}_performance_presentation_{timestamp}_{suffix}.pptx"
             output_path = self.output_dir / filename
@@ -194,7 +194,7 @@ class PowerPointGenerator:
         """
         try:
             # Generate filename
-            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
             presentation_type = presentation_config.get('type', 'custom')
             filename = f"{self.client_name.lower().replace(' ', '_')}_{presentation_type}_presentation_{timestamp}.pptx"
             output_path = self.output_dir / filename
@@ -264,7 +264,7 @@ class PowerPointGenerator:
                 'author': author or 'Siege Analytics',
                 'client': client,
                 'presentation_type': presentation_type,
-                'created_date': datetime.now().isoformat(),
+                'created_date': datetime.now(tz=timezone.utc).isoformat(),
                 'version': '1.0'
             },
             'slide_structure': {
@@ -279,7 +279,7 @@ class PowerPointGenerator:
                     'subtitle': f"{presentation_type.title()} Presentation",
                     'author': author or 'Siege Analytics',
                     'client': client,
-                    'date': datetime.now().strftime('%B %d, %Y'),
+                    'date': datetime.now(tz=timezone.utc).strftime('%B %d, %Y'),
                     'level': 0
                 }
             ]
@@ -549,7 +549,7 @@ class PowerPointGenerator:
 
         # Set subtitle
         subtitle_shape = slide.placeholders[1]
-        subtitle_shape.text = f"Generated on {datetime.now().strftime('%B %d, %Y')}\n{self.client_name}"
+        subtitle_shape.text = f"Generated on {datetime.now(tz=timezone.utc).strftime('%B %d, %Y')}\n{self.client_name}"
 
         # Apply formatting
         self._format_title_slide(slide)
@@ -1021,7 +1021,7 @@ class PowerPointGenerator:
         """
         try:
             # Generate filename
-            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
             filename = f"{self.client_name.lower().replace(' ', '_')}_dataframe_presentation_{timestamp}.pptx"
             output_path = self.output_dir / filename
             

--- a/siege_utilities/reporting/report_generator.py
+++ b/siege_utilities/reporting/report_generator.py
@@ -8,7 +8,7 @@ import os
 import uuid
 from pathlib import Path
 from typing import Dict, List, Any, Optional, Union
-from datetime import datetime
+from datetime import datetime, timezone
 import pandas as pd
 
 # Try to import PIL Image, fall back to Any if not available
@@ -109,7 +109,7 @@ class ReportGenerator:
             'type': 'analytics_report',
             'sections': [],
             'metadata': {
-                'created_date': datetime.now().isoformat(),
+                'created_date': datetime.now(tz=timezone.utc).isoformat(),
                 'total_charts': len(charts),
                 'total_insights': len(insights),
                 'total_recommendations': len(recommendations)
@@ -206,7 +206,7 @@ class ReportGenerator:
                 'author': author or 'Siege Analytics',
                 'client': client,
                 'report_type': report_type,
-                'created_date': datetime.now().isoformat(),
+                'created_date': datetime.now(tz=timezone.utc).isoformat(),
                 'version': '1.0'
             },
             'document_structure': {
@@ -221,7 +221,7 @@ class ReportGenerator:
                     'subtitle': f"{report_type.title()} Report",
                     'author': author or 'Siege Analytics',
                     'client': client,
-                    'date': datetime.now().strftime('%B %d, %Y'),
+                    'date': datetime.now(tz=timezone.utc).strftime('%B %d, %Y'),
                     'level': 0
                 }
             ]

--- a/siege_utilities/reporting/templates/content_page_template.py
+++ b/siege_utilities/reporting/templates/content_page_template.py
@@ -21,7 +21,7 @@ except ImportError:
     inch = None
     Table = TableStyle = Paragraph = None
     getSampleStyleSheet = ParagraphStyle = None
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Any, List
 
 from siege_utilities.core.logging import log_info, log_warning
@@ -340,7 +340,7 @@ class ContentPageTemplate:
         self.canvas.setFont('Helvetica', 9)
         
         # Left side - generation info
-        footer_text = f"Generated: {datetime.now().strftime('%B %d, %Y')}"
+        footer_text = f"Generated: {datetime.now(tz=timezone.utc).strftime('%B %d, %Y')}"
         self.canvas.drawString(self.margin_left, 15, footer_text)
         
         # Right side - page number

--- a/siege_utilities/reporting/templates/title_page_template.py
+++ b/siege_utilities/reporting/templates/title_page_template.py
@@ -21,7 +21,7 @@ except ImportError:
     Color = HexColor = None
     pdfmetrics = None
     TTFont = None
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Any
 
 from siege_utilities.core.logging import log_info, log_warning
@@ -216,7 +216,7 @@ class TitlePageTemplate:
             details_y -= line_height
         
         # Generation date
-        generation_date = datetime.now().strftime("%B %d, %Y")
+        generation_date = datetime.now(tz=timezone.utc).strftime("%B %d, %Y")
         self.canvas.drawString(self.margin_left, details_y, f"Generated: {generation_date}")
         details_y -= line_height
         


### PR DESCRIPTION
All 110 `datetime.now()` calls in the codebase produced naive datetimes,
causing silent bugs when:
- Compared to timezone-aware datetimes from databases/APIs (TypeError)
- Used for cache expiry on machines in different timezones (wrong TTL)
- Serialized to ISO format and parsed back on another system (ambiguous)

**Fix:** `datetime.now(tz=timezone.utc)` everywhere, plus 5
`datetime.fromtimestamp(x, tz=timezone.utc)` fixes in cache-expiry
code that now correctly compares aware timestamps.

**Scope:** 32 files across config/models, analytics, geo, reporting, git.

**Breaking change:** Any downstream code that compares these timestamps
with other naive datetimes will now get `TypeError`. This is intentional
— it surfaces bugs rather than silently producing wrong results.