### PR TITLE
fix: complete fallback None in optional-import guards

### DIFF
--- a/siege_utilities/geo/django/management/commands/stage_boundaries_s3.py
+++ b/siege_utilities/geo/django/management/commands/stage_boundaries_s3.py
@@ -24,6 +24,7 @@ try:
     from botocore.exceptions import ClientError
 except ImportError:
     boto3 = None
+    ClientError = type('ClientError', (Exception,), {})
 
 try:
     import geopandas as gpd

--- a/siege_utilities/reference/sample_data.py
+++ b/siege_utilities/reference/sample_data.py
@@ -38,6 +38,8 @@ try:
     GEOPANDAS_AVAILABLE = True
 except ImportError:
     GEOPANDAS_AVAILABLE = False
+    gpd = None
+    Polygon = None
     gpd = None  # type: ignore[assignment]
 
 # Import existing Census utilities (kept as availability probe even though

--- a/siege_utilities/reporting/engines/composite_engine.py
+++ b/siege_utilities/reporting/engines/composite_engine.py
@@ -14,6 +14,7 @@ try:
 except ImportError:
     MATPLOTLIB_AVAILABLE = False
     plt = None
+    mpatches = None
     sns = None
 
 # Data processing

--- a/siege_utilities/reporting/engines/map_engine.py
+++ b/siege_utilities/reporting/engines/map_engine.py
@@ -37,6 +37,7 @@ try:
 except ImportError:
     FOLIUM_AVAILABLE = False
     folium = None
+    plugins = None
 
 # Geographic data processing
 try:

--- a/siege_utilities/reporting/legend_manager.py
+++ b/siege_utilities/reporting/legend_manager.py
@@ -15,6 +15,7 @@ try:
 except ImportError:
     MATPLOTLIB_AVAILABLE = False
     plt = None
+    mpatches = None
 
 # ReportLab for PDF generation
 try:

--- a/siege_utilities/reporting/powerpoint_generator.py
+++ b/siege_utilities/reporting/powerpoint_generator.py
@@ -18,6 +18,9 @@ try:
 except ImportError:
     PPTX_AVAILABLE = False
     Presentation = None
+    Inches = None
+    Pt = None
+    PP_ALIGN = None
 
 log = logging.getLogger(__name__)
 

--- a/siege_utilities/reporting/report_generator.py
+++ b/siege_utilities/reporting/report_generator.py
@@ -27,7 +27,14 @@ try:
     REPORTLAB_AVAILABLE = True
 except ImportError:
     REPORTLAB_AVAILABLE = False
-    PageBreak = None  # Define for type hints
+    Paragraph = None
+    Spacer = None
+    Table = None
+    TableStyle = None
+    PageBreak = None
+    RLImage = None
+    colors = None
+    inch = None
 
 from .templates.base_template import BaseReportTemplate
 from .chart_generator import ChartGenerator


### PR DESCRIPTION
Seven files had `try: import X` blocks where some imported names were not
assigned `None` (or a stub) in the `except ImportError` handler. If the
optional dependency is absent, any runtime reference to the unguarded name
raises `NameError` instead of following the clean guard-checked path.

**Files fixed:**
- `reporting/engines/map_engine.py` — `plugins = None`
- `reporting/engines/composite_engine.py` — `mpatches = None`
- `reporting/powerpoint_generator.py` — `Inches`, `Pt`, `PP_ALIGN = None`
- `reporting/report_generator.py` — `Paragraph`, `Spacer`, `Table`, `TableStyle`, `RLImage`, `colors`, `inch = None`
- `reporting/legend_manager.py` — `mpatches = None`
- `reference/sample_data.py` — `gpd`, `Polygon = None`
- `geo/django/.../stage_boundaries_s3.py` — `ClientError` stub exception class

**Verification:** all 7 files pass `ast.parse()`.