### PR TITLE
fix: guard division-by-zero in rollup and variable filter

### DIFF
--- a/siege_utilities/geo/census_data_selector.py
+++ b/siege_utilities/geo/census_data_selector.py
@@ -170,18 +170,20 @@ class CensusDataSelector:
         
         return filtered
     
-    def _filter_by_variables(self, datasets: List, 
+    def _filter_by_variables(self, datasets: List,
                            required_variables: List[str]) -> List:
         """Filter datasets by variable availability."""
-        
+        if not required_variables:
+            return list(datasets)
+
         filtered = []
         for dataset in datasets:
             # Check if dataset has most required variables
             available_vars = [var.lower() for var in dataset.variables]
             required_vars = [var.lower() for var in required_variables]
-            
+
             # Calculate variable coverage
-            coverage = sum(1 for var in required_vars 
+            coverage = sum(1 for var in required_vars
                          if any(req_var in var for req_var in available_vars))
             coverage_ratio = coverage / len(required_vars)
             

--- a/siege_utilities/geo/django/services/rollup_service.py
+++ b/siege_utilities/geo/django/services/rollup_service.py
@@ -268,9 +268,9 @@ class DemographicRollupService:
                                 v * p for v, p in zip(values, pops)
                             ) / total_pop
                         else:
-                            agg_value = sum(values) / len(values)
+                            agg_value = sum(values) / len(values) if values else 0
                     else:
-                        agg_value = sum(values) / len(values)
+                        agg_value = sum(values) / len(values) if values else 0
                 else:
                     result.errors.append(f"Unknown operation: {operation}")
                     break


### PR DESCRIPTION
Audited all 17 sites where a `/ len(x)` or `/ x.sum()` division could
hit zero. 15 were already guarded; 2 were not:

- `rollup_service.py` — weighted-average fallback paths lacked the
  `if values else 0` guard present on the primary avg path
- `census_data_selector.py` — `_filter_by_variables` divided by
  `len(required_vars)` without handling empty input list

Both fixed with minimal guards matching adjacent patterns.