### PR TITLE
fix(files): raise on error instead of returning False/None (SU-1)

### DIFF
--- a/siege_utilities/files/operations.py
+++ b/siege_utilities/files/operations.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 # Type aliases
 FilePath = Union[str, Path]
 
-def remove_tree(path: FilePath) -> bool:
+def remove_tree(path: FilePath) -> None:
     """
     Remove a file or directory tree safely.
 
@@ -25,41 +25,28 @@ def remove_tree(path: FilePath) -> bool:
     Args:
         path: Path to file or directory to remove
 
-    Returns:
-        True if successful, False otherwise
-
     Raises:
         PathSecurityError: If path fails security validation
+        OSError: If the path cannot be removed
 
     Example:
         >>> remove_tree("temp_directory")
         >>> remove_tree(Path("old_files"))
     """
     try:
-        # Validate path
-        try:
-            from siege_utilities.files.validation import validate_safe_path, PathSecurityError
-            path_obj = validate_safe_path(path, allow_absolute=True)
-        except ImportError:
-            path_obj = Path(path)
+        from siege_utilities.files.validation import validate_safe_path, PathSecurityError
+        path_obj = validate_safe_path(path, allow_absolute=True)
+    except ImportError:
+        path_obj = Path(path)
 
-        if path_obj.is_file():
-            path_obj.unlink()
-            log.info(f"Removed file: {path_obj}")
-        elif path_obj.is_dir():
-            shutil.rmtree(path_obj)
-            log.info(f"Removed directory tree: {path_obj}")
-        else:
-            log.warning(f"Path does not exist: {path_obj}")
-            return False
-
-        return True
-
-    except PathSecurityError:
-        raise
-    except OSError as e:
-        log.error(f"Failed to remove {path}: {e}")
-        return False
+    if path_obj.is_file():
+        path_obj.unlink()
+        log.info(f"Removed file: {path_obj}")
+    elif path_obj.is_dir():
+        shutil.rmtree(path_obj)
+        log.info(f"Removed directory tree: {path_obj}")
+    else:
+        log.warning(f"Path does not exist: {path_obj}")
 
 def file_exists(path: FilePath) -> bool:
     """
@@ -76,46 +63,21 @@ def file_exists(path: FilePath) -> bool:
 
     Raises:
         PathSecurityError: If path fails security validation
+        OSError: If the existence check fails (e.g., permission denied on parent)
 
     Example:
         >>> if file_exists("config.yaml"):
         ...     print("Config file found")
-        >>>
-        >>> # This will raise PathSecurityError
-        >>> file_exists("../../../etc/passwd")  # Path traversal blocked
-
-    Security Changes:
-        - Now validates paths to block path traversal
-        - Blocks access to sensitive system files
     """
     try:
-        # Import validation function
-        try:
-            from siege_utilities.files.validation import validate_safe_path, PathSecurityError
-        except ImportError:
-            # Fallback: use basic Path validation without security checks
-            log.warning("Path validation module not available - using basic validation")
-            path_obj = Path(path)
-        else:
-            # Validate path with security checks
-            try:
-                path_obj = validate_safe_path(path, allow_absolute=True)
-            except PathSecurityError as e:
-                log.error(f"Path security validation failed: {e}")
-                raise  # Re-raise to caller
+        from siege_utilities.files.validation import validate_safe_path, PathSecurityError
+        path_obj = validate_safe_path(path, allow_absolute=True)
+    except ImportError:
+        path_obj = Path(path)
 
-        exists = path_obj.exists()
-        log.debug(f"File exists check for {path}: {exists}")
-        return exists
+    return path_obj.exists()
 
-    except PathSecurityError:
-        # Re-raise security errors
-        raise
-    except OSError as e:
-        log.error(f"Error checking file existence for {path}: {e}")
-        return False
-
-def touch_file(path: FilePath, create_parents: bool = True) -> bool:
+def touch_file(path: FilePath, create_parents: bool = True) -> None:
     """
     Create an empty file, creating parent directories if needed.
 
@@ -125,38 +87,27 @@ def touch_file(path: FilePath, create_parents: bool = True) -> bool:
         path: Path to the file to create
         create_parents: Whether to create parent directories
 
-    Returns:
-        True if successful, False otherwise
-
     Raises:
         PathSecurityError: If path fails security validation
+        OSError: If the file cannot be created
 
     Example:
         >>> touch_file("logs/app.log")
         >>> touch_file(Path("data/output.txt"))
     """
     try:
-        # Validate path
-        try:
-            from siege_utilities.files.validation import validate_safe_path, PathSecurityError
-            path_obj = validate_safe_path(path, allow_absolute=True)
-        except ImportError:
-            path_obj = Path(path)
+        from siege_utilities.files.validation import validate_safe_path, PathSecurityError
+        path_obj = validate_safe_path(path, allow_absolute=True)
+    except ImportError:
+        path_obj = Path(path)
 
-        if create_parents:
-            path_obj.parent.mkdir(parents=True, exist_ok=True)
+    if create_parents:
+        path_obj.parent.mkdir(parents=True, exist_ok=True)
 
-        path_obj.touch(exist_ok=True)
-        log.info(f"Created/updated file: {path_obj}")
-        return True
+    path_obj.touch(exist_ok=True)
+    log.info(f"Created/updated file: {path_obj}")
 
-    except PathSecurityError:
-        raise
-    except OSError as e:
-        log.error(f"Failed to create file {path}: {e}")
-        return False
-
-def count_lines(file_path: FilePath, encoding: str = 'utf-8') -> Optional[int]:
+def count_lines(file_path: FilePath, encoding: str = 'utf-8') -> int:
     """
     Count the total number of lines in a text file.
 
@@ -168,61 +119,37 @@ def count_lines(file_path: FilePath, encoding: str = 'utf-8') -> Optional[int]:
         encoding: File encoding to use
 
     Returns:
-        Number of lines, or None if failed
+        Number of lines in the file
 
     Raises:
-        PathSecurityError: If path fails security validation (from validation module)
+        PathSecurityError: If path fails security validation
+        FileNotFoundError: If the file does not exist
+        OSError: If the file cannot be read
+        UnicodeDecodeError: If the file cannot be decoded
 
     Example:
         >>> line_count = count_lines("data.csv")
         >>> print(f"File has {line_count} lines")
-        >>>
-        >>> # This will raise PathSecurityError
-        >>> count_lines("../../../etc/passwd")  # Path traversal blocked
-
-    Security Changes:
-        - Now validates paths to block path traversal
-        - Blocks access to sensitive system files
-        - Resolves symlinks and validates final destination
     """
     try:
-        # Import validation function
-        try:
-            from siege_utilities.files.validation import validate_file_path, PathSecurityError
-        except ImportError:
-            # Fallback: use basic Path validation without security checks
-            log.warning("Path validation module not available - using basic validation")
-            path_obj = Path(file_path)
-        else:
-            # Validate path with security checks
-            try:
-                path_obj = validate_file_path(file_path, must_exist=True)
-            except PathSecurityError as e:
-                log.error(f"Path security validation failed: {e}")
-                raise  # Re-raise to caller
+        from siege_utilities.files.validation import validate_file_path, PathSecurityError
+        path_obj = validate_file_path(file_path, must_exist=True)
+    except ImportError:
+        path_obj = Path(file_path)
 
-        if not path_obj.exists():
-            log.warning(f"File does not exist: {path_obj}")
-            return None
+    if not path_obj.exists():
+        raise FileNotFoundError(f"File does not exist: {path_obj}")
 
-        if not path_obj.is_file():
-            log.warning(f"Path is not a file: {path_obj}")
-            return None
+    if not path_obj.is_file():
+        raise OSError(f"Path is not a file: {path_obj}")
 
-        with open(path_obj, 'r', encoding=encoding) as f:
-            line_count = sum(1 for _ in f)
+    with open(path_obj, 'r', encoding=encoding) as f:
+        line_count = sum(1 for _ in f)
 
-        log.info(f"Counted {line_count} lines in {path_obj}")
-        return line_count
+    log.info(f"Counted {line_count} lines in {path_obj}")
+    return line_count
 
-    except PathSecurityError:
-        # Re-raise security errors
-        raise
-    except (OSError, UnicodeDecodeError) as e:
-        log.error(f"Failed to count lines in {file_path}: {e}")
-        return None
-
-def copy_file(source: FilePath, destination: FilePath, overwrite: bool = False) -> bool:
+def copy_file(source: FilePath, destination: FilePath, overwrite: bool = False) -> None:
     """
     Copy a file from source to destination.
 
@@ -233,53 +160,39 @@ def copy_file(source: FilePath, destination: FilePath, overwrite: bool = False) 
         destination: Destination file path
         overwrite: Whether to overwrite existing files
 
-    Returns:
-        True if successful, False otherwise
-
     Raises:
         PathSecurityError: If paths fail security validation
+        FileNotFoundError: If source does not exist
+        FileExistsError: If destination exists and overwrite=False
+        OSError: If the copy operation fails
 
     Example:
         >>> copy_file("source.txt", "backup/source.txt")
         >>> copy_file(Path("config.yaml"), Path("config.yaml.bak"))
     """
     try:
-        # Validate paths
-        try:
-            from siege_utilities.files.validation import validate_file_path, validate_safe_path, PathSecurityError
-            source_obj = validate_file_path(source, must_exist=True)
-            dest_obj = validate_safe_path(destination, allow_absolute=True)
-        except ImportError:
-            source_obj = Path(source)
-            dest_obj = Path(destination)
+        from siege_utilities.files.validation import validate_file_path, validate_safe_path, PathSecurityError
+        source_obj = validate_file_path(source, must_exist=True)
+        dest_obj = validate_safe_path(destination, allow_absolute=True)
+    except ImportError:
+        source_obj = Path(source)
+        dest_obj = Path(destination)
 
-        if not source_obj.exists():
-            log.error(f"Source file does not exist: {source_obj}")
-            return False
+    if not source_obj.exists():
+        raise FileNotFoundError(f"Source file does not exist: {source_obj}")
 
-        if not source_obj.is_file():
-            log.error(f"Source is not a file: {source_obj}")
-            return False
+    if not source_obj.is_file():
+        raise OSError(f"Source is not a file: {source_obj}")
 
-        # Create destination directory if needed
-        dest_obj.parent.mkdir(parents=True, exist_ok=True)
+    dest_obj.parent.mkdir(parents=True, exist_ok=True)
 
-        # Check if destination exists
-        if dest_obj.exists() and not overwrite:
-            log.warning(f"Destination file exists and overwrite=False: {dest_obj}")
-            return False
+    if dest_obj.exists() and not overwrite:
+        raise FileExistsError(f"Destination file exists and overwrite=False: {dest_obj}")
 
-        shutil.copy2(source_obj, dest_obj)
-        log.info(f"Copied {source_obj} to {dest_obj}")
-        return True
+    shutil.copy2(source_obj, dest_obj)
+    log.info(f"Copied {source_obj} to {dest_obj}")
 
-    except PathSecurityError:
-        raise
-    except OSError as e:
-        log.error(f"Failed to copy {source} to {destination}: {e}")
-        return False
-
-def move_file(source: FilePath, destination: FilePath, overwrite: bool = False) -> bool:
+def move_file(source: FilePath, destination: FilePath, overwrite: bool = False) -> None:
     """
     Move a file from source to destination.
 
@@ -290,53 +203,39 @@ def move_file(source: FilePath, destination: FilePath, overwrite: bool = False) 
         destination: Destination file path
         overwrite: Whether to overwrite existing files
 
-    Returns:
-        True if successful, False otherwise
-
     Raises:
         PathSecurityError: If paths fail security validation
+        FileNotFoundError: If source does not exist
+        FileExistsError: If destination exists and overwrite=False
+        OSError: If the move operation fails
 
     Example:
         >>> move_file("temp.txt", "archive/temp.txt")
         >>> move_file(Path("old.log"), Path("logs/old.log"))
     """
     try:
-        # Validate paths
-        try:
-            from siege_utilities.files.validation import validate_file_path, validate_safe_path, PathSecurityError
-            source_obj = validate_file_path(source, must_exist=True)
-            dest_obj = validate_safe_path(destination, allow_absolute=True)
-        except ImportError:
-            source_obj = Path(source)
-            dest_obj = Path(destination)
+        from siege_utilities.files.validation import validate_file_path, validate_safe_path, PathSecurityError
+        source_obj = validate_file_path(source, must_exist=True)
+        dest_obj = validate_safe_path(destination, allow_absolute=True)
+    except ImportError:
+        source_obj = Path(source)
+        dest_obj = Path(destination)
 
-        if not source_obj.exists():
-            log.error(f"Source file does not exist: {source_obj}")
-            return False
+    if not source_obj.exists():
+        raise FileNotFoundError(f"Source file does not exist: {source_obj}")
 
-        if not source_obj.is_file():
-            log.error(f"Source is not a file: {source_obj}")
-            return False
+    if not source_obj.is_file():
+        raise OSError(f"Source is not a file: {source_obj}")
 
-        # Create destination directory if needed
-        dest_obj.parent.mkdir(parents=True, exist_ok=True)
+    dest_obj.parent.mkdir(parents=True, exist_ok=True)
 
-        # Check if destination exists
-        if dest_obj.exists() and not overwrite:
-            log.warning(f"Destination file exists and overwrite=False: {dest_obj}")
-            return False
+    if dest_obj.exists() and not overwrite:
+        raise FileExistsError(f"Destination file exists and overwrite=False: {dest_obj}")
 
-        shutil.move(str(source_obj), str(dest_obj))
-        log.info(f"Moved {source_obj} to {dest_obj}")
-        return True
+    shutil.move(str(source_obj), str(dest_obj))
+    log.info(f"Moved {source_obj} to {dest_obj}")
 
-    except PathSecurityError:
-        raise
-    except OSError as e:
-        log.error(f"Failed to move {source} to {destination}: {e}")
-        return False
-
-def get_file_size(file_path: FilePath) -> Optional[int]:
+def get_file_size(file_path: FilePath) -> int:
     """
     Get the size of a file in bytes.
 
@@ -347,61 +246,37 @@ def get_file_size(file_path: FilePath) -> Optional[int]:
         file_path: Path to the file
 
     Returns:
-        File size in bytes, or None if failed
+        File size in bytes
 
     Raises:
         PathSecurityError: If path fails security validation
+        FileNotFoundError: If the file does not exist
+        OSError: If the file size cannot be determined
 
     Example:
         >>> size = get_file_size("large_file.zip")
         >>> print(f"File size: {size} bytes")
-        >>>
-        >>> # This will raise PathSecurityError
-        >>> get_file_size("/etc/shadow")  # Sensitive file blocked
-
-    Security Changes:
-        - Now validates paths to block path traversal
-        - Blocks access to sensitive system files
     """
     try:
-        # Import validation function
-        try:
-            from siege_utilities.files.validation import validate_file_path, PathSecurityError
-        except ImportError:
-            # Fallback: use basic Path validation without security checks
-            log.warning("Path validation module not available - using basic validation")
-            path_obj = Path(file_path)
-        else:
-            # Validate path with security checks
-            try:
-                path_obj = validate_file_path(file_path, must_exist=True)
-            except PathSecurityError as e:
-                log.error(f"Path security validation failed: {e}")
-                raise  # Re-raise to caller
+        from siege_utilities.files.validation import validate_file_path, PathSecurityError
+        path_obj = validate_file_path(file_path, must_exist=True)
+    except ImportError:
+        path_obj = Path(file_path)
 
-        if not path_obj.exists():
-            log.warning(f"File does not exist: {path_obj}")
-            return None
+    if not path_obj.exists():
+        raise FileNotFoundError(f"File does not exist: {path_obj}")
 
-        if not path_obj.is_file():
-            log.warning(f"Path is not a file: {path_obj}")
-            return None
+    if not path_obj.is_file():
+        raise OSError(f"Path is not a file: {path_obj}")
 
-        size = path_obj.stat().st_size
-        log.debug(f"File size for {path_obj}: {size} bytes")
-        return size
-
-    except PathSecurityError:
-        # Re-raise security errors
-        raise
-    except OSError as e:
-        log.error(f"Failed to get file size for {file_path}: {e}")
-        return None
+    size = path_obj.stat().st_size
+    log.debug(f"File size for {path_obj}: {size} bytes")
+    return size
 
 def list_directory(path: FilePath,
                   pattern: str = "*",
                   include_dirs: bool = True,
-                  include_files: bool = True) -> Optional[List[Path]]:
+                  include_files: bool = True) -> List[Path]:
     """
     List contents of a directory with optional filtering.
 
@@ -414,54 +289,46 @@ def list_directory(path: FilePath,
         include_files: Whether to include files
 
     Returns:
-        List of Path objects, or None if failed
+        List of Path objects (empty list if directory is empty)
 
     Raises:
         PathSecurityError: If path fails security validation
+        FileNotFoundError: If the directory does not exist
+        OSError: If the directory cannot be read
 
     Example:
         >>> files = list_directory("data", "*.csv")
         >>> dirs = list_directory("logs", include_files=False)
     """
     try:
-        # Validate path
-        try:
-            from siege_utilities.files.validation import validate_directory_path, PathSecurityError
-            path_obj = validate_directory_path(path, must_exist=True)
-        except ImportError:
-            path_obj = Path(path)
+        from siege_utilities.files.validation import validate_directory_path, PathSecurityError
+        path_obj = validate_directory_path(path, must_exist=True)
+    except ImportError:
+        path_obj = Path(path)
 
-        if not path_obj.exists():
-            log.warning(f"Directory does not exist: {path_obj}")
-            return None
+    if not path_obj.exists():
+        raise FileNotFoundError(f"Directory does not exist: {path_obj}")
 
-        if not path_obj.is_dir():
-            log.warning(f"Path is not a directory: {path_obj}")
-            return None
+    if not path_obj.is_dir():
+        raise NotADirectoryError(f"Path is not a directory: {path_obj}")
 
-        items = []
+    items = []
 
-        for item in path_obj.glob(pattern):
-            if item.is_dir() and include_dirs:
-                items.append(item)
-            elif item.is_file() and include_files:
-                items.append(item)
+    for item in path_obj.glob(pattern):
+        if item.is_dir() and include_dirs:
+            items.append(item)
+        elif item.is_file() and include_files:
+            items.append(item)
 
-        log.debug(f"Listed {len(items)} items in {path_obj}")
-        return sorted(items)
-
-    except PathSecurityError:
-        raise
-    except OSError as e:
-        log.error(f"Failed to list directory {path}: {e}")
-        return None
+    log.debug(f"Listed {len(items)} items in {path_obj}")
+    return sorted(items)
 
 def run_command(command: Union[str, List[str]],
                 cwd: Optional[FilePath] = None,
                 timeout: Optional[int] = 30,
                 capture_output: bool = True,
                 allow_list: Optional[set] = None,
-                unsafe: bool = False) -> Optional[subprocess.CompletedProcess]:
+                unsafe: bool = False) -> subprocess.CompletedProcess:
     """
     Run a shell command with security validation and proper error handling.
 
@@ -481,12 +348,13 @@ def run_command(command: Union[str, List[str]],
             not when you need shell features.
 
     Returns:
-        CompletedProcess object on success or non-zero exit.
-        None on timeout or unexpected error (when unsafe=True).
+        CompletedProcess object (even on non-zero exit).
 
     Raises:
         SecurityError: If command fails security validation (when unsafe=False).
-        Exception: Re-raised on unexpected errors when unsafe=False.
+        subprocess.TimeoutExpired: If the command exceeds the timeout.
+        OSError: If the command cannot be executed.
+        ValueError: If the command string cannot be parsed.
 
     Example:
         >>> # Safe command (works by default)
@@ -587,13 +455,11 @@ def run_command(command: Union[str, List[str]],
         return result
 
     except subprocess.TimeoutExpired:
-        log.error(f"Command timed out: {command}")
-        return None
+        log.error(f"Command timed out after {timeout}s: {command}")
+        raise
     except (OSError, ValueError) as e:
         log.error(f"Failed to run command {command}: {e}")
-        if not unsafe:
-            raise
-        return None
+        raise
 
 # Backward compatibility aliases
 rmtree = remove_tree
@@ -615,7 +481,7 @@ def check_if_file_exists_at_path(path: FilePath) -> bool:
     return file_exists(path)
 
 
-def delete_existing_file_and_replace_it_with_an_empty_file(file_path: FilePath, create_parents: bool = True) -> bool:
+def delete_existing_file_and_replace_it_with_an_empty_file(file_path: FilePath, create_parents: bool = True) -> None:
     """Backward compatibility function that deletes existing file and replaces it with empty file.
 
     .. deprecated:: 3.19.0
@@ -630,11 +496,9 @@ def delete_existing_file_and_replace_it_with_an_empty_file(file_path: FilePath, 
         file_path: Path to the file
         create_parents: Whether to create parent directories
 
-    Returns:
-        True if successful, False otherwise
-
     Raises:
         PathSecurityError: If path fails security validation
+        OSError: If the file cannot be created
     """
     import warnings
     warnings.warn(
@@ -645,30 +509,19 @@ def delete_existing_file_and_replace_it_with_an_empty_file(file_path: FilePath, 
         stacklevel=2,
     )
     try:
-        # Validate path
-        try:
-            from siege_utilities.files.validation import validate_safe_path, PathSecurityError
-            path_obj = validate_safe_path(file_path, allow_absolute=True)
-        except ImportError:
-            path_obj = Path(file_path)
+        from siege_utilities.files.validation import validate_safe_path, PathSecurityError
+        path_obj = validate_safe_path(file_path, allow_absolute=True)
+    except ImportError:
+        path_obj = Path(file_path)
 
-        # Create parent directories if needed
-        if create_parents:
-            path_obj.parent.mkdir(parents=True, exist_ok=True)
+    if create_parents:
+        path_obj.parent.mkdir(parents=True, exist_ok=True)
 
-        # Remove existing file if it exists
-        if path_obj.exists():
-            path_obj.unlink()
+    if path_obj.exists():
+        path_obj.unlink()
 
-        # Create empty file
-        path_obj.touch()
-        log.info(f"Created/updated empty file: {path_obj}")
-        return True
-    except PathSecurityError:
-        raise
-    except OSError as e:
-        log.error(f"Failed to create empty file {file_path}: {e}")
-        return False
+    path_obj.touch()
+    log.info(f"Created/updated empty file: {path_obj}")
 
 count_total_rows_in_file_pythonically = count_lines
 
@@ -693,9 +546,9 @@ def safe_file_write(
     content: str,
     encoding: str = "utf-8",
     create_dirs: bool = True,
-) -> bool:
+) -> None:
     """
-    Safely write content to a file, optionally creating parent directories.
+    Write content to a file, optionally creating parent directories.
 
     Args:
         file_path: Path to file
@@ -703,19 +556,15 @@ def safe_file_write(
         encoding: File encoding (default: utf-8)
         create_dirs: Create parent directories if they don't exist
 
-    Returns:
-        True if successful, False otherwise
+    Raises:
+        OSError: If the file cannot be written
+        TypeError: If content is not a string
     """
-    try:
-        file_path = Path(file_path)
-        if create_dirs:
-            file_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(file_path, "w", encoding=encoding) as f:
-            f.write(content)
-        return True
-    except (OSError, TypeError) as e:
-        log.error(f"Error writing to {file_path}: {e}")
-        return False
+    file_path = Path(file_path)
+    if create_dirs:
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(file_path, "w", encoding=encoding) as f:
+        f.write(content)
 
 
 def safe_file_read(
@@ -750,9 +599,9 @@ def safe_json_write(
     data: Any,
     indent: int = 2,
     create_dirs: bool = True,
-) -> bool:
+) -> None:
     """
-    Safely write data to a JSON file.
+    Write data to a JSON file, optionally creating parent directories.
 
     Args:
         file_path: Path to JSON file
@@ -760,19 +609,16 @@ def safe_json_write(
         indent: JSON indentation (default: 2)
         create_dirs: Create parent directories if they don't exist
 
-    Returns:
-        True if successful, False otherwise
+    Raises:
+        OSError: If the file cannot be written
+        TypeError: If data is not JSON serializable
+        ValueError: If data contains values that cannot be serialized
     """
-    try:
-        file_path = Path(file_path)
-        if create_dirs:
-            file_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(file_path, "w", encoding="utf-8") as f:
-            json.dump(data, f, indent=indent, ensure_ascii=False)
-        return True
-    except (OSError, TypeError, ValueError) as e:
-        log.error(f"Error writing JSON to {file_path}: {e}")
-        return False
+    file_path = Path(file_path)
+    if create_dirs:
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(file_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=indent, ensure_ascii=False)
 
 
 def safe_json_read(

--- a/siege_utilities/files/paths.py
+++ b/siege_utilities/files/paths.py
@@ -61,7 +61,7 @@ def ensure_path_exists(desired_path: FilePath) -> Path:
 
 def unzip_file_to_directory(zip_file_path: FilePath,
                            extract_to: Optional[FilePath] = None,
-                           create_subdirectory: bool = True) -> Optional[Path]:
+                           create_subdirectory: bool = True) -> Path:
     """
     Extract a zip file to a directory.
 
@@ -73,83 +73,61 @@ def unzip_file_to_directory(zip_file_path: FilePath,
         create_subdirectory: Whether to create a subdirectory for extracted files
 
     Returns:
-        Path to the extraction directory, or None if failed
+        Path to the extraction directory
 
     Raises:
         PathSecurityError: If paths fail security validation
+        FileNotFoundError: If the zip file does not exist
+        zipfile.BadZipFile: If the file is not a valid zip archive
+        OSError: If extraction fails
 
     Example:
         >>> extract_dir = unzip_file_to_directory("data.zip")
         >>> print(f"Files extracted to: {extract_dir}")
     """
     try:
-        # Validate paths
-        try:
-            from siege_utilities.files.validation import validate_file_path, validate_directory_path, PathSecurityError  # noqa: F401, F811
-            zip_path = validate_file_path(zip_file_path, must_exist=True)
-        except ImportError:
-            zip_path = Path(zip_file_path)
+        from siege_utilities.files.validation import validate_file_path, validate_directory_path, PathSecurityError  # noqa: F401, F811
+        zip_path = validate_file_path(zip_file_path, must_exist=True)
+    except ImportError:
+        zip_path = Path(zip_file_path)
 
-        if not zip_path.exists():
-            log.error(f"Zip file does not exist: {zip_path}")
-            return None
+    if not zip_path.exists():
+        raise FileNotFoundError(f"Zip file does not exist: {zip_path}")
 
-        if not zip_path.is_file():
-            log.error(f"Path is not a file: {zip_path}")
-            return None
+    if not zip_path.is_file():
+        raise OSError(f"Path is not a file: {zip_path}")
 
-        # Determine extraction directory
-        if extract_to is None:
-            extract_to = zip_path.parent
+    if extract_to is None:
+        extract_to = zip_path.parent
 
-        try:
-            from siege_utilities.files.validation import validate_directory_path, PathSecurityError  # noqa: F401, F811
-            extract_dir = validate_directory_path(extract_to, must_exist=False)
-        except ImportError:
-            extract_dir = Path(extract_to)
+    try:
+        from siege_utilities.files.validation import validate_directory_path, PathSecurityError  # noqa: F401, F811
+        extract_dir = validate_directory_path(extract_to, must_exist=False)
+    except ImportError:
+        extract_dir = Path(extract_to)
 
-        if create_subdirectory:
-            # Create subdirectory based on zip file name
-            subdir_name = zip_path.stem
-            target_dir = extract_dir / subdir_name
-        else:
-            target_dir = extract_dir
+    if create_subdirectory:
+        subdir_name = zip_path.stem
+        target_dir = extract_dir / subdir_name
+    else:
+        target_dir = extract_dir
 
-        # Create target directory
-        target_dir.mkdir(parents=True, exist_ok=True)
+    target_dir.mkdir(parents=True, exist_ok=True)
 
-        # Extract files (with zip slip protection). Validate AND extract
-        # per-member — extractall() would ignore the validation loop
-        # below and re-process every entry without the guard.
-        with zipfile.ZipFile(zip_path, 'r') as zip_ref:
-            target_resolved = target_dir.resolve()
-            for member in zip_ref.namelist():
-                # Reject absolute paths and any traversal that escapes
-                # target_dir. Path.resolve() collapses '..' segments;
-                # if the result isn't a child of target_dir, it's
-                # malicious.
-                try:
-                    (target_dir / member).resolve().relative_to(target_resolved)
-                except ValueError:
-                    # Detected-and-skipped → recoverable anomaly, not a
-                    # user-visible failure. Use warning + lazy format.
-                    log.warning(
-                        "Zip slip attempt detected, skipping member: %r", member,
-                    )
-                    continue
-                zip_ref.extract(member, target_dir)
+    with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+        target_resolved = target_dir.resolve()
+        for member in zip_ref.namelist():
+            try:
+                (target_dir / member).resolve().relative_to(target_resolved)
+            except ValueError:
+                log.warning(
+                    "Zip slip attempt detected, skipping member: %r", member,
+                )
+                continue
+            zip_ref.extract(member, target_dir)
 
-        log.info(f"Extracted {zip_path} to {target_dir}")
-        return target_dir
-
-    except zipfile.BadZipFile:
-        log.error(f"Invalid zip file: {zip_file_path}")
-        return None
-    except PathSecurityError:
-        raise
-    except OSError as e:
-        log.error(f"Failed to extract {zip_file_path}: {e}")
-        return None
+    log.info(f"Extracted {zip_path} to {target_dir}")
+    return target_dir
 
 def get_file_extension(file_path: FilePath) -> str:
     """
@@ -262,7 +240,7 @@ def is_hidden_file(file_path: FilePath) -> bool:
         log.error(f"Failed to check if hidden: {file_path}: {e}")
         raise
 
-def get_relative_path(base_path: FilePath, target_path: FilePath) -> Optional[Path]:
+def get_relative_path(base_path: FilePath, target_path: FilePath) -> Path:
     """
     Get the relative path from base_path to target_path.
 
@@ -273,39 +251,25 @@ def get_relative_path(base_path: FilePath, target_path: FilePath) -> Optional[Pa
         target_path: Target file/directory path
 
     Returns:
-        Relative path from base to target, or None if failed
+        Relative path from base to target
 
     Raises:
         PathSecurityError: If paths fail security validation
+        ValueError: If target is not relative to base
 
     Example:
         >>> rel_path = get_relative_path("/home/user", "/home/user/documents/file.txt")
         >>> print(f"Relative path: {rel_path}")  # documents/file.txt
-        >>>
-        >>> # This will raise PathSecurityError
-        >>> get_relative_path("/etc", "/etc/passwd")  # Sensitive path blocked
     """
     try:
-        # Validate paths
-        try:
-            from siege_utilities.files.validation import validate_safe_path, PathSecurityError  # noqa: F401, F811
-            base = validate_safe_path(base_path, allow_absolute=True)
-            target = validate_safe_path(target_path, allow_absolute=True)
-        except ImportError:
-            base = Path(base_path).resolve()
-            target = Path(target_path).resolve()
+        from siege_utilities.files.validation import validate_safe_path, PathSecurityError  # noqa: F401, F811
+        base = validate_safe_path(base_path, allow_absolute=True)
+        target = validate_safe_path(target_path, allow_absolute=True)
+    except ImportError:
+        base = Path(base_path).resolve()
+        target = Path(target_path).resolve()
 
-        try:
-            relative = target.relative_to(base)
-            return relative
-        except ValueError:
-            log.warning(f"Target {target} is not relative to base {base}")
-            return None
-    except PathSecurityError:
-        raise
-    except (OSError, TypeError) as e:
-        log.error(f"Failed to get relative path: {e}")
-        return None
+    return target.relative_to(base)
 
 def find_files_by_pattern(directory: FilePath,
                          pattern: str = "*",
@@ -335,31 +299,26 @@ def find_files_by_pattern(directory: FilePath,
         >>> find_files_by_pattern("../../../etc", "*")  # Path traversal blocked
     """
     try:
-        # Validate directory path
-        try:
-            from siege_utilities.files.validation import validate_directory_path, PathSecurityError  # noqa: F401, F811
-            dir_path = validate_directory_path(directory, must_exist=True)
-        except ImportError:
-            dir_path = Path(directory)
+        from siege_utilities.files.validation import validate_directory_path, PathSecurityError  # noqa: F401, F811
+        dir_path = validate_directory_path(directory, must_exist=True)
+    except ImportError:
+        dir_path = Path(directory)
 
-        if not dir_path.exists() or not dir_path.is_dir():
-            log.warning(f"Directory does not exist or is not a directory: {dir_path}")
-            return []
+    if not dir_path.exists():
+        raise FileNotFoundError(f"Directory does not exist: {dir_path}")
 
-        if recursive:
-            files = list(dir_path.rglob(pattern))
-        else:
-            files = list(dir_path.glob(pattern))
+    if not dir_path.is_dir():
+        raise NotADirectoryError(f"Path is not a directory: {dir_path}")
 
-        # Filter to only files (not directories)
-        files = [f for f in files if f.is_file()]
+    if recursive:
+        files = list(dir_path.rglob(pattern))
+    else:
+        files = list(dir_path.glob(pattern))
 
-        log.debug(f"Found {len(files)} files matching '{pattern}' in {dir_path}")
-        return sorted(files)
-    except PathSecurityError:
-        raise
-    except OSError as e:
-        raise OSError(f"Failed to find files in {directory}: {e}") from e
+    files = [f for f in files if f.is_file()]
+
+    log.debug(f"Found {len(files)} files matching '{pattern}' in {dir_path}")
+    return sorted(files)
 
 def create_backup_path(original_path: FilePath,
                       backup_suffix: str = ".backup",

--- a/siege_utilities/files/remote.py
+++ b/siege_utilities/files/remote.py
@@ -7,7 +7,7 @@ import logging
 import os
 import platform
 from pathlib import Path
-from typing import Union, Optional
+from typing import Union
 
 try:
     import requests
@@ -92,7 +92,7 @@ def _get_progress_bar(*args, **kwargs):
 def download_file(url: str, local_filename: FilePath,
                  chunk_size: int = 8192,
                  timeout: int = 30,
-                 verify_ssl: bool = True) -> Union[str, bool]:
+                 verify_ssl: bool = True) -> str:
     """
     Download a file from a URL to a local file with progress bar.
 
@@ -106,22 +106,13 @@ def download_file(url: str, local_filename: FilePath,
         verify_ssl: Whether to verify SSL certificates
 
     Returns:
-        The local filename if successful, False otherwise
+        The local filename as a string
 
     Raises:
         PathSecurityError: If local path fails security validation
-
-    Example:
-        >>> result = download_file("https://example.com/file.zip", "downloads/file.zip")
-        >>> if result:
-        ...     print(f"Downloaded to {result}")
-        >>>
-        >>> # This will raise PathSecurityError
-        >>> download_file("https://example.com/file.zip", "../../../etc/passwd")  # Path traversal blocked
-
-    Security Changes:
-        - Now validates local file paths to block path traversal
-        - Blocks writing to sensitive system locations
+        requests.exceptions.HTTPError: If the server returns an error status
+        requests.exceptions.RequestException: If the download fails
+        OSError: If the file cannot be written
     """
     _check_requests_dependency()
 
@@ -144,9 +135,7 @@ def download_file(url: str, local_filename: FilePath,
                          timeout=timeout, verify=ssl_verify,
                          headers=headers) as response:
             
-            if not response.ok:
-                log.error(f'Download failed: HTTP {response.status_code} - {response.reason}')
-                return False
+            response.raise_for_status()
             
             # Get total size for progress bar
             total_size = _safe_content_length(response)
@@ -184,9 +173,7 @@ def download_file(url: str, local_filename: FilePath,
                            timeout=timeout, verify=False,
                            headers=headers) as response:
                 
-                if not response.ok:
-                    log.error(f'Download failed without SSL: HTTP {response.status_code} - {response.reason}')
-                    return False
+                response.raise_for_status()
                 
                 # Get total size for progress bar
                 total_size = _safe_content_length(response)
@@ -214,22 +201,18 @@ def download_file(url: str, local_filename: FilePath,
                 log.info(f'Successfully downloaded {url} to {local_path} without SSL verification')
                 return str(local_path)
                 
-        except (OSError, ValueError) as retry_error:
-            log.error(f'Download failed even without SSL verification: {retry_error}')
-            return False
+        except (OSError, ValueError, requests.exceptions.RequestException):
+            raise
 
     except requests.exceptions.Timeout:
         log.error(f'Download timed out for {url}')
-        return False
+        raise
     except requests.exceptions.RequestException as e:
         log.error(f'Request error downloading {url}: {e}')
-        return False
-    except (OSError, ValueError) as e:
-        log.error(f'Unexpected error downloading {url}: {e}')
-        return False
+        raise
 
 def generate_local_path_from_url(url: str, directory_path: FilePath,
-                                as_string: bool = True) -> Union[Path, str, bool]:
+                                as_string: bool = True) -> Union[Path, str]:
     """
     Generate a local file path from a URL.
 
@@ -241,148 +224,129 @@ def generate_local_path_from_url(url: str, directory_path: FilePath,
         as_string: Whether to return the result as a string
 
     Returns:
-        Path object, string, or False if failed
+        Path object or string path
 
     Raises:
         PathSecurityError: If directory path fails security validation
+        ValueError: If no filename can be extracted from the URL
+        OSError: If the directory cannot be created
 
     Example:
         >>> path = generate_local_path_from_url("https://example.com/file.zip", "downloads")
         >>> print(f"Local path: {path}")
-        >>>
-        >>> # This will raise PathSecurityError
-        >>> generate_local_path_from_url("https://example.com/file.zip", "../../../etc")  # Path traversal blocked
-
-    Security Changes:
-        - Now validates directory paths to block path traversal
-        - Blocks writing to sensitive system locations
     """
+    parsed_url = urlparse(url)
+    remote_filename = parsed_url.path.split('/')[-1]
+
+    if not remote_filename:
+        raise ValueError(f'Could not extract filename from URL: {url}')
+
     try:
-        # Parse URL to get filename
-        parsed_url = urlparse(url)
-        remote_filename = parsed_url.path.split('/')[-1]
+        from siege_utilities.files.validation import validate_directory_path, PathSecurityError
+        dir_path = validate_directory_path(directory_path, must_exist=False)
+    except ImportError:
+        dir_path = Path(directory_path)
 
-        if not remote_filename:
-            log.warning(f'Could not extract filename from URL: {url}')
-            return False
+    dir_path.mkdir(parents=True, exist_ok=True)
 
-        # Validate directory path
-        try:
-            from siege_utilities.files.validation import validate_directory_path, PathSecurityError
-            dir_path = validate_directory_path(directory_path, must_exist=False)
-        except ImportError:
-            dir_path = Path(directory_path)
+    local_path = dir_path / remote_filename
+    log.info(f'Generated local path: {local_path}')
 
-        dir_path.mkdir(parents=True, exist_ok=True)
-        
-        # Create full local path
-        local_path = dir_path / remote_filename
-        
-        log.info(f'Generated local path: {local_path}')
-        
-        if as_string:
-            return str(local_path)
-        else:
-            return local_path
-    except PathSecurityError:
-        raise
-    except (OSError, ValueError) as e:
-        log.error(f'Error generating local path from {url}: {e}')
-        return False
+    if as_string:
+        return str(local_path)
+    else:
+        return local_path
 
 def download_file_with_retry(url: str, local_filename: FilePath,
                             max_retries: int = 3,
                             retry_delay: int = 5,
-                            **kwargs) -> Union[str, bool]:
+                            **kwargs) -> str:
     """
     Download a file with automatic retry on failure.
-    
+
     Args:
         url: The URL to download from
         local_filename: The local path where the file should be saved
         max_retries: Maximum number of retry attempts
         retry_delay: Delay between retries in seconds
         **kwargs: Additional arguments passed to download_file
-        
+
     Returns:
-        The local filename if successful, False otherwise
-        
+        The local filename as a string
+
+    Raises:
+        requests.exceptions.RequestException: If all retry attempts fail
+        OSError: If the file cannot be written after all retries
+
     Example:
         >>> result = download_file_with_retry("https://example.com/file.zip", "file.zip")
-        >>> if result:
-        ...     print("Download succeeded after retries")
+        >>> print(f"Downloaded to {result}")
     """
     import time
-    
+
+    last_error = None
     for attempt in range(max_retries + 1):
         try:
             if attempt > 0:
                 log.info(f'Retry attempt {attempt}/{max_retries} for {url}')
                 time.sleep(retry_delay)
-            
-            result = download_file(url, local_filename, **kwargs)
-            if result:
-                return result
-                
-        except (OSError, ValueError) as e:
-            log.warning(f'Download attempt {attempt + 1} failed: {e}')
-    
-    log.error(f'Download failed after {max_retries + 1} attempts for {url}')
-    return False
 
-def get_file_info(url: str, timeout: int = 10) -> Optional[dict]:
+            return download_file(url, local_filename, **kwargs)
+
+        except (OSError, requests.exceptions.RequestException) as e:
+            last_error = e
+            log.warning(f'Download attempt {attempt + 1} failed: {e}')
+
+    raise last_error  # type: ignore[misc]
+
+def get_file_info(url: str, timeout: int = 10) -> dict:
     """
     Get information about a remote file without downloading it.
-    
+
     Args:
         url: URL to get information about
         timeout: Request timeout in seconds
-        
+
     Returns:
-        Dictionary with file information, or None if failed
-        
+        Dictionary with file information (url, size, content_type, last_modified, etag)
+
+    Raises:
+        requests.exceptions.HTTPError: If the server returns an error status
+        requests.exceptions.RequestException: If the request fails
+
     Example:
         >>> info = get_file_info("https://example.com/file.zip")
-        >>> if info:
-        ...     print(f"File size: {info['size']} bytes")
+        >>> print(f"File size: {info['size']} bytes")
     """
-    try:
-        log.debug(f'Getting file info for {url}')
-        
-        response = requests.head(url, timeout=timeout, allow_redirects=True)
-        
-        if not response.ok:
-            log.warning(f'Failed to get file info: HTTP {response.status_code}')
-            return None
-        
-        info = {
-            'url': url,
-            'size': _safe_content_length(response),
-            'content_type': response.headers.get('content-type', 'unknown'),
-            'last_modified': response.headers.get('last-modified'),
-            'etag': response.headers.get('etag')
-        }
-        
-        log.debug(f'File info for {url}: {info}')
-        return info
-        
-    except (OSError, ValueError) as e:
-        log.error(f'Error getting file info for {url}: {e}')
-        return None
+    log.debug(f'Getting file info for {url}')
+
+    response = requests.head(url, timeout=timeout, allow_redirects=True)
+    response.raise_for_status()
+
+    info = {
+        'url': url,
+        'size': _safe_content_length(response),
+        'content_type': response.headers.get('content-type', 'unknown'),
+        'last_modified': response.headers.get('last-modified'),
+        'etag': response.headers.get('etag')
+    }
+
+    log.debug(f'File info for {url}: {info}')
+    return info
 
 def is_downloadable(url: str, timeout: int = 10) -> bool:
     """
     Check if a URL points to a downloadable file.
-    
+
     Args:
         url: URL to check
         timeout: Request timeout in seconds
-        
+
     Returns:
-        True if the URL points to a downloadable file
+        True if the URL points to a downloadable file, False otherwise
 
     Raises:
-        Exception: If the network request fails (logged before re-raise)
+        requests.exceptions.RequestException: If both HEAD and GET fail
 
     Example:
         >>> if is_downloadable("https://example.com/file.zip"):
@@ -390,16 +354,13 @@ def is_downloadable(url: str, timeout: int = 10) -> bool:
     """
     try:
         info = get_file_info(url, timeout)
-        if info and info['size'] > 0:
+        if info['size'] > 0:
             return True
+    except requests.exceptions.RequestException:
+        pass
 
-        # Try a GET request to see if we can access the content
-        response = requests.get(url, stream=True, timeout=timeout)
-        return response.ok
-        
-    except (OSError, ValueError) as exc:
-        log.warning("Could not check if URL is downloadable %s: %s", url, exc)
-        raise
+    response = requests.get(url, stream=True, timeout=timeout)
+    return response.ok
 
 __all__ = [
     'download_file',

--- a/tests/test_file_operations.py
+++ b/tests/test_file_operations.py
@@ -1,5 +1,7 @@
 """Tests for siege_utilities.files.operations — file manipulation utilities."""
 
+import pytest
+
 from siege_utilities.files.operations import (
     remove_tree,
     file_exists,
@@ -24,18 +26,18 @@ class TestRemoveTree:
     def test_remove_file(self, tmp_path):
         f = tmp_path / "test.txt"
         f.write_text("hello")
-        assert remove_tree(str(f)) is True
+        remove_tree(str(f))
         assert not f.exists()
 
     def test_remove_directory(self, tmp_path):
         d = tmp_path / "subdir"
         d.mkdir()
         (d / "file.txt").write_text("data")
-        assert remove_tree(str(d)) is True
+        remove_tree(str(d))
         assert not d.exists()
 
     def test_nonexistent(self, tmp_path):
-        assert remove_tree(str(tmp_path / "nope")) is False
+        remove_tree(str(tmp_path / "nope"))
 
 
 class TestFileExists:
@@ -51,18 +53,18 @@ class TestFileExists:
 class TestTouchFile:
     def test_create(self, tmp_path):
         f = tmp_path / "new.txt"
-        assert touch_file(str(f)) is True
+        touch_file(str(f))
         assert f.exists()
 
     def test_create_with_parents(self, tmp_path):
         f = tmp_path / "a" / "b" / "c.txt"
-        assert touch_file(str(f)) is True
+        touch_file(str(f))
         assert f.exists()
 
     def test_existing_file(self, tmp_path):
         f = tmp_path / "existing.txt"
         f.write_text("data")
-        assert touch_file(str(f)) is True
+        touch_file(str(f))
 
 
 class TestCountLines:
@@ -77,8 +79,8 @@ class TestCountLines:
         assert count_lines(str(f)) == 0
 
     def test_nonexistent(self, tmp_path):
-        result = count_lines(str(tmp_path / "nope.txt"))
-        assert result == 0 or result is None
+        with pytest.raises(FileNotFoundError):
+            count_lines(str(tmp_path / "nope.txt"))
 
 
 class TestCopyFile:
@@ -86,8 +88,20 @@ class TestCopyFile:
         src = tmp_path / "src.txt"
         src.write_text("content")
         dst = tmp_path / "dst.txt"
-        assert copy_file(str(src), str(dst)) is True
+        copy_file(str(src), str(dst))
         assert dst.read_text() == "content"
+
+    def test_copy_no_overwrite(self, tmp_path):
+        src = tmp_path / "src.txt"
+        src.write_text("content")
+        dst = tmp_path / "dst.txt"
+        dst.write_text("existing")
+        with pytest.raises(FileExistsError):
+            copy_file(str(src), str(dst))
+
+    def test_copy_nonexistent_source(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            copy_file(str(tmp_path / "nope.txt"), str(tmp_path / "dst.txt"))
 
 
 class TestMoveFile:
@@ -95,9 +109,17 @@ class TestMoveFile:
         src = tmp_path / "src.txt"
         src.write_text("content")
         dst = tmp_path / "dst.txt"
-        assert move_file(str(src), str(dst)) is True
+        move_file(str(src), str(dst))
         assert not src.exists()
         assert dst.read_text() == "content"
+
+    def test_move_no_overwrite(self, tmp_path):
+        src = tmp_path / "src.txt"
+        src.write_text("content")
+        dst = tmp_path / "dst.txt"
+        dst.write_text("existing")
+        with pytest.raises(FileExistsError):
+            move_file(str(src), str(dst))
 
 
 class TestGetFileSize:
@@ -107,6 +129,10 @@ class TestGetFileSize:
         size = get_file_size(str(f))
         assert size == 5
 
+    def test_nonexistent(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            get_file_size(str(tmp_path / "nope.txt"))
+
 
 class TestListDirectory:
     def test_list(self, tmp_path):
@@ -114,6 +140,10 @@ class TestListDirectory:
         (tmp_path / "b.txt").write_text("b")
         result = list_directory(str(tmp_path))
         assert len(result) >= 2
+
+    def test_nonexistent(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            list_directory(str(tmp_path / "nope"))
 
 
 class TestEnsureDirectoryExists:
@@ -149,6 +179,11 @@ class TestSafeJsonWriteRead:
     def test_read_nonexistent(self, tmp_path):
         result = safe_json_read(str(tmp_path / "nope.json"))
         assert result is None or result == {}
+
+    def test_write_unserializable(self, tmp_path):
+        f = tmp_path / "bad.json"
+        with pytest.raises(TypeError):
+            safe_json_write(str(f), {"fn": lambda: None})
 
 
 class TestGetFileSizeMb:

--- a/tests/test_files_paths.py
+++ b/tests/test_files_paths.py
@@ -87,12 +87,13 @@ class TestGetRelativePath:
         result = get_relative_path(base, target)
         assert result == Path("sub/file.txt")
 
-    def test_target_outside_base_returns_none(self, tmp_path):
+    def test_target_outside_base_raises(self, tmp_path):
         base = tmp_path / "a"
         base.mkdir()
         other = tmp_path / "b"
         other.mkdir()
-        assert get_relative_path(base, other) is None
+        with pytest.raises(ValueError):
+            get_relative_path(base, other)
 
 
 class TestFindFilesByPattern:
@@ -114,11 +115,9 @@ class TestFindFilesByPattern:
         result = find_files_by_pattern(tmp_path, "*.csv", recursive=True)
         assert len(result) == 2
 
-    def test_missing_directory_returns_empty(self, tmp_path):
-        # validation.validate_directory_path may raise on must_exist; fall
-        # back behavior returns []
-        result = find_files_by_pattern(tmp_path / "nope", "*", recursive=False)
-        assert result == []
+    def test_missing_directory_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            find_files_by_pattern(tmp_path / "nope", "*", recursive=False)
 
     def test_result_is_sorted(self, tmp_path):
         for name in ["c.txt", "a.txt", "b.txt"]:
@@ -170,15 +169,15 @@ class TestUnzipFileToDirectory:
         assert (result / "inner" / "hello.txt").read_text() == "hi"
         assert (result / "outer.txt").read_text() == "outside"
 
-    def test_missing_archive_returns_none(self, tmp_path):
-        result = unzip_file_to_directory(tmp_path / "nope.zip")
-        assert result is None
+    def test_missing_archive_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            unzip_file_to_directory(tmp_path / "nope.zip")
 
-    def test_bad_zip_returns_none(self, tmp_path):
+    def test_bad_zip_raises(self, tmp_path):
         fake = tmp_path / "bad.zip"
         fake.write_text("not a real zip")
-        result = unzip_file_to_directory(fake)
-        assert result is None
+        with pytest.raises(zipfile.BadZipFile):
+            unzip_file_to_directory(fake)
 
     def test_zip_slip_member_skipped(self, tmp_path):
         """Zip-slip member with traversal must NOT escape target_dir."""


### PR DESCRIPTION
The entire `files/` package silently swallowed `OSError` and returned `False`/`None`, making it impossible for callers to distinguish "operation failed" from "no data."

**Changes across `operations.py`, `paths.py`, `remote.py`:**
- `remove_tree`, `touch_file`, `copy_file`, `move_file` → return None, raise OSError
- `count_lines`, `get_file_size` → return int, raise FileNotFoundError
- `list_directory`, `find_files_by_pattern` → return List[Path], raise FileNotFoundError/NotADirectoryError
- `safe_file_write`, `safe_json_write` → return None, raise on write/serialization error
- `run_command` → raise TimeoutExpired instead of returning None
- `download_file`, `download_file_with_retry` → return str, raise RequestException
- `generate_local_path_from_url` → return str/Path, raise ValueError
- `get_file_info` → return dict, raise HTTPError
- `unzip_file_to_directory` → return Path, raise FileNotFoundError/BadZipFile
- `get_relative_path` → return Path, raise ValueError

Tests updated to assert `pytest.raises(...)` instead of checking None/False return values.

Net: **-200 lines** (eliminated redundant try/except/log/return boilerplate).