### PR TITLE
fix(geo,config): raise on error in spatial converters and config save/load (SU-1)

### DIFF
--- a/siege_utilities/config/enhanced_config.py
+++ b/siege_utilities/config/enhanced_config.py
@@ -450,7 +450,7 @@ def _convert_to_yaml_safe(obj: Any) -> Any:
         return obj
 
 
-def save_user_profile(profile: UserProfile, username: str, config_dir: Optional[Path] = None) -> bool:
+def save_user_profile(profile: UserProfile, username: str, config_dir: Optional[Path] = None) -> None:
     """
     Save user profile to YAML file (legacy compatibility).
 
@@ -462,32 +462,26 @@ def save_user_profile(profile: UserProfile, username: str, config_dir: Optional[
         username: Username to save as
         config_dir: Configuration directory
 
-    Returns:
-        True if successful, False otherwise
+    Raises:
+        OSError: If the file cannot be written
+        yaml.YAMLError: If the profile cannot be serialized
     """
     warnings.warn(
         "save_user_profile() is deprecated and will be removed in v4.0.0. Use HydraConfigManager.save_user() for the modern User model.",
         DeprecationWarning,
         stacklevel=2,
     )
-    try:
-        config_dir = config_dir or Path.home() / ".siege_utilities" / "profiles" / "users"
-        config_dir.mkdir(parents=True, exist_ok=True)
-        config_file = config_dir / f"{username}.yaml"
+    config_dir = config_dir or Path.home() / ".siege_utilities" / "profiles" / "users"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_file = config_dir / f"{username}.yaml"
 
-        # Convert to dict and make YAML-safe
-        profile_data = profile.model_dump()
-        profile_data = _convert_to_yaml_safe(profile_data)
+    profile_data = profile.model_dump()
+    profile_data = _convert_to_yaml_safe(profile_data)
 
-        with open(config_file, 'w', encoding='utf-8') as f:
-            yaml.dump(profile_data, f, default_flow_style=False)
+    with open(config_file, 'w', encoding='utf-8') as f:
+        yaml.dump(profile_data, f, default_flow_style=False)
 
-        logger.info(f"Saved user profile: {config_file}")
-        return True
-
-    except (OSError, yaml.YAMLError) as e:
-        logger.error(f"Failed to save user profile {username}: {e}")
-        return False
+    logger.info(f"Saved user profile: {config_file}")
 
 
 def get_download_directory(username: str, config_dir: Optional[Path] = None) -> Path:
@@ -553,7 +547,7 @@ def load_client_profile(client_code: str, config_dir: Optional[Path] = None) -> 
         return None
 
 
-def save_client_profile(profile: ClientProfile, config_dir: Optional[Path] = None) -> bool:
+def save_client_profile(profile: ClientProfile, config_dir: Optional[Path] = None) -> None:
     """
     Save client profile to YAML file (legacy compatibility).
 
@@ -564,32 +558,26 @@ def save_client_profile(profile: ClientProfile, config_dir: Optional[Path] = Non
         profile: ClientProfile object to save
         config_dir: Configuration directory
 
-    Returns:
-        True if successful, False otherwise
+    Raises:
+        OSError: If the file cannot be written
+        yaml.YAMLError: If the profile cannot be serialized
     """
     warnings.warn(
         "save_client_profile() is deprecated and will be removed in v4.0.0. Use HydraConfigManager.save_client() for the modern Client model.",
         DeprecationWarning,
         stacklevel=2,
     )
-    try:
-        config_dir = config_dir or Path.home() / ".siege_utilities" / "profiles" / "clients"
-        config_dir.mkdir(parents=True, exist_ok=True)
-        config_file = config_dir / f"{profile.client_code}.yaml"
+    config_dir = config_dir or Path.home() / ".siege_utilities" / "profiles" / "clients"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_file = config_dir / f"{profile.client_code}.yaml"
 
-        # Convert to dict and make YAML-safe
-        profile_data = profile.model_dump()
-        profile_data = _convert_to_yaml_safe(profile_data)
+    profile_data = profile.model_dump()
+    profile_data = _convert_to_yaml_safe(profile_data)
 
-        with open(config_file, 'w', encoding='utf-8') as f:
-            yaml.dump(profile_data, f, default_flow_style=False)
+    with open(config_file, 'w', encoding='utf-8') as f:
+        yaml.dump(profile_data, f, default_flow_style=False)
 
-        logger.info(f"Saved client profile: {config_file}")
-        return True
-
-    except (OSError, yaml.YAMLError) as e:
-        logger.error(f"Failed to save client profile {profile.client_code}: {e}")
-        return False
+    logger.info(f"Saved client profile: {config_file}")
 
 
 class SiegeConfig:
@@ -646,52 +634,46 @@ def list_client_profiles(config_dir: Optional[Path] = None) -> List[str]:
         raise
 
 
-def export_config_yaml(config_data: Dict[str, Any], output_file: Path) -> bool:
+def export_config_yaml(config_data: Dict[str, Any], output_file: Path) -> None:
     """
     Export configuration data to YAML file (legacy compatibility).
-    
+
     Args:
         config_data: Configuration data to export
         output_file: Output file path
-        
-    Returns:
-        True if successful, False otherwise
+
+    Raises:
+        OSError: If the file cannot be written
+        yaml.YAMLError: If the data cannot be serialized
     """
-    try:
-        output_file.parent.mkdir(parents=True, exist_ok=True)
-        
-        with open(output_file, 'w', encoding='utf-8') as f:
-            yaml.dump(config_data, f, default_flow_style=False)
-            
-        logger.info(f"Exported configuration to: {output_file}")
-        return True
-        
-    except (OSError, yaml.YAMLError) as e:
-        logger.error(f"Failed to export configuration: {e}")
-        return False
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(output_file, 'w', encoding='utf-8') as f:
+        yaml.dump(config_data, f, default_flow_style=False)
+
+    logger.info(f"Exported configuration to: {output_file}")
 
 
-def import_config_yaml(input_file: Path) -> Optional[Dict[str, Any]]:
+def import_config_yaml(input_file: Path) -> Dict[str, Any]:
     """
     Import configuration data from YAML file (legacy compatibility).
-    
+
     Args:
         input_file: Input file path
-        
+
     Returns:
-        Configuration data or None if failed
+        Configuration data dictionary
+
+    Raises:
+        FileNotFoundError: If the file does not exist
+        OSError: If the file cannot be read
+        yaml.YAMLError: If the file is not valid YAML
     """
-    try:
-        if not input_file.exists():
-            logger.warning(f"Configuration file not found: {input_file}")
-            return None
-            
-        with open(input_file, 'r', encoding='utf-8') as f:
-            config_data = yaml.safe_load(f)
-            
-        logger.info(f"Imported configuration from: {input_file}")
-        return config_data
-        
-    except (OSError, yaml.YAMLError) as e:
-        logger.error(f"Failed to import configuration: {e}")
-        return None
+    if not input_file.exists():
+        raise FileNotFoundError(f"Configuration file not found: {input_file}")
+
+    with open(input_file, 'r', encoding='utf-8') as f:
+        config_data = yaml.safe_load(f)
+
+    logger.info(f"Imported configuration from: {input_file}")
+    return config_data

--- a/siege_utilities/config/hydra_manager.py
+++ b/siege_utilities/config/hydra_manager.py
@@ -343,7 +343,12 @@ class HydraConfigManager:
             profiles_dir: Directory containing user YAML files. Defaults to config_dir/profiles/users.
 
         Returns:
-            User instance, or None if file not found.
+            User instance, or None if file does not exist.
+
+        Raises:
+            OSError: If the file exists but cannot be read
+            yaml.YAMLError: If the file is not valid YAML
+            ValueError: If the YAML content is not a valid User
         """
         profiles_dir = profiles_dir or self.config_dir / "profiles" / "users"
         user_file = profiles_dir / f"{person_id}.yaml"
@@ -352,13 +357,9 @@ class HydraConfigManager:
             logger.warning(f"User profile not found: {user_file}")
             return None
 
-        try:
-            user = User.from_yaml(user_file)
-            logger.info(f"Loaded modern User: {person_id}")
-            return user
-        except (OSError, yaml.YAMLError, ValueError) as e:
-            logger.error(f"Failed to load User {person_id}: {e}")
-            return None
+        user = User.from_yaml(user_file)
+        logger.info(f"Loaded modern User: {person_id}")
+        return user
 
     def load_client(self, client_code: str, profiles_dir: Optional[Path] = None) -> Optional[Client]:
         """
@@ -369,7 +370,12 @@ class HydraConfigManager:
             profiles_dir: Directory containing client YAML files. Defaults to config_dir/profiles/clients.
 
         Returns:
-            Client instance, or None if file not found.
+            Client instance, or None if file does not exist.
+
+        Raises:
+            OSError: If the file exists but cannot be read
+            yaml.YAMLError: If the file is not valid YAML
+            ValueError: If the YAML content is not a valid Client
         """
         profiles_dir = profiles_dir or self.config_dir / "profiles" / "clients"
         client_file = profiles_dir / f"{client_code}.yaml"
@@ -378,15 +384,11 @@ class HydraConfigManager:
             logger.warning(f"Client profile not found: {client_file}")
             return None
 
-        try:
-            client = Client.from_yaml(client_file)
-            logger.info(f"Loaded modern Client: {client_code}")
-            return client
-        except (OSError, yaml.YAMLError, ValueError) as e:
-            logger.error(f"Failed to load Client {client_code}: {e}")
-            return None
+        client = Client.from_yaml(client_file)
+        logger.info(f"Loaded modern Client: {client_code}")
+        return client
 
-    def save_user(self, user: User, profiles_dir: Optional[Path] = None) -> bool:
+    def save_user(self, user: User, profiles_dir: Optional[Path] = None) -> None:
         """
         Save a modern User to YAML file.
 
@@ -394,22 +396,18 @@ class HydraConfigManager:
             user: User instance to save.
             profiles_dir: Directory to save the YAML file. Defaults to config_dir/profiles/users.
 
-        Returns:
-            True if successful, False otherwise.
+        Raises:
+            OSError: If the file cannot be written
+            yaml.YAMLError: If the user cannot be serialized
         """
         profiles_dir = profiles_dir or self.config_dir / "profiles" / "users"
         profiles_dir.mkdir(parents=True, exist_ok=True)
         user_file = profiles_dir / f"{user.person_id}.yaml"
 
-        try:
-            user.to_yaml(path=user_file)
-            logger.info(f"Saved modern User: {user.person_id}")
-            return True
-        except (OSError, yaml.YAMLError) as e:
-            logger.error(f"Failed to save User {user.person_id}: {e}")
-            return False
+        user.to_yaml(path=user_file)
+        logger.info(f"Saved modern User: {user.person_id}")
 
-    def save_client(self, client: Client, profiles_dir: Optional[Path] = None) -> bool:
+    def save_client(self, client: Client, profiles_dir: Optional[Path] = None) -> None:
         """
         Save a modern Client to YAML file.
 
@@ -417,20 +415,16 @@ class HydraConfigManager:
             client: Client instance to save.
             profiles_dir: Directory to save the YAML file. Defaults to config_dir/profiles/clients.
 
-        Returns:
-            True if successful, False otherwise.
+        Raises:
+            OSError: If the file cannot be written
+            yaml.YAMLError: If the client cannot be serialized
         """
         profiles_dir = profiles_dir or self.config_dir / "profiles" / "clients"
         profiles_dir.mkdir(parents=True, exist_ok=True)
         client_file = profiles_dir / f"{client.client_code}.yaml"
 
-        try:
-            client.to_yaml(path=client_file)
-            logger.info(f"Saved modern Client: {client.client_code}")
-            return True
-        except (OSError, yaml.YAMLError) as e:
-            logger.error(f"Failed to save Client {client.client_code}: {e}")
-            return False
+        client.to_yaml(path=client_file)
+        logger.info(f"Saved modern Client: {client.client_code}")
 
     def cleanup(self):
         """Clean up Hydra instance."""

--- a/siege_utilities/geo/spatial_transformations.py
+++ b/siege_utilities/geo/spatial_transformations.py
@@ -77,219 +77,144 @@ class SpatialDataTransformer:
         if DUCKDB_AVAILABLE:
             self.supported_formats['output'].append('duckdb')
     
-    def convert_format(self, gdf: GeoDataFrame, output_format: str, **kwargs) -> bool:
+    def convert_format(self, gdf: GeoDataFrame, output_format: str, **kwargs) -> None:
         """
         Convert GeoDataFrame to different format.
-        
+
         Args:
             gdf: Input GeoDataFrame
             output_format: Desired output format
             **kwargs: Additional format-specific parameters
-            
-        Returns:
-            True if successful, False otherwise
+
+        Raises:
+            ValueError: If output_format is unsupported
+            ImportError: If a required optional dependency is missing
+            OSError: If the file cannot be written
         """
-        try:
-            if output_format == 'shp':
-                return self._convert_to_shapefile(gdf, **kwargs)
-            elif output_format == 'geojson':
-                return self._convert_to_geojson(gdf, **kwargs)
-            elif output_format == 'gpkg':
-                return self._convert_to_geopackage(gdf, **kwargs)
-            elif output_format == 'kml':
-                return self._convert_to_kml(gdf, **kwargs)
-            elif output_format == 'gml':
-                return self._convert_to_gml(gdf, **kwargs)
-            elif output_format == 'wkt':
-                return self._convert_to_wkt(gdf, **kwargs)
-            elif output_format == 'wkb':
-                return self._convert_to_wkb(gdf, **kwargs)
-            elif output_format == 'postgis':
-                return self._convert_to_postgis(gdf, **kwargs)
-            elif output_format == 'duckdb':
-                if DUCKDB_AVAILABLE:
-                    return self._convert_to_duckdb(gdf, **kwargs)
-                else:
-                    log.error("DuckDB not available. Install with: pip install duckdb")
-                    return False
-            else:
-                log.error(f"Unsupported output format: {output_format}")
-                return False
-                
-        except (OSError, ValueError, TypeError, AttributeError, KeyError, ImportError) as e:
-            log.error(f"Format conversion failed: {e}")
-            return False
+        if output_format == 'shp':
+            self._convert_to_shapefile(gdf, **kwargs)
+        elif output_format == 'geojson':
+            self._convert_to_geojson(gdf, **kwargs)
+        elif output_format == 'gpkg':
+            self._convert_to_geopackage(gdf, **kwargs)
+        elif output_format == 'kml':
+            self._convert_to_kml(gdf, **kwargs)
+        elif output_format == 'gml':
+            self._convert_to_gml(gdf, **kwargs)
+        elif output_format == 'wkt':
+            self._convert_to_wkt(gdf, **kwargs)
+        elif output_format == 'wkb':
+            self._convert_to_wkb(gdf, **kwargs)
+        elif output_format == 'postgis':
+            self._convert_to_postgis(gdf, **kwargs)
+        elif output_format == 'duckdb':
+            if not DUCKDB_AVAILABLE:
+                raise ImportError("DuckDB not available. Install with: pip install duckdb")
+            self._convert_to_duckdb(gdf, **kwargs)
+        else:
+            raise ValueError(f"Unsupported output format: {output_format}")
     
-    def _convert_to_shapefile(self, gdf: GeoDataFrame, **kwargs) -> bool:
+    def _convert_to_shapefile(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to ESRI Shapefile format."""
-        try:
-            output_path = kwargs.get('output_path', 'output.shp')
-            gdf.to_file(output_path, driver='ESRI Shapefile')
-            log.info(f"Successfully converted to Shapefile: {output_path}")
-            return True
-        except (OSError, ValueError, TypeError, RuntimeError) as e:
-            log.error(f"Failed to convert to Shapefile: {e}")
-            return False
-    
-    def _convert_to_geojson(self, gdf: GeoDataFrame, **kwargs) -> bool:
+        output_path = kwargs.get('output_path', 'output.shp')
+        gdf.to_file(output_path, driver='ESRI Shapefile')
+        log.info(f"Successfully converted to Shapefile: {output_path}")
+
+    def _convert_to_geojson(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to GeoJSON format."""
-        try:
-            output_path = kwargs.get('output_path', 'output.geojson')
-            gdf.to_file(output_path, driver='GeoJSON')
-            log.info(f"Successfully converted to GeoJSON: {output_path}")
-            return True
-        except (OSError, ValueError, TypeError, RuntimeError) as e:
-            log.error(f"Failed to convert to GeoJSON: {e}")
-            return False
-    
-    def _convert_to_geopackage(self, gdf: GeoDataFrame, **kwargs) -> bool:
+        output_path = kwargs.get('output_path', 'output.geojson')
+        gdf.to_file(output_path, driver='GeoJSON')
+        log.info(f"Successfully converted to GeoJSON: {output_path}")
+
+    def _convert_to_geopackage(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to GeoPackage format."""
-        try:
-            output_path = kwargs.get('output_path', 'output.gpkg')
-            gdf.to_file(output_path, driver='GPKG')
-            log.info(f"Successfully converted to GeoPackage: {output_path}")
-            return True
-        except (OSError, ValueError, TypeError, RuntimeError) as e:
-            log.error(f"Failed to convert to GeoPackage: {e}")
-            return False
-    
-    def _convert_to_kml(self, gdf: GeoDataFrame, **kwargs) -> bool:
+        output_path = kwargs.get('output_path', 'output.gpkg')
+        gdf.to_file(output_path, driver='GPKG')
+        log.info(f"Successfully converted to GeoPackage: {output_path}")
+
+    def _convert_to_kml(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to KML format."""
-        try:
-            output_path = kwargs.get('output_path', 'output.kml')
-            gdf.to_file(output_path, driver='KML')
-            log.info(f"Successfully converted to KML: {output_path}")
-            return True
-        except (OSError, ValueError, TypeError, RuntimeError) as e:
-            log.error(f"Failed to convert to KML: {e}")
-            return False
-    
-    def _convert_to_gml(self, gdf: GeoDataFrame, **kwargs) -> bool:
+        output_path = kwargs.get('output_path', 'output.kml')
+        gdf.to_file(output_path, driver='KML')
+        log.info(f"Successfully converted to KML: {output_path}")
+
+    def _convert_to_gml(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to GML format."""
-        try:
-            output_path = kwargs.get('output_path', 'output.gml')
-            gdf.to_file(output_path, driver='GML')
-            log.info(f"Successfully converted to GML: {output_path}")
-            return True
-        except (OSError, ValueError, TypeError, RuntimeError) as e:
-            log.error(f"Failed to convert to GML: {e}")
-            return False
+        output_path = kwargs.get('output_path', 'output.gml')
+        gdf.to_file(output_path, driver='GML')
+        log.info(f"Successfully converted to GML: {output_path}")
     
-    def _convert_to_wkt(self, gdf: GeoDataFrame, **kwargs) -> bool:
+    def _convert_to_wkt(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to WKT (Well-Known Text) format."""
-        try:
-            output_path = kwargs.get('output_path', 'output.wkt')
-            
-            # Convert geometries to WKT strings
-            wkt_data = gdf.copy()
-            wkt_data['geometry'] = wkt_data.geometry.astype(str)
-            
-            # Save as CSV with WKT geometries
-            wkt_data.to_csv(output_path, index=False)
-            log.info(f"Successfully converted to WKT: {output_path}")
-            return True
-        except (OSError, ValueError, TypeError, AttributeError) as e:
-            log.error(f"Failed to convert to WKT: {e}")
-            return False
-    
-    def _convert_to_wkb(self, gdf: GeoDataFrame, **kwargs) -> bool:
+        output_path = kwargs.get('output_path', 'output.wkt')
+
+        wkt_data = gdf.copy()
+        wkt_data['geometry'] = wkt_data.geometry.astype(str)
+
+        wkt_data.to_csv(output_path, index=False)
+        log.info(f"Successfully converted to WKT: {output_path}")
+
+    def _convert_to_wkb(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to WKB (Well-Known Binary) format."""
-        try:
-            output_path = kwargs.get('output_path', 'output.wkb')
-            
-            # Convert geometries to WKB bytes
-            wkb_data = gdf.copy()
-            wkb_data['geometry'] = wkb_data.geometry.apply(lambda geom: geom.wkb)
-            
-            # Save as pickle (WKB is binary data)
-            wkb_data.to_pickle(output_path)
-            log.info(f"Successfully converted to WKB: {output_path}")
-            return True
-        except (OSError, ValueError, TypeError, AttributeError) as e:
-            log.error(f"Failed to convert to WKB: {e}")
-            return False
-    
-    def _convert_to_postgis(self, gdf: GeoDataFrame, **kwargs) -> bool:
-        """Convert to PostGIS format (upload to PostgreSQL database)."""
-        try:
-            # This would require psycopg2 and database connection
-            # For now, just save as SQL file that can be imported
-            output_path = kwargs.get('output_path', 'output.sql')
-            
-            # Generate SQL INSERT statements. WKT comes from shapely
-            # which can't normally produce single quotes, but the file
-            # is written for human inspection / re-import — escape
-            # defensively so a hand-edited row can't break out of the
-            # literal.
-            from siege_utilities.core.sql_safety import escape_sql_string_literal as escape_string_literal
-            # Vectorised: pull the geometry column into a Series of WKT
-            # strings in one pass and join with newlines. The previous
-            # row-at-a-time iterrows produced O(N) Python-level
-            # attribute lookups; on a 100K-row state file that was
-            # measurably slower than the IO it bookended.
-            wkt_series = gdf.geometry.apply(lambda g: escape_string_literal(g.wkt))
-            sql_lines = (
-                "INSERT INTO spatial_table (geom) VALUES (ST_GeomFromText('"
-                + wkt_series
-                + "'));"
-            )
+        output_path = kwargs.get('output_path', 'output.wkb')
 
-            with open(output_path, 'w', encoding='utf-8') as f:
-                f.write('\n'.join(sql_lines))
-            
-            log.info(f"Successfully generated PostGIS SQL: {output_path}")
-            return True
-        except (OSError, ValueError, TypeError, AttributeError, ImportError) as e:
-            log.error(f"Failed to convert to PostGIS: {e}")
-            return False
+        wkb_data = gdf.copy()
+        wkb_data['geometry'] = wkb_data.geometry.apply(lambda geom: geom.wkb)
+
+        wkb_data.to_pickle(output_path)
+        log.info(f"Successfully converted to WKB: {output_path}")
     
-    def _convert_to_duckdb(self, gdf: GeoDataFrame, **kwargs) -> bool:
+    def _convert_to_postgis(self, gdf: GeoDataFrame, **kwargs) -> None:
+        """Convert to PostGIS format (generate SQL file for import)."""
+        output_path = kwargs.get('output_path', 'output.sql')
+
+        from siege_utilities.core.sql_safety import escape_sql_string_literal as escape_string_literal
+        wkt_series = gdf.geometry.apply(lambda g: escape_string_literal(g.wkt))
+        sql_lines = (
+            "INSERT INTO spatial_table (geom) VALUES (ST_GeomFromText('"
+            + wkt_series
+            + "'));"
+        )
+
+        with open(output_path, 'w', encoding='utf-8') as f:
+            f.write('\n'.join(sql_lines))
+
+        log.info(f"Successfully generated PostGIS SQL: {output_path}")
+    
+    def _convert_to_duckdb(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to DuckDB format and save to database."""
-        if not DUCKDB_AVAILABLE:
-            log.error("DuckDB not available")
-            return False
-            
-        try:
-            # Get database parameters from user config or kwargs.
-            db_path = kwargs.get('db_path')
-            if db_path is None and self.user_config is not None:
-                try:
-                    db_path = self.user_config.get_database_connection('duckdb')
-                except (AttributeError, ValueError, KeyError, TypeError) as e:
-                    log.warning(f"user_config.get_database_connection('duckdb') failed: {e}")
-            db_path = db_path or ':memory:'
-            table_name = kwargs.get('table_name', 'spatial_data')
+        db_path = kwargs.get('db_path')
+        if db_path is None and self.user_config is not None:
+            try:
+                db_path = self.user_config.get_database_connection('duckdb')
+            except (AttributeError, ValueError, KeyError, TypeError) as e:
+                log.warning(f"user_config.get_database_connection('duckdb') failed: {e}")
+        db_path = db_path or ':memory:'
+        table_name = kwargs.get('table_name', 'spatial_data')
 
-            # DuckDB doesn't permit parameter-bound identifiers, so the
-            # table name has to be validated up front.
-            from siege_utilities.core.sql_safety import validate_sql_identifier as validate_identifier
-            validate_identifier(table_name, label="table name", allow_dotted=False)
+        from siege_utilities.core.sql_safety import validate_sql_identifier as validate_identifier
+        validate_identifier(table_name, label="table name", allow_dotted=False)
 
-            with duckdb.connect(db_path) as con:
-                df = gdf.copy()
-                df['geometry_wkt'] = df.geometry.apply(lambda geom: geom.wkt)
-                df = df.drop(columns=['geometry'])
-                con.register("siege_upload_df", df)
+        with duckdb.connect(db_path) as con:
+            df = gdf.copy()
+            df['geometry_wkt'] = df.geometry.apply(lambda geom: geom.wkt)
+            df = df.drop(columns=['geometry'])
+            con.register("siege_upload_df", df)
+            try:
+                con.execute(
+                    f"CREATE TABLE IF NOT EXISTS {table_name} "
+                    f"AS SELECT * FROM siege_upload_df"
+                )
+            finally:
                 try:
-                    con.execute(
-                        f"CREATE TABLE IF NOT EXISTS {table_name} "
-                        f"AS SELECT * FROM siege_upload_df"
+                    con.unregister("siege_upload_df")
+                except (_DuckDBError, RuntimeError) as cleanup_exc:
+                    log.warning(
+                        "Failed to unregister siege_upload_df: %s",
+                        cleanup_exc,
                     )
-                finally:
-                    try:
-                        con.unregister("siege_upload_df")
-                    except (_DuckDBError, RuntimeError) as cleanup_exc:
-                        log.warning(
-                            "Failed to unregister siege_upload_df: %s",
-                            cleanup_exc,
-                        )
 
-            log.info(f"Successfully uploaded to DuckDB table: {table_name}")
-            return True
-
-        except (_DuckDBError, OSError, ValueError, TypeError, AttributeError, KeyError) as e:
-            log.error(f"Failed to convert to DuckDB: {e}")
-            return False
+        log.info(f"Successfully uploaded to DuckDB table: {table_name}")
 
 
 class PostGISConnector:
@@ -350,19 +275,13 @@ class PostGISConnector:
     def __exit__(self, *exc_info):
         self.close()
 
-    def upload_spatial_data(self, gdf: GeoDataFrame, table_name: str, **kwargs) -> bool:
+    def upload_spatial_data(self, gdf: GeoDataFrame, table_name: str, **kwargs) -> None:
         """
         Upload spatial data to PostGIS with all columns preserved.
 
         Uses geopandas.GeoDataFrame.to_postgis under the hood, which
         handles full-column writes (geometry + every attribute column) via
-        SQLAlchemy + GeoAlchemy2. This is the canonical geopandas idiom
-        for PostGIS upload.
-
-        Pre-#516 behavior (replaced): the old implementation manually
-        built `INSERT INTO {table} (geom) VALUES (...)` statements,
-        dropping all tabular columns from the GeoDataFrame. Any caller
-        passing attribute data got an empty-attribute table silently.
+        SQLAlchemy + GeoAlchemy2.
 
         Args:
             gdf: GeoDataFrame to upload (all columns including geometry).
@@ -372,24 +291,16 @@ class PostGISConnector:
                     ``'replace'`` (default), or ``'append'``.
                 schema: PostgreSQL schema name (default ``'public'``).
 
-        Returns:
-            True if successful, False otherwise.
-
-        Note:
-            Requires ``geoalchemy2`` (declared in the ``geo`` optional
-            extra). If missing, the import error is logged and the
-            upload returns False with a clear remediation hint.
+        Raises:
+            ConnectionError: If no connection string is configured
+            ImportError: If geoalchemy2 is not installed
         """
         if not self.connection_string:
-            log.error("No PostGIS connection_string available")
-            return False
+            raise ConnectionError("No PostGIS connection_string available")
 
         if_exists = kwargs.get('if_exists', 'replace')
         schema = kwargs.get('schema', 'public')
 
-        # Validate identifiers before they reach SQL. to_postgis itself
-        # uses parameterized SQL but defense-in-depth keeps the validation
-        # consistent with download_spatial_data + the prior implementation.
         from siege_utilities.core.sql_safety import validate_sql_identifier as validate_identifier
         validate_identifier(schema, label="schema name", allow_dotted=False)
         validate_identifier(table_name, label="table name", allow_dotted=False)
@@ -397,33 +308,26 @@ class PostGISConnector:
         try:
             import geoalchemy2  # noqa: F401  -- presence-check; to_postgis needs it
         except ImportError:
-            log.error(
+            raise ImportError(
                 "geoalchemy2 not available -- upload_spatial_data requires it "
                 "for full-column writes. Install with: pip install 'siege_utilities[geo]'"
             )
-            return False
 
+        from sqlalchemy import create_engine
+        engine = create_engine(self.connection_string)
         try:
-            from sqlalchemy import create_engine
-            engine = create_engine(self.connection_string)
-            try:
-                gdf.to_postgis(
-                    name=table_name,
-                    con=engine,
-                    schema=schema,
-                    if_exists=if_exists,
-                )
-            finally:
-                engine.dispose()
-            log.info(
-                f"Successfully uploaded to PostGIS table: {schema}.{table_name} "
-                f"({len(gdf)} rows, {len(gdf.columns)} columns)"
+            gdf.to_postgis(
+                name=table_name,
+                con=engine,
+                schema=schema,
+                if_exists=if_exists,
             )
-            return True
-
-        except (_Psycopg2Error, OSError, ValueError, TypeError, AttributeError, ImportError) as e:
-            log.error(f"Failed to upload to PostGIS: {e}")
-            return False
+        finally:
+            engine.dispose()
+        log.info(
+            f"Successfully uploaded to PostGIS table: {schema}.{table_name} "
+            f"({len(gdf)} rows, {len(gdf.columns)} columns)"
+        )
     
     def download_spatial_data(self, table_name: str, *, crs: str | None = None, **kwargs) -> GeoDataFrame:
         """
@@ -620,14 +524,14 @@ class DuckDBConnector:
         self.connection = None
     
     def connect(self):
-        """Establish database connection."""
-        try:
-            self.connection = duckdb.connect(self.db_path)
-            log.info("Successfully connected to DuckDB")
-            return True
-        except (_DuckDBError, OSError) as e:
-            log.error(f"Failed to connect to DuckDB: {e}")
-            return False
+        """Establish database connection.
+
+        Raises:
+            duckdb.Error: If the connection fails
+            OSError: If the database file cannot be accessed
+        """
+        self.connection = duckdb.connect(self.db_path)
+        log.info("Successfully connected to DuckDB")
 
     def close(self):
         """Close the database connection."""
@@ -644,57 +548,48 @@ class DuckDBConnector:
     def __exit__(self, *exc_info):
         self.close()
 
-    def upload_spatial_data(self, gdf: GeoDataFrame, table_name: str, **kwargs) -> bool:
+    def upload_spatial_data(self, gdf: GeoDataFrame, table_name: str, **kwargs) -> None:
         """
         Upload spatial data to DuckDB.
-        
+
         Args:
             gdf: GeoDataFrame to upload
             table_name: Target table name
             **kwargs: Additional parameters
-            
-        Returns:
-            True if successful, False otherwise
+
+        Raises:
+            duckdb.Error: If the upload fails
+            OSError: If the database file cannot be accessed
         """
         if not self.connection:
-            if not self.connect():
-                return False
-        
+            self.connect()
+
         from siege_utilities.core.sql_safety import validate_sql_identifier
         validate_sql_identifier(table_name, "table name")
 
+        df = gdf.copy()
+        df['geometry_wkt'] = df.geometry.apply(lambda geom: geom.wkt)
+        df = df.drop(columns=['geometry'])
+
+        if_exists = kwargs.get('if_exists', 'replace')
+        if if_exists == 'replace':
+            self.connection.execute(f"DROP TABLE IF EXISTS {table_name}")
+
+        self.connection.register("siege_upload_df", df)
         try:
-            df = gdf.copy()
-            df['geometry_wkt'] = df.geometry.apply(lambda geom: geom.wkt)
-            df = df.drop(columns=['geometry'])
-
-            if_exists = kwargs.get('if_exists', 'replace')
-            if if_exists == 'replace':
-                self.connection.execute(f"DROP TABLE IF EXISTS {table_name}")
-
-            # table_name validated above; pin the DataFrame under an
-            # explicit name rather than relying on duckdb's replacement
-            # scan picking it up from the caller frame.
-            self.connection.register("siege_upload_df", df)
+            self.connection.execute(
+                f"CREATE TABLE {table_name} AS SELECT * FROM siege_upload_df"
+            )
+        finally:
             try:
-                self.connection.execute(
-                    f"CREATE TABLE {table_name} AS SELECT * FROM siege_upload_df"
+                self.connection.unregister("siege_upload_df")
+            except (_DuckDBError, RuntimeError) as cleanup_exc:
+                log.warning(
+                    "Failed to unregister siege_upload_df: %s",
+                    cleanup_exc,
                 )
-            finally:
-                try:
-                    self.connection.unregister("siege_upload_df")
-                except (_DuckDBError, RuntimeError) as cleanup_exc:
-                    log.warning(
-                        "Failed to unregister siege_upload_df: %s",
-                        cleanup_exc,
-                    )
 
-            log.info(f"Successfully uploaded to DuckDB: {table_name}")
-            return True
-
-        except (_DuckDBError, OSError, ValueError, TypeError, AttributeError) as e:
-            log.error(f"Failed to upload to DuckDB: {e}")
-            return False
+        log.info(f"Successfully uploaded to DuckDB: {table_name}")
     
     def download_spatial_data(self, table_name: str, *, crs: str | None = None, **kwargs) -> GeoDataFrame:
         """


### PR DESCRIPTION
## Summary

Two commits fixing SU-1 violations in `geo/spatial_transformations.py` and `config/`:

**spatial_transformations.py** (-105 lines):
- `SpatialDataTransformer.convert_format()` and all `_convert_to_*()` methods no longer catch-and-return-False
- `PostGISConnector.upload_spatial_data()` raises `ConnectionError`/`ImportError` instead of returning False
- `DuckDBConnector.connect()` / `upload_spatial_data()` let `duckdb.Error` propagate

**config/enhanced_config.py + hydra_manager.py**:
- `save_user_profile`, `save_client_profile`, `export_config_yaml` → return None, raise on failure
- `import_config_yaml` → raises `FileNotFoundError`/`YAMLError`
- `HydraConfigManager.load_user/load_client` → None for missing (valid), raise for corrupt
- `HydraConfigManager.save_user/save_client` → return None, raise on failure