### PR TITLE
fix(reporting,geo): raise on error in report generators and NLRB client (SU-1)

### DIFF
--- a/siege_utilities/geo/providers/nlrb_clients.py
+++ b/siege_utilities/geo/providers/nlrb_clients.py
@@ -357,17 +357,13 @@ class NLRBLabordataClient:
         )
         return result
 
-    def _download_csv(self, dataset: str) -> Optional[list[dict]]:
+    def _download_csv(self, dataset: str) -> list[dict]:
         path = LABORDATA_FILES.get(dataset)
         if not path:
-            return None
+            raise ValueError(f"Unknown labordata dataset: {dataset!r}")
         url = self._base_url + path
-        try:
-            resp = self._get_session().get(url, timeout=self._timeout)
-            resp.raise_for_status()
-        except (_RequestException, OSError) as exc:
-            log.warning("labordata: failed to download %s: %s", dataset, exc)
-            return None
+        resp = self._get_session().get(url, timeout=self._timeout)
+        resp.raise_for_status()
 
         reader = csv.DictReader(io.StringIO(resp.text))
         return list(reader)

--- a/siege_utilities/reporting/engines/base_engine.py
+++ b/siege_utilities/reporting/engines/base_engine.py
@@ -217,7 +217,7 @@ class BaseChartEngine:
         return self._create_placeholder_chart(width, height, f"{label} — saved to {map_path}")
 
     def save_figure_as_vector(self, fig, output_path: Union[str, Path],
-                              fmt: str = 'svg') -> Optional[Path]:
+                              fmt: str = 'svg') -> Path:
         """Save a matplotlib figure as a vector file (SVG, EPS, or PDF).
 
         Args:
@@ -226,23 +226,22 @@ class BaseChartEngine:
             fmt: Vector format — ``'svg'``, ``'eps'``, or ``'pdf'``.
 
         Returns:
-            Path to the saved file, or ``None`` on error.
+            Path to the saved file.
+
+        Raises:
+            ValueError: If *fmt* is not one of the allowed formats.
+            OSError: If the file cannot be written.
         """
         allowed = {'svg', 'eps', 'pdf'}
         if fmt not in allowed:
-            log.error(f"Unsupported vector format '{fmt}'; expected one of {allowed}")
-            return None
+            raise ValueError(f"Unsupported vector format '{fmt}'; expected one of {allowed}")
 
-        try:
-            out = Path(output_path).with_suffix(f'.{fmt}')
-            out.parent.mkdir(parents=True, exist_ok=True)
-            fig.savefig(str(out), format=fmt, bbox_inches='tight',
-                        facecolor='white', edgecolor='none', pad_inches=0.1)
-            log.info(f"Saved vector chart: {out}")
-            return out
-        except (OSError, ValueError, TypeError) as e:
-            log.error(f"Error saving vector chart to {output_path}: {e}")
-            return None
+        out = Path(output_path).with_suffix(f'.{fmt}')
+        out.parent.mkdir(parents=True, exist_ok=True)
+        fig.savefig(str(out), format=fmt, bbox_inches='tight',
+                    facecolor='white', edgecolor='none', pad_inches=0.1)
+        log.info(f"Saved vector chart: {out}")
+        return out
 
     def _matplotlib_to_reportlab_image(self, fig, width: float, height: float,
                                        max_width: Optional[float] = None,

--- a/siege_utilities/reporting/examples/ga_geographic_analysis.py
+++ b/siege_utilities/reporting/examples/ga_geographic_analysis.py
@@ -161,133 +161,119 @@ def aggregate_by_state(ga_city_df: pd.DataFrame) -> pd.DataFrame:
 
 def create_state_choropleth(state_data: pd.DataFrame, value_column: str = 'sessions',
                             title: str = "Website Traffic by State",
-                            output_path: Optional[str] = None) -> Optional[str]:
+                            output_path: Optional[str] = None) -> str:
     """
     Create a choropleth map of US states colored by a metric.
     """
     if not GEOPANDAS_AVAILABLE or not MATPLOTLIB_AVAILABLE:
-        log.warning("GeoPandas or matplotlib not available for choropleth")
-        return None
+        raise RuntimeError("GeoPandas or matplotlib not available for choropleth")
 
-    try:
-        # Load US states shapefile (from Census TIGER/Line)
-        if GEO_AVAILABLE:
-            states_gdf = get_geographic_boundaries(
-                boundary_type='state',
-                year=2020,
-                state=None  # All states
-            )
-        else:
-            log.warning("siege_utilities geo module not available")
-            return None
+    if not GEO_AVAILABLE:
+        raise RuntimeError("siege_utilities geo module not available for choropleth")
 
-        if states_gdf is None or states_gdf.empty:
-            log.warning("Could not load state boundaries")
-            return None
+    states_gdf = get_geographic_boundaries(
+        boundary_type='state',
+        year=2020,
+        state=None
+    )
 
-        # Merge with GA data
-        merged = states_gdf.merge(
-            state_data,
-            left_on='STATEFP',
-            right_on='state_fips',
-            how='left'
-        )
+    if states_gdf is None or states_gdf.empty:
+        raise ValueError("Could not load state boundaries")
 
-        # Create figure
-        fig, ax = plt.subplots(1, 1, figsize=(14, 8))
+    # Merge with GA data
+    merged = states_gdf.merge(
+        state_data,
+        left_on='STATEFP',
+        right_on='state_fips',
+        how='left'
+    )
 
-        # Plot states
-        merged.plot(
-            column=value_column,
-            ax=ax,
-            legend=True,
-            cmap='Blues',
-            missing_kwds={'color': 'lightgray', 'label': 'No data'},
-            legend_kwds={'label': value_column.replace('_', ' ').title()}
-        )
+    # Create figure
+    fig, ax = plt.subplots(1, 1, figsize=(14, 8))
 
-        # Styling
-        ax.set_title(title, fontsize=16, fontweight='bold')
-        ax.set_axis_off()
+    # Plot states
+    merged.plot(
+        column=value_column,
+        ax=ax,
+        legend=True,
+        cmap='Blues',
+        missing_kwds={'color': 'lightgray', 'label': 'No data'},
+        legend_kwds={'label': value_column.replace('_', ' ').title()}
+    )
 
-        # Crop to continental US
-        ax.set_xlim(-130, -65)
-        ax.set_ylim(24, 50)
+    # Styling
+    ax.set_title(title, fontsize=16, fontweight='bold')
+    ax.set_axis_off()
 
-        plt.tight_layout()
+    # Crop to continental US
+    ax.set_xlim(-130, -65)
+    ax.set_ylim(24, 50)
 
-        # Save or return path
-        if output_path:
-            plt.savefig(output_path, dpi=150, bbox_inches='tight')
+    plt.tight_layout()
+
+    # Save or return path
+    if output_path:
+        plt.savefig(output_path, dpi=150, bbox_inches='tight')
+        plt.close()
+        return output_path
+    else:
+        with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as tmp:
+            plt.savefig(tmp.name, dpi=150, bbox_inches='tight')
             plt.close()
-            return output_path
-        else:
-            with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as tmp:
-                plt.savefig(tmp.name, dpi=150, bbox_inches='tight')
-                plt.close()
-                return tmp.name
+            return tmp.name
 
-    except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
-        log.error(f"Error creating state choropleth: {e}")
-        return None
 
 
 def create_city_heatmap(ga_city_df: pd.DataFrame, value_column: str = 'sessions',
-                        output_path: Optional[str] = None) -> Optional[str]:
+                        output_path: Optional[str] = None) -> str:
     """
     Create an interactive heatmap of traffic intensity by city.
     """
     if not FOLIUM_AVAILABLE:
-        log.warning("Folium not available for heatmap")
-        return None
+        raise RuntimeError("Folium not available for heatmap")
 
-    try:
-        # Filter to geocoded cities
-        valid = ga_city_df[ga_city_df['latitude'].notna()].copy()
+    # Filter to geocoded cities
+    valid = ga_city_df[ga_city_df['latitude'].notna()].copy()
 
-        if valid.empty:
-            log.warning("No geocoded cities for heatmap")
-            return None
+    if valid.empty:
+        raise ValueError("No geocoded cities for heatmap")
 
-        # Create base map centered on US
-        center_lat = valid['latitude'].mean()
-        center_lon = valid['longitude'].mean()
-        m = folium.Map(location=[center_lat, center_lon], zoom_start=4)
+    # Create base map centered on US
+    center_lat = valid['latitude'].mean()
+    center_lon = valid['longitude'].mean()
+    m = folium.Map(location=[center_lat, center_lon], zoom_start=4)
 
-        # Prepare heatmap data
-        heat_data = []
-        for _, row in valid.iterrows():
-            col_max = valid[value_column].max()
-            weight = (row[value_column] / col_max) if col_max else 0
-            heat_data.append([row['latitude'], row['longitude'], weight])
+    # Prepare heatmap data
+    heat_data = []
+    for _, row in valid.iterrows():
+        col_max = valid[value_column].max()
+        weight = (row[value_column] / col_max) if col_max else 0
+        heat_data.append([row['latitude'], row['longitude'], weight])
 
-        # Add heatmap layer
-        HeatMap(heat_data, radius=25, blur=15).add_to(m)
+    # Add heatmap layer
+    HeatMap(heat_data, radius=25, blur=15).add_to(m)
 
-        # Add markers for top cities
-        top_cities = valid.nlargest(10, value_column)
-        for _, row in top_cities.iterrows():
-            folium.CircleMarker(
-                location=[row['latitude'], row['longitude']],
-                radius=8,
-                popup=f"{row['city']}: {row[value_column]:,} {value_column}",
-                color='red',
-                fill=True,
-                fill_opacity=0.7
-            ).add_to(m)
+    # Add markers for top cities
+    top_cities = valid.nlargest(10, value_column)
+    for _, row in top_cities.iterrows():
+        folium.CircleMarker(
+            location=[row['latitude'], row['longitude']],
+            radius=8,
+            popup=f"{row['city']}: {row[value_column]:,} {value_column}",
+            color='red',
+            fill=True,
+            fill_opacity=0.7
+        ).add_to(m)
 
-        # Save map
-        if output_path:
-            m.save(output_path)
-            return output_path
-        else:
-            with tempfile.NamedTemporaryFile(suffix='.html', delete=False) as tmp:
-                m.save(tmp.name)
-                return tmp.name
+    # Save map
+    if output_path:
+        m.save(output_path)
+        return output_path
+    else:
+        with tempfile.NamedTemporaryFile(suffix='.html', delete=False) as tmp:
+            m.save(tmp.name)
+            return tmp.name
 
-    except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
-        log.error(f"Error creating city heatmap: {e}")
-        return None
 
 
 def create_traffic_demographics_comparison(ga_state_data: pd.DataFrame,
@@ -342,99 +328,95 @@ def create_traffic_demographics_comparison(ga_state_data: pd.DataFrame,
 
 
 def create_bivariate_traffic_income_map(merged_data: pd.DataFrame,
-                                         output_path: Optional[str] = None) -> Optional[str]:
+                                         output_path: Optional[str] = None) -> str:
     """
     Create a bivariate choropleth showing traffic vs income.
     """
     if not GEOPANDAS_AVAILABLE or not MATPLOTLIB_AVAILABLE:
-        return None
+        raise RuntimeError("GeoPandas or matplotlib not available for bivariate map")
 
-    try:
-        if GEO_AVAILABLE:
-            states_gdf = get_geographic_boundaries(
-                boundary_type='state',
-                year=2020,
-                state=None
-            )
-        else:
-            return None
+    if not GEO_AVAILABLE:
+        raise RuntimeError("siege_utilities geo module not available for bivariate map")
 
-        if states_gdf is None or states_gdf.empty:
-            return None
+    states_gdf = get_geographic_boundaries(
+        boundary_type='state',
+        year=2020,
+        state=None
+    )
 
-        # Merge data
-        gdf = states_gdf.merge(
-            merged_data,
-            left_on='STATEFP',
-            right_on='state_fips',
-            how='left'
-        )
+    if states_gdf is None or states_gdf.empty:
+        raise ValueError("Could not load state boundaries for bivariate map")
 
-        # Create quantile bins for both variables
-        gdf['traffic_bin'] = pd.qcut(gdf['sessions'].fillna(0), q=3, labels=['Low', 'Medium', 'High'])
-        gdf['income_bin'] = pd.qcut(gdf['median_income'].fillna(0), q=3, labels=['Low', 'Medium', 'High'])
+    # Merge data
+    gdf = states_gdf.merge(
+        merged_data,
+        left_on='STATEFP',
+        right_on='state_fips',
+        how='left'
+    )
 
-        # Create bivariate color matrix
-        bivariate_colors = {
-            ('Low', 'Low'): '#e8e8e8',
-            ('Low', 'Medium'): '#b8d6be',
-            ('Low', 'High'): '#73ae80',
-            ('Medium', 'Low'): '#b5c0da',
-            ('Medium', 'Medium'): '#90b2b3',
-            ('Medium', 'High'): '#5a9178',
-            ('High', 'Low'): '#6c83b5',
-            ('High', 'Medium'): '#567994',
-            ('High', 'High'): '#2a5a5b',
-        }
+    # Create quantile bins for both variables
+    gdf['traffic_bin'] = pd.qcut(gdf['sessions'].fillna(0), q=3, labels=['Low', 'Medium', 'High'])
+    gdf['income_bin'] = pd.qcut(gdf['median_income'].fillna(0), q=3, labels=['Low', 'Medium', 'High'])
 
-        def get_color(row):
-            if pd.isna(row['traffic_bin']) or pd.isna(row['income_bin']):
-                return '#ffffff'
-            return bivariate_colors.get((row['traffic_bin'], row['income_bin']), '#ffffff')
+    # Create bivariate color matrix
+    bivariate_colors = {
+        ('Low', 'Low'): '#e8e8e8',
+        ('Low', 'Medium'): '#b8d6be',
+        ('Low', 'High'): '#73ae80',
+        ('Medium', 'Low'): '#b5c0da',
+        ('Medium', 'Medium'): '#90b2b3',
+        ('Medium', 'High'): '#5a9178',
+        ('High', 'Low'): '#6c83b5',
+        ('High', 'Medium'): '#567994',
+        ('High', 'High'): '#2a5a5b',
+    }
 
-        gdf['color'] = gdf.apply(get_color, axis=1)
+    def get_color(row):
+        if pd.isna(row['traffic_bin']) or pd.isna(row['income_bin']):
+            return '#ffffff'
+        return bivariate_colors.get((row['traffic_bin'], row['income_bin']), '#ffffff')
 
-        # Create figure
-        fig, ax = plt.subplots(1, 1, figsize=(14, 10))
+    gdf['color'] = gdf.apply(get_color, axis=1)
 
-        # Plot with custom colors
-        gdf.plot(
-            ax=ax,
-            color=gdf['color'],
-            edgecolor='white',
-            linewidth=0.5
-        )
+    # Create figure
+    fig, ax = plt.subplots(1, 1, figsize=(14, 10))
 
-        # Title and styling
-        ax.set_title('Website Traffic vs. Median Income by State', fontsize=16, fontweight='bold')
-        ax.set_axis_off()
-        ax.set_xlim(-130, -65)
-        ax.set_ylim(24, 50)
+    # Plot with custom colors
+    gdf.plot(
+        ax=ax,
+        color=gdf['color'],
+        edgecolor='white',
+        linewidth=0.5
+    )
 
-        # Add legend
-        legend_elements = [
-            Patch(facecolor='#73ae80', label='High Income, Low Traffic'),
-            Patch(facecolor='#2a5a5b', label='High Income, High Traffic'),
-            Patch(facecolor='#e8e8e8', label='Low Income, Low Traffic'),
-            Patch(facecolor='#6c83b5', label='Low Income, High Traffic'),
-        ]
-        ax.legend(handles=legend_elements, loc='lower right', fontsize=9)
+    # Title and styling
+    ax.set_title('Website Traffic vs. Median Income by State', fontsize=16, fontweight='bold')
+    ax.set_axis_off()
+    ax.set_xlim(-130, -65)
+    ax.set_ylim(24, 50)
 
-        plt.tight_layout()
+    # Add legend
+    legend_elements = [
+        Patch(facecolor='#73ae80', label='High Income, Low Traffic'),
+        Patch(facecolor='#2a5a5b', label='High Income, High Traffic'),
+        Patch(facecolor='#e8e8e8', label='Low Income, Low Traffic'),
+        Patch(facecolor='#6c83b5', label='Low Income, High Traffic'),
+    ]
+    ax.legend(handles=legend_elements, loc='lower right', fontsize=9)
 
-        if output_path:
-            plt.savefig(output_path, dpi=150, bbox_inches='tight')
+    plt.tight_layout()
+
+    if output_path:
+        plt.savefig(output_path, dpi=150, bbox_inches='tight')
+        plt.close()
+        return output_path
+    else:
+        with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as tmp:
+            plt.savefig(tmp.name, dpi=150, bbox_inches='tight')
             plt.close()
-            return output_path
-        else:
-            with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as tmp:
-                plt.savefig(tmp.name, dpi=150, bbox_inches='tight')
-                plt.close()
-                return tmp.name
+            return tmp.name
 
-    except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
-        log.error(f"Error creating bivariate map: {e}")
-        return None
 
 
 def generate_geographic_insights(merged_data: pd.DataFrame) -> List[str]:

--- a/siege_utilities/reporting/powerpoint_generator.py
+++ b/siege_utilities/reporting/powerpoint_generator.py
@@ -525,7 +525,14 @@ class PowerPointGenerator:
 
             # Process each section
             for section in presentation_content.get('sections', []):
-                slide = self._create_slide_from_section(section, prs)
+                try:
+                    slide = self._create_slide_from_section(section, prs)
+                except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
+                    log.warning(
+                        "Skipping slide for section %r: %s",
+                        section.get('type', 'text_slide'), e,
+                    )
+                    continue
                 if slide and section.get('notes'):
                     notes_slide = slide.notes_slide
                     notes_slide.notes_text_frame.text = section['notes']
@@ -1168,33 +1175,27 @@ class PowerPointGenerator:
             Created slide object
         """
         section_type = section.get('type', 'text_slide')
-        
-        try:
-            if section_type == 'title_slide':
-                return self._create_title_slide(section, prs)
-            elif section_type == 'table_of_contents':
-                return self._create_toc_slide(section, prs)
-            elif section_type == 'agenda':
-                return self._create_agenda_slide(section, prs)
-            elif section_type == 'text_slide':
-                return self._create_text_slide(section, prs)
-            elif section_type == 'chart_slide':
-                return self._create_chart_slide(section, prs)
-            elif section_type == 'map_slide':
-                return self._create_map_slide(section, prs)
-            elif section_type == 'table_slide':
-                return self._create_table_slide(section, prs)
-            elif section_type == 'comparison_slide':
-                return self._create_comparison_slide(section, prs)
-            elif section_type == 'summary_slide':
-                return self._create_summary_slide(section, prs)
-            else:
-                # Default to text slide
-                return self._create_text_slide(section, prs)
-                
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-            log.error(f"Error creating slide for section {section_type}: {e}")
-            return None
+
+        if section_type == 'title_slide':
+            return self._create_title_slide(section, prs)
+        elif section_type == 'table_of_contents':
+            return self._create_toc_slide(section, prs)
+        elif section_type == 'agenda':
+            return self._create_agenda_slide(section, prs)
+        elif section_type == 'text_slide':
+            return self._create_text_slide(section, prs)
+        elif section_type == 'chart_slide':
+            return self._create_chart_slide(section, prs)
+        elif section_type == 'map_slide':
+            return self._create_map_slide(section, prs)
+        elif section_type == 'table_slide':
+            return self._create_table_slide(section, prs)
+        elif section_type == 'comparison_slide':
+            return self._create_comparison_slide(section, prs)
+        elif section_type == 'summary_slide':
+            return self._create_summary_slide(section, prs)
+        else:
+            return self._create_text_slide(section, prs)
 
     def _create_title_slide(self, section: Dict[str, Any], prs: Presentation) -> Any:
         """Create a title slide."""

--- a/siege_utilities/reporting/report_generator.py
+++ b/siege_utilities/reporting/report_generator.py
@@ -432,42 +432,38 @@ class ReportGenerator:
                            output_path: str, template_config: str = None) -> bool:
         """
         Generate a comprehensive PDF report with full document structure.
-        
+
         Args:
             report_content: Report content structure
             output_path: Output PDF file path
             template_config: Template configuration file path
-            
+
         Returns:
-            True if successful, False otherwise
+            True on success.
+
+        Raises:
+            OSError: If the output directory cannot be created or is not writable,
+                or if the final rename fails.
+            ValueError, TypeError, KeyError, AttributeError: On malformed input.
         """
+        # Pre-check writability: ReportLab buffers the entire PDF in
+        # memory and only attempts disk I/O at the very end. A
+        # missing parent dir or a read-only mount that was
+        # discoverable up-front would otherwise burn a full
+        # generation pass (slow on multi-hundred-page reports)
+        # before failing. Build to a sibling temp file and rename
+        # atomically so a partial PDF never appears at *output_path*.
+        final = Path(output_path)
+        parent = final.parent if str(final.parent) else Path(".")
+        parent.mkdir(parents=True, exist_ok=True)
+        if not os.access(parent, os.W_OK):
+            raise OSError(
+                f"generate_pdf_report: output directory {parent} is not writable"
+            )
+
+        tmp_path = parent / f".{final.name}.{uuid.uuid4().hex[:8]}.part"
+
         try:
-            # Pre-check writability: ReportLab buffers the entire PDF in
-            # memory and only attempts disk I/O at the very end. A
-            # missing parent dir or a read-only mount that was
-            # discoverable up-front would otherwise burn a full
-            # generation pass (slow on multi-hundred-page reports)
-            # before failing. Build to a sibling temp file and rename
-            # atomically so a partial PDF never appears at *output_path*.
-            final = Path(output_path)
-            parent = final.parent if str(final.parent) else Path(".")
-            try:
-                parent.mkdir(parents=True, exist_ok=True)
-            except OSError as exc:
-                log.error(
-                    "generate_pdf_report: cannot create output directory "
-                    "%s: %s", parent, exc,
-                )
-                return False
-            if not os.access(parent, os.W_OK):
-                log.error(
-                    "generate_pdf_report: output directory %s is not "
-                    "writable", parent,
-                )
-                return False
-
-            tmp_path = parent / f".{final.name}.{uuid.uuid4().hex[:8]}.part"
-
             # Initialize template with the temp path; we rename to the
             # final name only after a successful build.
             template = self._get_template(str(tmp_path), template_config)
@@ -497,37 +493,29 @@ class ReportGenerator:
 
             # Build PDF using the template's build_document method
             template.build_document(story)
-
-            # Atomic rename. os.replace is atomic on POSIX and on Windows
-            # (per docs) when source and dest live on the same FS — which
-            # they do, since we created the temp alongside the target.
+        except BaseException:
             try:
-                os.replace(tmp_path, final)
-            except OSError as exc:
-                log.error(
-                    "generate_pdf_report: built %s but could not rename "
-                    "to %s: %s", tmp_path, final, exc,
-                )
-                try:
-                    if tmp_path.exists():
-                        tmp_path.unlink()
-                except OSError:
-                    pass
-                return False
-
-            log.info(f"PDF report generated successfully: {output_path}")
-            return True
-
-        except (OSError, ValueError, TypeError, KeyError, AttributeError) as e:
-            log.error(f"Error generating PDF report: {e}")
-            # Best-effort cleanup of the partial file. The variable may
-            # not be bound yet if we failed before assigning it.
-            try:
-                if 'tmp_path' in locals() and tmp_path.exists():
+                if tmp_path.exists():
                     tmp_path.unlink()
             except OSError:
                 pass
-            return False
+            raise
+
+        # Atomic rename. os.replace is atomic on POSIX and on Windows
+        # (per docs) when source and dest live on the same FS — which
+        # they do, since we created the temp alongside the target.
+        try:
+            os.replace(tmp_path, final)
+        except OSError:
+            try:
+                if tmp_path.exists():
+                    tmp_path.unlink()
+            except OSError:
+                pass
+            raise
+
+        log.info(f"PDF report generated successfully: {output_path}")
+        return True
 
     def _process_chart_list(self, charts: List[Any], width: float = 6,
                              height: float = 4) -> List:

--- a/siege_utilities/reporting/templates/base_template.py
+++ b/siege_utilities/reporting/templates/base_template.py
@@ -265,35 +265,30 @@ class BaseReportTemplate:
                 return str(cached_path)
 
             log.info(f"Downloading image from URL: {image_source}")
-            try:
-                response = requests.get(image_source, stream=True, timeout=30)
-                response.raise_for_status()
+            response = requests.get(image_source, stream=True, timeout=30)
+            response.raise_for_status()
 
-                # More robust extension determination from content type
-                content_type = response.headers.get('Content-Type', '').lower()
-                if 'image/jpeg' in content_type:
-                    cached_path = cached_path.with_suffix('.jpg')
-                elif 'image/png' in content_type:
-                    cached_path = cached_path.with_suffix('.png')
-                elif 'image/gif' in content_type:
-                    cached_path = cached_path.with_suffix('.gif')
+            # More robust extension determination from content type
+            content_type = response.headers.get('Content-Type', '').lower()
+            if 'image/jpeg' in content_type:
+                cached_path = cached_path.with_suffix('.jpg')
+            elif 'image/png' in content_type:
+                cached_path = cached_path.with_suffix('.png')
+            elif 'image/gif' in content_type:
+                cached_path = cached_path.with_suffix('.gif')
 
-                with open(cached_path, 'wb') as f:
-                    for chunk in response.iter_content(chunk_size=8192):
-                        f.write(chunk)
-                log.info(f"Image cached to: {cached_path}")
-                return str(cached_path)
-            except requests.exceptions.RequestException as e:
-                log.error(f"Error downloading image from {image_source}: {e}")
-                return None
+            with open(cached_path, 'wb') as f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    f.write(chunk)
+            log.info(f"Image cached to: {cached_path}")
+            return str(cached_path)
         else:
             local_path = Path(image_source)
             if local_path.exists():
                 log.debug(f"Using local image file: {local_path}")
                 return str(local_path)
             else:
-                log.error(f"Local image file not found: {local_path}")
-                return None
+                raise FileNotFoundError(f"Local image file not found: {local_path}")
 
     def _header_footer_on_page(self, canvas, doc):
         """


### PR DESCRIPTION
## Summary

SU-1 compliance for 6 files across reporting/ and geo/providers/:

- `save_figure_as_vector` → raises ValueError/OSError
- `generate_pdf_report` → raises OSError (cleans up temp files before re-raise)
- `_create_slide_from_section` → propagates; caller loop catches per-slide
- `_get_image_data_for_reportlab` → raises FileNotFoundError/RequestException
- `ga_geographic_analysis.py` — 3 choropleth functions raise (SU-3 applies)
- `nlrb_clients._download_csv` → raises ValueError/RequestException

This completes the bulk SU-1 sweep. Remaining instances are cache/registry lookups where None = "not cached" (legitimate design, not error suppression).