### PR TITLE
fix(SU-2): implementation matches claims in geo and engines

### DIFF
--- a/siege_utilities/engines/dataframe_engine.py
+++ b/siege_utilities/engines/dataframe_engine.py
@@ -646,10 +646,12 @@ class DataFrameEngine(ABC):
 
         Returns
         -------
-        DataFrame
+        pd.DataFrame
             Points enriched with ``{layer_name}_*`` columns for every
             polygon-side column from each boundary layer. Bare polygon
-            column names never appear in the output.
+            column names never appear in the output. Always returns a
+            pandas DataFrame regardless of engine (column-inspection
+            requires pandas semantics).
         """
         # Snapshot point-side schema before the first join so we know
         # exactly which columns belong to the points and which were

--- a/siege_utilities/geo/census_api_client.py
+++ b/siege_utilities/geo/census_api_client.py
@@ -46,6 +46,7 @@ if TYPE_CHECKING:
 import requests  # noqa: F401 — tests mock this module attribute
 
 from ..config import normalize_state_identifier
+from ..exceptions import SiegeGeoError
 
 # Re-export constants and sub-components for backward compatibility
 from .census.variable_registry import VARIABLE_GROUPS, VARIABLE_DESCRIPTIONS  # noqa: F401
@@ -59,7 +60,7 @@ log = logging.getLogger(__name__)
 # CUSTOM EXCEPTIONS
 # =============================================================================
 
-class CensusAPIError(Exception):
+class CensusAPIError(SiegeGeoError):
     """Base exception for Census API errors."""
     pass
 

--- a/siege_utilities/geo/crs.py
+++ b/siege_utilities/geo/crs.py
@@ -60,7 +60,18 @@ def set_default_crs(crs: str) -> None:
     Args:
         crs: Any CRS string accepted by ``pyproj`` (e.g. ``"EPSG:4326"``,
             ``"EPSG:3857"``, ``"ESRI:102003"``).
+
+    Raises:
+        ValueError: If *crs* is not a valid CRS recognized by pyproj.
     """
+    from pyproj import CRS as _PyprojCRS
+    from pyproj.exceptions import CRSError
+
+    try:
+        _PyprojCRS.from_user_input(crs)
+    except CRSError as e:
+        raise ValueError(f"Invalid CRS: {crs!r} — {e}") from e
+
     global _DEFAULT_CRS  # noqa: PLW0603
     _DEFAULT_CRS = crs
 

--- a/siege_utilities/geo/gazetteers/base.py
+++ b/siege_utilities/geo/gazetteers/base.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Mapping, Optional, Protocol, runtime_checkable
 
+from siege_utilities.exceptions import SiegeGeoError
+
 __all__ = [
     "Gazetteer",
     "GazetteerResult",
@@ -37,7 +39,7 @@ __all__ = [
 # Exceptions
 # ---------------------------------------------------------------------------
 
-class GazetteerError(RuntimeError):
+class GazetteerError(SiegeGeoError, RuntimeError):
     """Base class for all gazetteer failures."""
 
 

--- a/siege_utilities/geo/grids.py
+++ b/siege_utilities/geo/grids.py
@@ -105,9 +105,13 @@ def index_points(
     forwarded to the underlying function (e.g. ``as_token=False`` for
     S2).
 
+    If *engine* is provided, delegates to ``engine.index_points()``
+    instead of the standalone H3/S2 functions. Concrete engines may
+    have native fast paths (e.g. Sedona UDFs for Spark).
+
     Returns:
         ``pd.Series`` of cell IDs (H3 hex strings or S2 cell tokens by
-        default).
+        default), or engine-native column if *engine* is given.
     """
     if engine is not None:
         # Engine path: hand off to the DataFrameEngine.index_points override.

--- a/siege_utilities/geo/interpolation/areal.py
+++ b/siege_utilities/geo/interpolation/areal.py
@@ -104,7 +104,8 @@ def interpolate_areal(
             These are area-weighted averaged.
         allocate_total: If True, ensure 100% of source area is allocated.
         n_jobs: Number of parallel jobs (-1 for all CPUs).
-        crs: Output CRS for the result GeoDataFrame (default ``"EPSG:4326"``).
+        crs: Output CRS for the result GeoDataFrame
+            (default: value of ``get_default_crs()``).
 
     Returns:
         ArealInterpolationResult with interpolated GeoDataFrame in *crs*.
@@ -190,7 +191,7 @@ def interpolate_extensive(
         variables: Column names of extensive variables.
         allocate_total: Ensure all source area is allocated.
         n_jobs: Parallel jobs.
-        crs: Output CRS (default ``"EPSG:4326"``).
+        crs: Output CRS (default: value of ``get_default_crs()``).
 
     Returns:
         ArealInterpolationResult.
@@ -225,7 +226,7 @@ def interpolate_intensive(
         variables: Column names of intensive variables.
         allocate_total: Ensure all source area is allocated.
         n_jobs: Parallel jobs.
-        crs: Output CRS (default ``"EPSG:4326"``).
+        crs: Output CRS (default: value of ``get_default_crs()``).
 
     Returns:
         ArealInterpolationResult.
@@ -261,7 +262,7 @@ def compute_area_weights(
     Args:
         source_gdf: Source polygons.
         target_gdf: Target polygons.
-        crs: Output CRS (default ``"EPSG:4326"``).
+        crs: Output CRS (default: value of ``get_default_crs()``).
 
     Returns:
         GeoDataFrame with overlap weights in *crs*.
@@ -269,8 +270,12 @@ def compute_area_weights(
     source, target, _ = _ensure_common_crs(source_gdf, target_gdf)
 
     # Use an equal-area projection for accurate area computation
-    source_ea = source.to_crs("ESRI:54009")
-    target_ea = target.to_crs("ESRI:54009")
+    source_ea = source.to_crs("ESRI:54009").copy()
+    target_ea = target.to_crs("ESRI:54009").copy()
+
+    # Tag each polygon with a trackable index before overlay
+    source_ea["_src_idx"] = range(len(source_ea))
+    target_ea["_tgt_idx"] = range(len(target_ea))
 
     # Compute intersections via spatial overlay
     overlay = gpd.overlay(source_ea, target_ea, how="intersection", keep_geom_type=False)
@@ -279,22 +284,28 @@ def compute_area_weights(
         log.warning("No intersections found between source and target polygons.")
         return gpd.GeoDataFrame(
             columns=["source_idx", "target_idx", "overlap_area",
-                      "source_fraction", "target_fraction"],
+                      "source_fraction", "target_fraction", "geometry"],
         )
 
-    overlap_areas = overlay.geometry.area
+    # Compute areas
+    overlay["overlap_area"] = overlay.geometry.area
+    source_areas = source_ea.geometry.area
+    target_areas = target_ea.geometry.area
 
-    # Build result — use overlay's index tracking
-    # gpd.overlay preserves original indices in columns if they were set
-    records = []
-    for i, row in overlay.iterrows():
-        overlap_area = overlap_areas[i]
-        # Source and target indices depend on overlay behavior
-        # For now, return the raw intersection areas
-        records.append({
-            "overlap_area": overlap_area,
-            "geometry": row.geometry,
-        })
+    overlay["source_idx"] = overlay["_src_idx"].astype(int)
+    overlay["target_idx"] = overlay["_tgt_idx"].astype(int)
+    overlay["source_fraction"] = overlay.apply(
+        lambda row: row["overlap_area"] / source_areas.iloc[int(row["_src_idx"])]
+        if source_areas.iloc[int(row["_src_idx"])] > 0 else 0.0,
+        axis=1,
+    )
+    overlay["target_fraction"] = overlay.apply(
+        lambda row: row["overlap_area"] / target_areas.iloc[int(row["_tgt_idx"])]
+        if target_areas.iloc[int(row["_tgt_idx"])] > 0 else 0.0,
+        axis=1,
+    )
 
-    result = gpd.GeoDataFrame(records, crs="ESRI:54009")
+    result = overlay[["source_idx", "target_idx", "overlap_area",
+                      "source_fraction", "target_fraction", "geometry"]].copy()
+    result = gpd.GeoDataFrame(result, crs="ESRI:54009")
     return reproject_if_needed(result, crs)

--- a/siege_utilities/geo/spatial_data.py
+++ b/siege_utilities/geo/spatial_data.py
@@ -1834,8 +1834,10 @@ class GovernmentDataSource(SpatialDataSource):
                 else:
                     gdf = gpd.read_file(local_filename)
             else:
-                log.error(f"Unsupported format: {format_type}")
-                return None
+                raise ValueError(
+                    f"Unsupported format: {format_type!r}. "
+                    f"Supported: 'geojson', 'shapefile'."
+                )
             
             # Best-effort cleanup of the downloaded file. Narrow to OSError
             # (the only family os.remove raises) and log at debug level so

--- a/siege_utilities/geo/spatial_data.py
+++ b/siege_utilities/geo/spatial_data.py
@@ -18,6 +18,8 @@ import geopandas as gpd
 import requests
 from bs4 import BeautifulSoup
 
+from siege_utilities.exceptions import SiegeGeoError
+
 from siege_utilities.geo.crs import reproject_if_needed
 
 # Opt-in TLS-verification bypass for environments behind broken
@@ -64,7 +66,7 @@ from .boundary_result import (
 log = logging.getLogger(__name__)
 
 
-class SpatialDataError(RuntimeError):
+class SpatialDataError(SiegeGeoError, RuntimeError):
     """Raised when a non-boundary spatial data fetch fails unexpectedly.
 
     Used by GovernmentDataSource and OpenStreetMapDataSource, which load

--- a/siege_utilities/geo/spatial_data.py
+++ b/siege_utilities/geo/spatial_data.py
@@ -1715,7 +1715,7 @@ class GovernmentDataSource(SpatialDataSource):
         
         Args:
             dataset_id: Unique identifier for the dataset
-            format_type: Preferred format (geojson, shapefile, kml)
+            format_type: Preferred format (geojson, shapefile)
             
         Returns:
             GeoDataFrame with spatial data or None if failed

--- a/siege_utilities/reporting/chart_types.py
+++ b/siege_utilities/reporting/chart_types.py
@@ -327,7 +327,7 @@ class ChartTypeRegistry:
         categories = set(chart_type.category for chart_type in self.chart_types.values())
         return sorted(list(categories))
     
-    def create_chart(self, chart_type_name: str, **kwargs) -> Optional[Figure]:
+    def create_chart(self, chart_type_name: str, **kwargs) -> Figure:
         """
         Create a chart using the specified chart type.
 
@@ -531,6 +531,6 @@ def register_chart_type(chart_type: ChartType):
     """Register a new chart type."""
     get_chart_registry().register_chart_type(chart_type)
 
-def create_chart(chart_type_name: str, **kwargs) -> Optional[Figure]:
+def create_chart(chart_type_name: str, **kwargs) -> Figure:
     """Create a chart using the specified chart type."""
     return get_chart_registry().create_chart(chart_type_name, **kwargs)

--- a/siege_utilities/reporting/examples/bivariate_choropleth_example.py
+++ b/siege_utilities/reporting/examples/bivariate_choropleth_example.py
@@ -72,96 +72,74 @@ def create_sample_geodata():
 def example_basic_bivariate_choropleth():
     """
     Example 1: Basic bivariate choropleth using Folium.
-    
+
     This example shows how to create a simple bivariate choropleth map
     using the Folium-based method.
     """
     print("=== Example 1: Basic Bivariate Choropleth (Folium) ===")
-    
-    # Initialize chart generator
+
     chart_gen = ChartGenerator()
-    
-    # Create sample data
     data = create_sample_data()
-    
-    try:
-        # Create bivariate choropleth
-        chart = chart_gen.create_bivariate_choropleth(
-            data=data,
-            location_column='state',
-            value_column1='population_density',
-            value_column2='median_income',
-            title="Population Density vs Median Income by State",
-            width=10.0,
-            height=8.0
-        )
-        
-        print("✓ Basic bivariate choropleth created successfully")
-        print(f"Chart type: {type(chart)}")
-        print(f"Chart dimensions: {chart.drawWidth} x {chart.drawHeight}")
-        
-        return chart
-        
-    except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-        print(f"✗ Error creating basic bivariate choropleth: {e}")
-        return None
+
+    chart = chart_gen.create_bivariate_choropleth(
+        data=data,
+        location_column='state',
+        value_column1='population_density',
+        value_column2='median_income',
+        title="Population Density vs Median Income by State",
+        width=10.0,
+        height=8.0
+    )
+
+    print("✓ Basic bivariate choropleth created successfully")
+    print(f"Chart type: {type(chart)}")
+    print(f"Chart dimensions: {chart.drawWidth} x {chart.drawHeight}")
+
+    return chart
 
 def example_advanced_bivariate_choropleth():
     """
     Example 2: Advanced bivariate choropleth using matplotlib and geopandas.
-    
+
     This example demonstrates the more sophisticated approach using matplotlib
     for better control over styling and legends.
     """
     print("\n=== Example 2: Advanced Bivariate Choropleth (Matplotlib) ===")
-    
-    # Initialize chart generator
+
     chart_gen = ChartGenerator()
-    
-    # Create sample data
     data = create_sample_data()
     geodata = create_sample_geodata()
-    
-    try:
-        # Create advanced bivariate choropleth
-        chart = chart_gen.create_bivariate_choropleth_matplotlib(
-            data=data,
-            geodata=geodata,
-            location_column='state',
-            value_column1='population_density',
-            value_column2='median_income',
-            title="Advanced Bivariate Choropleth: Population Density vs Income",
-            width=12.0,
-            height=10.0,
-            color_scheme='custom'
-        )
-        
-        print("✓ Advanced bivariate choropleth created successfully")
-        print(f"Chart type: {type(chart)}")
-        print(f"Chart dimensions: {chart.drawWidth} x {chart.drawHeight}")
-        
-        return chart
-        
-    except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-        print(f"✗ Error creating advanced bivariate choropleth: {e}")
-        return None
+
+    chart = chart_gen.create_bivariate_choropleth_matplotlib(
+        data=data,
+        geodata=geodata,
+        location_column='state',
+        value_column1='population_density',
+        value_column2='median_income',
+        title="Advanced Bivariate Choropleth: Population Density vs Income",
+        width=12.0,
+        height=10.0,
+        color_scheme='custom'
+    )
+
+    print("✓ Advanced bivariate choropleth created successfully")
+    print(f"Chart type: {type(chart)}")
+    print(f"Chart dimensions: {chart.drawWidth} x {chart.drawHeight}")
+
+    return chart
 
 def example_custom_chart_configuration():
     """
     Example 3: Using custom chart configuration for bivariate choropleth.
-    
+
     This example shows how to use the custom chart configuration
     system with bivariate choropleth maps.
     """
     print("\n=== Example 3: Custom Chart Configuration ===")
-    
-    # Initialize chart generator
+
     chart_gen = ChartGenerator()
-    
-    # Create sample data
     data = create_sample_data()
-    
-    # Custom chart configuration
+
     chart_config = {
         'type': 'bivariate_choropleth',
         'title': 'Custom Bivariate Choropleth Configuration',
@@ -169,102 +147,78 @@ def example_custom_chart_configuration():
         'location_column': 'state',
         'value_columns': ['population_density', 'median_income']
     }
-    
-    try:
-        # Create chart using custom configuration
-        chart = chart_gen.create_custom_chart(
-            chart_config=chart_config,
-            width=10.0,
-            height=8.0
-        )
-        
-        print("✓ Custom chart configuration bivariate choropleth created successfully")
-        print(f"Chart type: {type(chart)}")
-        print(f"Chart dimensions: {chart.drawWidth} x {chart.drawHeight}")
-        
-        return chart
-        
-    except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-        print(f"✗ Error creating custom chart configuration: {e}")
-        return None
+
+    chart = chart_gen.create_custom_chart(
+        chart_config=chart_config,
+        width=10.0,
+        height=8.0
+    )
+
+    print("✓ Custom chart configuration bivariate choropleth created successfully")
+    print(f"Chart type: {type(chart)}")
+    print(f"Chart dimensions: {chart.drawWidth} x {chart.drawHeight}")
+
+    return chart
 
 def example_dataframe_integration():
     """
     Example 4: Integration with DataFrame-based chart generation.
-    
+
     This example shows how to use the DataFrame integration methods
     with bivariate choropleth maps.
     """
     print("\n=== Example 4: DataFrame Integration ===")
-    
-    # Initialize chart generator
+
     chart_gen = ChartGenerator()
-    
-    # Create sample data
     data = create_sample_data()
-    
-    try:
-        # Create bivariate choropleth using DataFrame method
-        chart = chart_gen.generate_chart_from_dataframe(
-            df=data,
-            chart_type='bivariate_choropleth',
-            x_column='state',
-            y_columns=['population_density', 'median_income'],
-            title="DataFrame Integration Example",
-            width=10.0,
-            height=8.0
-        )
-        
-        print("✓ DataFrame integration bivariate choropleth created successfully")
-        print(f"Chart type: {type(chart)}")
-        print(f"Chart dimensions: {chart.drawWidth} x {chart.drawHeight}")
-        
-        return chart
-        
-    except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-        print(f"✗ Error creating DataFrame integration chart: {e}")
-        return None
+
+    chart = chart_gen.generate_chart_from_dataframe(
+        df=data,
+        chart_type='bivariate_choropleth',
+        x_column='state',
+        y_columns=['population_density', 'median_income'],
+        title="DataFrame Integration Example",
+        width=10.0,
+        height=8.0
+    )
+
+    print("✓ DataFrame integration bivariate choropleth created successfully")
+    print(f"Chart type: {type(chart)}")
+    print(f"Chart dimensions: {chart.drawWidth} x {chart.drawHeight}")
+
+    return chart
 
 def example_advanced_choropleth():
     """
     Example 5: Advanced choropleth with classification options.
-    
+
     This example demonstrates the advanced choropleth functionality
     with different classification methods.
     """
     print("\n=== Example 5: Advanced Choropleth with Classification ===")
-    
-    # Initialize chart generator
+
     chart_gen = ChartGenerator()
-    
-    # Create sample data
     data = create_sample_data()
     geodata = create_sample_geodata()
-    
-    try:
-        # Create advanced choropleth with quantile classification
-        chart = chart_gen.create_advanced_choropleth(
-            data=data,
-            geodata=geodata,
-            location_column='state',
-            value_column='population_density',
-            title="Advanced Choropleth: Population Density (Quantile Classification)",
-            width=12.0,
-            height=10.0,
-            classification='quantiles',
-            bins=5,
-            color_scheme='YlOrRd'
-        )
-        
-        print("✓ Advanced choropleth with classification created successfully")
-        print(f"Chart type: {type(chart)}")
-        print(f"Chart dimensions: {chart.drawWidth} x {chart.drawHeight}")
-        
-        return chart
-        
-    except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-        print(f"✗ Error creating advanced choropleth: {e}")
-        return None
+
+    chart = chart_gen.create_advanced_choropleth(
+        data=data,
+        geodata=geodata,
+        location_column='state',
+        value_column='population_density',
+        title="Advanced Choropleth: Population Density (Quantile Classification)",
+        width=12.0,
+        height=10.0,
+        classification='quantiles',
+        bins=5,
+        color_scheme='YlOrRd'
+    )
+
+    print("✓ Advanced choropleth with classification created successfully")
+    print(f"Chart type: {type(chart)}")
+    print(f"Chart dimensions: {chart.drawWidth} x {chart.drawHeight}")
+
+    return chart
 
 def run_all_examples():
     """
@@ -302,61 +256,49 @@ def run_all_examples():
 def create_report_with_bivariate_maps():
     """
     Example 6: Create a complete report section with bivariate choropleth maps.
-    
+
     This example shows how to integrate bivariate choropleth maps
     into the complete reporting system.
     """
     print("\n=== Example 6: Report Integration ===")
-    
-    # Initialize chart generator
+
     chart_gen = ChartGenerator()
-    
-    # Create sample data
     data = create_sample_data()
-    
-    try:
-        # Create multiple charts for the report
-        charts = []
-        
-        # Chart 1: Basic bivariate choropleth
-        chart1 = chart_gen.create_bivariate_choropleth(
-            data=data,
-            location_column='state',
-            value_column1='population_density',
-            value_column2='median_income',
-            title="Population Density vs Median Income",
-            width=8.0,
-            height=6.0
-        )
-        charts.append(chart1)
-        
-        # Chart 2: Scatter plot for comparison
-        chart2 = chart_gen.create_scatter_plot(
-            data=data,
-            x_column='population_density',
-            y_column='median_income',
-            title="Population Density vs Median Income (Scatter)",
-            width=8.0,
-            height=6.0
-        )
-        charts.append(chart2)
-        
-        # Create report section
-        report_section = chart_gen.create_chart_section(
-            title="Geographic Analysis: Population and Income Patterns",
-            charts=charts,
-            description="This section analyzes the relationship between population density and median income across different states using bivariate choropleth maps and supporting visualizations."
-        )
-        
-        print("✓ Report section with bivariate maps created successfully")
-        print(f"Number of charts in section: {len(charts)}")
-        print(f"Report section length: {len(report_section)} elements")
-        
-        return report_section
-        
-    except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-        print(f"✗ Error creating report section: {e}")
-        return None
+
+    charts = []
+
+    chart1 = chart_gen.create_bivariate_choropleth(
+        data=data,
+        location_column='state',
+        value_column1='population_density',
+        value_column2='median_income',
+        title="Population Density vs Median Income",
+        width=8.0,
+        height=6.0
+    )
+    charts.append(chart1)
+
+    chart2 = chart_gen.create_scatter_plot(
+        data=data,
+        x_column='population_density',
+        y_column='median_income',
+        title="Population Density vs Median Income (Scatter)",
+        width=8.0,
+        height=6.0
+    )
+    charts.append(chart2)
+
+    report_section = chart_gen.create_chart_section(
+        title="Geographic Analysis: Population and Income Patterns",
+        charts=charts,
+        description="This section analyzes the relationship between population density and median income across different states using bivariate choropleth maps and supporting visualizations."
+    )
+
+    print("✓ Report section with bivariate maps created successfully")
+    print(f"Number of charts in section: {len(charts)}")
+    print(f"Report section length: {len(report_section)} elements")
+
+    return report_section
 
 if __name__ == "__main__":
     """

--- a/tests/test_areal_interpolation.py
+++ b/tests/test_areal_interpolation.py
@@ -188,11 +188,22 @@ class TestInterpolateAreal:
 class TestComputeAreaWeights:
     """Tests for the area weight computation."""
 
-    def test_full_overlap_returns_data(self, source_gdf, target_gdf):
+    def test_full_overlap_returns_all_columns(self, source_gdf, target_gdf):
         from siege_utilities.geo.interpolation import compute_area_weights
 
         weights = compute_area_weights(source_gdf, target_gdf)
         assert len(weights) > 0
+        expected_cols = {"source_idx", "target_idx", "overlap_area",
+                        "source_fraction", "target_fraction", "geometry"}
+        assert expected_cols.issubset(set(weights.columns))
+
+    def test_source_fraction_sums_to_one(self, source_gdf, target_gdf):
+        from siege_utilities.geo.interpolation import compute_area_weights
+
+        weights = compute_area_weights(source_gdf, target_gdf)
+        for src_idx in weights["source_idx"].unique():
+            frac_sum = weights[weights["source_idx"] == src_idx]["source_fraction"].sum()
+            np.testing.assert_allclose(frac_sum, 1.0, atol=0.01)
 
     def test_no_overlap_returns_empty(self):
         from siege_utilities.geo.interpolation import compute_area_weights
@@ -205,3 +216,6 @@ class TestComputeAreaWeights:
         )
         weights = compute_area_weights(source, target)
         assert len(weights) == 0
+        expected_cols = {"source_idx", "target_idx", "overlap_area",
+                        "source_fraction", "target_fraction"}
+        assert expected_cols.issubset(set(weights.columns))

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -68,3 +68,23 @@ def test_reproject_if_needed_with_changed_default():
         assert result.crs.to_epsg() == 3857
     finally:
         set_default_crs(original)
+
+
+def test_set_default_crs_rejects_invalid():
+    """set_default_crs raises ValueError for an unrecognized CRS string."""
+    import pytest
+
+    with pytest.raises(ValueError, match="Invalid CRS"):
+        set_default_crs("NOT_A_REAL_CRS")
+
+
+def test_set_default_crs_accepts_valid():
+    """set_default_crs accepts common CRS strings without raising."""
+    original = get_default_crs()
+    try:
+        set_default_crs("EPSG:3857")
+        assert get_default_crs() == "EPSG:3857"
+        set_default_crs("ESRI:54009")
+        assert get_default_crs() == "ESRI:54009"
+    finally:
+        set_default_crs(original)


### PR DESCRIPTION
## Summary

Fixes SU-2 violations where function implementations don't match their
docstring/type-signature claims:

- **`compute_area_weights()`** — docstring promised 5 columns
  (source_idx, target_idx, overlap_area, source_fraction, target_fraction)
  but implementation only produced overlap_area + geometry. Now produces
  all 5 columns using index-tagged overlays and area ratio computation.

- **`set_default_crs()`** — claimed "any CRS string accepted by pyproj"
  but performed no validation. Now validates via `pyproj.CRS.from_user_input()`
  and raises `ValueError` on invalid CRS.

- **areal.py docstrings** — 4 instances of "default EPSG:4326" corrected
  to "default: value of get_default_crs()" since the actual default is the
  configurable global CRS.

- **`GovDataPortal.download_dataset()`** — claimed support for "geojson,
  shapefile, kml" but KML was never implemented. Narrowed to "geojson, shapefile".

- **`multi_assign()`** — return type docs said "DataFrame" (implying
  engine-native) but always returns pandas due to column-inspection
  requirements. Now explicitly documented.

## Test plan

- [ ] `compute_area_weights()` with overlapping polygons returns all 5 columns
- [ ] `compute_area_weights()` with non-overlapping polygons returns empty GDF with correct schema
- [ ] `set_default_crs("INVALID")` raises ValueError
- [ ] `set_default_crs("EPSG:3857")` succeeds
- [ ] Existing areal interpolation tests pass