### PR TITLE
fix(SU-1): raise on failure across analytics, distributed, and files packages

### DIFF
--- a/siege_utilities/analytics/datadotworld_connector.py
+++ b/siege_utilities/analytics/datadotworld_connector.py
@@ -33,330 +33,298 @@ log = logging.getLogger(__name__)
 
 class DataDotWorldConnector:
     """Data.world connector with advanced data discovery and access features."""
-    
-    def __init__(self, 
+
+    def __init__(self,
                  api_token: Optional[str] = None,
                  config_file: Optional[Union[str, Path]] = None):
         """
         Initialize Data.world connector.
-        
+
         Args:
             api_token: Data.world API token (optional if using config file)
             config_file: Path to configuration file
+
+        Raises:
+            ImportError: If datadotworld is not installed.
         """
         if not DATADOTWORLD_AVAILABLE:
             raise ImportError("Data.world connector not available. Install with: pip install datadotworld")
-        
+
         self.api_token = api_token
         self.config_file = config_file
-        
+
         # Load configuration if provided
         if config_file:
             self._load_config(config_file)
-        
+
         # Initialize client
         self.client = None
         self._initialize_client()
-        
+
         log.info("Initialized Data.world connector")
-    
+
     def _load_config(self, config_file: Union[str, Path]) -> None:
         """Load configuration from file."""
         config_path = Path(config_file)
         if not config_path.exists():
             raise FileNotFoundError(f"Configuration file not found: {config_path}")
-        
-        try:
-            with open(config_path, 'r', encoding='utf-8') as f:
-                config = json.load(f)
 
-            # Update instance variables with config values
-            if 'api_token' in config and config['api_token']:
-                self.api_token = config['api_token']
-                    
-        except (json.JSONDecodeError, OSError) as e:
-            log.error(f"Failed to load configuration: {e}")
-            raise
-    
+        with open(config_path, 'r', encoding='utf-8') as f:
+            config = json.load(f)
+
+        if 'api_token' in config and config['api_token']:
+            self.api_token = config['api_token']
+
     def _initialize_client(self) -> None:
         """Initialize the Data.world client."""
-        try:
-            if self.api_token:
-                self.client = dw.api_client(self.api_token)
+        if self.api_token:
+            self.client = dw.api_client(self.api_token)
+        else:
+            env_token = os.getenv('DATADOTWORLD_API_TOKEN')
+            if env_token:
+                self.client = dw.api_client(env_token)
             else:
-                # Try to get from environment variable
-                env_token = os.getenv('DATADOTWORLD_API_TOKEN')
-                if env_token:
-                    self.client = dw.api_client(env_token)
-                else:
-                    # Use anonymous client
-                    self.client = dw.api_client()
-                    log.warning("No API token provided. Using anonymous access with limited functionality.")
-            
-            log.info("Data.world client initialized successfully")
-            
-        except (ImportError, AttributeError, TypeError) as e:
-            log.error(f"Failed to initialize Data.world client: {e}")
-            raise
-    
-    def search_datasets(self, 
+                self.client = dw.api_client()
+                log.warning("No API token provided. Using anonymous access with limited functionality.")
+
+        log.info("Data.world client initialized successfully")
+
+    def search_datasets(self,
                        query: str,
                        limit: int = 50,
                        owner: Optional[str] = None,
-                       tags: Optional[List[str]] = None) -> Optional[List[Dict[str, Any]]]:
+                       tags: Optional[List[str]] = None) -> List[Dict[str, Any]]:
         """
         Search for datasets on data.world.
-        
+
         Args:
             query: Search query string
             limit: Maximum number of results to return
             owner: Filter by dataset owner
             tags: Filter by tags
-            
+
         Returns:
-            List of dataset information dictionaries
+            List of dataset information dictionaries.
+
+        Raises:
+            requests.RequestException: On network/API failure.
         """
-        try:
-            # Build search parameters
-            search_params = {
-                'q': query,
-                'limit': limit
+        search_params: Dict[str, Any] = {
+            'q': query,
+            'limit': limit
+        }
+
+        if owner:
+            search_params['owner'] = owner
+        if tags:
+            search_params['tags'] = ','.join(tags)
+
+        search_results = self.client.search_datasets(**search_params)
+
+        datasets = []
+        for result in search_results['records']:
+            dataset_info = {
+                'id': result.get('id'),
+                'title': result.get('title'),
+                'description': result.get('description'),
+                'owner': result.get('owner'),
+                'tags': result.get('tags', []),
+                'license': result.get('license'),
+                'visibility': result.get('visibility'),
+                'updated_at': result.get('updatedAt'),
+                'download_count': result.get('downloadCount', 0)
             }
-            
-            if owner:
-                search_params['owner'] = owner
-            if tags:
-                search_params['tags'] = ','.join(tags)
-            
-            # Perform search
-            search_results = self.client.search_datasets(**search_params)
-            
-            # Extract relevant information
-            datasets = []
-            for result in search_results['records']:
-                dataset_info = {
-                    'id': result.get('id'),
-                    'title': result.get('title'),
-                    'description': result.get('description'),
-                    'owner': result.get('owner'),
-                    'tags': result.get('tags', []),
-                    'license': result.get('license'),
-                    'visibility': result.get('visibility'),
-                    'updated_at': result.get('updatedAt'),
-                    'download_count': result.get('downloadCount', 0)
-                }
-                datasets.append(dataset_info)
-            
-            log.info(f"Found {len(datasets)} datasets matching query: {query}")
-            return datasets
-            
-        except (requests.RequestException, KeyError, ValueError) as e:
-            log.error(f"Dataset search failed: {e}")
-            return None
-    
-    def get_dataset_info(self, dataset_id: str) -> Optional[Dict[str, Any]]:
+            datasets.append(dataset_info)
+
+        log.info(f"Found {len(datasets)} datasets matching query: {query}")
+        return datasets
+
+    def get_dataset_info(self, dataset_id: str) -> Dict[str, Any]:
         """
         Get detailed information about a specific dataset.
-        
+
         Args:
             dataset_id: Dataset identifier (format: owner/dataset)
-            
+
         Returns:
-            Dictionary with detailed dataset information
+            Dictionary with detailed dataset information.
+
+        Raises:
+            requests.RequestException: On network/API failure.
         """
-        try:
-            dataset_info = self.client.get_dataset(dataset_id)
-            
-            # Extract relevant information
-            info = {
-                'id': dataset_info.get('id'),
-                'title': dataset_info.get('title'),
-                'description': dataset_info.get('description'),
-                'owner': dataset_info.get('owner'),
-                'tags': dataset_info.get('tags', []),
-                'license': dataset_info.get('license'),
-                'visibility': dataset_info.get('visibility'),
-                'created_at': dataset_info.get('createdAt'),
-                'updated_at': dataset_info.get('updatedAt'),
-                'download_count': dataset_info.get('downloadCount', 0),
-                'files': dataset_info.get('files', []),
-                'summary': dataset_info.get('summary', {})
-            }
-            
-            log.info(f"Retrieved dataset info for: {dataset_id}")
-            return info
-            
-        except (requests.RequestException, KeyError, ValueError) as e:
-            log.error(f"Failed to get dataset info for {dataset_id}: {e}")
-            return None
-    
-    def list_dataset_files(self, dataset_id: str) -> Optional[List[Dict[str, Any]]]:
+        dataset_info = self.client.get_dataset(dataset_id)
+
+        info = {
+            'id': dataset_info.get('id'),
+            'title': dataset_info.get('title'),
+            'description': dataset_info.get('description'),
+            'owner': dataset_info.get('owner'),
+            'tags': dataset_info.get('tags', []),
+            'license': dataset_info.get('license'),
+            'visibility': dataset_info.get('visibility'),
+            'created_at': dataset_info.get('createdAt'),
+            'updated_at': dataset_info.get('updatedAt'),
+            'download_count': dataset_info.get('downloadCount', 0),
+            'files': dataset_info.get('files', []),
+            'summary': dataset_info.get('summary', {})
+        }
+
+        log.info(f"Retrieved dataset info for: {dataset_id}")
+        return info
+
+    def list_dataset_files(self, dataset_id: str) -> List[Dict[str, Any]]:
         """
         List all files in a dataset.
-        
+
         Args:
             dataset_id: Dataset identifier (format: owner/dataset)
-            
+
         Returns:
-            List of file information dictionaries
+            List of file information dictionaries.
+
+        Raises:
+            requests.RequestException: On network/API failure.
         """
-        try:
-            dataset_info = self.client.get_dataset(dataset_id)
-            files = dataset_info.get('files', [])
-            
-            # Extract relevant file information
-            file_list = []
-            for file_info in files:
-                file_data = {
-                    'name': file_info.get('name'),
-                    'size': file_info.get('size'),
-                    'format': file_info.get('format'),
-                    'url': file_info.get('url'),
-                    'description': file_info.get('description'),
-                    'tags': file_info.get('tags', [])
-                }
-                file_list.append(file_data)
-            
-            log.info(f"Found {len(file_list)} files in dataset: {dataset_id}")
-            return file_list
-            
-        except (requests.RequestException, KeyError, ValueError) as e:
-            log.error(f"Failed to list files for dataset {dataset_id}: {e}")
-            return None
-    
-    def download_file(self, 
+        dataset_info = self.client.get_dataset(dataset_id)
+        files = dataset_info.get('files', [])
+
+        file_list = []
+        for file_info in files:
+            file_data = {
+                'name': file_info.get('name'),
+                'size': file_info.get('size'),
+                'format': file_info.get('format'),
+                'url': file_info.get('url'),
+                'description': file_info.get('description'),
+                'tags': file_info.get('tags', [])
+            }
+            file_list.append(file_data)
+
+        log.info(f"Found {len(file_list)} files in dataset: {dataset_id}")
+        return file_list
+
+    def download_file(self,
                      dataset_id: str,
                      file_name: str,
-                     output_path: Optional[Union[str, Path]] = None) -> Optional[Union[str, Path]]:
+                     output_path: Optional[Union[str, Path]] = None) -> Path:
         """
         Download a specific file from a dataset.
-        
+
         Args:
             dataset_id: Dataset identifier (format: owner/dataset)
             file_name: Name of the file to download
             output_path: Local path to save the file (optional)
-            
+
         Returns:
-            Path to the downloaded file
+            Path to the downloaded file.
+
+        Raises:
+            OSError: On filesystem or network failure.
+            requests.RequestException: On API failure.
         """
-        try:
-            if not output_path:
-                # Use default download directory
-                from siege_utilities.config.user_config import get_download_directory
-                output_path = get_download_directory() / "datadotworld" / dataset_id.replace('/', '_') / file_name
-            
-            # Ensure output directory exists
-            output_path = Path(output_path)
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            
-            # Download the file
-            self.client.download_file(dataset_id, file_name, output_path)
-            
-            log.info(f"Successfully downloaded {file_name} to {output_path}")
-            return output_path
-            
-        except (OSError, requests.RequestException) as e:
-            log.error(f"Failed to download file {file_name} from dataset {dataset_id}: {e}")
-            return None
-    
-    def load_dataset_as_dataframe(self, 
+        if not output_path:
+            from siege_utilities.config.user_config import get_download_directory
+            output_path = get_download_directory() / "datadotworld" / dataset_id.replace('/', '_') / file_name
+
+        output_path = Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        self.client.download_file(dataset_id, file_name, output_path)
+
+        log.info(f"Successfully downloaded {file_name} to {output_path}")
+        return output_path
+
+    def load_dataset_as_dataframe(self,
                                  dataset_id: str,
-                                 file_name: Optional[str] = None) -> Optional['pd.DataFrame']:
+                                 file_name: Optional[str] = None) -> 'pd.DataFrame':
         """
         Load a dataset file directly as a pandas DataFrame.
-        
+
         Args:
             dataset_id: Dataset identifier (format: owner/dataset)
             file_name: Name of the file to load (optional, loads first file if not specified)
-            
+
         Returns:
-            Pandas DataFrame with the data
+            Pandas DataFrame with the data.
+
+        Raises:
+            ImportError: If pandas is not installed.
+            requests.RequestException: On API failure.
         """
         if not PANDAS_AVAILABLE:
-            log.error("Pandas not available for DataFrame operations")
-            return None
-        
-        try:
-            if file_name:
-                # Load specific file
-                df = dw.load_dataset(dataset_id, file_name)
-            else:
-                # Load entire dataset
-                df = dw.load_dataset(dataset_id)
-            
-            log.info(f"Successfully loaded dataset {dataset_id} as DataFrame with {len(df)} rows")
-            return df
-            
-        except (requests.RequestException, ValueError) as e:
-            log.error(f"Failed to load dataset {dataset_id} as DataFrame: {e}")
-            return None
-    
-    def query_dataset(self, 
+            raise ImportError("Pandas not available for DataFrame operations. Install with: pip install pandas")
+
+        if file_name:
+            df = dw.load_dataset(dataset_id, file_name)
+        else:
+            df = dw.load_dataset(dataset_id)
+
+        log.info(f"Successfully loaded dataset {dataset_id} as DataFrame with {len(df)} rows")
+        return df
+
+    def query_dataset(self,
                      dataset_id: str,
                      query: str,
-                     query_type: str = 'sql') -> Optional['pd.DataFrame']:
+                     query_type: str = 'sql') -> 'pd.DataFrame':
         """
         Execute a query against a dataset.
-        
+
         Args:
             dataset_id: Dataset identifier (format: owner/dataset)
             query: Query string (SQL or SPARQL)
             query_type: Type of query ('sql' or 'sparql')
-            
+
         Returns:
-            Pandas DataFrame with query results
+            Pandas DataFrame with query results.
+
+        Raises:
+            ImportError: If pandas is not installed.
+            ValueError: If query_type is not 'sql' or 'sparql'.
+            requests.RequestException: On API failure.
         """
         if not PANDAS_AVAILABLE:
-            log.error("Pandas not available for DataFrame operations")
-            return None
-        
-        try:
-            if query_type.lower() == 'sql':
-                df = dw.query(dataset_id, query, query_type='sql')
-            elif query_type.lower() == 'sparql':
-                df = dw.query(dataset_id, query, query_type='sparql')
-            else:
-                raise ValueError("query_type must be 'sql' or 'sparql'")
-            
-            log.info(f"Successfully executed {query_type.upper()} query on dataset {dataset_id}")
-            return df
-            
-        except (requests.RequestException, ValueError) as e:
-            log.error(f"Query execution failed on dataset {dataset_id}: {e}")
-            return None
-    
-    def get_dataset_schema(self, dataset_id: str) -> Optional[Dict[str, Any]]:
+            raise ImportError("Pandas not available for DataFrame operations. Install with: pip install pandas")
+
+        if query_type.lower() == 'sql':
+            df = dw.query(dataset_id, query, query_type='sql')
+        elif query_type.lower() == 'sparql':
+            df = dw.query(dataset_id, query, query_type='sparql')
+        else:
+            raise ValueError("query_type must be 'sql' or 'sparql'")
+
+        log.info(f"Successfully executed {query_type.upper()} query on dataset {dataset_id}")
+        return df
+
+    def get_dataset_schema(self, dataset_id: str) -> Dict[str, Any]:
         """
         Get the schema information for a dataset.
-        
+
         Args:
             dataset_id: Dataset identifier (format: owner/dataset)
-            
+
         Returns:
-            Dictionary with schema information
+            Dictionary with schema information.
+
+        Raises:
+            requests.RequestException: On network/API failure.
         """
-        try:
-            dataset_info = self.client.get_dataset(dataset_id)
-            schema = dataset_info.get('schema', {})
-            
-            log.info(f"Retrieved schema for dataset: {dataset_id}")
-            return schema
-            
-        except (requests.RequestException, KeyError, ValueError) as e:
-            log.error(f"Failed to get schema for dataset {dataset_id}: {e}")
-            return None
-    
-    def create_dataset(self, 
+        dataset_info = self.client.get_dataset(dataset_id)
+        schema = dataset_info.get('schema', {})
+
+        log.info(f"Retrieved schema for dataset: {dataset_id}")
+        return schema
+
+    def create_dataset(self,
                       owner: str,
                       dataset_id: str,
                       title: str,
                       description: str,
                       tags: Optional[List[str]] = None,
                       license: str = 'Public Domain',
-                      visibility: str = 'OPEN') -> Optional[str]:
+                      visibility: str = 'OPEN') -> str:
         """
         Create a new dataset on data.world.
-        
+
         Args:
             owner: Dataset owner username
             dataset_id: Unique dataset identifier
@@ -365,218 +333,122 @@ class DataDotWorldConnector:
             tags: List of tags (optional)
             license: Dataset license (optional)
             visibility: Dataset visibility ('OPEN' or 'PRIVATE')
-            
+
         Returns:
-            Created dataset ID if successful, None otherwise
+            Created dataset ID (format: owner/dataset_id).
+
+        Raises:
+            ValueError: If API token is not set.
+            requests.RequestException: On API failure.
         """
-        try:
-            if not self.api_token:
-                raise ValueError("API token required to create datasets")
-            
-            # Create dataset
-            dataset_info = self.client.create_dataset(
-                owner=owner,
-                id=dataset_id,
-                title=title,
-                description=description,
-                tags=tags or [],
-                license=license,
-                visibility=visibility
-            )
-            
-            created_id = f"{owner}/{dataset_id}"
-            log.info(f"Successfully created dataset: {created_id}")
-            return created_id
-            
-        except (requests.RequestException, ValueError) as e:
-            log.error(f"Failed to create dataset: {e}")
-            return None
-    
-    def upload_file(self, 
+        if not self.api_token:
+            raise ValueError("API token required to create datasets")
+
+        self.client.create_dataset(
+            owner=owner,
+            id=dataset_id,
+            title=title,
+            description=description,
+            tags=tags or [],
+            license=license,
+            visibility=visibility
+        )
+
+        created_id = f"{owner}/{dataset_id}"
+        log.info(f"Successfully created dataset: {created_id}")
+        return created_id
+
+    def upload_file(self,
                    dataset_id: str,
                    file_path: Union[str, Path],
-                   file_name: Optional[str] = None) -> bool:
+                   file_name: Optional[str] = None) -> None:
         """
         Upload a file to an existing dataset.
-        
+
         Args:
             dataset_id: Dataset identifier (format: owner/dataset)
             file_path: Local path to the file to upload
             file_name: Name to use for the file on data.world (optional)
-            
-        Returns:
-            True if successful, False otherwise
+
+        Raises:
+            ValueError: If API token is not set.
+            FileNotFoundError: If file_path does not exist.
+            requests.RequestException: On API failure.
         """
-        try:
-            if not self.api_token:
-                raise ValueError("API token required to upload files")
-            
-            file_path = Path(file_path)
-            if not file_path.exists():
-                raise FileNotFoundError(f"File not found: {file_path}")
-            
-            if not file_name:
-                file_name = file_path.name
-            
-            # Upload the file
-            self.client.upload_file(dataset_id, file_path, file_name)
-            
-            log.info(f"Successfully uploaded {file_name} to dataset {dataset_id}")
-            return True
-            
-        except (FileNotFoundError, OSError, requests.RequestException) as e:
-            log.error(f"Failed to upload file to dataset {dataset_id}: {e}")
-            return False
-    
-    def update_dataset(self, 
+        if not self.api_token:
+            raise ValueError("API token required to upload files")
+
+        file_path = Path(file_path)
+        if not file_path.exists():
+            raise FileNotFoundError(f"File not found: {file_path}")
+
+        if not file_name:
+            file_name = file_path.name
+
+        self.client.upload_file(dataset_id, file_path, file_name)
+
+        log.info(f"Successfully uploaded {file_name} to dataset {dataset_id}")
+
+    def update_dataset(self,
                       dataset_id: str,
                       title: Optional[str] = None,
                       description: Optional[str] = None,
                       tags: Optional[List[str]] = None,
-                      license: Optional[str] = None) -> bool:
+                      license: Optional[str] = None) -> None:
         """
         Update an existing dataset.
-        
+
         Args:
             dataset_id: Dataset identifier (format: owner/dataset)
             title: New title (optional)
             description: New description (optional)
             tags: New tags (optional)
             license: New license (optional)
-            
-        Returns:
-            True if successful, False otherwise
+
+        Raises:
+            ValueError: If API token is not set or no update parameters provided.
+            requests.RequestException: On API failure.
         """
-        try:
-            if not self.api_token:
-                raise ValueError("API token required to update datasets")
-            
-            # Build update parameters
-            update_params = {}
-            if title:
-                update_params['title'] = title
-            if description:
-                update_params['description'] = description
-            if tags:
-                update_params['tags'] = tags
-            if license:
-                update_params['license'] = license
-            
-            if not update_params:
-                log.warning("No update parameters provided")
-                return False
-            
-            # Update dataset
-            self.client.update_dataset(dataset_id, **update_params)
-            
-            log.info(f"Successfully updated dataset: {dataset_id}")
-            return True
-            
-        except (requests.RequestException, ValueError) as e:
-            log.error(f"Failed to update dataset {dataset_id}: {e}")
-            return False
-    
-    def delete_dataset(self, dataset_id: str) -> bool:
+        if not self.api_token:
+            raise ValueError("API token required to update datasets")
+
+        update_params: Dict[str, Any] = {}
+        if title:
+            update_params['title'] = title
+        if description:
+            update_params['description'] = description
+        if tags:
+            update_params['tags'] = tags
+        if license:
+            update_params['license'] = license
+
+        if not update_params:
+            raise ValueError("No update parameters provided")
+
+        self.client.update_dataset(dataset_id, **update_params)
+
+        log.info(f"Successfully updated dataset: {dataset_id}")
+
+    def delete_dataset(self, dataset_id: str) -> None:
         """
         Delete a dataset.
-        
+
         Args:
             dataset_id: Dataset identifier (format: owner/dataset)
-            
-        Returns:
-            True if successful, False otherwise
+
+        Raises:
+            ValueError: If API token is not set.
+            requests.RequestException: On API failure.
         """
-        try:
-            if not self.api_token:
-                raise ValueError("API token required to delete datasets")
-            
-            # Delete dataset
-            self.client.delete_dataset(dataset_id)
-            
-            log.info(f"Successfully deleted dataset: {dataset_id}")
-            return True
-            
-        except (requests.RequestException, ValueError) as e:
-            log.error(f"Failed to delete dataset {dataset_id}: {e}")
-            return False
+        if not self.api_token:
+            raise ValueError("API token required to delete datasets")
+
+        self.client.delete_dataset(dataset_id)
+
+        log.info(f"Successfully deleted dataset: {dataset_id}")
 
 
 # Convenience functions
 def get_datadotworld_connector(config_file: Optional[Union[str, Path]] = None) -> DataDotWorldConnector:
     """Get Data.world connector instance from configuration."""
     return DataDotWorldConnector(config_file=config_file)
-
-
-def search_datadotworld_datasets(query: str, 
-                                config_file: Optional[Union[str, Path]] = None,
-                                **kwargs) -> Optional[List[Dict[str, Any]]]:
-    """Convenience function to search for datasets."""
-    with get_datadotworld_connector(config_file) as dw:
-        return dw.search_datasets(query, **kwargs)
-
-
-def load_datadotworld_dataset(dataset_id: str,
-                             config_file: Optional[Union[str, Path]] = None,
-                             **kwargs) -> Optional['pd.DataFrame']:
-    """Convenience function to load a dataset as DataFrame."""
-    with get_datadotworld_connector(config_file) as dw:
-        return dw.load_dataset_as_dataframe(dataset_id, **kwargs)
-
-
-def query_datadotworld_dataset(dataset_id: str,
-                              query: str,
-                              config_file: Optional[Union[str, Path]] = None,
-                              **kwargs) -> Optional['pd.DataFrame']:
-    """Convenience function to query a dataset."""
-    with get_datadotworld_connector(config_file) as dw:
-        return dw.query_dataset(dataset_id, query, **kwargs)
-
-
-def search_datasets(query: str,
-                   config_file: Optional[Union[str, Path]] = None,
-                   **kwargs) -> Optional[List[Dict[str, Any]]]:
-    """
-    Standalone function to search for datasets.
-    
-    Args:
-        query: Search query string
-        config_file: Path to configuration file (optional)
-        **kwargs: Additional search parameters
-    
-    Returns:
-        List of matching datasets or None if error
-    """
-    with get_datadotworld_connector(config_file) as dw:
-        return dw.search_datasets(query, **kwargs)
-
-def list_datasets(limit: int = 50,
-                 config_file: Optional[Union[str, Path]] = None,
-                 **kwargs) -> Optional[List[Dict[str, Any]]]:
-    """
-    Standalone function to list available datasets.
-    
-    Args:
-        limit: Maximum number of results to return
-        config_file: Optional configuration file path
-        **kwargs: Additional arguments to pass to search_datasets
-    
-    Returns:
-        List of dataset information dictionaries
-    """
-    with get_datadotworld_connector(config_file) as dw:
-        return dw.search_datasets("*", limit=limit, **kwargs)
-
-
-# Global instance for easy access
-datadotworld_connector = None
-
-__all__ = [
-    'DataDotWorldConnector',
-    'get_datadotworld_connector',
-    'search_datasets',
-    'search_datadotworld_datasets',
-    'load_datadotworld_dataset',
-    'query_datadotworld_dataset',
-    'datadotworld_connector',
-    'DATADOTWORLD_AVAILABLE'
-]

--- a/siege_utilities/analytics/facebook_business.py
+++ b/siege_utilities/analytics/facebook_business.py
@@ -271,7 +271,7 @@ class FacebookBusinessConnector:
             raise
 
     def save_as_pandas(self, df: pd.DataFrame, output_path: str,
-                       format: str = 'parquet') -> bool:
+                       format: str = 'parquet') -> None:
         """
         Save DataFrame as Pandas format.
 
@@ -280,31 +280,26 @@ class FacebookBusinessConnector:
             output_path: Output file path
             format: Output format (parquet, csv, excel, etc.)
 
-        Returns:
-            True if save successful
+        Raises:
+            ValueError: If format is not supported.
+            OSError: On filesystem failure.
         """
-        try:
-            output_path = pathlib.Path(output_path)
-            output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path = pathlib.Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
 
-            if format.lower() == 'parquet':
-                df.to_parquet(output_path, index=False)
-            elif format.lower() == 'csv':
-                df.to_csv(output_path, index=False)
-            elif format.lower() == 'excel':
-                df.to_excel(output_path, index=False)
-            else:
-                raise ValueError(f"Unsupported format: {format}")
+        if format.lower() == 'parquet':
+            df.to_parquet(output_path, index=False)
+        elif format.lower() == 'csv':
+            df.to_csv(output_path, index=False)
+        elif format.lower() == 'excel':
+            df.to_excel(output_path, index=False)
+        else:
+            raise ValueError(f"Unsupported format: {format}")
 
-            log_info(f"Saved DataFrame to {output_path} ({format} format)")
-            return True
-
-        except (OSError, ValueError) as e:
-            logger.error("Failed to save DataFrame: %s", e, exc_info=True)
-            return False
+        log_info(f"Saved DataFrame to {output_path} ({format} format)")
 
     def save_as_spark(self, df: pd.DataFrame, output_path: str,
-                      spark_session: Optional[SparkSession] = None) -> bool:
+                      spark_session: Optional[SparkSession] = None) -> None:
         """
         Save DataFrame as Spark DataFrame and optionally to storage.
 
@@ -313,31 +308,22 @@ class FacebookBusinessConnector:
             output_path: Output path for Spark DataFrame
             spark_session: Optional SparkSession (will create if not provided)
 
-        Returns:
-            True if save successful
+        Raises:
+            ImportError: If PySpark is not installed.
+            OSError: On storage failure.
         """
-        try:
-            if not SPARK_AVAILABLE:
-                raise ImportError("PySpark not available. Install: pip install pyspark")
+        if not SPARK_AVAILABLE:
+            raise ImportError("PySpark not available. Install: pip install pyspark")
 
-            # Create Spark session if not provided
-            if not spark_session:
-                spark_session = SparkSession.builder \
-                    .appName("FacebookBusinessData") \
-                    .getOrCreate()
+        if not spark_session:
+            spark_session = SparkSession.builder \
+                .appName("FacebookBusinessData") \
+                .getOrCreate()
 
-            # Convert to Spark DataFrame
-            spark_df = spark_session.createDataFrame(df)
+        spark_df = spark_session.createDataFrame(df)
+        spark_df.write.mode('overwrite').parquet(output_path)
 
-            # Save to storage
-            spark_df.write.mode('overwrite').parquet(output_path)
-
-            log_info(f"Saved DataFrame as Spark DataFrame to {output_path}")
-            return True
-
-        except (ImportError, OSError, TypeError, RuntimeError) as e:
-            logger.error("Failed to save as Spark DataFrame: %s", e, exc_info=True)
-            return False
+        log_info(f"Saved DataFrame as Spark DataFrame to {output_path}")
 
 
 def create_facebook_account_profile(client_id: str, fb_account_id: str,
@@ -410,7 +396,11 @@ def load_facebook_account_profile(account_id: str,
         config_directory: Directory containing config files
 
     Returns:
-        Facebook account profile dictionary or None if not found
+        Facebook account profile dictionary, or None if no profile file exists.
+
+    Raises:
+        OSError: If the file exists but cannot be read.
+        json.JSONDecodeError: If the file exists but contains invalid JSON.
     """
     config_dir = pathlib.Path(config_directory) / "facebook_business"
     config_file = config_dir / f"fb_account_{account_id}.json"
@@ -418,16 +408,11 @@ def load_facebook_account_profile(account_id: str,
     if not config_file.exists():
         return None
 
-    try:
-        with open(config_file, 'r', encoding='utf-8') as f:
-            profile = json.load(f)
+    with open(config_file, 'r', encoding='utf-8') as f:
+        profile = json.load(f)
 
-        log_info(f"Loaded Facebook account profile: {account_id}")
-        return profile
-
-    except (OSError, json.JSONDecodeError) as e:
-        logger.error("Failed to load Facebook account profile %s: %s", account_id, e, exc_info=True)
-        return None
+    log_info(f"Loaded Facebook account profile: {account_id}")
+    return profile
 
 
 def list_facebook_accounts_for_client(client_id: str,
@@ -478,109 +463,91 @@ def batch_retrieve_facebook_data(client_id: str, start_date: str, end_date: str,
         output_directory: Directory to save output files
 
     Returns:
-        Dictionary with retrieval results
+        Dictionary with retrieval results.
+
+    Raises:
+        ValueError: If no Facebook accounts found for the client.
     """
-    try:
-        # Get client's Facebook accounts
-        accounts = list_facebook_accounts_for_client(client_id)
+    accounts = list_facebook_accounts_for_client(client_id)
 
-        if not accounts:
-            return {
-                'success': False,
-                'error': f'No Facebook accounts found for client: {client_id}',
-                'accounts_processed': 0,
-                'total_rows': 0
-            }
+    if not accounts:
+        raise ValueError(f"No Facebook accounts found for client: {client_id}")
 
-        # Setup output directory
-        output_dir = pathlib.Path(output_directory)
-        output_dir.mkdir(parents=True, exist_ok=True)
+    # Setup output directory
+    output_dir = pathlib.Path(output_directory)
+    output_dir.mkdir(parents=True, exist_ok=True)
 
-        results = {
-            'success': True,
-            'client_id': client_id,
-            'start_date': start_date,
-            'end_date': end_date,
-            'accounts_processed': 0,
-            'total_rows': 0,
-            'output_files': [],
-            'errors': []
-        }
+    results = {
+        'success': True,
+        'client_id': client_id,
+        'start_date': start_date,
+        'end_date': end_date,
+        'accounts_processed': 0,
+        'total_rows': 0,
+        'output_files': [],
+        'errors': []
+    }
 
-        _VALID_DATA_TYPES = {'ad_account', 'page', 'business'}
-        if data_types is not None:
-            unknown = set(data_types) - _VALID_DATA_TYPES
-            if unknown:
-                import warnings
-                warnings.warn(
-                    f"batch_retrieve_facebook_data: unrecognized data_types "
-                    f"{sorted(unknown)}; valid values are {sorted(_VALID_DATA_TYPES)}",
-                    stacklevel=2,
+    _VALID_DATA_TYPES = {'ad_account', 'page', 'business'}
+    if data_types is not None:
+        unknown = set(data_types) - _VALID_DATA_TYPES
+        if unknown:
+            import warnings
+            warnings.warn(
+                f"batch_retrieve_facebook_data: unrecognized data_types "
+                f"{sorted(unknown)}; valid values are {sorted(_VALID_DATA_TYPES)}",
+                stacklevel=2,
+            )
+
+    # Process each account
+    for account in accounts:
+        try:
+            if data_types is not None and account['account_type'] not in data_types:
+                continue
+
+            if not account.get('access_token'):
+                results['errors'].append(f"No access token for account: {account['fb_account_id']}")
+                continue
+
+            connector = FacebookBusinessConnector(account['access_token'])
+
+            if account['account_type'] == 'ad_account':
+                df = connector.get_ad_insights(
+                    account['fb_account_id_raw'], start_date, end_date
                 )
+            elif account['account_type'] == 'page':
+                df = connector.get_page_insights(
+                    account['fb_account_id_raw'], start_date, end_date
+                )
+            elif account['account_type'] == 'business':
+                df = connector.get_business_insights(
+                    account['fb_account_id_raw'], start_date, end_date
+                )
+            else:
+                results['errors'].append(f"Unknown account type: {account['account_type']}")
+                continue
 
-        # Process each account
-        for account in accounts:
-            try:
-                # Skip accounts whose type doesn't match the requested data_types
-                if data_types is not None and account['account_type'] not in data_types:
-                    continue
+            if not df.empty:
+                output_file = output_dir / f"{account['fb_account_id']}_{start_date}_{end_date}.parquet"
 
-                # Load access token
-                if not account.get('access_token'):
-                    results['errors'].append(f"No access token for account: {account['fb_account_id']}")
-                    continue
+                if output_format in ['pandas', 'both']:
+                    connector.save_as_pandas(df, str(output_file), 'parquet')
+                    results['output_files'].append(str(output_file))
 
-                # Create connector
-                connector = FacebookBusinessConnector(account['access_token'])
+                if output_format in ['spark', 'both'] and SPARK_AVAILABLE:
+                    spark_output = output_dir / f"{account['fb_account_id']}_{start_date}_{end_date}_spark"
+                    connector.save_as_spark(df, str(spark_output))
+                    results['output_files'].append(str(spark_output))
 
-                # Retrieve data based on account type
-                if account['account_type'] == 'ad_account':
-                    df = connector.get_ad_insights(
-                        account['fb_account_id_raw'], start_date, end_date
-                    )
-                elif account['account_type'] == 'page':
-                    df = connector.get_page_insights(
-                        account['fb_account_id_raw'], start_date, end_date
-                    )
-                elif account['account_type'] == 'business':
-                    df = connector.get_business_insights(
-                        account['fb_account_id_raw'], start_date, end_date
-                    )
-                else:
-                    results['errors'].append(f"Unknown account type: {account['account_type']}")
-                    continue
+                results['total_rows'] += len(df)
+                results['accounts_processed'] += 1
 
-                if not df.empty:
-                    # Save data
-                    output_file = output_dir / f"{account['fb_account_id']}_{start_date}_{end_date}.parquet"
+                log_info(f"Processed Facebook account: {account['fb_account_id']} - {len(df)} rows")
 
-                    if output_format in ['pandas', 'both']:
-                        connector.save_as_pandas(df, str(output_file), 'parquet')
-                        results['output_files'].append(str(output_file))
+        except (*_FB_API_ERRORS, OSError, TypeError) as e:
+            error_msg = f"Error processing account {account['fb_account_id']}: {e}"
+            results['errors'].append(error_msg)
+            logger.error("Error processing account %s", account['fb_account_id'], exc_info=True)
 
-                    if output_format in ['spark', 'both'] and SPARK_AVAILABLE:
-                        spark_output = output_dir / f"{account['fb_account_id']}_{start_date}_{end_date}_spark"
-                        connector.save_as_spark(df, str(spark_output))
-                        results['output_files'].append(str(spark_output))
-
-                    results['total_rows'] += len(df)
-                    results['accounts_processed'] += 1
-
-                    log_info(f"Processed Facebook account: {account['fb_account_id']} - {len(df)} rows")
-
-            except (*_FB_API_ERRORS, OSError, TypeError) as e:
-                error_msg = f"Error processing account {account['fb_account_id']}: {e}"
-                results['errors'].append(error_msg)
-                logger.error("Error processing account %s", account['fb_account_id'], exc_info=True)
-
-        log_info(f"Batch Facebook data retrieval completed: {results['accounts_processed']} accounts, {results['total_rows']} rows")
-        return results
-
-    except (OSError, KeyError, AttributeError) as e:
-        logger.error("Batch Facebook data retrieval failed: %s", e, exc_info=True)
-        return {
-            'success': False,
-            'error': str(e),
-            'accounts_processed': 0,
-            'total_rows': 0
-        }
+    log_info(f"Batch Facebook data retrieval completed: {results['accounts_processed']} accounts, {results['total_rows']} rows")
+    return results

--- a/siege_utilities/analytics/google_analytics.py
+++ b/siege_utilities/analytics/google_analytics.py
@@ -113,61 +113,51 @@ class GoogleAnalyticsConnector:
 
         log_info(f"Initialized Google Analytics connector with {auth_method} authentication")
 
-    def authenticate(self, token_file: str = "ga_token.json") -> bool:
+    def authenticate(self, token_file: str = "ga_token.json") -> None:
         """
         Authenticate with Google Analytics using OAuth2.
 
         Args:
             token_file: Path to store/retrieve OAuth token
 
-        Returns:
-            True if authentication successful
+        Raises:
+            ValueError: On invalid credentials configuration.
+            OSError: On token file I/O failure.
         """
-        try:
-            token_path = pathlib.Path(token_file)
+        token_path = pathlib.Path(token_file)
 
-            # Try to load existing credentials
-            if token_path.exists():
-                self.credentials = Credentials.from_authorized_user_file(
-                    str(token_path),
-                    ['https://www.googleapis.com/auth/analytics.readonly']
-                )
+        if token_path.exists():
+            self.credentials = Credentials.from_authorized_user_file(
+                str(token_path),
+                ['https://www.googleapis.com/auth/analytics.readonly']
+            )
 
-                # Refresh if expired
-                if self.credentials.expired and self.credentials.refresh_token:
-                    self.credentials.refresh(Request())
-                    self._save_credentials(token_path)
-                    log_info("Refreshed expired Google Analytics credentials")
-                else:
-                    log_info("Loaded existing Google Analytics credentials")
-            else:
-                # New authentication flow
-                flow = InstalledAppFlow.from_client_config(
-                    {
-                        "installed": {
-                            "client_id": self.client_id,
-                            "client_secret": self.client_secret,
-                            "redirect_uris": [self.redirect_uri],
-                            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-                            "token_uri": "https://oauth2.googleapis.com/token"
-                        }
-                    },
-                    ['https://www.googleapis.com/auth/analytics.readonly']
-                )
-
-                self.credentials = flow.run_local_server(port=0)
+            if self.credentials.expired and self.credentials.refresh_token:
+                self.credentials.refresh(Request())
                 self._save_credentials(token_path)
-                log_info("Completed new Google Analytics authentication")
+                log_info("Refreshed expired Google Analytics credentials")
+            else:
+                log_info("Loaded existing Google Analytics credentials")
+        else:
+            flow = InstalledAppFlow.from_client_config(
+                {
+                    "installed": {
+                        "client_id": self.client_id,
+                        "client_secret": self.client_secret,
+                        "redirect_uris": [self.redirect_uri],
+                        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                        "token_uri": "https://oauth2.googleapis.com/token"
+                    }
+                },
+                ['https://www.googleapis.com/auth/analytics.readonly']
+            )
 
-            # Build services
-            self.analytics_service = build('analytics', 'v3', credentials=self.credentials)
-            self.ga4_client = BetaAnalyticsDataClient(credentials=self.credentials)
+            self.credentials = flow.run_local_server(port=0)
+            self._save_credentials(token_path)
+            log_info("Completed new Google Analytics authentication")
 
-            return True
-
-        except (*_GA_AUTH_ERRORS, OSError) as e:
-            logger.error("Google Analytics authentication failed: %s", e, exc_info=True)
-            return False
+        self.analytics_service = build('analytics', 'v3', credentials=self.credentials)
+        self.ga4_client = BetaAnalyticsDataClient(credentials=self.credentials)
 
     def _save_credentials(self, token_path: pathlib.Path):
         """Save OAuth credentials to file."""
@@ -175,50 +165,39 @@ class GoogleAnalyticsConnector:
             token.write(self.credentials.to_json())
         log_info(f"Saved credentials to: {token_path}")
 
-    def authenticate_service_account(self) -> bool:
+    def authenticate_service_account(self) -> None:
         """
         Authenticate with Google Analytics using service account.
-        Based on working implementation from GA project.
 
-        Returns:
-            True if authentication successful
+        Raises:
+            ValueError: If no service account data is configured.
+            RuntimeError: If temporary credentials file cannot be created.
+            OSError: On file I/O failure.
         """
+        from google.oauth2 import service_account
+        from ..config import create_temporary_service_account_file
+        from pathlib import Path
+
+        if not self.service_account_data:
+            raise ValueError("No service account data available for authentication")
+
+        temp_file = create_temporary_service_account_file(self.service_account_data)
+        if not temp_file:
+            raise RuntimeError("Failed to create temporary service account file")
+
         try:
-            from google.oauth2 import service_account
-            from ..config import create_temporary_service_account_file
-            from pathlib import Path
+            self.credentials = service_account.Credentials.from_service_account_file(
+                temp_file,
+                scopes=['https://www.googleapis.com/auth/analytics.readonly']
+            )
 
-            if not self.service_account_data:
-                log_error("No service account data available for authentication")
-                return False
+            self.analytics_service = build('analytics', 'v3', credentials=self.credentials)
+            self.ga4_client = BetaAnalyticsDataClient(credentials=self.credentials)
 
-            # Create temporary service account file
-            temp_file = create_temporary_service_account_file(self.service_account_data)
-            if not temp_file:
-                log_error("Failed to create temporary service account file")
-                return False
+            log_info(f"Service account authentication successful: {self.service_account_data['client_email']}")
 
-            try:
-                # Create credentials from service account file
-                self.credentials = service_account.Credentials.from_service_account_file(
-                    temp_file,
-                    scopes=['https://www.googleapis.com/auth/analytics.readonly']
-                )
-
-                # Build services
-                self.analytics_service = build('analytics', 'v3', credentials=self.credentials)
-                self.ga4_client = BetaAnalyticsDataClient(credentials=self.credentials)
-
-                log_info(f"Service account authentication successful: {self.service_account_data['client_email']}")
-                return True
-
-            finally:
-                # Clean up temporary file
-                Path(temp_file).unlink(missing_ok=True)
-
-        except (*_GA_AUTH_ERRORS, OSError) as e:
-            logger.error("Service account authentication failed: %s", e, exc_info=True)
-            return False
+        finally:
+            Path(temp_file).unlink(missing_ok=True)
 
     @staticmethod
     def _validate_ga_date(value: str, field: str) -> None:
@@ -367,7 +346,7 @@ class GoogleAnalyticsConnector:
             raise
 
     def save_as_pandas(self, df: pd.DataFrame, output_path: str,
-                       format: str = 'parquet') -> bool:
+                       format: str = 'parquet') -> None:
         """
         Save DataFrame as Pandas format.
 
@@ -376,31 +355,26 @@ class GoogleAnalyticsConnector:
             output_path: Output file path
             format: Output format (parquet, csv, excel, etc.)
 
-        Returns:
-            True if save successful
+        Raises:
+            ValueError: If format is not supported.
+            OSError: On filesystem failure.
         """
-        try:
-            output_path = pathlib.Path(output_path)
-            output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path = pathlib.Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
 
-            if format.lower() == 'parquet':
-                df.to_parquet(output_path, index=False)
-            elif format.lower() == 'csv':
-                df.to_csv(output_path, index=False)
-            elif format.lower() == 'excel':
-                df.to_excel(output_path, index=False)
-            else:
-                raise ValueError(f"Unsupported format: {format}")
+        if format.lower() == 'parquet':
+            df.to_parquet(output_path, index=False)
+        elif format.lower() == 'csv':
+            df.to_csv(output_path, index=False)
+        elif format.lower() == 'excel':
+            df.to_excel(output_path, index=False)
+        else:
+            raise ValueError(f"Unsupported format: {format}")
 
-            log_info(f"Saved DataFrame to {output_path} ({format} format)")
-            return True
-
-        except (OSError, ValueError) as e:
-            logger.error("Failed to save DataFrame: %s", e, exc_info=True)
-            return False
+        log_info(f"Saved DataFrame to {output_path} ({format} format)")
 
     def save_as_spark(self, df: pd.DataFrame, output_path: str,
-                      spark_session: Optional[SparkSession] = None) -> bool:
+                      spark_session: Optional[SparkSession] = None) -> None:
         """
         Save DataFrame as Spark DataFrame and optionally to storage.
 
@@ -409,31 +383,22 @@ class GoogleAnalyticsConnector:
             output_path: Output path for Spark DataFrame
             spark_session: Optional SparkSession (will create if not provided)
 
-        Returns:
-            True if save successful
+        Raises:
+            ImportError: If PySpark is not installed.
+            OSError: On storage failure.
         """
-        try:
-            if not SPARK_AVAILABLE:
-                raise ImportError("PySpark not available. Install: pip install pyspark")
+        if not SPARK_AVAILABLE:
+            raise ImportError("PySpark not available. Install: pip install pyspark")
 
-            # Create Spark session if not provided
-            if not spark_session:
-                spark_session = SparkSession.builder \
-                    .appName("GoogleAnalyticsData") \
-                    .getOrCreate()
+        if not spark_session:
+            spark_session = SparkSession.builder \
+                .appName("GoogleAnalyticsData") \
+                .getOrCreate()
 
-            # Convert to Spark DataFrame
-            spark_df = spark_session.createDataFrame(df)
+        spark_df = spark_session.createDataFrame(df)
+        spark_df.write.mode('overwrite').parquet(output_path)
 
-            # Save to storage
-            spark_df.write.mode('overwrite').parquet(output_path)
-
-            log_info(f"Saved DataFrame as Spark DataFrame to {output_path}")
-            return True
-
-        except (ImportError, OSError, TypeError, RuntimeError) as e:
-            logger.error("Failed to save as Spark DataFrame: %s", e, exc_info=True)
-            return False
+        log_info(f"Saved DataFrame as Spark DataFrame to {output_path}")
 
 
 def create_ga_account_profile(client_id: str, ga_property_id: str,
@@ -506,7 +471,11 @@ def load_ga_account_profile(account_id: str,
         config_directory: Directory containing config files
 
     Returns:
-        GA account profile dictionary or None if not found
+        GA account profile dictionary, or None if no profile file exists.
+
+    Raises:
+        OSError: If the file exists but cannot be read.
+        json.JSONDecodeError: If the file exists but contains invalid JSON.
     """
     config_dir = pathlib.Path(config_directory) / "google_analytics"
     config_file = config_dir / f"ga_account_{account_id}.json"
@@ -514,16 +483,11 @@ def load_ga_account_profile(account_id: str,
     if not config_file.exists():
         return None
 
-    try:
-        with open(config_file, 'r', encoding='utf-8') as f:
-            profile = json.load(f)
+    with open(config_file, 'r', encoding='utf-8') as f:
+        profile = json.load(f)
 
-        log_info(f"Loaded GA account profile: {account_id}")
-        return profile
-
-    except (OSError, json.JSONDecodeError) as e:
-        logger.error("Failed to load GA account profile %s: %s", account_id, e, exc_info=True)
-        return None
+    log_info(f"Loaded GA account profile: {account_id}")
+    return profile
 
 
 def list_ga_accounts_for_client(client_id: str,
@@ -685,7 +649,7 @@ def create_ga_connector_with_service_account(service_account_data: Dict[str, Any
     )
 
 
-def create_ga_connector_from_1password(item_title: str = "Google Analytics Service Account - Multi-Client Reporter") -> Optional[GoogleAnalyticsConnector]:
+def create_ga_connector_from_1password(item_title: str = "Google Analytics Service Account - Multi-Client Reporter") -> GoogleAnalyticsConnector:
     """
     Create a GoogleAnalyticsConnector using service account from 1Password.
 
@@ -708,7 +672,11 @@ def create_ga_connector_from_1password(item_title: str = "Google Analytics Servi
         item_title: Title of the 1Password item containing service account
 
     Returns:
-        GoogleAnalyticsConnector instance or None if failed
+        GoogleAnalyticsConnector instance.
+
+    Raises:
+        ImportError: If 1Password config module is not available.
+        RuntimeError: If service account data could not be retrieved.
     """
     import warnings
     warnings.warn(
@@ -719,19 +687,13 @@ def create_ga_connector_from_1password(item_title: str = "Google Analytics Servi
         DeprecationWarning,
         stacklevel=2,
     )
-    try:
-        from ..config import get_google_service_account_from_1password
-        service_account_data = get_google_service_account_from_1password(item_title)
+    from ..config import get_google_service_account_from_1password
+    service_account_data = get_google_service_account_from_1password(item_title)
 
-        if service_account_data:
-            return create_ga_connector_with_service_account(service_account_data)
-        else:
-            log_error("Could not retrieve service account from 1Password")
-            return None
+    if not service_account_data:
+        raise RuntimeError(f"Could not retrieve service account from 1Password (item: {item_title!r})")
 
-    except ImportError as e:
-        logger.error("Could not import 1Password function: %s", e, exc_info=True)
-        return None
+    return create_ga_connector_with_service_account(service_account_data)
 
 
 def create_ga_connector_with_oauth2(client_id: str, client_secret: str,

--- a/siege_utilities/analytics/snowflake_connector.py
+++ b/siege_utilities/analytics/snowflake_connector.py
@@ -37,10 +37,10 @@ log = logging.getLogger(__name__)
 
 class SnowflakeConnector:
     """Snowflake data warehouse connector with advanced features."""
-    
-    def __init__(self, 
-                 account: str,
-                 user: str,
+
+    def __init__(self,
+                 account: str = None,
+                 user: str = None,
                  password: Optional[str] = None,
                  warehouse: Optional[str] = None,
                  database: Optional[str] = None,
@@ -49,7 +49,7 @@ class SnowflakeConnector:
                  config_file: Optional[Union[str, Path]] = None):
         """
         Initialize Snowflake connector.
-        
+
         Args:
             account: Snowflake account identifier
             user: Snowflake username
@@ -59,10 +59,13 @@ class SnowflakeConnector:
             schema: Default schema to use
             role: Default role to use
             config_file: Path to configuration file
+
+        Raises:
+            ImportError: If snowflake-connector-python is not installed.
         """
         if not SNOWFLAKE_AVAILABLE:
             raise ImportError("Snowflake connector not available. Install with: pip install snowflake-connector-python")
-        
+
         self.account = account
         self.user = user
         self.password = password
@@ -71,39 +74,34 @@ class SnowflakeConnector:
         self.schema = schema
         self.role = role
         self.config_file = config_file
-        
+
         # Load configuration if provided
         if config_file:
             self._load_config(config_file)
-        
+
         # Initialize connection
         self.connection = None
         self.cursor = None
-        
+
         log.info(f"Initialized Snowflake connector for account: {account}")
-    
+
     def _load_config(self, config_file: Union[str, Path]) -> None:
         """Load configuration from file."""
         config_path = Path(config_file)
         if not config_path.exists():
             raise FileNotFoundError(f"Configuration file not found: {config_path}")
-        
-        try:
-            with open(config_path, 'r', encoding='utf-8') as f:
-                config = json.load(f)
 
-            _ALLOWED_CONFIG_KEYS = frozenset({
-                "account", "user", "password", "warehouse",
-                "database", "schema", "role",
-            })
-            for key, value in config.items():
-                if key in _ALLOWED_CONFIG_KEYS and value is not None:
-                    setattr(self, key, value)
-                    
-        except Exception as e:
-            log.error(f"Failed to load configuration: {e}")
-            raise
-    
+        with open(config_path, 'r', encoding='utf-8') as f:
+            config = json.load(f)
+
+        _ALLOWED_CONFIG_KEYS = frozenset({
+            "account", "user", "password", "warehouse",
+            "database", "schema", "role",
+        })
+        for key, value in config.items():
+            if key in _ALLOWED_CONFIG_KEYS and value is not None:
+                setattr(self, key, value)
+
     def connect(self) -> None:
         """Establish connection to Snowflake.
 
@@ -140,58 +138,52 @@ class SnowflakeConnector:
                 self.connection.close()
             log.info("Disconnected from Snowflake")
         except (*_SF_CONN_ERRORS, AttributeError) as e:
-            log.error(f"Error disconnecting from Snowflake: {e}")
-    
-    def execute_query(self, query: str, params: Optional[Dict[str, Any]] = None) -> Optional[List[tuple]]:
+            log.warning(f"Error during disconnect (connection may already be closed): {e}")
+
+    def execute_query(self, query: str, params: Optional[Dict[str, Any]] = None) -> List[tuple]:
         """
         Execute a SQL query.
-        
+
         Args:
             query: SQL query string
             params: Query parameters (optional)
-            
+
         Returns:
-            Query results as list of tuples
+            Query results as list of tuples.
+
+        Raises:
+            ConnectionError: If connection fails.
+            snowflake.connector.errors.ProgrammingError: On query failure.
         """
         if not self.connection:
             self.connect()
-        
-        try:
-            if params:
-                self.cursor.execute(query, params)
-            else:
-                self.cursor.execute(query)
-            
-            results = self.cursor.fetchall()
-            log.info(f"Query executed successfully. Rows returned: {len(results)}")
-            return results
-            
-        except (*_SF_QUERY_ERRORS, ValueError) as e:
-            log.error(f"Query execution failed: {e}")
-            return None
 
-    def execute_ddl(self, ddl_statement: str) -> bool:
+        if params:
+            self.cursor.execute(query, params)
+        else:
+            self.cursor.execute(query)
+
+        results = self.cursor.fetchall()
+        log.info(f"Query executed successfully. Rows returned: {len(results)}")
+        return results
+
+    def execute_ddl(self, ddl_statement: str) -> None:
         """
         Execute DDL statements (CREATE, ALTER, DROP, etc.).
-        
+
         Args:
             ddl_statement: DDL SQL statement
-            
-        Returns:
-            True if successful, False otherwise
+
+        Raises:
+            ConnectionError: If connection fails.
+            snowflake.connector.errors.ProgrammingError: On DDL failure.
         """
         if not self.connection:
             self.connect()
-        
-        try:
-            self.cursor.execute(ddl_statement)
-            self.connection.commit()
-            log.info("DDL statement executed successfully")
-            return True
-            
-        except (*_SF_QUERY_ERRORS,) as e:
-            log.error(f"DDL execution failed: {e}")
-            return False
+
+        self.cursor.execute(ddl_statement)
+        self.connection.commit()
+        log.info("DDL statement executed successfully")
 
     def upload_dataframe(self,
                         df: 'pd.DataFrame',
@@ -199,10 +191,10 @@ class SnowflakeConnector:
                         database: Optional[str] = None,
                         schema: Optional[str] = None,
                         auto_create_table: bool = True,
-                        overwrite: bool = False) -> bool:
+                        overwrite: bool = False) -> None:
         """
         Upload pandas DataFrame to Snowflake table.
-        
+
         Args:
             df: Pandas DataFrame to upload
             table_name: Target table name
@@ -210,82 +202,73 @@ class SnowflakeConnector:
             schema: Target schema (uses default if not specified)
             auto_create_table: Whether to automatically create table if it doesn't exist
             overwrite: Whether to overwrite existing table
-            
-        Returns:
-            True if successful, False otherwise
+
+        Raises:
+            ImportError: If pandas is not installed.
+            ConnectionError: If connection fails.
+            snowflake.connector.errors.ProgrammingError: On upload failure.
+            RuntimeError: If write_pandas reports failure.
         """
         if not PANDAS_AVAILABLE:
-            log.error("Pandas not available for DataFrame operations")
-            return False
-        
+            raise ImportError("Pandas not available for DataFrame operations. Install with: pip install pandas")
+
         if not self.connection:
             self.connect()
-        
+
         from siege_utilities.core.sql_safety import validate_sql_identifier as validate_identifier
         validate_identifier(table_name, label="table name")
-        try:
-            # Set database and schema context. Snowflake doesn't permit
-            # parameter-bound identifiers for USE; validation must do it.
-            if database:
-                validate_identifier(database, label="database name")
-                self.cursor.execute(f"USE DATABASE {database}")
-            if schema:
-                validate_identifier(schema, label="schema name")
-                self.cursor.execute(f"USE SCHEMA {schema}")
 
-            # Create table if needed
-            if auto_create_table:
-                self._create_table_from_dataframe(df, table_name, overwrite)
-            
-            # Upload data
-            success, nchunks, nrows, _ = write_pandas(
-                self.connection,
-                df,
-                table_name,
-                auto_create_table=False,
-                overwrite=overwrite
-            )
-            
-            if success:
-                log.info(f"Successfully uploaded {nrows} rows to table {table_name}")
-                return True
-            else:
-                log.error(f"Failed to upload data to table {table_name}")
-                return False
-                
-        except (*_SF_QUERY_ERRORS, ValueError) as e:
-            log.error(f"DataFrame upload failed: {e}")
-            return False
+        if database:
+            validate_identifier(database, label="database name")
+            self.cursor.execute(f"USE DATABASE {database}")
+        if schema:
+            validate_identifier(schema, label="schema name")
+            self.cursor.execute(f"USE SCHEMA {schema}")
+
+        if auto_create_table:
+            self._create_table_from_dataframe(df, table_name, overwrite)
+
+        success, nchunks, nrows, _ = write_pandas(
+            self.connection,
+            df,
+            table_name,
+            auto_create_table=False,
+            overwrite=overwrite
+        )
+
+        if not success:
+            raise RuntimeError(f"write_pandas reported failure for table {table_name}")
+
+        log.info(f"Successfully uploaded {nrows} rows to table {table_name}")
 
     def download_dataframe(self,
                           query: str,
-                          params: Optional[Dict[str, Any]] = None) -> Optional['pd.DataFrame']:
+                          params: Optional[Dict[str, Any]] = None) -> 'pd.DataFrame':
         """
         Download data from Snowflake as pandas DataFrame.
-        
+
         Args:
             query: SQL query to execute
             params: Query parameters (optional)
-            
+
         Returns:
-            Pandas DataFrame with query results
+            Pandas DataFrame with query results.
+
+        Raises:
+            ImportError: If pandas is not installed.
+            ConnectionError: If connection fails.
+            snowflake.connector.errors.ProgrammingError: On query failure.
         """
         if not PANDAS_AVAILABLE:
-            log.error("Pandas not available for DataFrame operations")
-            return None
-        
+            raise ImportError("Pandas not available for DataFrame operations. Install with: pip install pandas")
+
         if not self.connection:
             self.connect()
-        
-        try:
-            df = read_pandas(self.connection, query, params)
-            log.info(f"Successfully downloaded {len(df)} rows as DataFrame")
-            return df
-            
-        except (*_SF_QUERY_ERRORS, ValueError) as e:
-            log.error(f"DataFrame download failed: {e}")
-            return None
-    
+
+        df = read_pandas(self.connection, query, params)
+        log.info(f"Successfully downloaded {len(df)} rows as DataFrame")
+        return df
+
     def _create_table_from_dataframe(self, df: 'pd.DataFrame', table_name: str, overwrite: bool) -> None:
         """Create Snowflake table based on DataFrame structure."""
         from siege_utilities.core.sql_safety import validate_sql_identifier as validate_identifier
@@ -293,10 +276,8 @@ class SnowflakeConnector:
         if overwrite:
             self.cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
 
-        # Generate CREATE TABLE statement
         columns = []
         for col_name, dtype in df.dtypes.items():
-            # Validate every DataFrame column name before it lands in DDL.
             validate_identifier(str(col_name), label="column name", allow_dotted=False)
             snowflake_type = self._map_pandas_to_snowflake_type(dtype)
             columns.append(f"{col_name} {snowflake_type}")
@@ -304,11 +285,11 @@ class SnowflakeConnector:
         create_statement = f"CREATE TABLE IF NOT EXISTS {table_name} ({', '.join(columns)})"
         self.cursor.execute(create_statement)
         log.info(f"Created table {table_name} with {len(columns)} columns")
-    
+
     def _map_pandas_to_snowflake_type(self, pandas_dtype) -> str:
         """Map pandas data types to Snowflake data types."""
         dtype_str = str(pandas_dtype)
-        
+
         if 'int' in dtype_str:
             return 'NUMBER(38,0)'
         elif 'float' in dtype_str:
@@ -321,108 +302,101 @@ class SnowflakeConnector:
             return 'VARCHAR(16777216)'
         else:
             return 'VARCHAR(16777216)'
-    
-    def get_table_info(self, table_name: str, database: Optional[str] = None, schema: Optional[str] = None) -> Optional[Dict[str, Any]]:
+
+    def get_table_info(self, table_name: str, database: Optional[str] = None, schema: Optional[str] = None) -> Dict[str, Any]:
         """
         Get information about a Snowflake table.
-        
+
         Args:
             table_name: Name of the table
             database: Database name (uses default if not specified)
             schema: Schema name (uses default if not specified)
-            
+
         Returns:
-            Dictionary with table information
+            Dictionary with table information.
+
+        Raises:
+            ConnectionError: If connection fails.
+            snowflake.connector.errors.ProgrammingError: On query failure.
         """
         if not self.connection:
             self.connect()
-        
+
         from siege_utilities.core.sql_safety import validate_sql_identifier as validate_identifier
         validate_identifier(table_name, label="table name")
-        try:
-            # Set context (identifiers cannot be parameter-bound).
-            if database:
-                validate_identifier(database, label="database name")
-                self.cursor.execute(f"USE DATABASE {database}")
-            if schema:
-                validate_identifier(schema, label="schema name")
-                self.cursor.execute(f"USE SCHEMA {schema}")
 
-            # Get table description
-            self.cursor.execute(f"DESCRIBE TABLE {table_name}")
-            columns = self.cursor.fetchall()
+        if database:
+            validate_identifier(database, label="database name")
+            self.cursor.execute(f"USE DATABASE {database}")
+        if schema:
+            validate_identifier(schema, label="schema name")
+            self.cursor.execute(f"USE SCHEMA {schema}")
 
-            # Get row count
-            self.cursor.execute(f"SELECT COUNT(*) FROM {table_name}")
-            row_count = self.cursor.fetchone()[0]
+        self.cursor.execute(f"DESCRIBE TABLE {table_name}")
+        columns = self.cursor.fetchall()
 
-            # Get table size — scope to the active database+schema so we
-            # don't return a different schema's table with the same name.
-            self.cursor.execute(
-                """
-                SELECT BYTES, ROWS
-                FROM INFORMATION_SCHEMA.TABLES
-                WHERE TABLE_NAME = %s
-                  AND TABLE_SCHEMA = CURRENT_SCHEMA()
-                  AND TABLE_CATALOG = CURRENT_DATABASE()
-                """,
-                (table_name,),
-            )
-            size_info = self.cursor.fetchone()
-            
-            table_info = {
-                'name': table_name,
-                'columns': [{'name': col[0], 'type': col[1], 'nullable': col[2]} for col in columns],
-                'row_count': row_count,
-                'bytes': size_info[0] if size_info else None,
-                'rows': size_info[1] if size_info else None
-            }
-            
-            return table_info
-            
-        except (*_SF_QUERY_ERRORS, ValueError, IndexError) as e:
-            log.error(f"Failed to get table info: {e}")
-            return None
-    
-    def list_tables(self, database: Optional[str] = None, schema: Optional[str] = None) -> Optional[List[str]]:
+        self.cursor.execute(f"SELECT COUNT(*) FROM {table_name}")
+        row_count = self.cursor.fetchone()[0]
+
+        self.cursor.execute(
+            """
+            SELECT BYTES, ROWS
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE TABLE_NAME = %s
+              AND TABLE_SCHEMA = CURRENT_SCHEMA()
+              AND TABLE_CATALOG = CURRENT_DATABASE()
+            """,
+            (table_name,),
+        )
+        size_info = self.cursor.fetchone()
+
+        table_info = {
+            'name': table_name,
+            'columns': [{'name': col[0], 'type': col[1], 'nullable': col[2]} for col in columns],
+            'row_count': row_count,
+            'bytes': size_info[0] if size_info else None,
+            'rows': size_info[1] if size_info else None
+        }
+
+        return table_info
+
+    def list_tables(self, database: Optional[str] = None, schema: Optional[str] = None) -> List[str]:
         """
         List all tables in a database/schema.
-        
+
         Args:
             database: Database name (uses default if not specified)
             schema: Schema name (uses default if not specified)
-            
+
         Returns:
-            List of table names
+            List of table names.
+
+        Raises:
+            ConnectionError: If connection fails.
+            snowflake.connector.errors.ProgrammingError: On query failure.
         """
         if not self.connection:
             self.connect()
-        
-        from siege_utilities.core.sql_safety import validate_sql_identifier as validate_identifier
-        try:
-            # Set context (identifiers cannot be parameter-bound).
-            if database:
-                validate_identifier(database, label="database name")
-                self.cursor.execute(f"USE DATABASE {database}")
-            if schema:
-                validate_identifier(schema, label="schema name")
-                self.cursor.execute(f"USE SCHEMA {schema}")
 
-            # List tables
-            self.cursor.execute("SHOW TABLES")
-            tables = [row[1] for row in self.cursor.fetchall()]
-            
-            return tables
-            
-        except (*_SF_QUERY_ERRORS, ValueError, IndexError) as e:
-            log.error(f"Failed to list tables: {e}")
-            return None
-    
+        from siege_utilities.core.sql_safety import validate_sql_identifier as validate_identifier
+
+        if database:
+            validate_identifier(database, label="database name")
+            self.cursor.execute(f"USE DATABASE {database}")
+        if schema:
+            validate_identifier(schema, label="schema name")
+            self.cursor.execute(f"USE SCHEMA {schema}")
+
+        self.cursor.execute("SHOW TABLES")
+        tables = [row[1] for row in self.cursor.fetchall()]
+
+        return tables
+
     def __enter__(self):
         """Context manager entry."""
         self.connect()
         return self
-    
+
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Context manager exit."""
         self.disconnect()
@@ -434,38 +408,46 @@ def get_snowflake_connector(config_file: Optional[Union[str, Path]] = None) -> S
     if config_file:
         return SnowflakeConnector(config_file=config_file)
     else:
-        # Try to load from environment variables
         account = os.getenv('SNOWFLAKE_ACCOUNT')
         user = os.getenv('SNOWFLAKE_USER')
         password = os.getenv('SNOWFLAKE_PASSWORD')
-        
+
         if not all([account, user, password]):
             raise ValueError("Snowflake configuration not found. Set environment variables or provide config file.")
-        
+
         return SnowflakeConnector(account=account, user=user, password=password)
 
 
-def upload_to_snowflake(df: 'pd.DataFrame', 
+def upload_to_snowflake(df: 'pd.DataFrame',
                         table_name: str,
                         config_file: Optional[Union[str, Path]] = None,
-                        **kwargs) -> bool:
-    """Convenience function to upload DataFrame to Snowflake."""
+                        **kwargs) -> None:
+    """Upload DataFrame to Snowflake.
+
+    Raises on failure — does not return a boolean status.
+    """
     with get_snowflake_connector(config_file) as snow:
-        return snow.upload_dataframe(df, table_name, **kwargs)
+        snow.upload_dataframe(df, table_name, **kwargs)
 
 
 def download_from_snowflake(query: str,
                            config_file: Optional[Union[str, Path]] = None,
-                           **kwargs) -> Optional['pd.DataFrame']:
-    """Convenience function to download DataFrame from Snowflake."""
+                           **kwargs) -> 'pd.DataFrame':
+    """Download DataFrame from Snowflake.
+
+    Raises on failure — does not return None.
+    """
     with get_snowflake_connector(config_file) as snow:
         return snow.download_dataframe(query, **kwargs)
 
 
 def execute_snowflake_query(query: str,
                            config_file: Optional[Union[str, Path]] = None,
-                           **kwargs) -> Optional[List[tuple]]:
-    """Convenience function to execute Snowflake query."""
+                           **kwargs) -> List[tuple]:
+    """Execute a Snowflake query and return results.
+
+    Raises on failure — does not return None.
+    """
     with get_snowflake_connector(config_file) as snow:
         return snow.execute_query(query, **kwargs)
 

--- a/siege_utilities/distributed/hdfs_operations.py
+++ b/siege_utilities/distributed/hdfs_operations.py
@@ -158,95 +158,84 @@ class AbstractHDFSOperations:
 
             self.config.log_info('✓ Spark session created successfully')
             return spark
-        except ImportError:
-            self.config.log_error(
-                'PySpark not available - install with: pip install pyspark')
-            return None
-        except (_Py4JError, RuntimeError, OSError, ValueError) as e:
-            self.config.log_error(f'Failed to create Spark session: {e}')
-            return None
+        except ImportError as e:
+            raise ImportError(
+                'PySpark not available - install with: pip install pyspark') from e
 
-    def sync_directory_to_hdfs(self, local_path: Optional[str]=None,
-        hdfs_subdir: str='inputs') ->Tuple[Optional[str], Optional[Dict]]:
-        """Sync local directory/file to HDFS with proper verification"""
-        try:
-            if local_path is None:
-                local_path = self.config.data_path
-            if local_path is None:
-                self.config.log_error('No data path provided')
-                return None, None
-            local_path = pathlib.Path(local_path)
-            if not local_path.exists():
-                self.config.log_error(f'Local path not found: {local_path}')
-                return None, None
-            if not self.check_hdfs_status():
-                self.config.log_error('HDFS not accessible')
-                return None, None
-            if local_path.is_file():
-                hdfs_directory = (self.config.hdfs_base_directory +
-                    f'{hdfs_subdir}/')
-                hdfs_full_path = hdfs_directory + local_path.name
-            else:
-                hdfs_directory = (self.config.hdfs_base_directory +
-                    f'{hdfs_subdir}/{local_path.name}/')
-                hdfs_full_path = hdfs_directory
-            self.config.log_info(f'Syncing: {local_path} -> {hdfs_full_path}')
-            subprocess.run(['hdfs', 'dfs', '-mkdir', '-p', hdfs_directory],
-                check=True, timeout=60)
-            subprocess.run(['hdfs', 'dfs', '-put', '-f', str(local_path),
-                hdfs_full_path], check=True, timeout=self.config.
-                hdfs_copy_timeout)
-            result = subprocess.run(['hdfs', 'dfs', '-test', '-e',
-                hdfs_full_path], capture_output=True, timeout=60)
-            if result.returncode == 0:
-                self.config.log_info(f'✅ Sync complete: {hdfs_full_path}')
-                return hdfs_full_path, {local_path.name: {'path': str(
-                    local_path)}}
-            else:
-                self.config.log_error('❌ Sync verification failed')
-                return None, None
-        except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired, ValueError) as e:
-            self.config.log_error(f'Error syncing to HDFS: {e}')
-            return None, None
+    def sync_directory_to_hdfs(self, local_path: Optional[str] = None,
+        hdfs_subdir: str = 'inputs') -> Tuple[str, Dict]:
+        """Sync local directory/file to HDFS with proper verification.
 
-    def setup_distributed_environment(self, data_path: Optional[str]=None,
-        dependency_paths: Optional[List[str]]=None):
-        """Main setup function with proper verification"""
-        try:
-            self.config.log_info('🚀 Setting up distributed environment...')
-            if data_path is None:
-                data_path = self.config.data_path
-            if data_path is None:
-                self.config.log_error('No data path provided')
-                return None, None, None
-            local_path = pathlib.Path(data_path)
-            if not local_path.exists():
-                self.config.log_error(f'Data path not found: {data_path}')
-                return None, None, None
-            if self.check_hdfs_status():
-                self.config.log_info('📁 HDFS available - attempting sync...')
+        Raises:
+            ValueError: If no data path is provided or HDFS is not accessible.
+            FileNotFoundError: If the local path does not exist.
+            RuntimeError: If sync verification fails.
+            subprocess.CalledProcessError: If an HDFS command fails.
+            subprocess.TimeoutExpired: If an HDFS command times out.
+        """
+        if local_path is None:
+            local_path = self.config.data_path
+        if local_path is None:
+            raise ValueError('No data path provided for HDFS sync')
+        local_path = pathlib.Path(local_path)
+        if not local_path.exists():
+            raise FileNotFoundError(f'Local path not found: {local_path}')
+        if not self.check_hdfs_status():
+            raise RuntimeError('HDFS not accessible')
+        if local_path.is_file():
+            hdfs_directory = (self.config.hdfs_base_directory +
+                f'{hdfs_subdir}/')
+            hdfs_full_path = hdfs_directory + local_path.name
+        else:
+            hdfs_directory = (self.config.hdfs_base_directory +
+                f'{hdfs_subdir}/{local_path.name}/')
+            hdfs_full_path = hdfs_directory
+        self.config.log_info(f'Syncing: {local_path} -> {hdfs_full_path}')
+        subprocess.run(['hdfs', 'dfs', '-mkdir', '-p', hdfs_directory],
+            check=True, timeout=60)
+        subprocess.run(['hdfs', 'dfs', '-put', '-f', str(local_path),
+            hdfs_full_path], check=True, timeout=self.config.hdfs_copy_timeout)
+        result = subprocess.run(['hdfs', 'dfs', '-test', '-e',
+            hdfs_full_path], capture_output=True, timeout=60)
+        if result.returncode != 0:
+            raise RuntimeError(f'HDFS sync verification failed for {hdfs_full_path}')
+        self.config.log_info(f'✅ Sync complete: {hdfs_full_path}')
+        return hdfs_full_path, {local_path.name: {'path': str(local_path)}}
+
+    def setup_distributed_environment(self, data_path: Optional[str] = None,
+        dependency_paths: Optional[List[str]] = None):
+        """Main setup function with proper verification.
+
+        Returns:
+            Tuple of (SparkSession, data_path_url, None).
+
+        Raises:
+            ValueError: If no data path is provided.
+            FileNotFoundError: If the data path does not exist.
+            ImportError: If PySpark is not installed.
+        """
+        self.config.log_info('🚀 Setting up distributed environment...')
+        if data_path is None:
+            data_path = self.config.data_path
+        if data_path is None:
+            raise ValueError('No data path provided')
+        local_path = pathlib.Path(data_path)
+        if not local_path.exists():
+            raise FileNotFoundError(f'Data path not found: {data_path}')
+        if self.check_hdfs_status():
+            self.config.log_info('📁 HDFS available - attempting sync...')
+            try:
                 hdfs_path, files_info = self.sync_directory_to_hdfs(data_path)
-                if hdfs_path:
-                    spark = self.create_spark_session()
-                    if spark:
-                        self.config.log_info(
-                            '✅ Using HDFS for distributed processing')
-                        return spark, hdfs_path, None
-                    else:
-                        self.config.log_error('Spark session creation failed')
-            self.config.log_info('💻 Using local filesystem...')
-            file_url = f'file://{local_path.absolute()}'
-            spark = self.create_spark_session()
-            if spark:
-                self.config.log_info(
-                    '✅ Distributed environment setup complete!')
-                return spark, file_url, None
-            else:
-                self.config.log_error('Failed to create Spark session')
-                return None, None, None
-        except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired, ImportError, ValueError) as e:
-            self.config.log_error(f'Error setting up environment: {e}')
-            return None, None, None
+                spark = self.create_spark_session()
+                self.config.log_info('✅ Using HDFS for distributed processing')
+                return spark, hdfs_path, None
+            except (RuntimeError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+                self.config.log_info(f'HDFS sync failed ({e}), falling back to local filesystem')
+        self.config.log_info('💻 Using local filesystem...')
+        file_url = f'file://{local_path.absolute()}'
+        spark = self.create_spark_session()
+        self.config.log_info('✅ Distributed environment setup complete!')
+        return spark, file_url, None
 
 
 def setup_distributed_environment(config, data_path: Optional[str]=None,

--- a/siege_utilities/distributed/spark_utils.py
+++ b/siege_utilities/distributed/spark_utils.py
@@ -50,7 +50,7 @@ RESULTS_OUTPUT_FORMAT = 'csv'
 RESULTS_OUTPUT_DELIMITER = ','
 DEBUG_SUBDIRECTORY = Path('debug_output')
 
-def sanitise_dataframe_column_names(df: "DataFrame") ->Optional["DataFrame"]:
+def sanitise_dataframe_column_names(df: "DataFrame") -> "DataFrame":
     """
     Cleans dataframe column names by converting them to lowercase and replacing
     slashes/spaces with underscores.
@@ -59,28 +59,16 @@ def sanitise_dataframe_column_names(df: "DataFrame") ->Optional["DataFrame"]:
         df (DataFrame): Input Spark DataFrame.
 
     Returns:
-        Optional["DataFrame"]: Sanitised DataFrame or None if an error occurred.
+        DataFrame: Sanitised DataFrame.
     """
-    try:
-        message = f'Sanitising column names for dataframe {df}'
-        log_info(message)
-        df = df.toDF(*[c.lower().strip().replace('/', '_').replace(' ', '_'
-            ) for c in df.columns])
-        message = (
-            f'Successfully sanitised columns for dataframe {df}: {list(df.columns)}'
-            )
-        log_info(message)
-        return df
-    except (_SparkAnalysisException, _Py4JError, AttributeError, TypeError) as e:
-        message = (
-            f'There was a problem sanitising column names for dataframe {df}:\n{e}'
-            )
-        log_error(message)
-        return None
+    log_info(f'Sanitising column names for dataframe {df}')
+    df = df.toDF(*[c.lower().strip().replace('/', '_').replace(' ', '_')
+                   for c in df.columns])
+    log_info(f'Successfully sanitised columns for dataframe {df}: {list(df.columns)}')
+    return df
 
 
-def tabulate_null_vs_not_null(df: "DataFrame", column_name: str) ->Optional[
-    DataFrame]:
+def tabulate_null_vs_not_null(df: "DataFrame", column_name: str) -> "DataFrame":
     """
     Returns a dataframe showing the count of null and non-null values for a given column.
 
@@ -89,25 +77,19 @@ def tabulate_null_vs_not_null(df: "DataFrame", column_name: str) ->Optional[
         column_name (str): Name of the column to analyze.
 
     Returns:
-        Optional["DataFrame"]: Resulting DataFrame with null vs non-null counts.
+        DataFrame: Resulting DataFrame with null vs non-null counts.
     """
-    try:
-        NULL_COLUMNS_NAME = f'{column_name}_null_count'
-        NOT_NULL_COLUMNS_NAME = f'{column_name}_not_null_count'
-        result_df = df.groupBy(column_name).agg(sum(when(col(column_name).
-            isNull(), 1).otherwise(0)).alias(NULL_COLUMNS_NAME), sum(when(
-            col(column_name).isNotNull(), 1).otherwise(0)).alias(
-            NOT_NULL_COLUMNS_NAME))
-        result_df.show(truncate=False)
-        return result_df
-    except (_SparkAnalysisException, _Py4JError, AttributeError, TypeError, ValueError) as e:
-        log_error(
-            f'Error in tabulate_null_vs_not_null for column {column_name}: {e}'
-            )
-        return None
+    NULL_COLUMNS_NAME = f'{column_name}_null_count'
+    NOT_NULL_COLUMNS_NAME = f'{column_name}_not_null_count'
+    result_df = df.groupBy(column_name).agg(
+        sum(when(col(column_name).isNull(), 1).otherwise(0)).alias(NULL_COLUMNS_NAME),
+        sum(when(col(column_name).isNotNull(), 1).otherwise(0)).alias(NOT_NULL_COLUMNS_NAME)
+    )
+    result_df.show(truncate=False)
+    return result_df
 
 
-def get_row_count(df: "DataFrame") ->Optional[int]:
+def get_row_count(df: "DataFrame") -> int:
     """
     Returns the count of rows in the dataframe.
 
@@ -115,19 +97,14 @@ def get_row_count(df: "DataFrame") ->Optional[int]:
         df (DataFrame): Input Spark DataFrame.
 
     Returns:
-        Optional[int]: Row count or None if an error occurred.
+        int: Row count.
     """
-    try:
-        count = df.count()
-        log_info(f'Row count for dataframe: {count}')
-        return count
-    except (_SparkAnalysisException, _Py4JError, AttributeError) as e:
-        log_error(f'Error getting row count: {e}')
-        return None
+    count = df.count()
+    log_info(f'Row count for dataframe: {count}')
+    return count
 
 
-def repartition_and_cache(df: "DataFrame", partitions: int=100) ->Optional[
-    DataFrame]:
+def repartition_and_cache(df: "DataFrame", partitions: int = 100) -> "DataFrame":
     """
     Repartitions and caches a dataframe.
 
@@ -136,40 +113,26 @@ def repartition_and_cache(df: "DataFrame", partitions: int=100) ->Optional[
         partitions (int, optional): Number of partitions. Default is 100.
 
     Returns:
-        Optional["DataFrame"]: Repartitioned and cached DataFrame or None if an error occurred.
+        DataFrame: Repartitioned and cached DataFrame.
     """
-    try:
-        df = df.repartition(partitions).cache()
-        log_info(
-            f'Dataframe repartitioned to {partitions} partitions and cached.')
-        return df
-    except (_SparkAnalysisException, _Py4JError, AttributeError, ValueError) as e:
-        log_error(f'Error repartitioning and caching dataframe: {e}')
-        return None
+    df = df.repartition(partitions).cache()
+    log_info(f'Dataframe repartitioned to {partitions} partitions and cached.')
+    return df
 
 
-def register_temp_table(df: "DataFrame", table_name: str) ->bool:
+def register_temp_table(df: "DataFrame", table_name: str) -> None:
     """
     Registers a temporary view from a dataframe.
 
     Args:
         df (DataFrame): Input Spark DataFrame.
         table_name (str): Name for the temporary view.
-
-    Returns:
-        bool: True if successful, False otherwise.
     """
-    try:
-        df.createOrReplaceTempView(table_name)
-        log_info(f"Temporary view '{table_name}' registered.")
-        return True
-    except (_SparkAnalysisException, _Py4JError, AttributeError, ValueError) as e:
-        log_error(f"Error registering temporary table '{table_name}': {e}")
-        return False
+    df.createOrReplaceTempView(table_name)
+    log_info(f"Temporary view '{table_name}' registered.")
 
 
-def move_column_to_front_of_dataframe(df: "DataFrame", column_name: str
-    ) ->Optional["DataFrame"]:
+def move_column_to_front_of_dataframe(df: "DataFrame", column_name: str) -> "DataFrame":
     """Reorder *df* so *column_name* is the leftmost column.
 
     The Spark schema order is what most CSV / parquet readers surface
@@ -177,24 +140,16 @@ def move_column_to_front_of_dataframe(df: "DataFrame", column_name: str
     left-to-right. Moving the join key / identifier to the front makes
     the rest of the pipeline more readable without changing semantics.
 
-    Returns the reordered DataFrame, or ``None`` on failure (logged).
     The original *df* is unchanged.
     """
-    try:
-        columns = list(df.columns)
-        column_to_move = column_name
-        new_column_order = [column_to_move] + [col for col in columns if
-            col != column_to_move]
-        df_reordered = df.select(*new_column_order)
-        df_reordered.printSchema()
-        return df_reordered
-    except (_SparkAnalysisException, _Py4JError, AttributeError, ValueError, KeyError) as e:
-        log_error(f'Error repartitioning and caching dataframe: {e}')
-        return None
+    columns = list(df.columns)
+    new_column_order = [column_name] + [c for c in columns if c != column_name]
+    df_reordered = df.select(*new_column_order)
+    df_reordered.printSchema()
+    return df_reordered
 
 
-def write_df_to_parquet(df: "DataFrame", path: str, mode: str='overwrite'
-    ) ->bool:
+def write_df_to_parquet(df: "DataFrame", path: str, mode: str = 'overwrite') -> None:
     """
     Writes a DataFrame to a Parquet file.
 
@@ -202,20 +157,12 @@ def write_df_to_parquet(df: "DataFrame", path: str, mode: str='overwrite'
         df (DataFrame): Input Spark DataFrame.
         path (str): Output path.
         mode (str): Write mode. Defaults to "overwrite".
-
-    Returns:
-        bool: True if successful, False otherwise.
     """
-    try:
-        df.write.mode(mode).parquet(path)
-        log_info(f"Dataframe written to parquet at {path} with mode '{mode}'")
-        return True
-    except (_SparkAnalysisException, _Py4JError, OSError, AttributeError) as e:
-        log_error(f'Error writing dataframe to parquet at {path}: {e}')
-        return False
+    df.write.mode(mode).parquet(path)
+    log_info(f"Dataframe written to parquet at {path} with mode '{mode}'")
 
 
-def read_parquet_to_df(spark: "SparkSession", path: str) ->Optional["DataFrame"]:
+def read_parquet_to_df(spark: "SparkSession", path: str) -> "DataFrame":
     """
     Reads a Parquet file into a Spark DataFrame.
 
@@ -224,15 +171,11 @@ def read_parquet_to_df(spark: "SparkSession", path: str) ->Optional["DataFrame"]
         path (str): Path to the Parquet file.
 
     Returns:
-        Optional["DataFrame"]: Loaded DataFrame or None if an error occurred.
+        DataFrame: Loaded DataFrame.
     """
-    try:
-        df = spark.read.parquet(path)
-        log_info(f'Successfully read parquet from {path}')
-        return df
-    except (_SparkAnalysisException, _Py4JError, OSError, AttributeError) as e:
-        log_error(f'Error reading parquet from {path}: {e}')
-        return None
+    df = spark.read.parquet(path)
+    log_info(f'Successfully read parquet from {path}')
+    return df
 
 
 def flatten_json_column_and_join_back_to_df(df: "DataFrame", json_column: str,
@@ -913,8 +856,8 @@ def backup_full_dataframe(df, step_name: str) -> None:
 
 
 def atomic_write_with_staging(df: "DataFrame", final_destination: str,
-    staging_directory: str, file_format: str='csv', delimiter: str=',',
-    header: bool=True, mode: str='overwrite') ->bool:
+    staging_directory: str, file_format: str = 'csv', delimiter: str = ',',
+    header: bool = True, mode: str = 'overwrite') -> None:
     """
     Performs atomic write operations using a staging directory to prevent partial/corrupted files.
     """
@@ -939,8 +882,7 @@ def atomic_write_with_staging(df: "DataFrame", final_destination: str,
         log_info('Successfully wrote data to staging directory')
         if os.path.exists(final_destination):
             backup_dir = f'{final_destination}_backup_{int(time.time())}'
-            if os.path.isdir(final_destination) and os.listdir(
-                final_destination):
+            if os.path.isdir(final_destination) and os.listdir(final_destination):
                 log_info(f'Backing up existing data to {backup_dir}')
                 shutil.move(final_destination, backup_dir)
                 log_info('Existing data backed up successfully')
@@ -958,20 +900,15 @@ def atomic_write_with_staging(df: "DataFrame", final_destination: str,
             else:
                 shutil.copy2(source_path, dest_path)
             files_moved += 1
-        log_info(f'Successfully moved {files_moved} items to final destination'
-            )
+        log_info(f'Successfully moved {files_moved} items to final destination')
         log_info('Atomic write operation completed successfully')
-        return True
-    except (_SparkAnalysisException, _Py4JError, OSError, ValueError, AttributeError) as e:
-        log_error(f'Error in atomic write operation: {e}')
-        return False
     finally:
         try:
             if os.path.exists(staging_directory):
                 shutil.rmtree(staging_directory)
                 log_info('Cleaned up staging directory')
         except OSError as cleanup_error:
-            log_error(f'Error cleaning up staging directory: {cleanup_error}')
+            log_warning(f'Error cleaning up staging directory: {cleanup_error}')
 
 
 def create_unique_staging_directory(base_path, operation_name: str = 'operation') -> str:

--- a/siege_utilities/files/hashing.py
+++ b/siege_utilities/files/hashing.py
@@ -57,7 +57,7 @@ def _update_from_file(hash_obj, fp) -> None:
         hash_obj.update(chunk)
 
 
-def generate_sha256_hash_for_file(file_path) ->Optional[str]:
+def generate_sha256_hash_for_file(file_path) -> str:
     """Generate SHA256 hash for a file - chunked reading for large files.
 
     .. deprecated:: 3.19.0
@@ -71,16 +71,13 @@ def generate_sha256_hash_for_file(file_path) ->Optional[str]:
         file_path: Path to the file (str or Path object)
 
     Returns:
-        SHA256 hash as hexadecimal string, or None if error
+        SHA256 hash as hexadecimal string.
 
     Raises:
-        PathSecurityError: If path fails security validation
-
-    Example:
-        >>> hash_val = generate_sha256_hash_for_file("data.txt")
-        >>>
-        >>> # This will raise PathSecurityError
-        >>> generate_sha256_hash_for_file("/etc/shadow")  # Sensitive file blocked
+        PathSecurityError: If path fails security validation.
+        FileNotFoundError: If the file does not exist.
+        ValueError: If the path is not a regular file.
+        OSError: On I/O failure.
     """
     import warnings
     warnings.warn(
@@ -89,22 +86,12 @@ def generate_sha256_hash_for_file(file_path) ->Optional[str]:
         DeprecationWarning,
         stacklevel=2,
     )
-    try:
-        path_obj = _validated_path(file_path, must_exist=True)
-        if not path_obj.exists() or not path_obj.is_file():
-            return None
-        sha256_hash = hashlib.sha256()
-        with open(path_obj, 'rb') as f:
-            _update_from_file(sha256_hash, f)
-        return sha256_hash.hexdigest()
-    except (OSError, ValueError) as e:
-        log_error(f'Error generating SHA256 hash for {file_path}: {e}')
-        return None
+    return get_file_hash(file_path, 'sha256')
 
 
-def get_file_hash(file_path, algorithm='sha256') ->Optional[str]:
+def get_file_hash(file_path, algorithm='sha256') -> str:
     """
-    Generate hash for a file using specified algorithm
+    Generate hash for a file using specified algorithm.
 
     SECURITY: This function validates paths to prevent path traversal attacks
     and access to sensitive system files.
@@ -114,44 +101,35 @@ def get_file_hash(file_path, algorithm='sha256') ->Optional[str]:
         algorithm: Hash algorithm to use ('sha256', 'md5', 'sha1', etc.)
 
     Returns:
-        Hash as hexadecimal string, or None if error
+        Hash as hexadecimal string.
 
     Raises:
-        PathSecurityError: If path fails security validation
-
-    Example:
-        >>> hash_val = get_file_hash("data.txt", "sha256")
-        >>>
-        >>> # This will raise PathSecurityError
-        >>> get_file_hash("../../../etc/passwd")  # Path traversal blocked
-
-    Security Changes:
-        - Now validates paths to block path traversal
-        - Blocks access to sensitive system files
+        PathSecurityError: If path fails security validation.
+        FileNotFoundError: If the file does not exist.
+        ValueError: If the path is not a regular file or algorithm is unknown.
+        OSError: On I/O failure.
     """
-    try:
-        path_obj = _validated_path(file_path, must_exist=True)
-        if not path_obj.exists() or not path_obj.is_file():
-            return None
-        if algorithm.lower() == 'sha256':
-            hash_func = hashlib.sha256()
-        elif algorithm.lower() == 'md5':
-            hash_func = hashlib.md5()
-        elif algorithm.lower() == 'sha1':
-            hash_func = hashlib.sha1()
-        else:
-            hash_func = hashlib.new(algorithm)
-        with open(path_obj, 'rb') as f:
-            _update_from_file(hash_func, f)
-        return hash_func.hexdigest()
-    except (OSError, ValueError) as e:
-        log_error(f'Error generating {algorithm} hash for {file_path}: {e}')
-        return None
+    path_obj = _validated_path(file_path, must_exist=True)
+    if not path_obj.exists():
+        raise FileNotFoundError(f"File does not exist: {path_obj}")
+    if not path_obj.is_file():
+        raise ValueError(f"Path is not a file: {path_obj}")
+    if algorithm.lower() == 'sha256':
+        hash_func = hashlib.sha256()
+    elif algorithm.lower() == 'md5':
+        hash_func = hashlib.md5()
+    elif algorithm.lower() == 'sha1':
+        hash_func = hashlib.sha1()
+    else:
+        hash_func = hashlib.new(algorithm)
+    with open(path_obj, 'rb') as f:
+        _update_from_file(hash_func, f)
+    return hash_func.hexdigest()
 
 
-def calculate_file_hash(file_path) ->Optional[str]:
+def calculate_file_hash(file_path) -> str:
     """
-    Alias for get_file_hash with SHA256 - for backward compatibility
+    Alias for get_file_hash with SHA256 - for backward compatibility.
     """
     return get_file_hash(file_path, 'sha256')
 

--- a/siege_utilities/files/operations.py
+++ b/siege_utilities/files/operations.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 # Type aliases
 FilePath = Union[str, Path]
 
-def remove_tree(path: FilePath) -> bool:
+def remove_tree(path: FilePath) -> None:
     """
     Remove a file or directory tree safely.
 
@@ -25,41 +25,25 @@ def remove_tree(path: FilePath) -> bool:
     Args:
         path: Path to file or directory to remove
 
-    Returns:
-        True if successful, False otherwise
-
     Raises:
-        PathSecurityError: If path fails security validation
-
-    Example:
-        >>> remove_tree("temp_directory")
-        >>> remove_tree(Path("old_files"))
+        PathSecurityError: If path fails security validation.
+        FileNotFoundError: If path does not exist.
+        OSError: On removal failure.
     """
     try:
-        # Validate path
-        try:
-            from siege_utilities.files.validation import validate_safe_path, PathSecurityError
-            path_obj = validate_safe_path(path, allow_absolute=True)
-        except ImportError:
-            path_obj = Path(path)
+        from siege_utilities.files.validation import validate_safe_path, PathSecurityError
+        path_obj = validate_safe_path(path, allow_absolute=True)
+    except ImportError:
+        path_obj = Path(path)
 
-        if path_obj.is_file():
-            path_obj.unlink()
-            log.info(f"Removed file: {path_obj}")
-        elif path_obj.is_dir():
-            shutil.rmtree(path_obj)
-            log.info(f"Removed directory tree: {path_obj}")
-        else:
-            log.warning(f"Path does not exist: {path_obj}")
-            return False
-
-        return True
-
-    except PathSecurityError:
-        raise
-    except OSError as e:
-        log.error(f"Failed to remove {path}: {e}")
-        return False
+    if path_obj.is_file():
+        path_obj.unlink()
+        log.info(f"Removed file: {path_obj}")
+    elif path_obj.is_dir():
+        shutil.rmtree(path_obj)
+        log.info(f"Removed directory tree: {path_obj}")
+    else:
+        raise FileNotFoundError(f"Path does not exist: {path_obj}")
 
 def file_exists(path: FilePath) -> bool:
     """
@@ -115,7 +99,7 @@ def file_exists(path: FilePath) -> bool:
         log.error(f"Error checking file existence for {path}: {e}")
         return False
 
-def touch_file(path: FilePath, create_parents: bool = True) -> bool:
+def touch_file(path: FilePath, create_parents: bool = True) -> None:
     """
     Create an empty file, creating parent directories if needed.
 
@@ -125,38 +109,23 @@ def touch_file(path: FilePath, create_parents: bool = True) -> bool:
         path: Path to the file to create
         create_parents: Whether to create parent directories
 
-    Returns:
-        True if successful, False otherwise
-
     Raises:
-        PathSecurityError: If path fails security validation
-
-    Example:
-        >>> touch_file("logs/app.log")
-        >>> touch_file(Path("data/output.txt"))
+        PathSecurityError: If path fails security validation.
+        OSError: On filesystem failure.
     """
     try:
-        # Validate path
-        try:
-            from siege_utilities.files.validation import validate_safe_path, PathSecurityError
-            path_obj = validate_safe_path(path, allow_absolute=True)
-        except ImportError:
-            path_obj = Path(path)
+        from siege_utilities.files.validation import validate_safe_path, PathSecurityError
+        path_obj = validate_safe_path(path, allow_absolute=True)
+    except ImportError:
+        path_obj = Path(path)
 
-        if create_parents:
-            path_obj.parent.mkdir(parents=True, exist_ok=True)
+    if create_parents:
+        path_obj.parent.mkdir(parents=True, exist_ok=True)
 
-        path_obj.touch(exist_ok=True)
-        log.info(f"Created/updated file: {path_obj}")
-        return True
+    path_obj.touch(exist_ok=True)
+    log.info(f"Created/updated file: {path_obj}")
 
-    except PathSecurityError:
-        raise
-    except OSError as e:
-        log.error(f"Failed to create file {path}: {e}")
-        return False
-
-def count_lines(file_path: FilePath, encoding: str = 'utf-8') -> Optional[int]:
+def count_lines(file_path: FilePath, encoding: str = 'utf-8') -> int:
     """
     Count the total number of lines in a text file.
 
@@ -168,61 +137,34 @@ def count_lines(file_path: FilePath, encoding: str = 'utf-8') -> Optional[int]:
         encoding: File encoding to use
 
     Returns:
-        Number of lines, or None if failed
+        Number of lines.
 
     Raises:
-        PathSecurityError: If path fails security validation (from validation module)
-
-    Example:
-        >>> line_count = count_lines("data.csv")
-        >>> print(f"File has {line_count} lines")
-        >>>
-        >>> # This will raise PathSecurityError
-        >>> count_lines("../../../etc/passwd")  # Path traversal blocked
-
-    Security Changes:
-        - Now validates paths to block path traversal
-        - Blocks access to sensitive system files
-        - Resolves symlinks and validates final destination
+        PathSecurityError: If path fails security validation.
+        FileNotFoundError: If the file does not exist.
+        ValueError: If the path is not a regular file.
+        OSError: On I/O failure.
+        UnicodeDecodeError: If the file cannot be decoded with the given encoding.
     """
     try:
-        # Import validation function
-        try:
-            from siege_utilities.files.validation import validate_file_path, PathSecurityError
-        except ImportError:
-            # Fallback: use basic Path validation without security checks
-            log.warning("Path validation module not available - using basic validation")
-            path_obj = Path(file_path)
-        else:
-            # Validate path with security checks
-            try:
-                path_obj = validate_file_path(file_path, must_exist=True)
-            except PathSecurityError as e:
-                log.error(f"Path security validation failed: {e}")
-                raise  # Re-raise to caller
+        from siege_utilities.files.validation import validate_file_path, PathSecurityError
+        path_obj = validate_file_path(file_path, must_exist=True)
+    except ImportError:
+        path_obj = Path(file_path)
 
-        if not path_obj.exists():
-            log.warning(f"File does not exist: {path_obj}")
-            return None
+    if not path_obj.exists():
+        raise FileNotFoundError(f"File does not exist: {path_obj}")
 
-        if not path_obj.is_file():
-            log.warning(f"Path is not a file: {path_obj}")
-            return None
+    if not path_obj.is_file():
+        raise ValueError(f"Path is not a file: {path_obj}")
 
-        with open(path_obj, 'r', encoding=encoding) as f:
-            line_count = sum(1 for _ in f)
+    with open(path_obj, 'r', encoding=encoding) as f:
+        line_count = sum(1 for _ in f)
 
-        log.info(f"Counted {line_count} lines in {path_obj}")
-        return line_count
+    log.info(f"Counted {line_count} lines in {path_obj}")
+    return line_count
 
-    except PathSecurityError:
-        # Re-raise security errors
-        raise
-    except (OSError, UnicodeDecodeError) as e:
-        log.error(f"Failed to count lines in {file_path}: {e}")
-        return None
-
-def copy_file(source: FilePath, destination: FilePath, overwrite: bool = False) -> bool:
+def copy_file(source: FilePath, destination: FilePath, overwrite: bool = False) -> None:
     """
     Copy a file from source to destination.
 
@@ -233,53 +175,36 @@ def copy_file(source: FilePath, destination: FilePath, overwrite: bool = False) 
         destination: Destination file path
         overwrite: Whether to overwrite existing files
 
-    Returns:
-        True if successful, False otherwise
-
     Raises:
-        PathSecurityError: If paths fail security validation
-
-    Example:
-        >>> copy_file("source.txt", "backup/source.txt")
-        >>> copy_file(Path("config.yaml"), Path("config.yaml.bak"))
+        PathSecurityError: If paths fail security validation.
+        FileNotFoundError: If source does not exist.
+        ValueError: If source is not a regular file.
+        FileExistsError: If destination exists and overwrite=False.
+        OSError: On I/O failure.
     """
     try:
-        # Validate paths
-        try:
-            from siege_utilities.files.validation import validate_file_path, validate_safe_path, PathSecurityError
-            source_obj = validate_file_path(source, must_exist=True)
-            dest_obj = validate_safe_path(destination, allow_absolute=True)
-        except ImportError:
-            source_obj = Path(source)
-            dest_obj = Path(destination)
+        from siege_utilities.files.validation import validate_file_path, validate_safe_path, PathSecurityError
+        source_obj = validate_file_path(source, must_exist=True)
+        dest_obj = validate_safe_path(destination, allow_absolute=True)
+    except ImportError:
+        source_obj = Path(source)
+        dest_obj = Path(destination)
 
-        if not source_obj.exists():
-            log.error(f"Source file does not exist: {source_obj}")
-            return False
+    if not source_obj.exists():
+        raise FileNotFoundError(f"Source file does not exist: {source_obj}")
 
-        if not source_obj.is_file():
-            log.error(f"Source is not a file: {source_obj}")
-            return False
+    if not source_obj.is_file():
+        raise ValueError(f"Source is not a file: {source_obj}")
 
-        # Create destination directory if needed
-        dest_obj.parent.mkdir(parents=True, exist_ok=True)
+    dest_obj.parent.mkdir(parents=True, exist_ok=True)
 
-        # Check if destination exists
-        if dest_obj.exists() and not overwrite:
-            log.warning(f"Destination file exists and overwrite=False: {dest_obj}")
-            return False
+    if dest_obj.exists() and not overwrite:
+        raise FileExistsError(f"Destination file exists and overwrite=False: {dest_obj}")
 
-        shutil.copy2(source_obj, dest_obj)
-        log.info(f"Copied {source_obj} to {dest_obj}")
-        return True
+    shutil.copy2(source_obj, dest_obj)
+    log.info(f"Copied {source_obj} to {dest_obj}")
 
-    except PathSecurityError:
-        raise
-    except OSError as e:
-        log.error(f"Failed to copy {source} to {destination}: {e}")
-        return False
-
-def move_file(source: FilePath, destination: FilePath, overwrite: bool = False) -> bool:
+def move_file(source: FilePath, destination: FilePath, overwrite: bool = False) -> None:
     """
     Move a file from source to destination.
 
@@ -290,53 +215,36 @@ def move_file(source: FilePath, destination: FilePath, overwrite: bool = False) 
         destination: Destination file path
         overwrite: Whether to overwrite existing files
 
-    Returns:
-        True if successful, False otherwise
-
     Raises:
-        PathSecurityError: If paths fail security validation
-
-    Example:
-        >>> move_file("temp.txt", "archive/temp.txt")
-        >>> move_file(Path("old.log"), Path("logs/old.log"))
+        PathSecurityError: If paths fail security validation.
+        FileNotFoundError: If source does not exist.
+        ValueError: If source is not a regular file.
+        FileExistsError: If destination exists and overwrite=False.
+        OSError: On I/O failure.
     """
     try:
-        # Validate paths
-        try:
-            from siege_utilities.files.validation import validate_file_path, validate_safe_path, PathSecurityError
-            source_obj = validate_file_path(source, must_exist=True)
-            dest_obj = validate_safe_path(destination, allow_absolute=True)
-        except ImportError:
-            source_obj = Path(source)
-            dest_obj = Path(destination)
+        from siege_utilities.files.validation import validate_file_path, validate_safe_path, PathSecurityError
+        source_obj = validate_file_path(source, must_exist=True)
+        dest_obj = validate_safe_path(destination, allow_absolute=True)
+    except ImportError:
+        source_obj = Path(source)
+        dest_obj = Path(destination)
 
-        if not source_obj.exists():
-            log.error(f"Source file does not exist: {source_obj}")
-            return False
+    if not source_obj.exists():
+        raise FileNotFoundError(f"Source file does not exist: {source_obj}")
 
-        if not source_obj.is_file():
-            log.error(f"Source is not a file: {source_obj}")
-            return False
+    if not source_obj.is_file():
+        raise ValueError(f"Source is not a file: {source_obj}")
 
-        # Create destination directory if needed
-        dest_obj.parent.mkdir(parents=True, exist_ok=True)
+    dest_obj.parent.mkdir(parents=True, exist_ok=True)
 
-        # Check if destination exists
-        if dest_obj.exists() and not overwrite:
-            log.warning(f"Destination file exists and overwrite=False: {dest_obj}")
-            return False
+    if dest_obj.exists() and not overwrite:
+        raise FileExistsError(f"Destination file exists and overwrite=False: {dest_obj}")
 
-        shutil.move(str(source_obj), str(dest_obj))
-        log.info(f"Moved {source_obj} to {dest_obj}")
-        return True
+    shutil.move(str(source_obj), str(dest_obj))
+    log.info(f"Moved {source_obj} to {dest_obj}")
 
-    except PathSecurityError:
-        raise
-    except OSError as e:
-        log.error(f"Failed to move {source} to {destination}: {e}")
-        return False
-
-def get_file_size(file_path: FilePath) -> Optional[int]:
+def get_file_size(file_path: FilePath) -> int:
     """
     Get the size of a file in bytes.
 
@@ -347,61 +255,34 @@ def get_file_size(file_path: FilePath) -> Optional[int]:
         file_path: Path to the file
 
     Returns:
-        File size in bytes, or None if failed
+        File size in bytes.
 
     Raises:
-        PathSecurityError: If path fails security validation
-
-    Example:
-        >>> size = get_file_size("large_file.zip")
-        >>> print(f"File size: {size} bytes")
-        >>>
-        >>> # This will raise PathSecurityError
-        >>> get_file_size("/etc/shadow")  # Sensitive file blocked
-
-    Security Changes:
-        - Now validates paths to block path traversal
-        - Blocks access to sensitive system files
+        PathSecurityError: If path fails security validation.
+        FileNotFoundError: If the file does not exist.
+        ValueError: If the path is not a regular file.
+        OSError: On I/O failure.
     """
     try:
-        # Import validation function
-        try:
-            from siege_utilities.files.validation import validate_file_path, PathSecurityError
-        except ImportError:
-            # Fallback: use basic Path validation without security checks
-            log.warning("Path validation module not available - using basic validation")
-            path_obj = Path(file_path)
-        else:
-            # Validate path with security checks
-            try:
-                path_obj = validate_file_path(file_path, must_exist=True)
-            except PathSecurityError as e:
-                log.error(f"Path security validation failed: {e}")
-                raise  # Re-raise to caller
+        from siege_utilities.files.validation import validate_file_path, PathSecurityError
+        path_obj = validate_file_path(file_path, must_exist=True)
+    except ImportError:
+        path_obj = Path(file_path)
 
-        if not path_obj.exists():
-            log.warning(f"File does not exist: {path_obj}")
-            return None
+    if not path_obj.exists():
+        raise FileNotFoundError(f"File does not exist: {path_obj}")
 
-        if not path_obj.is_file():
-            log.warning(f"Path is not a file: {path_obj}")
-            return None
+    if not path_obj.is_file():
+        raise ValueError(f"Path is not a file: {path_obj}")
 
-        size = path_obj.stat().st_size
-        log.debug(f"File size for {path_obj}: {size} bytes")
-        return size
-
-    except PathSecurityError:
-        # Re-raise security errors
-        raise
-    except OSError as e:
-        log.error(f"Failed to get file size for {file_path}: {e}")
-        return None
+    size = path_obj.stat().st_size
+    log.debug(f"File size for {path_obj}: {size} bytes")
+    return size
 
 def list_directory(path: FilePath,
                   pattern: str = "*",
                   include_dirs: bool = True,
-                  include_files: bool = True) -> Optional[List[Path]]:
+                  include_files: bool = True) -> List[Path]:
     """
     List contents of a directory with optional filtering.
 
@@ -414,54 +295,43 @@ def list_directory(path: FilePath,
         include_files: Whether to include files
 
     Returns:
-        List of Path objects, or None if failed
+        List of Path objects.
 
     Raises:
-        PathSecurityError: If path fails security validation
-
-    Example:
-        >>> files = list_directory("data", "*.csv")
-        >>> dirs = list_directory("logs", include_files=False)
+        PathSecurityError: If path fails security validation.
+        FileNotFoundError: If the directory does not exist.
+        ValueError: If the path is not a directory.
+        OSError: On I/O failure.
     """
     try:
-        # Validate path
-        try:
-            from siege_utilities.files.validation import validate_directory_path, PathSecurityError
-            path_obj = validate_directory_path(path, must_exist=True)
-        except ImportError:
-            path_obj = Path(path)
+        from siege_utilities.files.validation import validate_directory_path, PathSecurityError
+        path_obj = validate_directory_path(path, must_exist=True)
+    except ImportError:
+        path_obj = Path(path)
 
-        if not path_obj.exists():
-            log.warning(f"Directory does not exist: {path_obj}")
-            return None
+    if not path_obj.exists():
+        raise FileNotFoundError(f"Directory does not exist: {path_obj}")
 
-        if not path_obj.is_dir():
-            log.warning(f"Path is not a directory: {path_obj}")
-            return None
+    if not path_obj.is_dir():
+        raise ValueError(f"Path is not a directory: {path_obj}")
 
-        items = []
+    items = []
 
-        for item in path_obj.glob(pattern):
-            if item.is_dir() and include_dirs:
-                items.append(item)
-            elif item.is_file() and include_files:
-                items.append(item)
+    for item in path_obj.glob(pattern):
+        if item.is_dir() and include_dirs:
+            items.append(item)
+        elif item.is_file() and include_files:
+            items.append(item)
 
-        log.debug(f"Listed {len(items)} items in {path_obj}")
-        return sorted(items)
-
-    except PathSecurityError:
-        raise
-    except OSError as e:
-        log.error(f"Failed to list directory {path}: {e}")
-        return None
+    log.debug(f"Listed {len(items)} items in {path_obj}")
+    return sorted(items)
 
 def run_command(command: Union[str, List[str]],
                 cwd: Optional[FilePath] = None,
                 timeout: Optional[int] = 30,
                 capture_output: bool = True,
                 allow_list: Optional[set] = None,
-                unsafe: bool = False) -> Optional[subprocess.CompletedProcess]:
+                unsafe: bool = False) -> subprocess.CompletedProcess:
     """
     Run a shell command with security validation and proper error handling.
 
@@ -481,12 +351,13 @@ def run_command(command: Union[str, List[str]],
             not when you need shell features.
 
     Returns:
-        CompletedProcess object on success or non-zero exit.
-        None on timeout or unexpected error (when unsafe=True).
+        CompletedProcess object (may have non-zero returncode).
 
     Raises:
         SecurityError: If command fails security validation (when unsafe=False).
-        Exception: Re-raised on unexpected errors when unsafe=False.
+        subprocess.TimeoutExpired: If command exceeds timeout.
+        OSError: If the command executable cannot be found/run.
+        ValueError: If the command string contains shell metacharacters in unsafe mode.
 
     Example:
         >>> # Safe command (works by default)
@@ -587,13 +458,9 @@ def run_command(command: Union[str, List[str]],
         return result
 
     except subprocess.TimeoutExpired:
-        log.error(f"Command timed out: {command}")
-        return None
-    except (OSError, ValueError) as e:
-        log.error(f"Failed to run command {command}: {e}")
-        if not unsafe:
-            raise
-        return None
+        raise
+    except (OSError, ValueError):
+        raise
 
 # Backward compatibility aliases
 rmtree = remove_tree
@@ -615,7 +482,7 @@ def check_if_file_exists_at_path(path: FilePath) -> bool:
     return file_exists(path)
 
 
-def delete_existing_file_and_replace_it_with_an_empty_file(file_path: FilePath, create_parents: bool = True) -> bool:
+def delete_existing_file_and_replace_it_with_an_empty_file(file_path: FilePath, create_parents: bool = True) -> None:
     """Backward compatibility function that deletes existing file and replaces it with empty file.
 
     .. deprecated:: 3.19.0
@@ -630,11 +497,9 @@ def delete_existing_file_and_replace_it_with_an_empty_file(file_path: FilePath, 
         file_path: Path to the file
         create_parents: Whether to create parent directories
 
-    Returns:
-        True if successful, False otherwise
-
     Raises:
-        PathSecurityError: If path fails security validation
+        PathSecurityError: If path fails security validation.
+        OSError: On filesystem failure.
     """
     import warnings
     warnings.warn(
@@ -645,30 +510,19 @@ def delete_existing_file_and_replace_it_with_an_empty_file(file_path: FilePath, 
         stacklevel=2,
     )
     try:
-        # Validate path
-        try:
-            from siege_utilities.files.validation import validate_safe_path, PathSecurityError
-            path_obj = validate_safe_path(file_path, allow_absolute=True)
-        except ImportError:
-            path_obj = Path(file_path)
+        from siege_utilities.files.validation import validate_safe_path, PathSecurityError
+        path_obj = validate_safe_path(file_path, allow_absolute=True)
+    except ImportError:
+        path_obj = Path(file_path)
 
-        # Create parent directories if needed
-        if create_parents:
-            path_obj.parent.mkdir(parents=True, exist_ok=True)
+    if create_parents:
+        path_obj.parent.mkdir(parents=True, exist_ok=True)
 
-        # Remove existing file if it exists
-        if path_obj.exists():
-            path_obj.unlink()
+    if path_obj.exists():
+        path_obj.unlink()
 
-        # Create empty file
-        path_obj.touch()
-        log.info(f"Created/updated empty file: {path_obj}")
-        return True
-    except PathSecurityError:
-        raise
-    except OSError as e:
-        log.error(f"Failed to create empty file {file_path}: {e}")
-        return False
+    path_obj.touch()
+    log.info(f"Created/updated empty file: {path_obj}")
 
 count_total_rows_in_file_pythonically = count_lines
 

--- a/siege_utilities/files/paths.py
+++ b/siege_utilities/files/paths.py
@@ -61,7 +61,7 @@ def ensure_path_exists(desired_path: FilePath) -> Path:
 
 def unzip_file_to_directory(zip_file_path: FilePath,
                            extract_to: Optional[FilePath] = None,
-                           create_subdirectory: bool = True) -> Optional[Path]:
+                           create_subdirectory: bool = True) -> Path:
     """
     Extract a zip file to a directory.
 
@@ -73,83 +73,58 @@ def unzip_file_to_directory(zip_file_path: FilePath,
         create_subdirectory: Whether to create a subdirectory for extracted files
 
     Returns:
-        Path to the extraction directory, or None if failed
+        Path to the extraction directory.
 
     Raises:
-        PathSecurityError: If paths fail security validation
-
-    Example:
-        >>> extract_dir = unzip_file_to_directory("data.zip")
-        >>> print(f"Files extracted to: {extract_dir}")
+        PathSecurityError: If paths fail security validation.
+        FileNotFoundError: If the zip file does not exist.
+        ValueError: If the path is not a regular file.
+        zipfile.BadZipFile: If the file is not a valid zip.
+        OSError: On I/O failure.
     """
     try:
-        # Validate paths
-        try:
-            from siege_utilities.files.validation import validate_file_path, validate_directory_path, PathSecurityError  # noqa: F401, F811
-            zip_path = validate_file_path(zip_file_path, must_exist=True)
-        except ImportError:
-            zip_path = Path(zip_file_path)
+        from siege_utilities.files.validation import validate_file_path, validate_directory_path, PathSecurityError  # noqa: F401, F811
+        zip_path = validate_file_path(zip_file_path, must_exist=True)
+    except ImportError:
+        zip_path = Path(zip_file_path)
 
-        if not zip_path.exists():
-            log.error(f"Zip file does not exist: {zip_path}")
-            return None
+    if not zip_path.exists():
+        raise FileNotFoundError(f"Zip file does not exist: {zip_path}")
 
-        if not zip_path.is_file():
-            log.error(f"Path is not a file: {zip_path}")
-            return None
+    if not zip_path.is_file():
+        raise ValueError(f"Path is not a file: {zip_path}")
 
-        # Determine extraction directory
-        if extract_to is None:
-            extract_to = zip_path.parent
+    if extract_to is None:
+        extract_to = zip_path.parent
 
-        try:
-            from siege_utilities.files.validation import validate_directory_path, PathSecurityError  # noqa: F401, F811
-            extract_dir = validate_directory_path(extract_to, must_exist=False)
-        except ImportError:
-            extract_dir = Path(extract_to)
+    try:
+        from siege_utilities.files.validation import validate_directory_path, PathSecurityError  # noqa: F401, F811
+        extract_dir = validate_directory_path(extract_to, must_exist=False)
+    except ImportError:
+        extract_dir = Path(extract_to)
 
-        if create_subdirectory:
-            # Create subdirectory based on zip file name
-            subdir_name = zip_path.stem
-            target_dir = extract_dir / subdir_name
-        else:
-            target_dir = extract_dir
+    if create_subdirectory:
+        subdir_name = zip_path.stem
+        target_dir = extract_dir / subdir_name
+    else:
+        target_dir = extract_dir
 
-        # Create target directory
-        target_dir.mkdir(parents=True, exist_ok=True)
+    target_dir.mkdir(parents=True, exist_ok=True)
 
-        # Extract files (with zip slip protection). Validate AND extract
-        # per-member — extractall() would ignore the validation loop
-        # below and re-process every entry without the guard.
-        with zipfile.ZipFile(zip_path, 'r') as zip_ref:
-            target_resolved = target_dir.resolve()
-            for member in zip_ref.namelist():
-                # Reject absolute paths and any traversal that escapes
-                # target_dir. Path.resolve() collapses '..' segments;
-                # if the result isn't a child of target_dir, it's
-                # malicious.
-                try:
-                    (target_dir / member).resolve().relative_to(target_resolved)
-                except ValueError:
-                    # Detected-and-skipped → recoverable anomaly, not a
-                    # user-visible failure. Use warning + lazy format.
-                    log.warning(
-                        "Zip slip attempt detected, skipping member: %r", member,
-                    )
-                    continue
-                zip_ref.extract(member, target_dir)
+    with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+        target_resolved = target_dir.resolve()
+        for member in zip_ref.namelist():
+            try:
+                (target_dir / member).resolve().relative_to(target_resolved)
+            except ValueError:
+                log.warning(
+                    "Zip slip attempt detected, skipping member: %r", member,
+                )
+                continue
+            zip_ref.extract(member, target_dir)
 
-        log.info(f"Extracted {zip_path} to {target_dir}")
-        return target_dir
-
-    except zipfile.BadZipFile:
-        log.error(f"Invalid zip file: {zip_file_path}")
-        return None
-    except PathSecurityError:
-        raise
-    except OSError as e:
-        log.error(f"Failed to extract {zip_file_path}: {e}")
-        return None
+    log.info(f"Extracted {zip_path} to {target_dir}")
+    return target_dir
 
 def get_file_extension(file_path: FilePath) -> str:
     """
@@ -273,38 +248,24 @@ def get_relative_path(base_path: FilePath, target_path: FilePath) -> Optional[Pa
         target_path: Target file/directory path
 
     Returns:
-        Relative path from base to target, or None if failed
+        Relative path from base to target, or None if target is not
+        under base.
 
     Raises:
-        PathSecurityError: If paths fail security validation
-
-    Example:
-        >>> rel_path = get_relative_path("/home/user", "/home/user/documents/file.txt")
-        >>> print(f"Relative path: {rel_path}")  # documents/file.txt
-        >>>
-        >>> # This will raise PathSecurityError
-        >>> get_relative_path("/etc", "/etc/passwd")  # Sensitive path blocked
+        PathSecurityError: If paths fail security validation.
+        OSError: On path resolution failure.
     """
     try:
-        # Validate paths
-        try:
-            from siege_utilities.files.validation import validate_safe_path, PathSecurityError  # noqa: F401, F811
-            base = validate_safe_path(base_path, allow_absolute=True)
-            target = validate_safe_path(target_path, allow_absolute=True)
-        except ImportError:
-            base = Path(base_path).resolve()
-            target = Path(target_path).resolve()
+        from siege_utilities.files.validation import validate_safe_path, PathSecurityError  # noqa: F401, F811
+        base = validate_safe_path(base_path, allow_absolute=True)
+        target = validate_safe_path(target_path, allow_absolute=True)
+    except ImportError:
+        base = Path(base_path).resolve()
+        target = Path(target_path).resolve()
 
-        try:
-            relative = target.relative_to(base)
-            return relative
-        except ValueError:
-            log.warning(f"Target {target} is not relative to base {base}")
-            return None
-    except PathSecurityError:
-        raise
-    except (OSError, TypeError) as e:
-        log.error(f"Failed to get relative path: {e}")
+    try:
+        return target.relative_to(base)
+    except ValueError:
         return None
 
 def find_files_by_pattern(directory: FilePath,

--- a/siege_utilities/files/remote.py
+++ b/siege_utilities/files/remote.py
@@ -92,7 +92,7 @@ def _get_progress_bar(*args, **kwargs):
 def download_file(url: str, local_filename: FilePath,
                  chunk_size: int = 8192,
                  timeout: int = 30,
-                 verify_ssl: bool = True) -> Union[str, bool]:
+                 verify_ssl: bool = True) -> str:
     """
     Download a file from a URL to a local file with progress bar.
 
@@ -106,130 +106,69 @@ def download_file(url: str, local_filename: FilePath,
         verify_ssl: Whether to verify SSL certificates
 
     Returns:
-        The local filename if successful, False otherwise
+        The local filename as a string.
 
     Raises:
-        PathSecurityError: If local path fails security validation
-
-    Example:
-        >>> result = download_file("https://example.com/file.zip", "downloads/file.zip")
-        >>> if result:
-        ...     print(f"Downloaded to {result}")
-        >>>
-        >>> # This will raise PathSecurityError
-        >>> download_file("https://example.com/file.zip", "../../../etc/passwd")  # Path traversal blocked
-
-    Security Changes:
-        - Now validates local file paths to block path traversal
-        - Blocks writing to sensitive system locations
+        PathSecurityError: If local path fails security validation.
+        requests.exceptions.HTTPError: If the server returns a non-2xx status.
+        requests.exceptions.Timeout: On request timeout.
+        requests.exceptions.RequestException: On other network failures.
+        OSError: On filesystem failure.
     """
     _check_requests_dependency()
 
+    log.info(f'Downloading {url} to {local_filename}')
+
     try:
-        log.info(f'Downloading {url} to {local_filename}')
+        from siege_utilities.files.validation import validate_safe_path, PathSecurityError
+        local_path = validate_safe_path(local_filename, allow_absolute=True)
+    except ImportError:
+        local_path = Path(local_filename)
 
-        # Validate local file path
-        try:
-            from siege_utilities.files.validation import validate_safe_path, PathSecurityError
-            local_path = validate_safe_path(local_filename, allow_absolute=True)
-        except ImportError:
-            local_path = Path(local_filename)
+    local_path.parent.mkdir(parents=True, exist_ok=True)
 
-        local_path.parent.mkdir(parents=True, exist_ok=True)
-        
-        # Make the request with streaming, using smart SSL verification
-        ssl_verify = _get_ssl_verify_path() if verify_ssl else False
-        headers = {'User-Agent': 'siege_utilities/1.0 (Census/GIS data client)'}
+    ssl_verify = _get_ssl_verify_path() if verify_ssl else False
+    headers = {'User-Agent': 'siege_utilities/1.0 (Census/GIS data client)'}
+
+    try:
         with requests.get(url, stream=True, allow_redirects=True,
                          timeout=timeout, verify=ssl_verify,
                          headers=headers) as response:
-            
-            if not response.ok:
-                log.error(f'Download failed: HTTP {response.status_code} - {response.reason}')
-                return False
-            
-            # Get total size for progress bar
-            total_size = _safe_content_length(response)
-            
-            if total_size > 0:
-                log.info(f'Download started, file size: {total_size} bytes')
-            else:
-                log.info('Download started, file size unknown')
-            
-            # Download with progress bar
-            with open(local_path, 'wb') as file:
-                with _get_progress_bar(
-                    total=total_size,
-                    unit='B',
-                    unit_scale=True,
-                    desc=local_path.name,
-                    ascii=True
-                ) as progress_bar:
-                    
-                    for chunk in response.iter_content(chunk_size=chunk_size):
-                        if chunk:
-                            file.write(chunk)
-                            progress_bar.update(len(chunk))
-            
+            response.raise_for_status()
+            _download_response_to_file(response, local_path, chunk_size)
             log.info(f'Successfully downloaded {url} to {local_path}')
             return str(local_path)
-    except PathSecurityError:
-        raise
+
     except requests.exceptions.SSLError as e:
         log.warning(f'SSL verification failed for {url}, retrying without verification: {e}')
-        # Retry without SSL verification
-        try:
-            headers = {'User-Agent': 'siege_utilities/1.0 (Census/GIS data client)'}
-            with requests.get(url, stream=True, allow_redirects=True,
-                           timeout=timeout, verify=False,
-                           headers=headers) as response:
-                
-                if not response.ok:
-                    log.error(f'Download failed without SSL: HTTP {response.status_code} - {response.reason}')
-                    return False
-                
-                # Get total size for progress bar
-                total_size = _safe_content_length(response)
-                
-                if total_size > 0:
-                    log.info(f'Download started without SSL, file size: {total_size} bytes')
-                else:
-                    log.info('Download started without SSL, file size unknown')
-                
-                # Download with progress bar
-                with open(local_path, 'wb') as file:
-                    with _get_progress_bar(
-                        total=total_size,
-                        unit='B',
-                        unit_scale=True,
-                        desc=f"{local_path.name} (no SSL)",
-                        ascii=True
-                    ) as progress_bar:
-                        
-                        for chunk in response.iter_content(chunk_size=chunk_size):
-                            if chunk:
-                                file.write(chunk)
-                                progress_bar.update(len(chunk))
-                
-                log.info(f'Successfully downloaded {url} to {local_path} without SSL verification')
-                return str(local_path)
-                
-        except (OSError, ValueError) as retry_error:
-            log.error(f'Download failed even without SSL verification: {retry_error}')
-            return False
+        with requests.get(url, stream=True, allow_redirects=True,
+                       timeout=timeout, verify=False,
+                       headers=headers) as response:
+            response.raise_for_status()
+            _download_response_to_file(response, local_path, chunk_size)
+            log.info(f'Successfully downloaded {url} to {local_path} without SSL verification')
+            return str(local_path)
 
-    except requests.exceptions.Timeout:
-        log.error(f'Download timed out for {url}')
-        return False
-    except requests.exceptions.RequestException as e:
-        log.error(f'Request error downloading {url}: {e}')
-        return False
-    except (OSError, ValueError) as e:
-        log.error(f'Unexpected error downloading {url}: {e}')
-        return False
+
+def _download_response_to_file(response, local_path: Path, chunk_size: int) -> None:
+    """Write a streaming response to a local file with progress bar."""
+    total_size = _safe_content_length(response)
+
+    with open(local_path, 'wb') as file:
+        with _get_progress_bar(
+            total=total_size,
+            unit='B',
+            unit_scale=True,
+            desc=local_path.name,
+            ascii=True
+        ) as progress_bar:
+            for chunk in response.iter_content(chunk_size=chunk_size):
+                if chunk:
+                    file.write(chunk)
+                    progress_bar.update(len(chunk))
 
 def generate_local_path_from_url(url: str, directory_path: FilePath,
-                                as_string: bool = True) -> Union[Path, str, bool]:
+                                as_string: bool = True) -> Union[Path, str]:
     """
     Generate a local file path from a URL.
 
@@ -241,165 +180,127 @@ def generate_local_path_from_url(url: str, directory_path: FilePath,
         as_string: Whether to return the result as a string
 
     Returns:
-        Path object, string, or False if failed
+        Path object or string.
 
     Raises:
-        PathSecurityError: If directory path fails security validation
-
-    Example:
-        >>> path = generate_local_path_from_url("https://example.com/file.zip", "downloads")
-        >>> print(f"Local path: {path}")
-        >>>
-        >>> # This will raise PathSecurityError
-        >>> generate_local_path_from_url("https://example.com/file.zip", "../../../etc")  # Path traversal blocked
-
-    Security Changes:
-        - Now validates directory paths to block path traversal
-        - Blocks writing to sensitive system locations
+        PathSecurityError: If directory path fails security validation.
+        ValueError: If no filename can be extracted from the URL.
+        OSError: On directory creation failure.
     """
+    parsed_url = urlparse(url)
+    remote_filename = parsed_url.path.split('/')[-1]
+
+    if not remote_filename:
+        raise ValueError(f'Could not extract filename from URL: {url}')
+
     try:
-        # Parse URL to get filename
-        parsed_url = urlparse(url)
-        remote_filename = parsed_url.path.split('/')[-1]
+        from siege_utilities.files.validation import validate_directory_path, PathSecurityError
+        dir_path = validate_directory_path(directory_path, must_exist=False)
+    except ImportError:
+        dir_path = Path(directory_path)
 
-        if not remote_filename:
-            log.warning(f'Could not extract filename from URL: {url}')
-            return False
+    dir_path.mkdir(parents=True, exist_ok=True)
 
-        # Validate directory path
-        try:
-            from siege_utilities.files.validation import validate_directory_path, PathSecurityError
-            dir_path = validate_directory_path(directory_path, must_exist=False)
-        except ImportError:
-            dir_path = Path(directory_path)
+    local_path = dir_path / remote_filename
 
-        dir_path.mkdir(parents=True, exist_ok=True)
-        
-        # Create full local path
-        local_path = dir_path / remote_filename
-        
-        log.info(f'Generated local path: {local_path}')
-        
-        if as_string:
-            return str(local_path)
-        else:
-            return local_path
-    except PathSecurityError:
-        raise
-    except (OSError, ValueError) as e:
-        log.error(f'Error generating local path from {url}: {e}')
-        return False
+    log.info(f'Generated local path: {local_path}')
+
+    if as_string:
+        return str(local_path)
+    else:
+        return local_path
 
 def download_file_with_retry(url: str, local_filename: FilePath,
                             max_retries: int = 3,
                             retry_delay: int = 5,
-                            **kwargs) -> Union[str, bool]:
+                            **kwargs) -> str:
     """
     Download a file with automatic retry on failure.
-    
+
     Args:
         url: The URL to download from
         local_filename: The local path where the file should be saved
         max_retries: Maximum number of retry attempts
         retry_delay: Delay between retries in seconds
         **kwargs: Additional arguments passed to download_file
-        
+
     Returns:
-        The local filename if successful, False otherwise
-        
-    Example:
-        >>> result = download_file_with_retry("https://example.com/file.zip", "file.zip")
-        >>> if result:
-        ...     print("Download succeeded after retries")
+        The local filename as a string.
+
+    Raises:
+        The last exception from download_file after all retries are exhausted.
     """
     import time
-    
+
+    last_error: Optional[BaseException] = None
     for attempt in range(max_retries + 1):
         try:
             if attempt > 0:
                 log.info(f'Retry attempt {attempt}/{max_retries} for {url}')
                 time.sleep(retry_delay)
-            
-            result = download_file(url, local_filename, **kwargs)
-            if result:
-                return result
-                
-        except (OSError, ValueError) as e:
-            log.warning(f'Download attempt {attempt + 1} failed: {e}')
-    
-    log.error(f'Download failed after {max_retries + 1} attempts for {url}')
-    return False
 
-def get_file_info(url: str, timeout: int = 10) -> Optional[dict]:
+            return download_file(url, local_filename, **kwargs)
+
+        except (OSError, requests.exceptions.RequestException) as e:
+            last_error = e
+            log.warning(f'Download attempt {attempt + 1} failed: {e}')
+
+    raise last_error  # type: ignore[misc]
+
+def get_file_info(url: str, timeout: int = 10) -> dict:
     """
     Get information about a remote file without downloading it.
-    
+
     Args:
         url: URL to get information about
         timeout: Request timeout in seconds
-        
+
     Returns:
-        Dictionary with file information, or None if failed
-        
-    Example:
-        >>> info = get_file_info("https://example.com/file.zip")
-        >>> if info:
-        ...     print(f"File size: {info['size']} bytes")
+        Dictionary with file information (url, size, content_type, last_modified, etag).
+
+    Raises:
+        requests.exceptions.HTTPError: If the server returns a non-2xx status.
+        requests.exceptions.RequestException: On network failure.
     """
-    try:
-        log.debug(f'Getting file info for {url}')
-        
-        response = requests.head(url, timeout=timeout, allow_redirects=True)
-        
-        if not response.ok:
-            log.warning(f'Failed to get file info: HTTP {response.status_code}')
-            return None
-        
-        info = {
-            'url': url,
-            'size': _safe_content_length(response),
-            'content_type': response.headers.get('content-type', 'unknown'),
-            'last_modified': response.headers.get('last-modified'),
-            'etag': response.headers.get('etag')
-        }
-        
-        log.debug(f'File info for {url}: {info}')
-        return info
-        
-    except (OSError, ValueError) as e:
-        log.error(f'Error getting file info for {url}: {e}')
-        return None
+    _check_requests_dependency()
+    log.debug(f'Getting file info for {url}')
+
+    response = requests.head(url, timeout=timeout, allow_redirects=True)
+    response.raise_for_status()
+
+    info = {
+        'url': url,
+        'size': _safe_content_length(response),
+        'content_type': response.headers.get('content-type', 'unknown'),
+        'last_modified': response.headers.get('last-modified'),
+        'etag': response.headers.get('etag')
+    }
+
+    log.debug(f'File info for {url}: {info}')
+    return info
 
 def is_downloadable(url: str, timeout: int = 10) -> bool:
     """
     Check if a URL points to a downloadable file.
-    
+
     Args:
         url: URL to check
         timeout: Request timeout in seconds
-        
+
     Returns:
-        True if the URL points to a downloadable file
+        True if the URL points to a downloadable file (has content).
 
     Raises:
-        Exception: If the network request fails (logged before re-raise)
-
-    Example:
-        >>> if is_downloadable("https://example.com/file.zip"):
-        ...     print("URL is downloadable")
+        requests.exceptions.RequestException: On network failure.
     """
-    try:
-        info = get_file_info(url, timeout)
-        if info and info['size'] > 0:
-            return True
+    _check_requests_dependency()
+    info = get_file_info(url, timeout)
+    if info['size'] > 0:
+        return True
 
-        # Try a GET request to see if we can access the content
-        response = requests.get(url, stream=True, timeout=timeout)
-        return response.ok
-        
-    except (OSError, ValueError) as exc:
-        log.warning("Could not check if URL is downloadable %s: %s", url, exc)
-        raise
+    response = requests.get(url, stream=True, timeout=timeout)
+    response.close()
+    return response.ok
 
 __all__ = [
     'download_file',


### PR DESCRIPTION
## Summary

Systematic SU-1 enforcement: functions must not return valid-shaped empty results
(`None`, `False`, `[]`, `{}`) on failure. Every function fixed in this PR previously
swallowed exceptions and returned a sentinel that callers couldn't distinguish from
a legitimate empty result.

**59 violations fixed across 10 files:**

- `analytics/datadotworld_connector.py` — 8 methods now raise instead of returning None
- `analytics/snowflake_connector.py` — 6 methods now raise instead of returning None/False
- `analytics/facebook_business.py` — 5 methods now raise instead of returning None/False
- `analytics/google_analytics.py` — 6 methods now raise instead of returning None/False
- `distributed/spark_utils.py` — 9 functions now raise instead of returning None/False
- `distributed/hdfs_operations.py` — 3 methods now raise instead of returning None
- `files/operations.py` — 10 functions now raise instead of returning None/False
- `files/remote.py` — 5 functions now raise instead of returning False
- `files/hashing.py` — 3 functions now raise instead of returning None
- `files/paths.py` — 2 functions now raise instead of returning None

**API changes (breaking):**
- Functions that returned `bool` for success/failure now return `None` (void) and raise on error
- Functions that returned `Optional[X]` now return `X` and raise on error
- `safe_*` functions in `files/operations.py` deliberately kept as-is (the "safe_" prefix is an explicit contract)
- `check_hdfs_status()` correctly returns bool (legitimate predicate)

## Test plan

- [ ] `ast.parse()` verification on all modified files (done pre-commit)
- [ ] CI test suite passes (no runtime deps available locally for these connectors)
- [ ] Verify no downstream callers rely on `if result:` pattern for these functions