### PR TITLE
fix: hostile review — SU-1/SU-2/SU-3 enforcement across 89 files

### DIFF
--- a/siege_utilities/admin/profile_manager.py
+++ b/siege_utilities/admin/profile_manager.py
@@ -6,7 +6,7 @@ Handles default locations, custom locations, and profile migration.
 import logging
 import shutil
 from pathlib import Path
-from typing import Optional, Dict, List, Tuple
+from typing import Any, Optional, Dict, List, Tuple
 from ..config.enhanced_config import (
     UserProfile, ClientProfile,
     save_user_profile,
@@ -277,7 +277,7 @@ def migrate_profiles(
         log.error(f"Migration failed: {e}")
         raise
 
-def get_profile_summary(profile_location: Optional[Path] = None) -> Dict[str, any]:
+def get_profile_summary(profile_location: Optional[Path] = None) -> Dict[str, Any]:
     """
     Get a summary of profiles in a location.
     

--- a/siege_utilities/analytics/datadotworld_connector.py
+++ b/siege_utilities/analytics/datadotworld_connector.py
@@ -33,39 +33,39 @@ log = logging.getLogger(__name__)
 
 class DataDotWorldConnector:
     """Data.world connector with advanced data discovery and access features."""
-    
-    def __init__(self, 
+
+    def __init__(self,
                  api_token: Optional[str] = None,
                  config_file: Optional[Union[str, Path]] = None):
         """
         Initialize Data.world connector.
-        
+
         Args:
             api_token: Data.world API token (optional if using config file)
             config_file: Path to configuration file
         """
         if not DATADOTWORLD_AVAILABLE:
             raise ImportError("Data.world connector not available. Install with: pip install datadotworld")
-        
+
         self.api_token = api_token
         self.config_file = config_file
-        
+
         # Load configuration if provided
         if config_file:
             self._load_config(config_file)
-        
+
         # Initialize client
         self.client = None
         self._initialize_client()
-        
+
         log.info("Initialized Data.world connector")
-    
+
     def _load_config(self, config_file: Union[str, Path]) -> None:
         """Load configuration from file."""
         config_path = Path(config_file)
         if not config_path.exists():
             raise FileNotFoundError(f"Configuration file not found: {config_path}")
-        
+
         try:
             with open(config_path, 'r', encoding='utf-8') as f:
                 config = json.load(f)
@@ -73,11 +73,11 @@ class DataDotWorldConnector:
             # Update instance variables with config values
             if 'api_token' in config and config['api_token']:
                 self.api_token = config['api_token']
-                    
+
         except (json.JSONDecodeError, OSError) as e:
             log.error(f"Failed to load configuration: {e}")
             raise
-    
+
     def _initialize_client(self) -> None:
         """Initialize the Data.world client."""
         try:
@@ -92,271 +92,269 @@ class DataDotWorldConnector:
                     # Use anonymous client
                     self.client = dw.api_client()
                     log.warning("No API token provided. Using anonymous access with limited functionality.")
-            
+
             log.info("Data.world client initialized successfully")
-            
+
         except (ImportError, AttributeError, TypeError) as e:
             log.error(f"Failed to initialize Data.world client: {e}")
             raise
-    
-    def search_datasets(self, 
+
+    def search_datasets(self,
                        query: str,
                        limit: int = 50,
                        owner: Optional[str] = None,
-                       tags: Optional[List[str]] = None) -> Optional[List[Dict[str, Any]]]:
+                       tags: Optional[List[str]] = None) -> List[Dict[str, Any]]:
         """
         Search for datasets on data.world.
-        
+
         Args:
             query: Search query string
             limit: Maximum number of results to return
             owner: Filter by dataset owner
             tags: Filter by tags
-            
+
         Returns:
             List of dataset information dictionaries
+
+        Raises:
+            ConnectionError: If the API request fails.
         """
+        search_params = {
+            'q': query,
+            'limit': limit
+        }
+
+        if owner:
+            search_params['owner'] = owner
+        if tags:
+            search_params['tags'] = ','.join(tags)
+
         try:
-            # Build search parameters
-            search_params = {
-                'q': query,
-                'limit': limit
-            }
-            
-            if owner:
-                search_params['owner'] = owner
-            if tags:
-                search_params['tags'] = ','.join(tags)
-            
-            # Perform search
             search_results = self.client.search_datasets(**search_params)
-            
-            # Extract relevant information
-            datasets = []
-            for result in search_results['records']:
-                dataset_info = {
-                    'id': result.get('id'),
-                    'title': result.get('title'),
-                    'description': result.get('description'),
-                    'owner': result.get('owner'),
-                    'tags': result.get('tags', []),
-                    'license': result.get('license'),
-                    'visibility': result.get('visibility'),
-                    'updated_at': result.get('updatedAt'),
-                    'download_count': result.get('downloadCount', 0)
-                }
-                datasets.append(dataset_info)
-            
-            log.info(f"Found {len(datasets)} datasets matching query: {query}")
-            return datasets
-            
-        except (requests.RequestException, KeyError, ValueError) as e:
-            log.error(f"Dataset search failed: {e}")
-            return None
-    
-    def get_dataset_info(self, dataset_id: str) -> Optional[Dict[str, Any]]:
+        except (requests.RequestException, OSError) as e:
+            raise ConnectionError(f"Dataset search failed: {e}") from e
+
+        datasets = []
+        for result in search_results['records']:
+            dataset_info = {
+                'id': result.get('id'),
+                'title': result.get('title'),
+                'description': result.get('description'),
+                'owner': result.get('owner'),
+                'tags': result.get('tags', []),
+                'license': result.get('license'),
+                'visibility': result.get('visibility'),
+                'updated_at': result.get('updatedAt'),
+                'download_count': result.get('downloadCount', 0)
+            }
+            datasets.append(dataset_info)
+
+        log.info(f"Found {len(datasets)} datasets matching query: {query}")
+        return datasets
+
+    def get_dataset_info(self, dataset_id: str) -> Dict[str, Any]:
         """
         Get detailed information about a specific dataset.
-        
+
         Args:
             dataset_id: Dataset identifier (format: owner/dataset)
-            
+
         Returns:
             Dictionary with detailed dataset information
+
+        Raises:
+            ConnectionError: If the API request fails.
         """
         try:
             dataset_info = self.client.get_dataset(dataset_id)
-            
-            # Extract relevant information
-            info = {
-                'id': dataset_info.get('id'),
-                'title': dataset_info.get('title'),
-                'description': dataset_info.get('description'),
-                'owner': dataset_info.get('owner'),
-                'tags': dataset_info.get('tags', []),
-                'license': dataset_info.get('license'),
-                'visibility': dataset_info.get('visibility'),
-                'created_at': dataset_info.get('createdAt'),
-                'updated_at': dataset_info.get('updatedAt'),
-                'download_count': dataset_info.get('downloadCount', 0),
-                'files': dataset_info.get('files', []),
-                'summary': dataset_info.get('summary', {})
-            }
-            
-            log.info(f"Retrieved dataset info for: {dataset_id}")
-            return info
-            
-        except (requests.RequestException, KeyError, ValueError) as e:
-            log.error(f"Failed to get dataset info for {dataset_id}: {e}")
-            return None
-    
-    def list_dataset_files(self, dataset_id: str) -> Optional[List[Dict[str, Any]]]:
+        except (requests.RequestException, OSError) as e:
+            raise ConnectionError(f"Failed to get dataset info for {dataset_id}: {e}") from e
+
+        info = {
+            'id': dataset_info.get('id'),
+            'title': dataset_info.get('title'),
+            'description': dataset_info.get('description'),
+            'owner': dataset_info.get('owner'),
+            'tags': dataset_info.get('tags', []),
+            'license': dataset_info.get('license'),
+            'visibility': dataset_info.get('visibility'),
+            'created_at': dataset_info.get('createdAt'),
+            'updated_at': dataset_info.get('updatedAt'),
+            'download_count': dataset_info.get('downloadCount', 0),
+            'files': dataset_info.get('files', []),
+            'summary': dataset_info.get('summary', {})
+        }
+
+        log.info(f"Retrieved dataset info for: {dataset_id}")
+        return info
+
+    def list_dataset_files(self, dataset_id: str) -> List[Dict[str, Any]]:
         """
         List all files in a dataset.
-        
+
         Args:
             dataset_id: Dataset identifier (format: owner/dataset)
-            
+
         Returns:
             List of file information dictionaries
+
+        Raises:
+            ConnectionError: If the API request fails.
         """
         try:
             dataset_info = self.client.get_dataset(dataset_id)
-            files = dataset_info.get('files', [])
-            
-            # Extract relevant file information
-            file_list = []
-            for file_info in files:
-                file_data = {
-                    'name': file_info.get('name'),
-                    'size': file_info.get('size'),
-                    'format': file_info.get('format'),
-                    'url': file_info.get('url'),
-                    'description': file_info.get('description'),
-                    'tags': file_info.get('tags', [])
-                }
-                file_list.append(file_data)
-            
-            log.info(f"Found {len(file_list)} files in dataset: {dataset_id}")
-            return file_list
-            
-        except (requests.RequestException, KeyError, ValueError) as e:
-            log.error(f"Failed to list files for dataset {dataset_id}: {e}")
-            return None
-    
-    def download_file(self, 
+        except (requests.RequestException, OSError) as e:
+            raise ConnectionError(f"Failed to list files for dataset {dataset_id}: {e}") from e
+
+        files = dataset_info.get('files', [])
+
+        file_list = []
+        for file_info in files:
+            file_data = {
+                'name': file_info.get('name'),
+                'size': file_info.get('size'),
+                'format': file_info.get('format'),
+                'url': file_info.get('url'),
+                'description': file_info.get('description'),
+                'tags': file_info.get('tags', [])
+            }
+            file_list.append(file_data)
+
+        log.info(f"Found {len(file_list)} files in dataset: {dataset_id}")
+        return file_list
+
+    def download_file(self,
                      dataset_id: str,
                      file_name: str,
-                     output_path: Optional[Union[str, Path]] = None) -> Optional[Union[str, Path]]:
+                     output_path: Optional[Union[str, Path]] = None) -> Path:
         """
         Download a specific file from a dataset.
-        
+
         Args:
             dataset_id: Dataset identifier (format: owner/dataset)
             file_name: Name of the file to download
             output_path: Local path to save the file (optional)
-            
+
         Returns:
             Path to the downloaded file
+
+        Raises:
+            ConnectionError: If the download fails.
+            OSError: If writing to disk fails.
         """
+        if not output_path:
+            from siege_utilities.config.user_config import get_download_directory
+            output_path = get_download_directory() / "datadotworld" / dataset_id.replace('/', '_') / file_name
+
+        output_path = Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
         try:
-            if not output_path:
-                # Use default download directory
-                from siege_utilities.config.user_config import get_download_directory
-                output_path = get_download_directory() / "datadotworld" / dataset_id.replace('/', '_') / file_name
-            
-            # Ensure output directory exists
-            output_path = Path(output_path)
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            
-            # Download the file
             self.client.download_file(dataset_id, file_name, output_path)
-            
-            log.info(f"Successfully downloaded {file_name} to {output_path}")
-            return output_path
-            
-        except (OSError, requests.RequestException) as e:
-            log.error(f"Failed to download file {file_name} from dataset {dataset_id}: {e}")
-            return None
-    
-    def load_dataset_as_dataframe(self, 
+        except (requests.RequestException, OSError) as e:
+            raise ConnectionError(f"Failed to download file {file_name} from dataset {dataset_id}: {e}") from e
+
+        log.info(f"Successfully downloaded {file_name} to {output_path}")
+        return output_path
+
+    def load_dataset_as_dataframe(self,
                                  dataset_id: str,
-                                 file_name: Optional[str] = None) -> Optional['pd.DataFrame']:
+                                 file_name: Optional[str] = None) -> 'pd.DataFrame':
         """
         Load a dataset file directly as a pandas DataFrame.
-        
+
         Args:
             dataset_id: Dataset identifier (format: owner/dataset)
             file_name: Name of the file to load (optional, loads first file if not specified)
-            
+
         Returns:
             Pandas DataFrame with the data
+
+        Raises:
+            ImportError: If pandas is not available.
+            ConnectionError: If the API request fails.
         """
         if not PANDAS_AVAILABLE:
-            log.error("Pandas not available for DataFrame operations")
-            return None
-        
+            raise ImportError("Pandas not available for DataFrame operations. Install with: pip install pandas")
+
         try:
             if file_name:
-                # Load specific file
                 df = dw.load_dataset(dataset_id, file_name)
             else:
-                # Load entire dataset
                 df = dw.load_dataset(dataset_id)
-            
-            log.info(f"Successfully loaded dataset {dataset_id} as DataFrame with {len(df)} rows")
-            return df
-            
-        except (requests.RequestException, ValueError) as e:
-            log.error(f"Failed to load dataset {dataset_id} as DataFrame: {e}")
-            return None
-    
-    def query_dataset(self, 
+        except (requests.RequestException, ValueError, OSError) as e:
+            raise ConnectionError(f"Failed to load dataset {dataset_id} as DataFrame: {e}") from e
+
+        log.info(f"Successfully loaded dataset {dataset_id} as DataFrame with {len(df)} rows")
+        return df
+
+    def query_dataset(self,
                      dataset_id: str,
                      query: str,
-                     query_type: str = 'sql') -> Optional['pd.DataFrame']:
+                     query_type: str = 'sql') -> 'pd.DataFrame':
         """
         Execute a query against a dataset.
-        
+
         Args:
             dataset_id: Dataset identifier (format: owner/dataset)
             query: Query string (SQL or SPARQL)
             query_type: Type of query ('sql' or 'sparql')
-            
+
         Returns:
             Pandas DataFrame with query results
+
+        Raises:
+            ImportError: If pandas is not available.
+            ValueError: If query_type is invalid.
+            ConnectionError: If the query fails.
         """
         if not PANDAS_AVAILABLE:
-            log.error("Pandas not available for DataFrame operations")
-            return None
-        
+            raise ImportError("Pandas not available for DataFrame operations. Install with: pip install pandas")
+
+        if query_type.lower() not in ('sql', 'sparql'):
+            raise ValueError(f"query_type must be 'sql' or 'sparql', got: {query_type!r}")
+
         try:
-            if query_type.lower() == 'sql':
-                df = dw.query(dataset_id, query, query_type='sql')
-            elif query_type.lower() == 'sparql':
-                df = dw.query(dataset_id, query, query_type='sparql')
-            else:
-                raise ValueError("query_type must be 'sql' or 'sparql'")
-            
-            log.info(f"Successfully executed {query_type.upper()} query on dataset {dataset_id}")
-            return df
-            
-        except (requests.RequestException, ValueError) as e:
-            log.error(f"Query execution failed on dataset {dataset_id}: {e}")
-            return None
-    
-    def get_dataset_schema(self, dataset_id: str) -> Optional[Dict[str, Any]]:
+            df = dw.query(dataset_id, query, query_type=query_type.lower())
+        except (requests.RequestException, OSError) as e:
+            raise ConnectionError(f"Query execution failed on dataset {dataset_id}: {e}") from e
+
+        log.info(f"Successfully executed {query_type.upper()} query on dataset {dataset_id}")
+        return df
+
+    def get_dataset_schema(self, dataset_id: str) -> Dict[str, Any]:
         """
         Get the schema information for a dataset.
-        
+
         Args:
             dataset_id: Dataset identifier (format: owner/dataset)
-            
+
         Returns:
             Dictionary with schema information
+
+        Raises:
+            ConnectionError: If the API request fails.
         """
         try:
             dataset_info = self.client.get_dataset(dataset_id)
-            schema = dataset_info.get('schema', {})
-            
-            log.info(f"Retrieved schema for dataset: {dataset_id}")
-            return schema
-            
-        except (requests.RequestException, KeyError, ValueError) as e:
-            log.error(f"Failed to get schema for dataset {dataset_id}: {e}")
-            return None
-    
-    def create_dataset(self, 
+        except (requests.RequestException, OSError) as e:
+            raise ConnectionError(f"Failed to get schema for dataset {dataset_id}: {e}") from e
+
+        schema = dataset_info.get('schema', {})
+        log.info(f"Retrieved schema for dataset: {dataset_id}")
+        return schema
+
+    def create_dataset(self,
                       owner: str,
                       dataset_id: str,
                       title: str,
                       description: str,
                       tags: Optional[List[str]] = None,
                       license: str = 'Public Domain',
-                      visibility: str = 'OPEN') -> Optional[str]:
+                      visibility: str = 'OPEN') -> str:
         """
         Create a new dataset on data.world.
-        
+
         Args:
             owner: Dataset owner username
             dataset_id: Unique dataset identifier
@@ -365,16 +363,19 @@ class DataDotWorldConnector:
             tags: List of tags (optional)
             license: Dataset license (optional)
             visibility: Dataset visibility ('OPEN' or 'PRIVATE')
-            
+
         Returns:
-            Created dataset ID if successful, None otherwise
+            Created dataset ID (format: owner/dataset_id)
+
+        Raises:
+            ValueError: If API token is not configured.
+            ConnectionError: If the API request fails.
         """
+        if not self.api_token:
+            raise ValueError("API token required to create datasets")
+
         try:
-            if not self.api_token:
-                raise ValueError("API token required to create datasets")
-            
-            # Create dataset
-            dataset_info = self.client.create_dataset(
+            self.client.create_dataset(
                 owner=owner,
                 id=dataset_id,
                 title=title,
@@ -383,122 +384,118 @@ class DataDotWorldConnector:
                 license=license,
                 visibility=visibility
             )
-            
-            created_id = f"{owner}/{dataset_id}"
-            log.info(f"Successfully created dataset: {created_id}")
-            return created_id
-            
-        except (requests.RequestException, ValueError) as e:
-            log.error(f"Failed to create dataset: {e}")
-            return None
-    
-    def upload_file(self, 
+        except (requests.RequestException, OSError) as e:
+            raise ConnectionError(f"Failed to create dataset {owner}/{dataset_id}: {e}") from e
+
+        created_id = f"{owner}/{dataset_id}"
+        log.info(f"Successfully created dataset: {created_id}")
+        return created_id
+
+    def upload_file(self,
                    dataset_id: str,
                    file_path: Union[str, Path],
-                   file_name: Optional[str] = None) -> bool:
+                   file_name: Optional[str] = None) -> None:
         """
         Upload a file to an existing dataset.
-        
+
         Args:
             dataset_id: Dataset identifier (format: owner/dataset)
             file_path: Local path to the file to upload
             file_name: Name to use for the file on data.world (optional)
-            
-        Returns:
-            True if successful, False otherwise
+
+        Raises:
+            ValueError: If API token is not configured.
+            FileNotFoundError: If the local file does not exist.
+            ConnectionError: If the upload fails.
         """
+        if not self.api_token:
+            raise ValueError("API token required to upload files")
+
+        file_path = Path(file_path)
+        if not file_path.exists():
+            raise FileNotFoundError(f"File not found: {file_path}")
+
+        if not file_name:
+            file_name = file_path.name
+
         try:
-            if not self.api_token:
-                raise ValueError("API token required to upload files")
-            
-            file_path = Path(file_path)
-            if not file_path.exists():
-                raise FileNotFoundError(f"File not found: {file_path}")
-            
-            if not file_name:
-                file_name = file_path.name
-            
-            # Upload the file
             self.client.upload_file(dataset_id, file_path, file_name)
-            
-            log.info(f"Successfully uploaded {file_name} to dataset {dataset_id}")
-            return True
-            
-        except (FileNotFoundError, OSError, requests.RequestException) as e:
-            log.error(f"Failed to upload file to dataset {dataset_id}: {e}")
-            return False
-    
-    def update_dataset(self, 
+        except (requests.RequestException, OSError) as e:
+            raise ConnectionError(f"Failed to upload file to dataset {dataset_id}: {e}") from e
+
+        log.info(f"Successfully uploaded {file_name} to dataset {dataset_id}")
+
+    def update_dataset(self,
                       dataset_id: str,
                       title: Optional[str] = None,
                       description: Optional[str] = None,
                       tags: Optional[List[str]] = None,
-                      license: Optional[str] = None) -> bool:
+                      license: Optional[str] = None) -> None:
         """
         Update an existing dataset.
-        
+
         Args:
             dataset_id: Dataset identifier (format: owner/dataset)
             title: New title (optional)
             description: New description (optional)
             tags: New tags (optional)
             license: New license (optional)
-            
-        Returns:
-            True if successful, False otherwise
+
+        Raises:
+            ValueError: If API token is not configured or no updates provided.
+            ConnectionError: If the API request fails.
         """
+        if not self.api_token:
+            raise ValueError("API token required to update datasets")
+
+        update_params = {}
+        if title:
+            update_params['title'] = title
+        if description:
+            update_params['description'] = description
+        if tags:
+            update_params['tags'] = tags
+        if license:
+            update_params['license'] = license
+
+        if not update_params:
+            raise ValueError("No update parameters provided")
+
         try:
-            if not self.api_token:
-                raise ValueError("API token required to update datasets")
-            
-            # Build update parameters
-            update_params = {}
-            if title:
-                update_params['title'] = title
-            if description:
-                update_params['description'] = description
-            if tags:
-                update_params['tags'] = tags
-            if license:
-                update_params['license'] = license
-            
-            if not update_params:
-                log.warning("No update parameters provided")
-                return False
-            
-            # Update dataset
             self.client.update_dataset(dataset_id, **update_params)
-            
-            log.info(f"Successfully updated dataset: {dataset_id}")
-            return True
-            
-        except (requests.RequestException, ValueError) as e:
-            log.error(f"Failed to update dataset {dataset_id}: {e}")
-            return False
-    
-    def delete_dataset(self, dataset_id: str) -> bool:
+        except (requests.RequestException, OSError) as e:
+            raise ConnectionError(f"Failed to update dataset {dataset_id}: {e}") from e
+
+        log.info(f"Successfully updated dataset: {dataset_id}")
+
+    def delete_dataset(self, dataset_id: str) -> None:
         """
         Delete a dataset.
-        
+
         Args:
             dataset_id: Dataset identifier (format: owner/dataset)
-            
-        Returns:
-            True if successful, False otherwise
+
+        Raises:
+            ValueError: If API token is not configured.
+            ConnectionError: If the API request fails.
         """
+        if not self.api_token:
+            raise ValueError("API token required to delete datasets")
+
         try:
-            if not self.api_token:
-                raise ValueError("API token required to delete datasets")
-            
-            # Delete dataset
             self.client.delete_dataset(dataset_id)
-            
-            log.info(f"Successfully deleted dataset: {dataset_id}")
-            return True
-            
-        except (requests.RequestException, ValueError) as e:
-            log.error(f"Failed to delete dataset {dataset_id}: {e}")
-            return False
+        except (requests.RequestException, OSError) as e:
+            raise ConnectionError(f"Failed to delete dataset {dataset_id}: {e}") from e
+
+        log.info(f"Successfully deleted dataset: {dataset_id}")
+
+    def __enter__(self):
+        """Context manager entry."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit."""
+        pass
 
 
 # Convenience functions
@@ -507,64 +504,64 @@ def get_datadotworld_connector(config_file: Optional[Union[str, Path]] = None) -
     return DataDotWorldConnector(config_file=config_file)
 
 
-def search_datadotworld_datasets(query: str, 
+def search_datadotworld_datasets(query: str,
                                 config_file: Optional[Union[str, Path]] = None,
-                                **kwargs) -> Optional[List[Dict[str, Any]]]:
+                                **kwargs) -> List[Dict[str, Any]]:
     """Convenience function to search for datasets."""
-    with get_datadotworld_connector(config_file) as dw:
-        return dw.search_datasets(query, **kwargs)
+    with get_datadotworld_connector(config_file) as conn:
+        return conn.search_datasets(query, **kwargs)
 
 
 def load_datadotworld_dataset(dataset_id: str,
                              config_file: Optional[Union[str, Path]] = None,
-                             **kwargs) -> Optional['pd.DataFrame']:
+                             **kwargs) -> 'pd.DataFrame':
     """Convenience function to load a dataset as DataFrame."""
-    with get_datadotworld_connector(config_file) as dw:
-        return dw.load_dataset_as_dataframe(dataset_id, **kwargs)
+    with get_datadotworld_connector(config_file) as conn:
+        return conn.load_dataset_as_dataframe(dataset_id, **kwargs)
 
 
 def query_datadotworld_dataset(dataset_id: str,
                               query: str,
                               config_file: Optional[Union[str, Path]] = None,
-                              **kwargs) -> Optional['pd.DataFrame']:
+                              **kwargs) -> 'pd.DataFrame':
     """Convenience function to query a dataset."""
-    with get_datadotworld_connector(config_file) as dw:
-        return dw.query_dataset(dataset_id, query, **kwargs)
+    with get_datadotworld_connector(config_file) as conn:
+        return conn.query_dataset(dataset_id, query, **kwargs)
 
 
 def search_datasets(query: str,
                    config_file: Optional[Union[str, Path]] = None,
-                   **kwargs) -> Optional[List[Dict[str, Any]]]:
+                   **kwargs) -> List[Dict[str, Any]]:
     """
     Standalone function to search for datasets.
-    
+
     Args:
         query: Search query string
         config_file: Path to configuration file (optional)
         **kwargs: Additional search parameters
-    
+
     Returns:
-        List of matching datasets or None if error
+        List of matching datasets
     """
-    with get_datadotworld_connector(config_file) as dw:
-        return dw.search_datasets(query, **kwargs)
+    with get_datadotworld_connector(config_file) as conn:
+        return conn.search_datasets(query, **kwargs)
 
 def list_datasets(limit: int = 50,
                  config_file: Optional[Union[str, Path]] = None,
-                 **kwargs) -> Optional[List[Dict[str, Any]]]:
+                 **kwargs) -> List[Dict[str, Any]]:
     """
     Standalone function to list available datasets.
-    
+
     Args:
         limit: Maximum number of results to return
         config_file: Optional configuration file path
         **kwargs: Additional arguments to pass to search_datasets
-    
+
     Returns:
         List of dataset information dictionaries
     """
-    with get_datadotworld_connector(config_file) as dw:
-        return dw.search_datasets("*", limit=limit, **kwargs)
+    with get_datadotworld_connector(config_file) as conn:
+        return conn.search_datasets("*", limit=limit, **kwargs)
 
 
 # Global instance for easy access
@@ -573,6 +570,7 @@ datadotworld_connector = None
 __all__ = [
     'DataDotWorldConnector',
     'get_datadotworld_connector',
+    'list_datasets',
     'search_datasets',
     'search_datadotworld_datasets',
     'load_datadotworld_dataset',

--- a/siege_utilities/analytics/facebook_business.py
+++ b/siege_utilities/analytics/facebook_business.py
@@ -271,7 +271,7 @@ class FacebookBusinessConnector:
             raise
 
     def save_as_pandas(self, df: pd.DataFrame, output_path: str,
-                       format: str = 'parquet') -> bool:
+                       format: str = 'parquet') -> None:
         """
         Save DataFrame as Pandas format.
 
@@ -280,31 +280,26 @@ class FacebookBusinessConnector:
             output_path: Output file path
             format: Output format (parquet, csv, excel, etc.)
 
-        Returns:
-            True if save successful
+        Raises:
+            ValueError: If the format is unsupported.
+            OSError: If the file cannot be written.
         """
-        try:
-            output_path = pathlib.Path(output_path)
-            output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path = pathlib.Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
 
-            if format.lower() == 'parquet':
-                df.to_parquet(output_path, index=False)
-            elif format.lower() == 'csv':
-                df.to_csv(output_path, index=False)
-            elif format.lower() == 'excel':
-                df.to_excel(output_path, index=False)
-            else:
-                raise ValueError(f"Unsupported format: {format}")
+        if format.lower() == 'parquet':
+            df.to_parquet(output_path, index=False)
+        elif format.lower() == 'csv':
+            df.to_csv(output_path, index=False)
+        elif format.lower() == 'excel':
+            df.to_excel(output_path, index=False)
+        else:
+            raise ValueError(f"Unsupported format: {format}")
 
-            log_info(f"Saved DataFrame to {output_path} ({format} format)")
-            return True
-
-        except (OSError, ValueError) as e:
-            logger.error("Failed to save DataFrame: %s", e, exc_info=True)
-            return False
+        log_info(f"Saved DataFrame to {output_path} ({format} format)")
 
     def save_as_spark(self, df: pd.DataFrame, output_path: str,
-                      spark_session: Optional[SparkSession] = None) -> bool:
+                      spark_session: Optional[SparkSession] = None) -> None:
         """
         Save DataFrame as Spark DataFrame and optionally to storage.
 
@@ -313,31 +308,22 @@ class FacebookBusinessConnector:
             output_path: Output path for Spark DataFrame
             spark_session: Optional SparkSession (will create if not provided)
 
-        Returns:
-            True if save successful
+        Raises:
+            ImportError: If PySpark is not available.
+            OSError: If the output path cannot be written.
         """
-        try:
-            if not SPARK_AVAILABLE:
-                raise ImportError("PySpark not available. Install: pip install pyspark")
+        if not SPARK_AVAILABLE:
+            raise ImportError("PySpark not available. Install: pip install pyspark")
 
-            # Create Spark session if not provided
-            if not spark_session:
-                spark_session = SparkSession.builder \
-                    .appName("FacebookBusinessData") \
-                    .getOrCreate()
+        if not spark_session:
+            spark_session = SparkSession.builder \
+                .appName("FacebookBusinessData") \
+                .getOrCreate()
 
-            # Convert to Spark DataFrame
-            spark_df = spark_session.createDataFrame(df)
+        spark_df = spark_session.createDataFrame(df)
+        spark_df.write.mode('overwrite').parquet(output_path)
 
-            # Save to storage
-            spark_df.write.mode('overwrite').parquet(output_path)
-
-            log_info(f"Saved DataFrame as Spark DataFrame to {output_path}")
-            return True
-
-        except (ImportError, OSError, TypeError, RuntimeError) as e:
-            logger.error("Failed to save as Spark DataFrame: %s", e, exc_info=True)
-            return False
+        log_info(f"Saved DataFrame as Spark DataFrame to {output_path}")
 
 
 def create_facebook_account_profile(client_id: str, fb_account_id: str,
@@ -426,8 +412,9 @@ def load_facebook_account_profile(account_id: str,
         return profile
 
     except (OSError, json.JSONDecodeError) as e:
-        logger.error("Failed to load Facebook account profile %s: %s", account_id, e, exc_info=True)
-        return None
+        raise RuntimeError(
+            f"Failed to load Facebook account profile {account_id}: {e}"
+        ) from e
 
 
 def list_facebook_accounts_for_client(client_id: str,
@@ -577,10 +564,6 @@ def batch_retrieve_facebook_data(client_id: str, start_date: str, end_date: str,
         return results
 
     except (OSError, KeyError, AttributeError) as e:
-        logger.error("Batch Facebook data retrieval failed: %s", e, exc_info=True)
-        return {
-            'success': False,
-            'error': str(e),
-            'accounts_processed': 0,
-            'total_rows': 0
-        }
+        raise RuntimeError(
+            f"Batch Facebook data retrieval failed: {e}"
+        ) from e

--- a/siege_utilities/analytics/google_analytics.py
+++ b/siege_utilities/analytics/google_analytics.py
@@ -13,6 +13,7 @@ import json
 import logging
 import pathlib
 import re
+import subprocess
 from datetime import datetime
 from typing import Dict, Any, Optional, List
 import pandas as pd
@@ -104,70 +105,59 @@ class GoogleAnalyticsConnector:
             try:
                 from ..config import get_google_service_account_from_1password
                 self.service_account_data = get_google_service_account_from_1password()
-                if self.service_account_data:
-                    self.authenticate_service_account()
-                else:
-                    log_warning("No service account data provided and could not retrieve from 1Password")
+                self.authenticate_service_account()
             except ImportError:
                 log_warning("Could not import 1Password service account function")
+            except subprocess.CalledProcessError:
+                log_warning("No service account data provided and could not retrieve from 1Password")
 
         log_info(f"Initialized Google Analytics connector with {auth_method} authentication")
 
-    def authenticate(self, token_file: str = "ga_token.json") -> bool:
+    def authenticate(self, token_file: str = "ga_token.json") -> None:
         """
         Authenticate with Google Analytics using OAuth2.
 
         Args:
             token_file: Path to store/retrieve OAuth token
 
-        Returns:
-            True if authentication successful
+        Raises:
+            google.auth.exceptions.*: On authentication failure.
+            OSError: If token file cannot be read/written.
         """
-        try:
-            token_path = pathlib.Path(token_file)
+        token_path = pathlib.Path(token_file)
 
-            # Try to load existing credentials
-            if token_path.exists():
-                self.credentials = Credentials.from_authorized_user_file(
-                    str(token_path),
-                    ['https://www.googleapis.com/auth/analytics.readonly']
-                )
+        if token_path.exists():
+            self.credentials = Credentials.from_authorized_user_file(
+                str(token_path),
+                ['https://www.googleapis.com/auth/analytics.readonly']
+            )
 
-                # Refresh if expired
-                if self.credentials.expired and self.credentials.refresh_token:
-                    self.credentials.refresh(Request())
-                    self._save_credentials(token_path)
-                    log_info("Refreshed expired Google Analytics credentials")
-                else:
-                    log_info("Loaded existing Google Analytics credentials")
-            else:
-                # New authentication flow
-                flow = InstalledAppFlow.from_client_config(
-                    {
-                        "installed": {
-                            "client_id": self.client_id,
-                            "client_secret": self.client_secret,
-                            "redirect_uris": [self.redirect_uri],
-                            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-                            "token_uri": "https://oauth2.googleapis.com/token"
-                        }
-                    },
-                    ['https://www.googleapis.com/auth/analytics.readonly']
-                )
-
-                self.credentials = flow.run_local_server(port=0)
+            if self.credentials.expired and self.credentials.refresh_token:
+                self.credentials.refresh(Request())
                 self._save_credentials(token_path)
-                log_info("Completed new Google Analytics authentication")
+                log_info("Refreshed expired Google Analytics credentials")
+            else:
+                log_info("Loaded existing Google Analytics credentials")
+        else:
+            flow = InstalledAppFlow.from_client_config(
+                {
+                    "installed": {
+                        "client_id": self.client_id,
+                        "client_secret": self.client_secret,
+                        "redirect_uris": [self.redirect_uri],
+                        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                        "token_uri": "https://oauth2.googleapis.com/token"
+                    }
+                },
+                ['https://www.googleapis.com/auth/analytics.readonly']
+            )
 
-            # Build services
-            self.analytics_service = build('analytics', 'v3', credentials=self.credentials)
-            self.ga4_client = BetaAnalyticsDataClient(credentials=self.credentials)
+            self.credentials = flow.run_local_server(port=0)
+            self._save_credentials(token_path)
+            log_info("Completed new Google Analytics authentication")
 
-            return True
-
-        except (*_GA_AUTH_ERRORS, OSError) as e:
-            logger.error("Google Analytics authentication failed: %s", e, exc_info=True)
-            return False
+        self.analytics_service = build('analytics', 'v3', credentials=self.credentials)
+        self.ga4_client = BetaAnalyticsDataClient(credentials=self.credentials)
 
     def _save_credentials(self, token_path: pathlib.Path):
         """Save OAuth credentials to file."""
@@ -175,50 +165,38 @@ class GoogleAnalyticsConnector:
             token.write(self.credentials.to_json())
         log_info(f"Saved credentials to: {token_path}")
 
-    def authenticate_service_account(self) -> bool:
+    def authenticate_service_account(self) -> None:
         """
         Authenticate with Google Analytics using service account.
         Based on working implementation from GA project.
 
-        Returns:
-            True if authentication successful
+        Raises:
+            ValueError: If no service account data is available.
+            google.auth.exceptions.*: On authentication failure.
+            OSError: If temp file operations fail.
         """
+        from google.oauth2 import service_account
+        from ..config import create_temporary_service_account_file
+        from pathlib import Path
+
+        if not self.service_account_data:
+            raise ValueError("No service account data available for authentication")
+
+        temp_file = create_temporary_service_account_file(self.service_account_data)
+
         try:
-            from google.oauth2 import service_account
-            from ..config import create_temporary_service_account_file
-            from pathlib import Path
+            self.credentials = service_account.Credentials.from_service_account_file(
+                temp_file,
+                scopes=['https://www.googleapis.com/auth/analytics.readonly']
+            )
 
-            if not self.service_account_data:
-                log_error("No service account data available for authentication")
-                return False
+            self.analytics_service = build('analytics', 'v3', credentials=self.credentials)
+            self.ga4_client = BetaAnalyticsDataClient(credentials=self.credentials)
 
-            # Create temporary service account file
-            temp_file = create_temporary_service_account_file(self.service_account_data)
-            if not temp_file:
-                log_error("Failed to create temporary service account file")
-                return False
+            log_info(f"Service account authentication successful: {self.service_account_data['client_email']}")
 
-            try:
-                # Create credentials from service account file
-                self.credentials = service_account.Credentials.from_service_account_file(
-                    temp_file,
-                    scopes=['https://www.googleapis.com/auth/analytics.readonly']
-                )
-
-                # Build services
-                self.analytics_service = build('analytics', 'v3', credentials=self.credentials)
-                self.ga4_client = BetaAnalyticsDataClient(credentials=self.credentials)
-
-                log_info(f"Service account authentication successful: {self.service_account_data['client_email']}")
-                return True
-
-            finally:
-                # Clean up temporary file
-                Path(temp_file).unlink(missing_ok=True)
-
-        except (*_GA_AUTH_ERRORS, OSError) as e:
-            logger.error("Service account authentication failed: %s", e, exc_info=True)
-            return False
+        finally:
+            Path(temp_file).unlink(missing_ok=True)
 
     @staticmethod
     def _validate_ga_date(value: str, field: str) -> None:
@@ -367,7 +345,7 @@ class GoogleAnalyticsConnector:
             raise
 
     def save_as_pandas(self, df: pd.DataFrame, output_path: str,
-                       format: str = 'parquet') -> bool:
+                       format: str = 'parquet') -> None:
         """
         Save DataFrame as Pandas format.
 
@@ -376,31 +354,26 @@ class GoogleAnalyticsConnector:
             output_path: Output file path
             format: Output format (parquet, csv, excel, etc.)
 
-        Returns:
-            True if save successful
+        Raises:
+            ValueError: If the format is unsupported.
+            OSError: If the file cannot be written.
         """
-        try:
-            output_path = pathlib.Path(output_path)
-            output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path = pathlib.Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
 
-            if format.lower() == 'parquet':
-                df.to_parquet(output_path, index=False)
-            elif format.lower() == 'csv':
-                df.to_csv(output_path, index=False)
-            elif format.lower() == 'excel':
-                df.to_excel(output_path, index=False)
-            else:
-                raise ValueError(f"Unsupported format: {format}")
+        if format.lower() == 'parquet':
+            df.to_parquet(output_path, index=False)
+        elif format.lower() == 'csv':
+            df.to_csv(output_path, index=False)
+        elif format.lower() == 'excel':
+            df.to_excel(output_path, index=False)
+        else:
+            raise ValueError(f"Unsupported format: {format}")
 
-            log_info(f"Saved DataFrame to {output_path} ({format} format)")
-            return True
-
-        except (OSError, ValueError) as e:
-            logger.error("Failed to save DataFrame: %s", e, exc_info=True)
-            return False
+        log_info(f"Saved DataFrame to {output_path} ({format} format)")
 
     def save_as_spark(self, df: pd.DataFrame, output_path: str,
-                      spark_session: Optional[SparkSession] = None) -> bool:
+                      spark_session: Optional[SparkSession] = None) -> None:
         """
         Save DataFrame as Spark DataFrame and optionally to storage.
 
@@ -409,31 +382,22 @@ class GoogleAnalyticsConnector:
             output_path: Output path for Spark DataFrame
             spark_session: Optional SparkSession (will create if not provided)
 
-        Returns:
-            True if save successful
+        Raises:
+            ImportError: If PySpark is not available.
+            OSError: If the output path cannot be written.
         """
-        try:
-            if not SPARK_AVAILABLE:
-                raise ImportError("PySpark not available. Install: pip install pyspark")
+        if not SPARK_AVAILABLE:
+            raise ImportError("PySpark not available. Install: pip install pyspark")
 
-            # Create Spark session if not provided
-            if not spark_session:
-                spark_session = SparkSession.builder \
-                    .appName("GoogleAnalyticsData") \
-                    .getOrCreate()
+        if not spark_session:
+            spark_session = SparkSession.builder \
+                .appName("GoogleAnalyticsData") \
+                .getOrCreate()
 
-            # Convert to Spark DataFrame
-            spark_df = spark_session.createDataFrame(df)
+        spark_df = spark_session.createDataFrame(df)
+        spark_df.write.mode('overwrite').parquet(output_path)
 
-            # Save to storage
-            spark_df.write.mode('overwrite').parquet(output_path)
-
-            log_info(f"Saved DataFrame as Spark DataFrame to {output_path}")
-            return True
-
-        except (ImportError, OSError, TypeError, RuntimeError) as e:
-            logger.error("Failed to save as Spark DataFrame: %s", e, exc_info=True)
-            return False
+        log_info(f"Saved DataFrame as Spark DataFrame to {output_path}")
 
 
 def create_ga_account_profile(client_id: str, ga_property_id: str,
@@ -522,8 +486,9 @@ def load_ga_account_profile(account_id: str,
         return profile
 
     except (OSError, json.JSONDecodeError) as e:
-        logger.error("Failed to load GA account profile %s: %s", account_id, e, exc_info=True)
-        return None
+        raise RuntimeError(
+            f"Failed to load GA account profile {account_id}: {e}"
+        ) from e
 
 
 def list_ga_accounts_for_client(client_id: str,
@@ -660,13 +625,9 @@ def batch_retrieve_ga_data(client_id: str, start_date: str, end_date: str,
         return results
 
     except (OSError, KeyError, AttributeError) as e:
-        logger.error("Batch GA data retrieval failed: %s", e, exc_info=True)
-        return {
-            'success': False,
-            'error': str(e),
-            'accounts_processed': 0,
-            'total_rows': 0
-        }
+        raise RuntimeError(
+            f"Batch GA data retrieval failed: {e}"
+        ) from e
 
 
 def create_ga_connector_with_service_account(service_account_data: Dict[str, Any] = None) -> GoogleAnalyticsConnector:
@@ -721,17 +682,12 @@ def create_ga_connector_from_1password(item_title: str = "Google Analytics Servi
     )
     try:
         from ..config import get_google_service_account_from_1password
-        service_account_data = get_google_service_account_from_1password(item_title)
-
-        if service_account_data:
-            return create_ga_connector_with_service_account(service_account_data)
-        else:
-            log_error("Could not retrieve service account from 1Password")
-            return None
-
     except ImportError as e:
         logger.error("Could not import 1Password function: %s", e, exc_info=True)
         return None
+
+    service_account_data = get_google_service_account_from_1password(item_title)
+    return create_ga_connector_with_service_account(service_account_data)
 
 
 def create_ga_connector_with_oauth2(client_id: str, client_secret: str,

--- a/siege_utilities/analytics/google_workspace.py
+++ b/siege_utilities/analytics/google_workspace.py
@@ -29,6 +29,7 @@ Usage:
 from __future__ import annotations
 
 import logging
+import subprocess
 from pathlib import Path
 from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union
 
@@ -164,11 +165,6 @@ class GoogleWorkspaceClient:
         client_config = get_google_oauth_document_from_1password(
             item_title=item_title, vault=vault, account=account,
         )
-        if client_config is None:
-            raise ValueError(
-                f"Could not retrieve credentials from 1Password "
-                f"item '{item_title}'"
-            )
 
         # Auto-detect: service account vs OAuth client secret
         if client_config.get("type") == "service_account":
@@ -228,13 +224,14 @@ class GoogleWorkspaceClient:
             from siege_utilities.config.credential_manager import (
                 get_google_service_account_from_1password,
             )
-            data = get_google_service_account_from_1password()
-            if data is None:
+            try:
+                data = get_google_service_account_from_1password()
+            except (subprocess.CalledProcessError, OSError) as e:
                 raise ValueError(
                     "No service account credentials found. Provide "
                     "service_account_data, service_account_file, or "
                     "configure 1Password with a Google service account item."
-                )
+                ) from e
             creds = service_account.Credentials.from_service_account_info(
                 data, scopes=scopes,
             )
@@ -278,13 +275,15 @@ class GoogleWorkspaceClient:
                 from siege_utilities.config.credential_manager import (
                     get_google_service_account_from_1password,
                 )
-                data = get_google_service_account_from_1password(item_title=ref)
-                if data:
-                    return cls.from_service_account(
-                        service_account_data=data, scopes=scopes
-                    )
-                raise ValueError(
-                    f"Could not resolve service account credentials for ref '{ref}'"
+                try:
+                    data = get_google_service_account_from_1password(item_title=ref)
+                except (subprocess.CalledProcessError, OSError) as e:
+                    raise ValueError(
+                        f"Could not resolve service_account_ref '{ref}' — "
+                        f"not a file path and 1Password lookup failed."
+                    ) from e
+                return cls.from_service_account(
+                    service_account_data=data, scopes=scopes
                 )
             # Fall back to 1Password
             return cls.from_service_account(scopes=scopes)

--- a/siege_utilities/analytics/snowflake_connector.py
+++ b/siege_utilities/analytics/snowflake_connector.py
@@ -37,8 +37,8 @@ log = logging.getLogger(__name__)
 
 class SnowflakeConnector:
     """Snowflake data warehouse connector with advanced features."""
-    
-    def __init__(self, 
+
+    def __init__(self,
                  account: str,
                  user: str,
                  password: Optional[str] = None,
@@ -49,7 +49,7 @@ class SnowflakeConnector:
                  config_file: Optional[Union[str, Path]] = None):
         """
         Initialize Snowflake connector.
-        
+
         Args:
             account: Snowflake account identifier
             user: Snowflake username
@@ -62,7 +62,7 @@ class SnowflakeConnector:
         """
         if not SNOWFLAKE_AVAILABLE:
             raise ImportError("Snowflake connector not available. Install with: pip install snowflake-connector-python")
-        
+
         self.account = account
         self.user = user
         self.password = password
@@ -71,23 +71,23 @@ class SnowflakeConnector:
         self.schema = schema
         self.role = role
         self.config_file = config_file
-        
+
         # Load configuration if provided
         if config_file:
             self._load_config(config_file)
-        
+
         # Initialize connection
         self.connection = None
         self.cursor = None
-        
+
         log.info(f"Initialized Snowflake connector for account: {account}")
-    
+
     def _load_config(self, config_file: Union[str, Path]) -> None:
         """Load configuration from file."""
         config_path = Path(config_file)
         if not config_path.exists():
             raise FileNotFoundError(f"Configuration file not found: {config_path}")
-        
+
         try:
             with open(config_path, 'r', encoding='utf-8') as f:
                 config = json.load(f)
@@ -99,11 +99,11 @@ class SnowflakeConnector:
             for key, value in config.items():
                 if key in _ALLOWED_CONFIG_KEYS and value is not None:
                     setattr(self, key, value)
-                    
+
         except Exception as e:
             log.error(f"Failed to load configuration: {e}")
             raise
-    
+
     def connect(self) -> None:
         """Establish connection to Snowflake.
 
@@ -141,57 +141,58 @@ class SnowflakeConnector:
             log.info("Disconnected from Snowflake")
         except (*_SF_CONN_ERRORS, AttributeError) as e:
             log.error(f"Error disconnecting from Snowflake: {e}")
-    
-    def execute_query(self, query: str, params: Optional[Dict[str, Any]] = None) -> Optional[List[tuple]]:
+
+    def execute_query(self, query: str, params: Optional[Dict[str, Any]] = None) -> List[tuple]:
         """
         Execute a SQL query.
-        
+
         Args:
             query: SQL query string
             params: Query parameters (optional)
-            
+
         Returns:
             Query results as list of tuples
+
+        Raises:
+            ConnectionError: If not connected and connection fails.
+            RuntimeError: If query execution fails.
         """
         if not self.connection:
             self.connect()
-        
+
         try:
             if params:
                 self.cursor.execute(query, params)
             else:
                 self.cursor.execute(query)
-            
+
             results = self.cursor.fetchall()
             log.info(f"Query executed successfully. Rows returned: {len(results)}")
             return results
-            
-        except (*_SF_QUERY_ERRORS, ValueError) as e:
-            log.error(f"Query execution failed: {e}")
-            return None
 
-    def execute_ddl(self, ddl_statement: str) -> bool:
+        except (*_SF_QUERY_ERRORS, ValueError) as e:
+            raise RuntimeError(f"Query execution failed: {e}") from e
+
+    def execute_ddl(self, ddl_statement: str) -> None:
         """
         Execute DDL statements (CREATE, ALTER, DROP, etc.).
-        
+
         Args:
             ddl_statement: DDL SQL statement
-            
-        Returns:
-            True if successful, False otherwise
+
+        Raises:
+            ConnectionError: If not connected and connection fails.
+            RuntimeError: If DDL execution fails.
         """
         if not self.connection:
             self.connect()
-        
+
         try:
             self.cursor.execute(ddl_statement)
             self.connection.commit()
             log.info("DDL statement executed successfully")
-            return True
-            
         except (*_SF_QUERY_ERRORS,) as e:
-            log.error(f"DDL execution failed: {e}")
-            return False
+            raise RuntimeError(f"DDL execution failed: {e}") from e
 
     def upload_dataframe(self,
                         df: 'pd.DataFrame',
@@ -199,10 +200,10 @@ class SnowflakeConnector:
                         database: Optional[str] = None,
                         schema: Optional[str] = None,
                         auto_create_table: bool = True,
-                        overwrite: bool = False) -> bool:
+                        overwrite: bool = False) -> None:
         """
         Upload pandas DataFrame to Snowflake table.
-        
+
         Args:
             df: Pandas DataFrame to upload
             table_name: Target table name
@@ -210,22 +211,21 @@ class SnowflakeConnector:
             schema: Target schema (uses default if not specified)
             auto_create_table: Whether to automatically create table if it doesn't exist
             overwrite: Whether to overwrite existing table
-            
-        Returns:
-            True if successful, False otherwise
+
+        Raises:
+            ImportError: If pandas is not available.
+            ConnectionError: If not connected and connection fails.
+            RuntimeError: If the upload fails.
         """
         if not PANDAS_AVAILABLE:
-            log.error("Pandas not available for DataFrame operations")
-            return False
-        
+            raise ImportError("Pandas not available for DataFrame operations. Install with: pip install pandas")
+
         if not self.connection:
             self.connect()
-        
+
         from siege_utilities.core.sql_safety import validate_sql_identifier as validate_identifier
         validate_identifier(table_name, label="table name")
         try:
-            # Set database and schema context. Snowflake doesn't permit
-            # parameter-bound identifiers for USE; validation must do it.
             if database:
                 validate_identifier(database, label="database name")
                 self.cursor.execute(f"USE DATABASE {database}")
@@ -233,11 +233,9 @@ class SnowflakeConnector:
                 validate_identifier(schema, label="schema name")
                 self.cursor.execute(f"USE SCHEMA {schema}")
 
-            # Create table if needed
             if auto_create_table:
                 self._create_table_from_dataframe(df, table_name, overwrite)
-            
-            # Upload data
+
             success, nchunks, nrows, _ = write_pandas(
                 self.connection,
                 df,
@@ -245,47 +243,47 @@ class SnowflakeConnector:
                 auto_create_table=False,
                 overwrite=overwrite
             )
-            
-            if success:
-                log.info(f"Successfully uploaded {nrows} rows to table {table_name}")
-                return True
-            else:
-                log.error(f"Failed to upload data to table {table_name}")
-                return False
-                
+
+            if not success:
+                raise RuntimeError(f"write_pandas reported failure for table {table_name}")
+
+            log.info(f"Successfully uploaded {nrows} rows to table {table_name}")
+
         except (*_SF_QUERY_ERRORS, ValueError) as e:
-            log.error(f"DataFrame upload failed: {e}")
-            return False
+            raise RuntimeError(f"DataFrame upload failed: {e}") from e
 
     def download_dataframe(self,
                           query: str,
-                          params: Optional[Dict[str, Any]] = None) -> Optional['pd.DataFrame']:
+                          params: Optional[Dict[str, Any]] = None) -> 'pd.DataFrame':
         """
         Download data from Snowflake as pandas DataFrame.
-        
+
         Args:
             query: SQL query to execute
             params: Query parameters (optional)
-            
+
         Returns:
             Pandas DataFrame with query results
+
+        Raises:
+            ImportError: If pandas is not available.
+            ConnectionError: If not connected and connection fails.
+            RuntimeError: If the query fails.
         """
         if not PANDAS_AVAILABLE:
-            log.error("Pandas not available for DataFrame operations")
-            return None
-        
+            raise ImportError("Pandas not available for DataFrame operations. Install with: pip install pandas")
+
         if not self.connection:
             self.connect()
-        
+
         try:
             df = read_pandas(self.connection, query, params)
             log.info(f"Successfully downloaded {len(df)} rows as DataFrame")
             return df
-            
+
         except (*_SF_QUERY_ERRORS, ValueError) as e:
-            log.error(f"DataFrame download failed: {e}")
-            return None
-    
+            raise RuntimeError(f"DataFrame download failed: {e}") from e
+
     def _create_table_from_dataframe(self, df: 'pd.DataFrame', table_name: str, overwrite: bool) -> None:
         """Create Snowflake table based on DataFrame structure."""
         from siege_utilities.core.sql_safety import validate_sql_identifier as validate_identifier
@@ -293,10 +291,8 @@ class SnowflakeConnector:
         if overwrite:
             self.cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
 
-        # Generate CREATE TABLE statement
         columns = []
         for col_name, dtype in df.dtypes.items():
-            # Validate every DataFrame column name before it lands in DDL.
             validate_identifier(str(col_name), label="column name", allow_dotted=False)
             snowflake_type = self._map_pandas_to_snowflake_type(dtype)
             columns.append(f"{col_name} {snowflake_type}")
@@ -304,11 +300,11 @@ class SnowflakeConnector:
         create_statement = f"CREATE TABLE IF NOT EXISTS {table_name} ({', '.join(columns)})"
         self.cursor.execute(create_statement)
         log.info(f"Created table {table_name} with {len(columns)} columns")
-    
+
     def _map_pandas_to_snowflake_type(self, pandas_dtype) -> str:
         """Map pandas data types to Snowflake data types."""
         dtype_str = str(pandas_dtype)
-        
+
         if 'int' in dtype_str:
             return 'NUMBER(38,0)'
         elif 'float' in dtype_str:
@@ -321,26 +317,29 @@ class SnowflakeConnector:
             return 'VARCHAR(16777216)'
         else:
             return 'VARCHAR(16777216)'
-    
-    def get_table_info(self, table_name: str, database: Optional[str] = None, schema: Optional[str] = None) -> Optional[Dict[str, Any]]:
+
+    def get_table_info(self, table_name: str, database: Optional[str] = None, schema: Optional[str] = None) -> Dict[str, Any]:
         """
         Get information about a Snowflake table.
-        
+
         Args:
             table_name: Name of the table
             database: Database name (uses default if not specified)
             schema: Schema name (uses default if not specified)
-            
+
         Returns:
             Dictionary with table information
+
+        Raises:
+            ConnectionError: If not connected and connection fails.
+            RuntimeError: If the query fails.
         """
         if not self.connection:
             self.connect()
-        
+
         from siege_utilities.core.sql_safety import validate_sql_identifier as validate_identifier
         validate_identifier(table_name, label="table name")
         try:
-            # Set context (identifiers cannot be parameter-bound).
             if database:
                 validate_identifier(database, label="database name")
                 self.cursor.execute(f"USE DATABASE {database}")
@@ -348,16 +347,12 @@ class SnowflakeConnector:
                 validate_identifier(schema, label="schema name")
                 self.cursor.execute(f"USE SCHEMA {schema}")
 
-            # Get table description
             self.cursor.execute(f"DESCRIBE TABLE {table_name}")
             columns = self.cursor.fetchall()
 
-            # Get row count
             self.cursor.execute(f"SELECT COUNT(*) FROM {table_name}")
             row_count = self.cursor.fetchone()[0]
 
-            # Get table size — scope to the active database+schema so we
-            # don't return a different schema's table with the same name.
             self.cursor.execute(
                 """
                 SELECT BYTES, ROWS
@@ -369,7 +364,7 @@ class SnowflakeConnector:
                 (table_name,),
             )
             size_info = self.cursor.fetchone()
-            
+
             table_info = {
                 'name': table_name,
                 'columns': [{'name': col[0], 'type': col[1], 'nullable': col[2]} for col in columns],
@@ -377,30 +372,32 @@ class SnowflakeConnector:
                 'bytes': size_info[0] if size_info else None,
                 'rows': size_info[1] if size_info else None
             }
-            
+
             return table_info
-            
+
         except (*_SF_QUERY_ERRORS, ValueError, IndexError) as e:
-            log.error(f"Failed to get table info: {e}")
-            return None
-    
-    def list_tables(self, database: Optional[str] = None, schema: Optional[str] = None) -> Optional[List[str]]:
+            raise RuntimeError(f"Failed to get table info for {table_name}: {e}") from e
+
+    def list_tables(self, database: Optional[str] = None, schema: Optional[str] = None) -> List[str]:
         """
         List all tables in a database/schema.
-        
+
         Args:
             database: Database name (uses default if not specified)
             schema: Schema name (uses default if not specified)
-            
+
         Returns:
             List of table names
+
+        Raises:
+            ConnectionError: If not connected and connection fails.
+            RuntimeError: If the query fails.
         """
         if not self.connection:
             self.connect()
-        
+
         from siege_utilities.core.sql_safety import validate_sql_identifier as validate_identifier
         try:
-            # Set context (identifiers cannot be parameter-bound).
             if database:
                 validate_identifier(database, label="database name")
                 self.cursor.execute(f"USE DATABASE {database}")
@@ -408,21 +405,19 @@ class SnowflakeConnector:
                 validate_identifier(schema, label="schema name")
                 self.cursor.execute(f"USE SCHEMA {schema}")
 
-            # List tables
             self.cursor.execute("SHOW TABLES")
             tables = [row[1] for row in self.cursor.fetchall()]
-            
+
             return tables
-            
+
         except (*_SF_QUERY_ERRORS, ValueError, IndexError) as e:
-            log.error(f"Failed to list tables: {e}")
-            return None
-    
+            raise RuntimeError(f"Failed to list tables: {e}") from e
+
     def __enter__(self):
         """Context manager entry."""
         self.connect()
         return self
-    
+
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Context manager exit."""
         self.disconnect()
@@ -434,29 +429,28 @@ def get_snowflake_connector(config_file: Optional[Union[str, Path]] = None) -> S
     if config_file:
         return SnowflakeConnector(config_file=config_file)
     else:
-        # Try to load from environment variables
         account = os.getenv('SNOWFLAKE_ACCOUNT')
         user = os.getenv('SNOWFLAKE_USER')
         password = os.getenv('SNOWFLAKE_PASSWORD')
-        
+
         if not all([account, user, password]):
             raise ValueError("Snowflake configuration not found. Set environment variables or provide config file.")
-        
+
         return SnowflakeConnector(account=account, user=user, password=password)
 
 
-def upload_to_snowflake(df: 'pd.DataFrame', 
+def upload_to_snowflake(df: 'pd.DataFrame',
                         table_name: str,
                         config_file: Optional[Union[str, Path]] = None,
-                        **kwargs) -> bool:
+                        **kwargs) -> None:
     """Convenience function to upload DataFrame to Snowflake."""
     with get_snowflake_connector(config_file) as snow:
-        return snow.upload_dataframe(df, table_name, **kwargs)
+        snow.upload_dataframe(df, table_name, **kwargs)
 
 
 def download_from_snowflake(query: str,
                            config_file: Optional[Union[str, Path]] = None,
-                           **kwargs) -> Optional['pd.DataFrame']:
+                           **kwargs) -> 'pd.DataFrame':
     """Convenience function to download DataFrame from Snowflake."""
     with get_snowflake_connector(config_file) as snow:
         return snow.download_dataframe(query, **kwargs)
@@ -464,7 +458,7 @@ def download_from_snowflake(query: str,
 
 def execute_snowflake_query(query: str,
                            config_file: Optional[Union[str, Path]] = None,
-                           **kwargs) -> Optional[List[tuple]]:
+                           **kwargs) -> List[tuple]:
     """Convenience function to execute Snowflake query."""
     with get_snowflake_connector(config_file) as snow:
         return snow.execute_query(query, **kwargs)

--- a/siege_utilities/analytics/vista_social.py
+++ b/siege_utilities/analytics/vista_social.py
@@ -293,7 +293,11 @@ class VistaSocialConnector:
         empty-on-error).
         """
         resp = self._request("GET", "/v1/accounts")
-        items = resp.data.get("data") if isinstance(resp.data, Mapping) else None
+        if not isinstance(resp.data, Mapping):
+            raise TypeError(
+                f"Expected mapping response from /v1/accounts, got {type(resp.data).__name__}"
+            )
+        items = resp.data.get("data")
         return list(items) if items else []
 
     def list_profiles(self, account_id: str) -> List[Mapping[str, Any]]:
@@ -304,7 +308,11 @@ class VistaSocialConnector:
         if not account_id:
             raise ValueError("list_profiles requires a non-empty account_id")
         resp = self._request("GET", f"/v1/accounts/{account_id}/profiles")
-        items = resp.data.get("data") if isinstance(resp.data, Mapping) else None
+        if not isinstance(resp.data, Mapping):
+            raise TypeError(
+                f"Expected mapping response from profiles endpoint, got {type(resp.data).__name__}"
+            )
+        items = resp.data.get("data")
         return list(items) if items else []
 
     def get_account_analytics(
@@ -341,7 +349,11 @@ class VistaSocialConnector:
         resp = self._request(
             "GET", f"/v1/accounts/{account_id}/analytics", params=params,
         )
-        return dict(resp.data) if isinstance(resp.data, Mapping) else {}
+        if not isinstance(resp.data, Mapping):
+            raise TypeError(
+                f"Expected mapping response from analytics endpoint, got {type(resp.data).__name__}"
+            )
+        return dict(resp.data)
 
     def list_posts(
         self,
@@ -368,5 +380,9 @@ class VistaSocialConnector:
         resp = self._request(
             "GET", f"/v1/accounts/{account_id}/posts", params=params,
         )
-        items = resp.data.get("data") if isinstance(resp.data, Mapping) else None
+        if not isinstance(resp.data, Mapping):
+            raise TypeError(
+                f"Expected mapping response from posts endpoint, got {type(resp.data).__name__}"
+            )
+        items = resp.data.get("data")
         return list(items) if items else []

--- a/siege_utilities/config/clients.py
+++ b/siege_utilities/config/clients.py
@@ -9,7 +9,7 @@ import pathlib
 import re
 import logging
 import tempfile
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any, List
 from datetime import datetime
 import uuid
 
@@ -168,62 +168,62 @@ def save_client_profile(
 
 
 def load_client_profile(
-    client_code: str, 
+    client_code: str,
     config_directory: str = "config"
-) -> Optional[Dict[str, Any]]:
+) -> Dict[str, Any]:
     """
     Load client profile from JSON file.
-    
+
     Args:
         client_code: Client code to load
         config_directory: Directory containing config files
-        
+
     Returns:
-        Client profile dictionary or None if not found
-        
+        Client profile dictionary.
+
+    Raises:
+        FileNotFoundError: If the profile file does not exist.
+        json.JSONDecodeError: If the file contains invalid JSON.
+        OSError: If the file cannot be read.
+
     Example:
         >>> profile = siege_utilities.load_client_profile("ACME001")
-        >>> if profile:
-        ...     print(f"Loaded: {profile['client_name']}")
+        >>> print(f"Loaded: {profile['client_name']}")
     """
-    
+
     client_code = _validate_client_code(client_code)
     config_file = pathlib.Path(config_directory) / f"client_{client_code}.json"
 
     if not config_file.exists():
-        log_warning(f"Client profile not found: {config_file}")
-        return None
-    
-    try:
-        with open(config_file, 'r', encoding='utf-8') as f:
-            profile = json.load(f)
-        
-        log_info(f"Loaded client profile: {client_code}")
-        return profile
-        
-    except (OSError, json.JSONDecodeError) as e:
-        log_error(f"Error loading client profile {config_file}: {e}")
-        return None
+        raise FileNotFoundError(f"Client profile not found: {config_file}")
+
+    with open(config_file, 'r', encoding='utf-8') as f:
+        profile = json.load(f)
+
+    log_info(f"Loaded client profile: {client_code}")
+    return profile
 
 
 def update_client_profile(
     client_code: str,
     updates: Dict[str, Any],
     config_directory: str = "config"
-) -> bool:
+) -> None:
     """
     Update an existing client profile.
-    
+
     Args:
         client_code: Client code to update
         updates: Dictionary of updates to apply
         config_directory: Directory containing config files
-        
-    Returns:
-        True if successful, False otherwise
-        
+
+    Raises:
+        FileNotFoundError: If the client profile does not exist.
+        OSError: If the profile cannot be read or written.
+        json.JSONDecodeError: If the existing profile is corrupt.
+
     Example:
-        >>> success = siege_utilities.update_client_profile(
+        >>> siege_utilities.update_client_profile(
         ...     "ACME001",
         ...     {
         ...         "contact_info": {"phone": "+1-555-9999"},
@@ -231,32 +231,20 @@ def update_client_profile(
         ...     }
         ... )
     """
-    
+
     profile = load_client_profile(client_code, config_directory)
-    
-    if profile is None:
-        log_error(f"Cannot update - client profile not found: {client_code}")
-        return False
-    
-    try:
-        # Apply updates recursively
-        def update_nested_dict(target: Dict, updates: Dict):
-            for key, value in updates.items():
-                if key in target and isinstance(target[key], dict) and isinstance(value, dict):
-                    update_nested_dict(target[key], value)
-                else:
-                    target[key] = value
-        
-        update_nested_dict(profile, updates)
-        
-        # Save updated profile
-        save_client_profile(profile, config_directory)
-        log_info(f"Updated client profile: {client_code}")
-        return True
-        
-    except (OSError, json.JSONDecodeError, KeyError, TypeError) as e:
-        log_error(f"Error updating client profile {client_code}: {e}")
-        return False
+
+    def update_nested_dict(target: Dict, source: Dict):
+        for key, value in source.items():
+            if key in target and isinstance(target[key], dict) and isinstance(value, dict):
+                update_nested_dict(target[key], value)
+            else:
+                target[key] = value
+
+    update_nested_dict(profile, updates)
+
+    save_client_profile(profile, config_directory)
+    log_info(f"Updated client profile: {client_code}")
 
 
 def list_client_profiles(
@@ -370,59 +358,38 @@ def associate_client_with_project(
     client_code: str,
     project_code: str,
     config_directory: str = "config"
-) -> bool:
+) -> None:
     """
     Associate a client with a project.
-    
+
     Args:
         client_code: Client code to associate
         project_code: Project code to associate with
         config_directory: Directory containing config files
-        
-    Returns:
-        True if successful, False otherwise
-        
+
+    Raises:
+        FileNotFoundError: If the client or project profile does not exist.
+        OSError: If profiles cannot be read or written.
+
     Example:
-        >>> success = siege_utilities.associate_client_with_project("ACME001", "PROJ001")
+        >>> siege_utilities.associate_client_with_project("ACME001", "PROJ001")
     """
-    
-    # Load client profile
+
     client_profile = load_client_profile(client_code, config_directory)
-    if not client_profile:
-        log_error(f"Client profile not found: {client_code}")
-        return False
-    
-    # Load project config
-    try:
-        from .projects import load_project_config
-        project_config = load_project_config(project_code, config_directory)
-        if not project_config:
-            log_error(f"Project config not found: {project_code}")
-            return False
-    except ImportError:
-        log_error("Projects module not available")
-        return False
-    
-    try:
-        # Add project association to client profile
-        if 'project_associations' not in client_profile:
-            client_profile['project_associations'] = []
-        
-        if project_code not in client_profile['project_associations']:
-            client_profile['project_associations'].append(project_code)
-            client_profile['metadata']['project_count'] = len(client_profile['project_associations'])
-            
-            # Save updated profile
-            save_client_profile(client_profile, config_directory)
-            log_info(f"Associated client {client_code} with project {project_code}")
-            return True
-        else:
-            log_info(f"Client {client_code} already associated with project {project_code}")
-            return True
-            
-    except (OSError, json.JSONDecodeError, KeyError, TypeError) as e:
-        log_error(f"Error associating client with project: {e}")
-        return False
+
+    from .projects import load_project_config
+    load_project_config(project_code, config_directory)
+
+    if 'project_associations' not in client_profile:
+        client_profile['project_associations'] = []
+
+    if project_code not in client_profile['project_associations']:
+        client_profile['project_associations'].append(project_code)
+        client_profile['metadata']['project_count'] = len(client_profile['project_associations'])
+        save_client_profile(client_profile, config_directory)
+        log_info(f"Associated client {client_code} with project {project_code}")
+    else:
+        log_info(f"Client {client_code} already associated with project {project_code}")
 
 
 def get_client_project_associations(
@@ -431,24 +398,23 @@ def get_client_project_associations(
 ) -> List[str]:
     """
     Get all projects associated with a client.
-    
+
     Args:
         client_code: Client code to check
         config_directory: Directory containing config files
-        
+
     Returns:
-        List of associated project codes
-        
+        List of associated project codes.
+
+    Raises:
+        FileNotFoundError: If the client profile does not exist.
+
     Example:
         >>> projects = siege_utilities.get_client_project_associations("ACME001")
         >>> print(f"Client has {len(projects)} projects")
     """
-    
+
     profile = load_client_profile(client_code, config_directory)
-    
-    if not profile:
-        return []
-    
     return profile.get('project_associations', [])
 
 

--- a/siege_utilities/config/connections.py
+++ b/siege_utilities/config/connections.py
@@ -145,42 +145,40 @@ def save_connection_profile(
 
 
 def load_connection_profile(
-    connection_id: str, 
+    connection_id: str,
     config_directory: str = "config"
-) -> Optional[Dict[str, Any]]:
+) -> Dict[str, Any]:
     """
     Load connection profile from JSON file.
-    
+
     Args:
         connection_id: Connection ID to load
         config_directory: Directory containing config files
-        
+
     Returns:
-        Connection profile dictionary or None if not found
-        
+        Connection profile dictionary.
+
+    Raises:
+        FileNotFoundError: If the connection profile does not exist.
+        json.JSONDecodeError: If the file contains invalid JSON.
+        OSError: If the file cannot be read.
+
     Example:
         >>> profile = siege_utilities.load_connection_profile("uuid-here")
-        >>> if profile:
-        ...     print(f"Loaded: {profile['name']}")
+        >>> print(f"Loaded: {profile['name']}")
     """
-    
+
     connections_dir = pathlib.Path(config_directory) / "connections"
     config_file = connections_dir / f"connection_{connection_id}.json"
-    
-    if not config_file.exists():
-        log_warning(f"Connection profile not found: {config_file}")
-        return None
-    
-    try:
-        with open(config_file, 'r', encoding='utf-8') as f:
-            profile = json.load(f)
 
-        log_info(f"Loaded connection profile: {connection_id}")
-        return profile
-        
-    except (OSError, json.JSONDecodeError) as e:
-        log_error(f"Error loading connection profile {config_file}: {e}")
-        return None
+    if not config_file.exists():
+        raise FileNotFoundError(f"Connection profile not found: {config_file}")
+
+    with open(config_file, 'r', encoding='utf-8') as f:
+        profile = json.load(f)
+
+    log_info(f"Loaded connection profile: {connection_id}")
+    return profile
 
 
 def find_connection_by_name(
@@ -281,50 +279,39 @@ def update_connection_profile(
     connection_id: str,
     updates: Dict[str, Any],
     config_directory: str = "config"
-) -> bool:
+) -> None:
     """
     Update an existing connection profile.
-    
+
     Args:
         connection_id: Connection ID to update
         updates: Dictionary of updates to apply
         config_directory: Directory containing config files
-        
-    Returns:
-        True if successful, False otherwise
-        
+
+    Raises:
+        FileNotFoundError: If the connection profile does not exist.
+        OSError: If the profile cannot be read or written.
+
     Example:
-        >>> success = siege_utilities.update_connection_profile(
+        >>> siege_utilities.update_connection_profile(
         ...     "uuid-here",
         ...     {"metadata": {"status": "inactive"}}
         ... )
     """
-    
+
     profile = load_connection_profile(connection_id, config_directory)
-    
-    if profile is None:
-        log_error(f"Cannot update - connection profile not found: {connection_id}")
-        return False
-    
-    try:
-        # Apply updates recursively
-        def update_nested_dict(target: Dict, updates: Dict):
-            for key, value in updates.items():
-                if key in target and isinstance(target[key], dict) and isinstance(value, dict):
-                    update_nested_dict(target[key], value)
-                else:
-                    target[key] = value
-        
-        update_nested_dict(profile, updates)
-        
-        # Save updated profile
-        save_connection_profile(profile, config_directory)
-        log_info(f"Updated connection profile: {connection_id}")
-        return True
-        
-    except (OSError, json.JSONDecodeError, KeyError, TypeError) as e:
-        log_error(f"Error updating connection profile {connection_id}: {e}")
-        return False
+
+    def update_nested_dict(target: Dict, source: Dict):
+        for key, value in source.items():
+            if key in target and isinstance(target[key], dict) and isinstance(value, dict):
+                update_nested_dict(target[key], value)
+            else:
+                target[key] = value
+
+    update_nested_dict(profile, updates)
+
+    save_connection_profile(profile, config_directory)
+    log_info(f"Updated connection profile: {connection_id}")
 
 
 def verify_connection_profile(
@@ -348,14 +335,7 @@ def verify_connection_profile(
     """
     
     profile = load_connection_profile(connection_id, config_directory)
-    
-    if not profile:
-        return {
-            'success': False,
-            'error': 'Connection profile not found',
-            'timestamp': datetime.now().isoformat()
-        }
-    
+
     connection_type = profile['connection_type']
     test_result = {
         'success': False,
@@ -457,13 +437,7 @@ def get_connection_status(
     """
     
     profile = load_connection_profile(connection_id, config_directory)
-    
-    if not profile:
-        return {
-            'status': 'not_found',
-            'error': 'Connection profile not found'
-        }
-    
+
     metadata = profile['metadata']
     last_connected = metadata.get('last_connected')
     

--- a/siege_utilities/config/credential_manager.py
+++ b/siege_utilities/config/credential_manager.py
@@ -462,22 +462,29 @@ class CredentialManager:
         return None
     
     def _get_from_keychain(self, service: str, username: str) -> Optional[str]:
-        """Get credential from Apple Keychain."""
-        try:
-            result = subprocess.run([
-                'security', 'find-generic-password',
-                '-s', service,
-                '-a', username,
-                '-w'
-            ], capture_output=True, text=True, timeout=60)
-            
-            if result.returncode == 0:
-                return result.stdout.strip()
+        """Get credential from Apple Keychain.
+
+        Returns None when the keychain simply doesn't contain the
+        credential (exit code 44 = item not found).  Raises on
+        transport / permission errors so the caller doesn't silently
+        fall through to the next backend.
+        """
+        result = subprocess.run([
+            'security', 'find-generic-password',
+            '-s', service,
+            '-a', username,
+            '-w'
+        ], capture_output=True, text=True, timeout=60)
+
+        if result.returncode == 0:
+            return result.stdout.strip()
+        if result.returncode == 44:
             return None
-            
-        except (subprocess.SubprocessError, OSError) as exc:
-            log_warning(f"Keychain lookup failed for {service}/{username}: {exc}")
-            return None
+        raise RuntimeError(
+            f"Keychain lookup for {service}/{username} failed with "
+            f"exit code {result.returncode}: "
+            f"{(result.stderr or result.stdout)[:200]!r}"
+        )
 
     def _get_from_prompt(self, service: str, username: str, field: str) -> Optional[str]:
         """Get credential via interactive prompt."""
@@ -696,19 +703,13 @@ class CredentialManager:
         if client_id and client_secret:
             return client_id, client_secret
 
-        # Fallback to general credential retrieval
+        # Fallback to general credential retrieval.
+        # get_credential raises CredentialNotFoundError on miss, so no
+        # need to check return values — if we reach the second call, the
+        # first succeeded.
         client_id = self.get_credential('google-analytics', 'api', 'client_id')
         client_secret = self.get_credential('google-analytics', 'api', 'client_secret')
-
-        if client_id and client_secret:
-            return client_id, client_secret
-
-        missing_field = 'client_id' if not client_id else 'client_secret'
-        raise CredentialNotFoundError(
-            'google-analytics', missing_field,
-            [('1password', f'item {item_title!r} missing field'),
-             ('general', 'get_credential returned falsy')],
-        )
+        return client_id, client_secret
     
     def list_stored_credentials(self, service_filter: Optional[str] = None,
                                 vault: Optional[str] = None,
@@ -1050,21 +1051,13 @@ def store_ga_service_account_from_file(credentials_file: Union[str, Path],
         subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=60)
 
         log_info(f"Stored Google Analytics service account: '{item_title}'")
-        
-        # Verify storage by retrieving client_email
-        test_email = get_credential('google-analytics-sa', service_account_data['client_email'], 'client_email')
-        if test_email:
-            log_info("Service account credential storage verified")
-            
-            # Delete original file if requested
-            if delete_file:
-                credentials_file.unlink()
-                log_info(f"Deleted original file: {credentials_file}")
-            
-            return True
-        else:
-            log_warning("Could not verify service account storage (but likely successful)")
-            return True  # Still consider success since 1Password command succeeded
+
+        # Delete original file if requested
+        if delete_file:
+            credentials_file.unlink()
+            log_info(f"Deleted original file: {credentials_file}")
+
+        return True
             
     except subprocess.CalledProcessError as e:
         log_error(f"Failed to store service account credentials: {e.stderr}")
@@ -1102,7 +1095,7 @@ def get_ga_service_account_credentials() -> Dict[str, str]:
 
 def get_google_service_account_from_1password(item_title: str = "Google Analytics Service Account - Multi-Client Reporter",
                                               vault: Optional[str] = None,
-                                              account: Optional[str] = None) -> Optional[Dict[str, str]]:
+                                              account: Optional[str] = None) -> Dict[str, str]:
     """
     Get Google service account credentials from 1Password.
     Based on working implementation from GA project.
@@ -1113,58 +1106,51 @@ def get_google_service_account_from_1password(item_title: str = "Google Analytic
         account: 1Password account shorthand or UUID
 
     Returns:
-        Service account credentials dictionary or None if not found
+        Service account credentials dictionary.
+
+    Raises:
+        subprocess.CalledProcessError: If 1Password CLI fails (item not found,
+            auth required, etc.)
+        OSError: If the ``op`` binary cannot be executed.
     """
-    try:
-        import subprocess
+    op_flags = []
+    if vault:
+        op_flags.append(f'--vault={vault}')
+    if account:
+        op_flags.append(f'--account={account}')
 
-        op_flags = []
-        if vault:
-            op_flags.append(f'--vault={vault}')
-        if account:
-            op_flags.append(f'--account={account}')
+    def get_field(field_name: str) -> str:
+        cmd = ['op', 'item', 'get', item_title, f'--field={field_name}', '--reveal'] + op_flags
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=60)
+        value = result.stdout.strip()
 
-        def get_field(field_name: str) -> str:
-            """Get a specific field from the 1Password item"""
-            cmd = ['op', 'item', 'get', item_title, f'--field={field_name}', '--reveal'] + op_flags
-            result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=60)
-            value = result.stdout.strip()
-            
-            # Clean up private key - remove extra quotes and fix newlines
-            if field_name == 'private_key':
-                value = value.strip('"')  # Remove surrounding quotes
-                value = value.replace('\\n', '\n')  # Fix escaped newlines
-            
-            return value
-        
-        service_account = {
-            "type": "service_account",
-            "project_id": get_field('project_id'),
-            "private_key_id": get_field('private_key_id'),
-            "private_key": get_field('private_key'),
-            "client_email": get_field('client_email'),
-            "client_id": get_field('client_id'),
-            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-            "token_uri": "https://oauth2.googleapis.com/token",
-            "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs"
-        }
-        
-        log_info(f"Retrieved Google service account: {service_account['client_email']}")
-        return service_account
-        
-    except subprocess.CalledProcessError as e:
-        log_error(f"Failed to get Google service account from 1Password: {e}")
-        return None
-    except (ValueError, KeyError, AttributeError) as e:
-        log_error(f"Error retrieving Google service account: {e}")
-        return None
+        if field_name == 'private_key':
+            value = value.strip('"')
+            value = value.replace('\\n', '\n')
+
+        return value
+
+    service_account = {
+        "type": "service_account",
+        "project_id": get_field('project_id'),
+        "private_key_id": get_field('private_key_id'),
+        "private_key": get_field('private_key'),
+        "client_email": get_field('client_email'),
+        "client_id": get_field('client_id'),
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs"
+    }
+
+    log_info(f"Retrieved Google service account: {service_account['client_email']}")
+    return service_account
 
 
 def get_google_oauth_from_1password(
     item_title: str = "Google Analytics API - Multi-Client Reporter",
     vault: Optional[str] = None,
     account: Optional[str] = None,
-) -> Optional[Dict[str, str]]:
+) -> Dict[str, str]:
     """Get Google OAuth2 client credentials from 1Password.
 
     Returns dict with client_id, client_secret, project_id, redirect_uri
@@ -1176,67 +1162,63 @@ def get_google_oauth_from_1password(
         account: 1Password account shorthand or UUID
 
     Returns:
-        Dict with OAuth2 credential fields, or None if not found
+        Dict with OAuth2 credential fields.
+
+    Raises:
+        subprocess.CalledProcessError: If 1Password CLI fails.
+        ValueError: If the item exists but lacks client_id or client_secret.
+        OSError: If the ``op`` binary cannot be executed.
     """
-    try:
-        op_flags = []
-        if vault:
-            op_flags.append(f'--vault={vault}')
-        if account:
-            op_flags.append(f'--account={account}')
+    op_flags = []
+    if vault:
+        op_flags.append(f'--vault={vault}')
+    if account:
+        op_flags.append(f'--account={account}')
 
-        def get_field(field_name: str) -> Optional[str]:
-            cmd = ['op', 'item', 'get', item_title, f'--field={field_name}', '--reveal'] + op_flags
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
-            if result.returncode == 0:
-                return result.stdout.strip()
-            return None
-
-        client_id = get_field('client_id')
-        client_secret = get_field('client_secret')
-
-        if not client_id or not client_secret:
-            log_warning(f"Could not retrieve OAuth2 credentials from 1Password item '{item_title}'")
-            return None
-
-        creds = {
-            'client_id': client_id,
-            'client_secret': client_secret,
-        }
-
-        # Get redirect_uri (stored as comma-separated redirect_uris)
-        redirect_uris = get_field('redirect_uris')
-        if redirect_uris:
-            # Take the first URI from the comma-separated list
-            creds['redirect_uri'] = redirect_uris.split(',')[0].strip()
-
-        # Try to extract project_id from raw_json if available
-        raw_json_str = get_field('raw_json')
-        if raw_json_str:
-            try:
-                raw_data = json.loads(raw_json_str)
-                installed = raw_data.get('installed', raw_data)
-                if 'project_id' in installed:
-                    creds['project_id'] = installed['project_id']
-            except (json.JSONDecodeError, TypeError):
-                pass
-
-        log_info(f"Retrieved Google OAuth2 credentials from 1Password: {client_id[:20]}...")
-        return creds
-
-    except subprocess.CalledProcessError as e:
-        log_error(f"Failed to get Google OAuth2 credentials from 1Password: {e}")
+    def get_field(field_name: str) -> Optional[str]:
+        cmd = ['op', 'item', 'get', item_title, f'--field={field_name}', '--reveal'] + op_flags
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+        if result.returncode == 0:
+            return result.stdout.strip()
         return None
-    except (ValueError, IndexError, AttributeError) as e:
-        log_error(f"Error retrieving Google OAuth2 credentials: {e}")
-        return None
+
+    client_id = get_field('client_id')
+    client_secret = get_field('client_secret')
+
+    if not client_id or not client_secret:
+        missing = 'client_id' if not client_id else 'client_secret'
+        raise ValueError(
+            f"1Password item '{item_title}' is missing required field '{missing}'"
+        )
+
+    creds: Dict[str, str] = {
+        'client_id': client_id,
+        'client_secret': client_secret,
+    }
+
+    redirect_uris = get_field('redirect_uris')
+    if redirect_uris:
+        creds['redirect_uri'] = redirect_uris.split(',')[0].strip()
+
+    raw_json_str = get_field('raw_json')
+    if raw_json_str:
+        try:
+            raw_data = json.loads(raw_json_str)
+            installed = raw_data.get('installed', raw_data)
+            if 'project_id' in installed:
+                creds['project_id'] = installed['project_id']
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+    log_info(f"Retrieved Google OAuth2 credentials from 1Password: {client_id[:20]}...")
+    return creds
 
 
 def get_google_oauth_document_from_1password(
     item_title: str = "Google OAuth Client - siege_utilities",
     vault: Optional[str] = None,
     account: Optional[str] = None,
-) -> Optional[Dict[str, Any]]:
+) -> Dict[str, Any]:
     """Get Google OAuth2 client secret JSON from a 1Password DOCUMENT item.
 
     Unlike :func:`get_google_oauth_from_1password` which reads individual fields,
@@ -1249,59 +1231,44 @@ def get_google_oauth_document_from_1password(
         account: 1Password account shorthand or UUID.
 
     Returns:
-        Parsed client secret dict (contains ``"installed"`` or ``"web"`` key),
-        or ``None`` if not found.
+        Parsed client secret dict (contains ``"installed"`` or ``"web"`` key).
+
+    Raises:
+        subprocess.CalledProcessError: If 1Password CLI fails (item not found,
+            auth required, etc.)
+        json.JSONDecodeError: If the document content is not valid JSON.
+        OSError: If the ``op`` binary cannot be executed.
     """
-    try:
-        cmd = ['op', 'document', 'get', item_title]
-        if vault:
-            cmd.append(f'--vault={vault}')
-        if account:
-            cmd.append(f'--account={account}')
+    cmd = ['op', 'document', 'get', item_title]
+    if vault:
+        cmd.append(f'--vault={vault}')
+    if account:
+        cmd.append(f'--account={account}')
 
-        result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=60)
-        client_config = json.loads(result.stdout)
-        log_info(f"Retrieved Google OAuth document from 1Password: {item_title}")
-        return client_config
-
-    except subprocess.CalledProcessError as e:
-        stderr = e.stderr.strip() if e.stderr else "(no stderr)"
-        log_error(
-            f"Failed to get Google OAuth document from 1Password: {e}\n"
-            f"  op stderr: {stderr}\n"
-            f"  command: {' '.join(e.cmd)}"
-        )
-        return None
-    except json.JSONDecodeError as e:
-        log_error(f"Invalid JSON in 1Password document '{item_title}': {e}")
-        return None
-    except (OSError, UnicodeDecodeError) as e:
-        log_error(f"Error retrieving Google OAuth document: {e}")
-        return None
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=60)
+    client_config = json.loads(result.stdout)
+    log_info(f"Retrieved Google OAuth document from 1Password: {item_title}")
+    return client_config
 
 
-def create_temporary_service_account_file(service_account_data: Dict[str, str]) -> Optional[str]:
+def create_temporary_service_account_file(service_account_data: Dict[str, str]) -> str:
     """
     Create a temporary service account file for Google APIs.
     Useful for APIs that require a file path.
-    
+
     Args:
         service_account_data: Service account credentials dictionary
-        
+
     Returns:
-        Path to temporary file or None if failed
+        Path to temporary file.
+
+    Raises:
+        OSError: If the temporary file cannot be created.
+        TypeError: If service_account_data is not JSON-serializable.
     """
-    try:
-        # `tempfile` and `json` are imported at module scope so tests can
-        # monkeypatch `tempfile.NamedTemporaryFile` via the module
-        # attribute.
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
-            json.dump(service_account_data, f, indent=2)
-            temp_file_path = f.name
-        
-        log_info(f"Created temporary service account file: {temp_file_path}")
-        return temp_file_path
-        
-    except (OSError, TypeError) as e:
-        log_error(f"Failed to create temporary service account file: {e}")
-        return None
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+        json.dump(service_account_data, f, indent=2)
+        temp_file_path = f.name
+
+    log_info(f"Created temporary service account file: {temp_file_path}")
+    return temp_file_path

--- a/siege_utilities/config/databases.py
+++ b/siege_utilities/config/databases.py
@@ -6,7 +6,7 @@ Handles database connection settings for Spark and other uses.
 import json
 import pathlib
 import logging
-from typing import Dict, Any, Optional
+from typing import Dict, Any
 
 logger = logging.getLogger(__name__)
 
@@ -132,7 +132,7 @@ def save_database_config(config: Dict[str, Any], config_directory: str = "config
     return str(config_file)
 
 
-def load_database_config(db_name: str, config_directory: str = "config") -> Optional[Dict[str, Any]]:
+def load_database_config(db_name: str, config_directory: str = "config") -> Dict[str, Any]:
     """
     Load database configuration from JSON file.
 
@@ -141,33 +141,31 @@ def load_database_config(db_name: str, config_directory: str = "config") -> Opti
         config_directory: Directory containing config files
 
     Returns:
-        Database configuration dictionary or None if not found
+        Database configuration dictionary.
+
+    Raises:
+        FileNotFoundError: If the database config file does not exist.
+        json.JSONDecodeError: If the file contains invalid JSON.
+        OSError: If the file cannot be read.
 
     Example:
         >>> db_config = siege_utilities.load_database_config("analytics_db")
-        >>> if db_config:
-        ...     print(f"Database: {db_config['database']}")
+        >>> print(f"Database: {db_config['database']}")
     """
 
     config_file = pathlib.Path(config_directory) / f"database_{db_name}.json"
 
     if not config_file.exists():
-        log_warning(f"Database config not found: {config_file}")
-        return None
+        raise FileNotFoundError(f"Database config not found: {config_file}")
 
-    try:
-        with open(config_file, 'r', encoding='utf-8') as f:
-            config = json.load(f)
+    with open(config_file, 'r', encoding='utf-8') as f:
+        config = json.load(f)
 
-        log_info(f"Loaded database config: {db_name}")
-        return config
-
-    except (OSError, json.JSONDecodeError) as e:
-        log_error(f"Error loading database config {config_file}: {e}")
-        return None
+    log_info(f"Loaded database config: {db_name}")
+    return config
 
 
-def get_spark_database_options(db_name: str, config_directory: str = "config") -> Optional[Dict[str, str]]:
+def get_spark_database_options(db_name: str, config_directory: str = "config") -> Dict[str, str]:
     """
     Get Spark-compatible options for database connection.
 
@@ -176,24 +174,25 @@ def get_spark_database_options(db_name: str, config_directory: str = "config") -
         config_directory: Directory containing config files
 
     Returns:
-        Dictionary of Spark options or None if config not found
+        Dictionary of Spark options.
+
+    Raises:
+        FileNotFoundError: If the database config does not exist.
+        KeyError: If the config is missing required keys.
 
     Example:
         >>> spark_options = siege_utilities.get_spark_database_options("analytics_db")
-        >>> if spark_options:
-        ...     df = spark.read.format("jdbc").options(**spark_options).option("dbtable", "users").load()
+        >>> df = spark.read.format("jdbc").options(**spark_options).option("dbtable", "users").load()
     """
 
     config = load_database_config(db_name, config_directory)
 
-    if config is None:
-        return None
-
     required_keys = ('jdbc_url', 'jdbc_driver', 'username', 'password')
     missing = [k for k in required_keys if k not in config]
     if missing:
-        log_error(f"Database config {db_name!r} missing required keys: {missing}")
-        return None
+        raise KeyError(
+            f"Database config {db_name!r} missing required keys: {missing}"
+        )
 
     spark_options = {
         'url': config['jdbc_url'],
@@ -202,7 +201,6 @@ def get_spark_database_options(db_name: str, config_directory: str = "config") -
         'password': config['password']
     }
 
-    # Add Spark-specific options
     spark_options.update(config.get('spark_options', {}))
 
     log_info(f"Retrieved Spark options for database: {db_name}")
@@ -227,13 +225,10 @@ def test_database_connection(db_name: str, config_directory: str = "config") -> 
 
     config = load_database_config(db_name, config_directory)
 
-    if config is None:
-        return False
-
     try:
         # Try basic connection test with SQLAlchemy if available
         try:
-            from sqlalchemy import create_engine
+            from sqlalchemy import create_engine, text
 
             connection_type = config['connection_type'].lower()
             host = config['host']
@@ -242,10 +237,12 @@ def test_database_connection(db_name: str, config_directory: str = "config") -> 
             username = config['username']
             password = config['password']
 
+            from urllib.parse import quote_plus
+
             if connection_type == 'postgres':
-                conn_string = f"postgresql://{username}:{password}@{host}:{port}/{database}"
+                conn_string = f"postgresql://{quote_plus(username)}:{quote_plus(password)}@{host}:{port}/{database}"
             elif connection_type == 'mysql':
-                conn_string = f"mysql+pymysql://{username}:{password}@{host}:{port}/{database}"
+                conn_string = f"mysql+pymysql://{quote_plus(username)}:{quote_plus(password)}@{host}:{port}/{database}"
             else:
                 log_warning(f"Connection test not implemented for {connection_type}")
                 return False
@@ -253,7 +250,7 @@ def test_database_connection(db_name: str, config_directory: str = "config") -> 
             engine = create_engine(conn_string)
             with engine.connect() as conn:
                 # Simple test query
-                result = conn.execute("SELECT 1")
+                result = conn.execute(text("SELECT 1"))
                 result.fetchone()
 
             log_info(f"Database connection test successful: {db_name}")
@@ -342,42 +339,41 @@ def create_spark_session_with_databases(app_name: str = "SiegeAnalytics",
 
     try:
         from pyspark.sql import SparkSession
-    except ImportError:
-        log_warning("PySpark not available. Install with: pip install pyspark")
-        return None
+    except ImportError as e:
+        raise ImportError(
+            "PySpark is required for create_spark_session_with_databases. "
+            "Install with: pip install pyspark"
+        ) from e
 
-    # Build Spark session
     builder = SparkSession.builder.appName(app_name)
 
-    # Add database drivers based on configured databases
     packages = []
     supported_connection_types = ('postgres', 'mysql', 'oracle')
 
     if database_names:
         for db_name in database_names:
             config = load_database_config(db_name, config_directory)
-            if config:
-                if 'connection_type' not in config:
-                    raise ValueError(
-                        f"Database config {db_name!r} missing 'connection_type' key"
-                    )
-                connection_type = config['connection_type'].lower()
+            if 'connection_type' not in config:
+                raise ValueError(
+                    f"Database config {db_name!r} missing 'connection_type' key"
+                )
+            connection_type = config['connection_type'].lower()
 
-                if connection_type == 'postgres':
-                    packages.append("org.postgresql:postgresql:42.3.1")
-                elif connection_type == 'mysql':
-                    packages.append("mysql:mysql-connector-java:8.0.28")
-                elif connection_type == 'oracle':
-                    packages.append("com.oracle.database.jdbc:ojdbc8:21.1.0.0")
-                else:
-                    raise ValueError(
-                        f"Unsupported connection_type {connection_type!r} for "
-                        f"database {db_name!r}. Supported types: "
-                        f"{', '.join(supported_connection_types)}. "
-                        f"Previously this case silently loaded the PostgreSQL "
-                        f"JDBC driver, which produced misleading connection "
-                        f"errors at runtime."
-                    )
+            if connection_type == 'postgres':
+                packages.append("org.postgresql:postgresql:42.3.1")
+            elif connection_type == 'mysql':
+                packages.append("mysql:mysql-connector-java:8.0.28")
+            elif connection_type == 'oracle':
+                packages.append("com.oracle.database.jdbc:ojdbc8:21.1.0.0")
+            else:
+                raise ValueError(
+                    f"Unsupported connection_type {connection_type!r} for "
+                    f"database {db_name!r}. Supported types: "
+                    f"{', '.join(supported_connection_types)}. "
+                    f"Previously this case silently loaded the PostgreSQL "
+                    f"JDBC driver, which produced misleading connection "
+                    f"errors at runtime."
+                )
 
     # Add common packages if none specified
     if not packages:

--- a/siege_utilities/config/directories.py
+++ b/siege_utilities/config/directories.py
@@ -61,7 +61,7 @@ def create_directory_structure(base_path: str, structure: Dict[str, Any]) -> Dic
             base_path_obj = validate_directory_path(base_path, must_exist=False)
         except ImportError:
             base_path_obj = pathlib.Path(base_path)
-    except Exception as e:
+    except (OSError, ValueError, FileNotFoundError) as e:
         log_error(f"Failed to validate base path: {e}")
         raise
 

--- a/siege_utilities/config/enhanced_config.py
+++ b/siege_utilities/config/enhanced_config.py
@@ -391,7 +391,7 @@ def backup_and_migrate(legacy_config_dir: Optional[Path] = None, backup_dir: Opt
 
 
 # Legacy compatibility functions for user_config.py
-def load_user_profile(username: str, config_dir: Optional[Path] = None) -> Optional[UserProfile]:
+def load_user_profile(username: str, config_dir: Optional[Path] = None) -> UserProfile:
     """
     Load user profile from YAML file (legacy compatibility).
 
@@ -403,35 +403,32 @@ def load_user_profile(username: str, config_dir: Optional[Path] = None) -> Optio
         config_dir: Configuration directory
 
     Returns:
-        UserProfile object or None if not found
+        UserProfile object.
+
+    Raises:
+        FileNotFoundError: If the profile YAML does not exist.
+        ValueError: If the YAML is not a mapping.
+        OSError: If the file cannot be read.
     """
     warnings.warn(
         "load_user_profile() is deprecated and will be removed in v4.0.0. Use HydraConfigManager.load_user() for the modern User model.",
         DeprecationWarning,
         stacklevel=2,
     )
-    try:
-        config_dir = config_dir or Path.home() / ".siege_utilities" / "profiles" / "users"
-        config_file = config_dir / f"{username}.yaml"
-        
-        if not config_file.exists():
-            logger.warning(f"User profile not found: {config_file}")
-            return None
-            
-        with open(config_file, 'r', encoding='utf-8') as f:
-            data = yaml.safe_load(f)
+    config_dir = config_dir or Path.home() / ".siege_utilities" / "profiles" / "users"
+    config_file = config_dir / f"{username}.yaml"
 
-        if not isinstance(data, dict):
-            logger.error(
-                "User profile %s is not a YAML mapping (got %s); cannot load.",
-                config_file, type(data).__name__,
-            )
-            return None
-        return UserProfile(**data)
+    if not config_file.exists():
+        raise FileNotFoundError(f"User profile not found: {config_file}")
 
-    except (OSError, yaml.YAMLError, ValueError):
-        logger.exception("Failed to load user profile %s", username)
-        return None
+    with open(config_file, 'r', encoding='utf-8') as f:
+        data = yaml.safe_load(f)
+
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"User profile {config_file} is not a YAML mapping (got {type(data).__name__})"
+        )
+    return UserProfile(**data)
 
 
 def _convert_to_yaml_safe(obj: Any) -> Any:
@@ -450,7 +447,7 @@ def _convert_to_yaml_safe(obj: Any) -> Any:
         return obj
 
 
-def save_user_profile(profile: UserProfile, username: str, config_dir: Optional[Path] = None) -> bool:
+def save_user_profile(profile: UserProfile, username: str, config_dir: Optional[Path] = None) -> None:
     """
     Save user profile to YAML file (legacy compatibility).
 
@@ -462,55 +459,51 @@ def save_user_profile(profile: UserProfile, username: str, config_dir: Optional[
         username: Username to save as
         config_dir: Configuration directory
 
-    Returns:
-        True if successful, False otherwise
+    Raises:
+        OSError: If the file cannot be written.
+        yaml.YAMLError: If serialization fails.
     """
     warnings.warn(
         "save_user_profile() is deprecated and will be removed in v4.0.0. Use HydraConfigManager.save_user() for the modern User model.",
         DeprecationWarning,
         stacklevel=2,
     )
-    try:
-        config_dir = config_dir or Path.home() / ".siege_utilities" / "profiles" / "users"
-        config_dir.mkdir(parents=True, exist_ok=True)
-        config_file = config_dir / f"{username}.yaml"
+    config_dir = config_dir or Path.home() / ".siege_utilities" / "profiles" / "users"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_file = config_dir / f"{username}.yaml"
 
-        # Convert to dict and make YAML-safe
-        profile_data = profile.model_dump()
-        profile_data = _convert_to_yaml_safe(profile_data)
+    profile_data = profile.model_dump()
+    profile_data = _convert_to_yaml_safe(profile_data)
 
-        with open(config_file, 'w', encoding='utf-8') as f:
-            yaml.dump(profile_data, f, default_flow_style=False)
+    with open(config_file, 'w', encoding='utf-8') as f:
+        yaml.dump(profile_data, f, default_flow_style=False)
 
-        logger.info(f"Saved user profile: {config_file}")
-        return True
-
-    except (OSError, yaml.YAMLError) as e:
-        logger.error(f"Failed to save user profile {username}: {e}")
-        return False
+    logger.info(f"Saved user profile: {config_file}")
 
 
 def get_download_directory(username: str, config_dir: Optional[Path] = None) -> Path:
     """
     Get download directory for user (legacy compatibility).
-    
+
     Args:
         username: Username
         config_dir: Configuration directory
-        
+
     Returns:
         Path to download directory
+
+    Raises:
+        FileNotFoundError: If the user profile does not exist.
     """
     profile = load_user_profile(username, config_dir)
-    if profile and profile.preferred_download_directory:
+    if profile.preferred_download_directory:
         return Path(profile.preferred_download_directory)
-    
-    # Default fallback
+
     return Path.home() / "Downloads" / "siege_utilities"
 
 
 # Additional legacy compatibility functions
-def load_client_profile(client_code: str, config_dir: Optional[Path] = None) -> Optional[ClientProfile]:
+def load_client_profile(client_code: str, config_dir: Optional[Path] = None) -> ClientProfile:
     """
     Load client profile from YAML file (legacy compatibility).
 
@@ -522,38 +515,35 @@ def load_client_profile(client_code: str, config_dir: Optional[Path] = None) -> 
         config_dir: Configuration directory
 
     Returns:
-        ClientProfile object or None if not found
+        ClientProfile object.
+
+    Raises:
+        FileNotFoundError: If the profile YAML does not exist.
+        ValueError: If the YAML is not a mapping.
+        OSError: If the file cannot be read.
     """
     warnings.warn(
         "load_client_profile() is deprecated and will be removed in v4.0.0. Use HydraConfigManager.load_client() for the modern Client model.",
         DeprecationWarning,
         stacklevel=2,
     )
-    try:
-        config_dir = config_dir or Path.home() / ".siege_utilities" / "profiles" / "clients"
-        config_file = config_dir / f"{client_code}.yaml"
-        
-        if not config_file.exists():
-            logger.warning(f"Client profile not found: {config_file}")
-            return None
-            
-        with open(config_file, 'r', encoding='utf-8') as f:
-            data = yaml.safe_load(f)
+    config_dir = config_dir or Path.home() / ".siege_utilities" / "profiles" / "clients"
+    config_file = config_dir / f"{client_code}.yaml"
 
-        if not isinstance(data, dict):
-            logger.error(
-                "Client profile %s is not a YAML mapping (got %s); cannot load.",
-                config_file, type(data).__name__,
-            )
-            return None
-        return ClientProfile(**data)
+    if not config_file.exists():
+        raise FileNotFoundError(f"Client profile not found: {config_file}")
 
-    except (OSError, yaml.YAMLError, ValueError):
-        logger.exception("Failed to load client profile %s", client_code)
-        return None
+    with open(config_file, 'r', encoding='utf-8') as f:
+        data = yaml.safe_load(f)
+
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"Client profile {config_file} is not a YAML mapping (got {type(data).__name__})"
+        )
+    return ClientProfile(**data)
 
 
-def save_client_profile(profile: ClientProfile, config_dir: Optional[Path] = None) -> bool:
+def save_client_profile(profile: ClientProfile, config_dir: Optional[Path] = None) -> None:
     """
     Save client profile to YAML file (legacy compatibility).
 
@@ -564,32 +554,26 @@ def save_client_profile(profile: ClientProfile, config_dir: Optional[Path] = Non
         profile: ClientProfile object to save
         config_dir: Configuration directory
 
-    Returns:
-        True if successful, False otherwise
+    Raises:
+        OSError: If the file cannot be written.
+        yaml.YAMLError: If serialization fails.
     """
     warnings.warn(
         "save_client_profile() is deprecated and will be removed in v4.0.0. Use HydraConfigManager.save_client() for the modern Client model.",
         DeprecationWarning,
         stacklevel=2,
     )
-    try:
-        config_dir = config_dir or Path.home() / ".siege_utilities" / "profiles" / "clients"
-        config_dir.mkdir(parents=True, exist_ok=True)
-        config_file = config_dir / f"{profile.client_code}.yaml"
+    config_dir = config_dir or Path.home() / ".siege_utilities" / "profiles" / "clients"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_file = config_dir / f"{profile.client_code}.yaml"
 
-        # Convert to dict and make YAML-safe
-        profile_data = profile.model_dump()
-        profile_data = _convert_to_yaml_safe(profile_data)
+    profile_data = profile.model_dump()
+    profile_data = _convert_to_yaml_safe(profile_data)
 
-        with open(config_file, 'w', encoding='utf-8') as f:
-            yaml.dump(profile_data, f, default_flow_style=False)
+    with open(config_file, 'w', encoding='utf-8') as f:
+        yaml.dump(profile_data, f, default_flow_style=False)
 
-        logger.info(f"Saved client profile: {config_file}")
-        return True
-
-    except (OSError, yaml.YAMLError) as e:
-        logger.error(f"Failed to save client profile {profile.client_code}: {e}")
-        return False
+    logger.info(f"Saved client profile: {config_file}")
 
 
 class SiegeConfig:
@@ -601,21 +585,21 @@ class SiegeConfig:
         self.config_dir = config_dir or Path.home() / ".siege_utilities" / "config"
         self.config_dir.mkdir(parents=True, exist_ok=True)
     
-    def get_user_profile(self, username: str) -> Optional[UserProfile]:
+    def get_user_profile(self, username: str) -> UserProfile:
         """Get user profile."""
         return load_user_profile(username, self.config_dir / "profiles" / "users")
-    
-    def get_client_profile(self, client_code: str) -> Optional[ClientProfile]:
+
+    def get_client_profile(self, client_code: str) -> ClientProfile:
         """Get client profile."""
         return load_client_profile(client_code, self.config_dir / "profiles" / "clients")
-    
-    def save_user_profile(self, profile: UserProfile, username: str) -> bool:
+
+    def save_user_profile(self, profile: UserProfile, username: str) -> None:
         """Save user profile."""
-        return save_user_profile(profile, username, self.config_dir / "profiles" / "users")
-    
-    def save_client_profile(self, profile: ClientProfile) -> bool:
+        save_user_profile(profile, username, self.config_dir / "profiles" / "users")
+
+    def save_client_profile(self, profile: ClientProfile) -> None:
         """Save client profile."""
-        return save_client_profile(profile, self.config_dir / "profiles" / "clients")
+        save_client_profile(profile, self.config_dir / "profiles" / "clients")
 
 
 # Additional utility functions
@@ -646,52 +630,46 @@ def list_client_profiles(config_dir: Optional[Path] = None) -> List[str]:
         raise
 
 
-def export_config_yaml(config_data: Dict[str, Any], output_file: Path) -> bool:
+def export_config_yaml(config_data: Dict[str, Any], output_file: Path) -> None:
     """
     Export configuration data to YAML file (legacy compatibility).
-    
+
     Args:
         config_data: Configuration data to export
         output_file: Output file path
-        
-    Returns:
-        True if successful, False otherwise
+
+    Raises:
+        OSError: If the file cannot be written.
+        yaml.YAMLError: If serialization fails.
     """
-    try:
-        output_file.parent.mkdir(parents=True, exist_ok=True)
-        
-        with open(output_file, 'w', encoding='utf-8') as f:
-            yaml.dump(config_data, f, default_flow_style=False)
-            
-        logger.info(f"Exported configuration to: {output_file}")
-        return True
-        
-    except (OSError, yaml.YAMLError) as e:
-        logger.error(f"Failed to export configuration: {e}")
-        return False
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(output_file, 'w', encoding='utf-8') as f:
+        yaml.dump(config_data, f, default_flow_style=False)
+
+    logger.info(f"Exported configuration to: {output_file}")
 
 
-def import_config_yaml(input_file: Path) -> Optional[Dict[str, Any]]:
+def import_config_yaml(input_file: Path) -> Dict[str, Any]:
     """
     Import configuration data from YAML file (legacy compatibility).
-    
+
     Args:
         input_file: Input file path
-        
+
     Returns:
-        Configuration data or None if failed
+        Configuration data.
+
+    Raises:
+        FileNotFoundError: If the input file does not exist.
+        OSError: If the file cannot be read.
+        yaml.YAMLError: If the YAML is malformed.
     """
-    try:
-        if not input_file.exists():
-            logger.warning(f"Configuration file not found: {input_file}")
-            return None
-            
-        with open(input_file, 'r', encoding='utf-8') as f:
-            config_data = yaml.safe_load(f)
-            
-        logger.info(f"Imported configuration from: {input_file}")
-        return config_data
-        
-    except (OSError, yaml.YAMLError) as e:
-        logger.error(f"Failed to import configuration: {e}")
-        return None
+    if not input_file.exists():
+        raise FileNotFoundError(f"Configuration file not found: {input_file}")
+
+    with open(input_file, 'r', encoding='utf-8') as f:
+        config_data = yaml.safe_load(f)
+
+    logger.info(f"Imported configuration from: {input_file}")
+    return config_data

--- a/siege_utilities/config/hydra_manager.py
+++ b/siege_utilities/config/hydra_manager.py
@@ -334,7 +334,7 @@ class HydraConfigManager:
         return branding
     
     # Modern Person/Actor model methods
-    def load_user(self, person_id: str, profiles_dir: Optional[Path] = None) -> Optional[User]:
+    def load_user(self, person_id: str, profiles_dir: Optional[Path] = None) -> User:
         """
         Load a modern User from YAML file.
 
@@ -343,24 +343,25 @@ class HydraConfigManager:
             profiles_dir: Directory containing user YAML files. Defaults to config_dir/profiles/users.
 
         Returns:
-            User instance, or None if file not found.
+            User instance.
+
+        Raises:
+            FileNotFoundError: If the user profile YAML file does not exist.
+            OSError: If the file cannot be read.
+            yaml.YAMLError: If the YAML is malformed.
+            ValueError: If the data cannot be parsed into a User.
         """
         profiles_dir = profiles_dir or self.config_dir / "profiles" / "users"
         user_file = profiles_dir / f"{person_id}.yaml"
 
         if not user_file.exists():
-            logger.warning(f"User profile not found: {user_file}")
-            return None
+            raise FileNotFoundError(f"User profile not found: {user_file}")
 
-        try:
-            user = User.from_yaml(user_file)
-            logger.info(f"Loaded modern User: {person_id}")
-            return user
-        except (OSError, yaml.YAMLError, ValueError) as e:
-            logger.error(f"Failed to load User {person_id}: {e}")
-            return None
+        user = User.from_yaml(user_file)
+        logger.info(f"Loaded modern User: {person_id}")
+        return user
 
-    def load_client(self, client_code: str, profiles_dir: Optional[Path] = None) -> Optional[Client]:
+    def load_client(self, client_code: str, profiles_dir: Optional[Path] = None) -> Client:
         """
         Load a modern Client from YAML file.
 
@@ -369,24 +370,25 @@ class HydraConfigManager:
             profiles_dir: Directory containing client YAML files. Defaults to config_dir/profiles/clients.
 
         Returns:
-            Client instance, or None if file not found.
+            Client instance.
+
+        Raises:
+            FileNotFoundError: If the client profile YAML file does not exist.
+            OSError: If the file cannot be read.
+            yaml.YAMLError: If the YAML is malformed.
+            ValueError: If the data cannot be parsed into a Client.
         """
         profiles_dir = profiles_dir or self.config_dir / "profiles" / "clients"
         client_file = profiles_dir / f"{client_code}.yaml"
 
         if not client_file.exists():
-            logger.warning(f"Client profile not found: {client_file}")
-            return None
+            raise FileNotFoundError(f"Client profile not found: {client_file}")
 
-        try:
-            client = Client.from_yaml(client_file)
-            logger.info(f"Loaded modern Client: {client_code}")
-            return client
-        except (OSError, yaml.YAMLError, ValueError) as e:
-            logger.error(f"Failed to load Client {client_code}: {e}")
-            return None
+        client = Client.from_yaml(client_file)
+        logger.info(f"Loaded modern Client: {client_code}")
+        return client
 
-    def save_user(self, user: User, profiles_dir: Optional[Path] = None) -> bool:
+    def save_user(self, user: User, profiles_dir: Optional[Path] = None) -> None:
         """
         Save a modern User to YAML file.
 
@@ -394,22 +396,18 @@ class HydraConfigManager:
             user: User instance to save.
             profiles_dir: Directory to save the YAML file. Defaults to config_dir/profiles/users.
 
-        Returns:
-            True if successful, False otherwise.
+        Raises:
+            OSError: If the file cannot be written.
+            yaml.YAMLError: If serialization fails.
         """
         profiles_dir = profiles_dir or self.config_dir / "profiles" / "users"
         profiles_dir.mkdir(parents=True, exist_ok=True)
         user_file = profiles_dir / f"{user.person_id}.yaml"
 
-        try:
-            user.to_yaml(path=user_file)
-            logger.info(f"Saved modern User: {user.person_id}")
-            return True
-        except (OSError, yaml.YAMLError) as e:
-            logger.error(f"Failed to save User {user.person_id}: {e}")
-            return False
+        user.to_yaml(path=user_file)
+        logger.info(f"Saved modern User: {user.person_id}")
 
-    def save_client(self, client: Client, profiles_dir: Optional[Path] = None) -> bool:
+    def save_client(self, client: Client, profiles_dir: Optional[Path] = None) -> None:
         """
         Save a modern Client to YAML file.
 
@@ -417,20 +415,16 @@ class HydraConfigManager:
             client: Client instance to save.
             profiles_dir: Directory to save the YAML file. Defaults to config_dir/profiles/clients.
 
-        Returns:
-            True if successful, False otherwise.
+        Raises:
+            OSError: If the file cannot be written.
+            yaml.YAMLError: If serialization fails.
         """
         profiles_dir = profiles_dir or self.config_dir / "profiles" / "clients"
         profiles_dir.mkdir(parents=True, exist_ok=True)
         client_file = profiles_dir / f"{client.client_code}.yaml"
 
-        try:
-            client.to_yaml(path=client_file)
-            logger.info(f"Saved modern Client: {client.client_code}")
-            return True
-        except (OSError, yaml.YAMLError) as e:
-            logger.error(f"Failed to save Client {client.client_code}: {e}")
-            return False
+        client.to_yaml(path=client_file)
+        logger.info(f"Saved modern Client: {client.client_code}")
 
     def cleanup(self):
         """Clean up Hydra instance."""

--- a/siege_utilities/config/projects.py
+++ b/siege_utilities/config/projects.py
@@ -150,7 +150,7 @@ def save_project_config(config: Dict[str, Any], config_directory: str = "config"
     return str(config_file)
 
 
-def load_project_config(project_code: str, config_directory: str = "config") -> Optional[Dict[str, Any]]:
+def load_project_config(project_code: str, config_directory: str = "config") -> Dict[str, Any]:
     """
     Load project configuration from JSON file.
 
@@ -161,53 +161,37 @@ def load_project_config(project_code: str, config_directory: str = "config") -> 
         config_directory: Directory containing config files
 
     Returns:
-        Project configuration dictionary or None if not found
+        Project configuration dictionary.
 
     Raises:
-        PathSecurityError: If config_directory fails security validation
+        FileNotFoundError: If the project config file does not exist.
+        json.JSONDecodeError: If the file contains invalid JSON.
+        OSError: If the file cannot be read.
+        PathSecurityError: If config_directory fails security validation.
 
     Example:
         >>> config = siege_utilities.load_project_config("MP001")
-        >>> if config:
-        ...     print(f"Loaded: {config['project_name']}")
-        >>>
-        >>> # This will raise PathSecurityError
-        >>> load_project_config("MP001", "../../../etc")  # Path traversal blocked
-
-    Security Changes:
-        - Now validates config_directory to block path traversal
-        - Blocks loading config files from sensitive system locations
+        >>> print(f"Loaded: {config['project_name']}")
     """
     try:
-        # Validate config directory path
-        try:
-            from siege_utilities.files.validation import validate_directory_path, PathSecurityError  # noqa: F401, F811
-            config_dir = validate_directory_path(config_directory, must_exist=False)
-        except ImportError:
-            config_dir = pathlib.Path(config_directory)
+        from siege_utilities.files.validation import validate_directory_path, PathSecurityError  # noqa: F401, F811
+        config_dir = validate_directory_path(config_directory, must_exist=False)
+    except ImportError:
+        config_dir = pathlib.Path(config_directory)
 
-        config_file = config_dir / f"project_{project_code}.json"
-    except (OSError, ValueError) as e:
-        log_error(f"Failed to access config directory: {e}")
-        raise
+    config_file = config_dir / f"project_{project_code}.json"
 
     if not config_file.exists():
-        log_warning(f"Project config not found: {config_file}")
-        return None
+        raise FileNotFoundError(f"Project config not found: {config_file}")
 
-    try:
-        with open(config_file, 'r', encoding='utf-8') as f:
-            config = json.load(f)
+    with open(config_file, 'r', encoding='utf-8') as f:
+        config = json.load(f)
 
-        log_info(f"Loaded project config: {project_code}")
-        return config
-
-    except (OSError, json.JSONDecodeError) as e:
-        log_error(f"Error loading project config {config_file}: {e}")
-        return None
+    log_info(f"Loaded project config: {project_code}")
+    return config
 
 
-def setup_project_directories(config: Dict[str, Any]) -> bool:
+def setup_project_directories(config: Dict[str, Any]) -> None:
     """
     Create the directory structure for a project.
 
@@ -216,53 +200,36 @@ def setup_project_directories(config: Dict[str, Any]) -> bool:
     Args:
         config: Project configuration dictionary
 
-    Returns:
-        True if successful, False otherwise
-
     Raises:
-        PathSecurityError: If any directory path fails security validation
+        OSError: If directories cannot be created.
+        PathSecurityError: If any directory path fails security validation.
 
     Example:
         >>> config = create_project_config("My Project", "MP001")
-        >>> success = siege_utilities.setup_project_directories(config)
-        >>> if success:
-        ...     print("Project directories created")
-
-    Security Changes:
-        - Now validates all directory paths to block path traversal
-        - Blocks creating directories in sensitive system locations
+        >>> siege_utilities.setup_project_directories(config)
     """
     try:
-        # Import validation function
-        try:
-            from siege_utilities.files.validation import validate_directory_path, PathSecurityError  # noqa: F401, F811
-            use_validation = True
-        except ImportError:
-            use_validation = False
+        from siege_utilities.files.validation import validate_directory_path, PathSecurityError  # noqa: F401, F811
+        use_validation = True
+    except ImportError:
+        use_validation = False
 
-        directories = config.get('directories', {})
+    directories = config.get('directories', {})
 
-        for dir_name, dir_path in directories.items():
-            # Validate each directory path
-            if use_validation:
-                path = validate_directory_path(dir_path, must_exist=False)
-            else:
-                path = pathlib.Path(dir_path)
+    for dir_name, dir_path in directories.items():
+        if use_validation:
+            path = validate_directory_path(dir_path, must_exist=False)
+        else:
+            path = pathlib.Path(dir_path)
 
-            path.mkdir(parents=True, exist_ok=True)
+        path.mkdir(parents=True, exist_ok=True)
 
-            # Create .gitkeep file to ensure directory is tracked
-            gitkeep = path / ".gitkeep"
-            gitkeep.touch(exist_ok=True)
+        gitkeep = path / ".gitkeep"
+        gitkeep.touch(exist_ok=True)
 
-            log_debug(f"Created directory: {dir_path}")
+        log_debug(f"Created directory: {dir_path}")
 
-        log_info(f"Project directories setup complete for {config['project_code']}")
-        return True
-
-    except OSError as e:
-        log_error(f"Error setting up project directories: {e}")
-        return False
+    log_info(f"Project directories setup complete for {config['project_code']}")
 
 
 def get_project_path(config: Dict[str, Any], path_type: str) -> Optional[str]:
@@ -357,7 +324,7 @@ def list_projects(config_directory: str = "config") -> list:
 
 
 def update_project_config(project_code: str, updates: Dict[str, Any],
-                          config_directory: str = "config") -> bool:
+                          config_directory: str = "config") -> None:
     """
     Update an existing project configuration.
 
@@ -366,11 +333,12 @@ def update_project_config(project_code: str, updates: Dict[str, Any],
         updates: Dictionary of updates to apply
         config_directory: Directory containing config files
 
-    Returns:
-        True if successful, False otherwise
+    Raises:
+        FileNotFoundError: If the project config does not exist.
+        OSError: If the config cannot be read or written.
 
     Example:
-        >>> success = siege_utilities.update_project_config(
+        >>> siege_utilities.update_project_config(
         ...     "MP001",
         ...     {"description": "Updated description", "settings": {"log_level": "DEBUG"}}
         ... )
@@ -378,25 +346,11 @@ def update_project_config(project_code: str, updates: Dict[str, Any],
 
     config = load_project_config(project_code, config_directory)
 
-    if config is None:
-        log_error(f"Cannot update - project config not found: {project_code}")
-        return False
+    for key, value in updates.items():
+        if key in config and isinstance(config[key], dict) and isinstance(value, dict):
+            config[key].update(value)
+        else:
+            config[key] = value
 
-    try:
-        # Apply updates
-        for key, value in updates.items():
-            if key in config and isinstance(config[key], dict) and isinstance(value, dict):
-                # Merge dictionaries
-                config[key].update(value)
-            else:
-                # Direct assignment
-                config[key] = value
-
-        # Save updated config
-        save_project_config(config, config_directory)
-        log_info(f"Updated project config: {project_code}")
-        return True
-
-    except (OSError, json.JSONDecodeError, KeyError, TypeError) as e:
-        log_error(f"Error updating project config {project_code}: {e}")
-        return False
+    save_project_config(config, config_directory)
+    log_info(f"Updated project config: {project_code}")

--- a/siege_utilities/data/statistics/cross_tabulation.py
+++ b/siege_utilities/data/statistics/cross_tabulation.py
@@ -149,6 +149,14 @@ def rate_table(
     Returns
     -------
     DataFrame of proportions summing to 1.0 along the requested axis.
+
+    Raises
+    ------
+    ZeroDivisionError
+        When the grand total, any row sum, or any column sum is zero
+        (normalization is mathematically undefined).
+    ValueError
+        When *normalize* is not one of the accepted values.
     """
     # Strip margins if present before normalizing
     has_total_row = "Total" in ct.index
@@ -162,13 +170,27 @@ def rate_table(
 
     if normalize == "all":
         total = inner.values.sum()
-        result = inner / total if total != 0 else inner * 0
+        if total == 0:
+            raise ZeroDivisionError(
+                "Cannot normalize: grand total is zero"
+            )
+        result = inner / total
     elif normalize == "index":
         row_sums = inner.sum(axis=1)
-        result = inner.div(row_sums, axis=0).fillna(0)
+        zero_rows = row_sums[row_sums == 0].index.tolist()
+        if zero_rows:
+            raise ZeroDivisionError(
+                f"Cannot normalize by index: rows sum to zero: {zero_rows}"
+            )
+        result = inner.div(row_sums, axis=0)
     elif normalize == "columns":
         col_sums = inner.sum(axis=0)
-        result = inner.div(col_sums, axis=1).fillna(0)
+        zero_cols = col_sums[col_sums == 0].index.tolist()
+        if zero_cols:
+            raise ZeroDivisionError(
+                f"Cannot normalize by columns: columns sum to zero: {zero_cols}"
+            )
+        result = inner.div(col_sums, axis=1)
     else:
         raise ValueError(f"normalize must be 'all', 'index', or 'columns', got '{normalize}'")
 

--- a/siege_utilities/data/statistics/moe_propagation.py
+++ b/siege_utilities/data/statistics/moe_propagation.py
@@ -131,9 +131,16 @@ def moe_proportion(
     -------
     Estimate
         Proportion with propagated MOE, bounded to [0, 1].
+
+    Raises
+    ------
+    ZeroDivisionError
+        If the denominator estimate is zero.
     """
     if denominator.value == 0:
-        return Estimate(value=0.0, moe=0.0)
+        raise ZeroDivisionError(
+            "Cannot compute proportion: denominator estimate is zero"
+        )
 
     p = numerator.value / denominator.value
 
@@ -171,9 +178,16 @@ def moe_ratio(
     Returns
     -------
     Estimate
+
+    Raises
+    ------
+    ZeroDivisionError
+        If the denominator estimate is zero.
     """
     if denominator.value == 0:
-        return Estimate(value=0.0, moe=0.0)
+        raise ZeroDivisionError(
+            "Cannot compute ratio: denominator estimate is zero"
+        )
 
     r = numerator.value / denominator.value
     se_num = numerator.se

--- a/siege_utilities/distributed/hdfs_operations.py
+++ b/siege_utilities/distributed/hdfs_operations.py
@@ -158,95 +158,91 @@ class AbstractHDFSOperations:
 
             self.config.log_info('✓ Spark session created successfully')
             return spark
-        except ImportError:
-            self.config.log_error(
-                'PySpark not available - install with: pip install pyspark')
-            return None
-        except (_Py4JError, RuntimeError, OSError, ValueError) as e:
-            self.config.log_error(f'Failed to create Spark session: {e}')
-            return None
+        except ImportError as e:
+            raise ImportError(
+                'PySpark not available - install with: pip install pyspark'
+            ) from e
 
     def sync_directory_to_hdfs(self, local_path: Optional[str]=None,
-        hdfs_subdir: str='inputs') ->Tuple[Optional[str], Optional[Dict]]:
-        """Sync local directory/file to HDFS with proper verification"""
-        try:
-            if local_path is None:
-                local_path = self.config.data_path
-            if local_path is None:
-                self.config.log_error('No data path provided')
-                return None, None
-            local_path = pathlib.Path(local_path)
-            if not local_path.exists():
-                self.config.log_error(f'Local path not found: {local_path}')
-                return None, None
-            if not self.check_hdfs_status():
-                self.config.log_error('HDFS not accessible')
-                return None, None
-            if local_path.is_file():
-                hdfs_directory = (self.config.hdfs_base_directory +
-                    f'{hdfs_subdir}/')
-                hdfs_full_path = hdfs_directory + local_path.name
-            else:
-                hdfs_directory = (self.config.hdfs_base_directory +
-                    f'{hdfs_subdir}/{local_path.name}/')
-                hdfs_full_path = hdfs_directory
-            self.config.log_info(f'Syncing: {local_path} -> {hdfs_full_path}')
-            subprocess.run(['hdfs', 'dfs', '-mkdir', '-p', hdfs_directory],
-                check=True, timeout=60)
-            subprocess.run(['hdfs', 'dfs', '-put', '-f', str(local_path),
-                hdfs_full_path], check=True, timeout=self.config.
-                hdfs_copy_timeout)
-            result = subprocess.run(['hdfs', 'dfs', '-test', '-e',
-                hdfs_full_path], capture_output=True, timeout=60)
-            if result.returncode == 0:
-                self.config.log_info(f'✅ Sync complete: {hdfs_full_path}')
-                return hdfs_full_path, {local_path.name: {'path': str(
-                    local_path)}}
-            else:
-                self.config.log_error('❌ Sync verification failed')
-                return None, None
-        except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired, ValueError) as e:
-            self.config.log_error(f'Error syncing to HDFS: {e}')
-            return None, None
+        hdfs_subdir: str='inputs') -> Tuple[str, Dict]:
+        """Sync local directory/file to HDFS with proper verification.
+
+        Raises:
+            ValueError: If no data path is provided.
+            FileNotFoundError: If the local path does not exist.
+            RuntimeError: If HDFS is not accessible or sync verification fails.
+            subprocess.CalledProcessError: If an HDFS command fails.
+            subprocess.TimeoutExpired: If an HDFS command times out.
+        """
+        if local_path is None:
+            local_path = self.config.data_path
+        if local_path is None:
+            raise ValueError('No data path provided')
+        local_path = pathlib.Path(local_path)
+        if not local_path.exists():
+            raise FileNotFoundError(f'Local path not found: {local_path}')
+        if not self.check_hdfs_status():
+            raise RuntimeError('HDFS not accessible')
+        if local_path.is_file():
+            hdfs_directory = (self.config.hdfs_base_directory +
+                f'{hdfs_subdir}/')
+            hdfs_full_path = hdfs_directory + local_path.name
+        else:
+            hdfs_directory = (self.config.hdfs_base_directory +
+                f'{hdfs_subdir}/{local_path.name}/')
+            hdfs_full_path = hdfs_directory
+        self.config.log_info(f'Syncing: {local_path} -> {hdfs_full_path}')
+        subprocess.run(['hdfs', 'dfs', '-mkdir', '-p', hdfs_directory],
+            check=True, timeout=60)
+        subprocess.run(['hdfs', 'dfs', '-put', '-f', str(local_path),
+            hdfs_full_path], check=True, timeout=self.config.
+            hdfs_copy_timeout)
+        result = subprocess.run(['hdfs', 'dfs', '-test', '-e',
+            hdfs_full_path], capture_output=True, timeout=60)
+        if result.returncode != 0:
+            raise RuntimeError('Sync verification failed: file not found on HDFS after put')
+        self.config.log_info(f'✅ Sync complete: {hdfs_full_path}')
+        return hdfs_full_path, {local_path.name: {'path': str(local_path)}}
 
     def setup_distributed_environment(self, data_path: Optional[str]=None,
         dependency_paths: Optional[List[str]]=None):
-        """Main setup function with proper verification"""
-        try:
-            self.config.log_info('🚀 Setting up distributed environment...')
-            if data_path is None:
-                data_path = self.config.data_path
-            if data_path is None:
-                self.config.log_error('No data path provided')
-                return None, None, None
-            local_path = pathlib.Path(data_path)
-            if not local_path.exists():
-                self.config.log_error(f'Data path not found: {data_path}')
-                return None, None, None
-            if self.check_hdfs_status():
-                self.config.log_info('📁 HDFS available - attempting sync...')
+        """Main setup function with proper verification.
+
+        Returns:
+            Tuple of (spark_session, data_url, None).
+
+        Raises:
+            ValueError: If no data path is provided.
+            FileNotFoundError: If the data path does not exist.
+            ImportError: If PySpark is not available.
+            RuntimeError: If HDFS sync or Spark session creation fails.
+        """
+        self.config.log_info('🚀 Setting up distributed environment...')
+        if data_path is None:
+            data_path = self.config.data_path
+        if data_path is None:
+            raise ValueError('No data path provided')
+        local_path = pathlib.Path(data_path)
+        if not local_path.exists():
+            raise FileNotFoundError(f'Data path not found: {data_path}')
+        if self.check_hdfs_status():
+            self.config.log_info('📁 HDFS available - attempting sync...')
+            try:
                 hdfs_path, files_info = self.sync_directory_to_hdfs(data_path)
-                if hdfs_path:
-                    spark = self.create_spark_session()
-                    if spark:
-                        self.config.log_info(
-                            '✅ Using HDFS for distributed processing')
-                        return spark, hdfs_path, None
-                    else:
-                        self.config.log_error('Spark session creation failed')
-            self.config.log_info('💻 Using local filesystem...')
-            file_url = f'file://{local_path.absolute()}'
-            spark = self.create_spark_session()
-            if spark:
+                spark = self.create_spark_session()
                 self.config.log_info(
-                    '✅ Distributed environment setup complete!')
-                return spark, file_url, None
-            else:
-                self.config.log_error('Failed to create Spark session')
-                return None, None, None
-        except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired, ImportError, ValueError) as e:
-            self.config.log_error(f'Error setting up environment: {e}')
-            return None, None, None
+                    '✅ Using HDFS for distributed processing')
+                return spark, hdfs_path, None
+            except (RuntimeError, subprocess.CalledProcessError,
+                    subprocess.TimeoutExpired) as e:
+                self.config.log_info(
+                    f'⚠️  HDFS sync failed, falling back to local: {e}')
+        self.config.log_info('💻 Using local filesystem...')
+        file_url = f'file://{local_path.absolute()}'
+        spark = self.create_spark_session()
+        self.config.log_info(
+            '✅ Distributed environment setup complete!')
+        return spark, file_url, None
 
 
 def setup_distributed_environment(config, data_path: Optional[str]=None,

--- a/siege_utilities/distributed/spark_utils.py
+++ b/siege_utilities/distributed/spark_utils.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Tuple, Dict, TYPE_CHECKING
+from typing import Any, Optional, Union, Tuple, Dict, TYPE_CHECKING
 import os
 import pathlib
 from pathlib import Path
@@ -50,7 +50,7 @@ RESULTS_OUTPUT_FORMAT = 'csv'
 RESULTS_OUTPUT_DELIMITER = ','
 DEBUG_SUBDIRECTORY = Path('debug_output')
 
-def sanitise_dataframe_column_names(df: "DataFrame") ->Optional["DataFrame"]:
+def sanitise_dataframe_column_names(df: "DataFrame") -> "DataFrame":
     """
     Cleans dataframe column names by converting them to lowercase and replacing
     slashes/spaces with underscores.
@@ -59,28 +59,16 @@ def sanitise_dataframe_column_names(df: "DataFrame") ->Optional["DataFrame"]:
         df (DataFrame): Input Spark DataFrame.
 
     Returns:
-        Optional["DataFrame"]: Sanitised DataFrame or None if an error occurred.
+        DataFrame: Sanitised DataFrame.
     """
-    try:
-        message = f'Sanitising column names for dataframe {df}'
-        log_info(message)
-        df = df.toDF(*[c.lower().strip().replace('/', '_').replace(' ', '_'
-            ) for c in df.columns])
-        message = (
-            f'Successfully sanitised columns for dataframe {df}: {list(df.columns)}'
-            )
-        log_info(message)
-        return df
-    except (_SparkAnalysisException, _Py4JError, AttributeError, TypeError) as e:
-        message = (
-            f'There was a problem sanitising column names for dataframe {df}:\n{e}'
-            )
-        log_error(message)
-        return None
+    log_info(f'Sanitising column names for dataframe {df}')
+    df = df.toDF(*[c.lower().strip().replace('/', '_').replace(' ', '_')
+        for c in df.columns])
+    log_info(f'Successfully sanitised columns for dataframe {df}: {list(df.columns)}')
+    return df
 
 
-def tabulate_null_vs_not_null(df: "DataFrame", column_name: str) ->Optional[
-    DataFrame]:
+def tabulate_null_vs_not_null(df: "DataFrame", column_name: str) -> "DataFrame":
     """
     Returns a dataframe showing the count of null and non-null values for a given column.
 
@@ -89,25 +77,19 @@ def tabulate_null_vs_not_null(df: "DataFrame", column_name: str) ->Optional[
         column_name (str): Name of the column to analyze.
 
     Returns:
-        Optional["DataFrame"]: Resulting DataFrame with null vs non-null counts.
+        DataFrame: Resulting DataFrame with null vs non-null counts.
     """
-    try:
-        NULL_COLUMNS_NAME = f'{column_name}_null_count'
-        NOT_NULL_COLUMNS_NAME = f'{column_name}_not_null_count'
-        result_df = df.groupBy(column_name).agg(sum(when(col(column_name).
-            isNull(), 1).otherwise(0)).alias(NULL_COLUMNS_NAME), sum(when(
-            col(column_name).isNotNull(), 1).otherwise(0)).alias(
-            NOT_NULL_COLUMNS_NAME))
-        result_df.show(truncate=False)
-        return result_df
-    except (_SparkAnalysisException, _Py4JError, AttributeError, TypeError, ValueError) as e:
-        log_error(
-            f'Error in tabulate_null_vs_not_null for column {column_name}: {e}'
-            )
-        return None
+    NULL_COLUMNS_NAME = f'{column_name}_null_count'
+    NOT_NULL_COLUMNS_NAME = f'{column_name}_not_null_count'
+    result_df = df.groupBy(column_name).agg(sum(when(col(column_name).
+        isNull(), 1).otherwise(0)).alias(NULL_COLUMNS_NAME), sum(when(
+        col(column_name).isNotNull(), 1).otherwise(0)).alias(
+        NOT_NULL_COLUMNS_NAME))
+    result_df.show(truncate=False)
+    return result_df
 
 
-def get_row_count(df: "DataFrame") ->Optional[int]:
+def get_row_count(df: "DataFrame") -> int:
     """
     Returns the count of rows in the dataframe.
 
@@ -115,19 +97,14 @@ def get_row_count(df: "DataFrame") ->Optional[int]:
         df (DataFrame): Input Spark DataFrame.
 
     Returns:
-        Optional[int]: Row count or None if an error occurred.
+        int: Row count.
     """
-    try:
-        count = df.count()
-        log_info(f'Row count for dataframe: {count}')
-        return count
-    except (_SparkAnalysisException, _Py4JError, AttributeError) as e:
-        log_error(f'Error getting row count: {e}')
-        return None
+    count = df.count()
+    log_info(f'Row count for dataframe: {count}')
+    return count
 
 
-def repartition_and_cache(df: "DataFrame", partitions: int=100) ->Optional[
-    DataFrame]:
+def repartition_and_cache(df: "DataFrame", partitions: int=100) -> "DataFrame":
     """
     Repartitions and caches a dataframe.
 
@@ -136,40 +113,27 @@ def repartition_and_cache(df: "DataFrame", partitions: int=100) ->Optional[
         partitions (int, optional): Number of partitions. Default is 100.
 
     Returns:
-        Optional["DataFrame"]: Repartitioned and cached DataFrame or None if an error occurred.
+        DataFrame: Repartitioned and cached DataFrame.
     """
-    try:
-        df = df.repartition(partitions).cache()
-        log_info(
-            f'Dataframe repartitioned to {partitions} partitions and cached.')
-        return df
-    except (_SparkAnalysisException, _Py4JError, AttributeError, ValueError) as e:
-        log_error(f'Error repartitioning and caching dataframe: {e}')
-        return None
+    df = df.repartition(partitions).cache()
+    log_info(f'Dataframe repartitioned to {partitions} partitions and cached.')
+    return df
 
 
-def register_temp_table(df: "DataFrame", table_name: str) ->bool:
+def register_temp_table(df: "DataFrame", table_name: str) -> None:
     """
     Registers a temporary view from a dataframe.
 
     Args:
         df (DataFrame): Input Spark DataFrame.
         table_name (str): Name for the temporary view.
-
-    Returns:
-        bool: True if successful, False otherwise.
     """
-    try:
-        df.createOrReplaceTempView(table_name)
-        log_info(f"Temporary view '{table_name}' registered.")
-        return True
-    except (_SparkAnalysisException, _Py4JError, AttributeError, ValueError) as e:
-        log_error(f"Error registering temporary table '{table_name}': {e}")
-        return False
+    df.createOrReplaceTempView(table_name)
+    log_info(f"Temporary view '{table_name}' registered.")
 
 
 def move_column_to_front_of_dataframe(df: "DataFrame", column_name: str
-    ) ->Optional["DataFrame"]:
+    ) -> "DataFrame":
     """Reorder *df* so *column_name* is the leftmost column.
 
     The Spark schema order is what most CSV / parquet readers surface
@@ -177,24 +141,17 @@ def move_column_to_front_of_dataframe(df: "DataFrame", column_name: str
     left-to-right. Moving the join key / identifier to the front makes
     the rest of the pipeline more readable without changing semantics.
 
-    Returns the reordered DataFrame, or ``None`` on failure (logged).
     The original *df* is unchanged.
     """
-    try:
-        columns = list(df.columns)
-        column_to_move = column_name
-        new_column_order = [column_to_move] + [col for col in columns if
-            col != column_to_move]
-        df_reordered = df.select(*new_column_order)
-        df_reordered.printSchema()
-        return df_reordered
-    except (_SparkAnalysisException, _Py4JError, AttributeError, ValueError, KeyError) as e:
-        log_error(f'Error repartitioning and caching dataframe: {e}')
-        return None
+    columns = list(df.columns)
+    new_column_order = [column_name] + [c for c in columns if c != column_name]
+    df_reordered = df.select(*new_column_order)
+    df_reordered.printSchema()
+    return df_reordered
 
 
 def write_df_to_parquet(df: "DataFrame", path: str, mode: str='overwrite'
-    ) ->bool:
+    ) -> None:
     """
     Writes a DataFrame to a Parquet file.
 
@@ -202,20 +159,12 @@ def write_df_to_parquet(df: "DataFrame", path: str, mode: str='overwrite'
         df (DataFrame): Input Spark DataFrame.
         path (str): Output path.
         mode (str): Write mode. Defaults to "overwrite".
-
-    Returns:
-        bool: True if successful, False otherwise.
     """
-    try:
-        df.write.mode(mode).parquet(path)
-        log_info(f"Dataframe written to parquet at {path} with mode '{mode}'")
-        return True
-    except (_SparkAnalysisException, _Py4JError, OSError, AttributeError) as e:
-        log_error(f'Error writing dataframe to parquet at {path}: {e}')
-        return False
+    df.write.mode(mode).parquet(path)
+    log_info(f"Dataframe written to parquet at {path} with mode '{mode}'")
 
 
-def read_parquet_to_df(spark: "SparkSession", path: str) ->Optional["DataFrame"]:
+def read_parquet_to_df(spark: "SparkSession", path: str) -> "DataFrame":
     """
     Reads a Parquet file into a Spark DataFrame.
 
@@ -224,19 +173,15 @@ def read_parquet_to_df(spark: "SparkSession", path: str) ->Optional["DataFrame"]
         path (str): Path to the Parquet file.
 
     Returns:
-        Optional["DataFrame"]: Loaded DataFrame or None if an error occurred.
+        DataFrame: Loaded DataFrame.
     """
-    try:
-        df = spark.read.parquet(path)
-        log_info(f'Successfully read parquet from {path}')
-        return df
-    except (_SparkAnalysisException, _Py4JError, OSError, AttributeError) as e:
-        log_error(f'Error reading parquet from {path}: {e}')
-        return None
+    df = spark.read.parquet(path)
+    log_info(f'Successfully read parquet from {path}')
+    return df
 
 
 def flatten_json_column_and_join_back_to_df(df: "DataFrame", json_column: str,
-    prefix: str='json_column_', logger: Optional[any]=None, drop_original:
+    prefix: str='json_column_', logger: Optional[Any]=None, drop_original:
     bool=True, explode_arrays: bool=False, flatten_level: str='shallow',
     verbose: bool=False, sample_size: int=5, show_samples: bool=True
     ) ->DataFrame:
@@ -248,7 +193,7 @@ def flatten_json_column_and_join_back_to_df(df: "DataFrame", json_column: str,
         df (DataFrame): The input Spark DataFrame.
         json_column (str): The name of the column containing JSON strings.
         prefix (str, optional): Prefix to add to the flattened column names. Defaults to "json_column_".
-        logger (Optional[any], optional): Logger object for logging messages. Defaults to None.
+        logger (Optional[Any], optional): Logger object for logging messages. Defaults to None.
         drop_original (bool, optional): Whether to drop the original JSON column after flattening. Defaults to True.
         explode_arrays (bool, optional): Whether to explode array columns. Defaults to False.
         flatten_level (str, optional):  "shallow" or "deep" flattening. Defaults to "shallow".
@@ -285,10 +230,10 @@ def flatten_json_column_and_join_back_to_df(df: "DataFrame", json_column: str,
     sample_json = df.filter(col(json_column).isNotNull() & (length(trim(col
         (json_column))) > 2)).select(json_column).limit(sample_size).collect()
     if not sample_json or len(sample_json) == 0 or not sample_json[0][0]:
-        _log_info(
-            f'No valid JSON sample available in column {json_column}, skipping flattening'
-            )
-        return df.drop(json_column) if drop_original else df
+        raise ValueError(
+            f"No valid JSON data available in column {json_column!r}; "
+            f"cannot infer schema for flattening"
+        )
     try:
         _log_info(f'Inferring schema from sample JSON in column {json_column}')
         sample_rdd = df.sparkSession.sparkContext.parallelize([sample_json[
@@ -344,7 +289,10 @@ def flatten_json_column_and_join_back_to_df(df: "DataFrame", json_column: str,
                 df_with_json = df_with_json.withColumn('parsed_json', when(
                     col('parsed_json').isNull(), lit(None).cast(StringType(
                     ))).otherwise(col('parsed_json')))
-                return df.drop(json_column) if drop_original else df
+                raise ValueError(
+                    f"All JSON samples in column {json_column!r} are corrupt; "
+                    f"cannot infer schema for flattening"
+                )
         _log_info(f'Inferred schema: {inferred_schema}')
         df_with_json = df.withColumn('parsed_json', from_json(col(
             json_column), inferred_schema))
@@ -380,11 +328,11 @@ def flatten_json_column_and_join_back_to_df(df: "DataFrame", json_column: str,
             df_with_json = df_with_json.withColumn('parsed_json', when(col(
                 'parsed_json').isNull(), lit(None).cast(StringType())).
                 otherwise(col('parsed_json')))
-        except (_SparkAnalysisException, _Py4JError, ValueError, TypeError):
-            _log_error(
-                f'Failed even with string schema for {json_column}. Returning original dataframe.'
-                )
-            return df.drop(json_column) if drop_original else df
+        except (_SparkAnalysisException, _Py4JError, TypeError) as fallback_exc:
+            raise ValueError(
+                f"Failed to parse JSON in column {json_column!r} even with "
+                f"string schema fallback: {fallback_exc}"
+            ) from fallback_exc
     columns_to_extract = df_with_json.select('parsed_json.*').columns
     result_df = df_with_json
     if flatten_level == 'shallow':
@@ -424,8 +372,7 @@ def flatten_json_column_and_join_back_to_df(df: "DataFrame", json_column: str,
                     df = df.drop(struct_col)
                 return df
             except (_SparkAnalysisException, _Py4JError, AttributeError, KeyError) as e:
-                _log_error(f'Error in flatten_struct: {e}')
-                return df
+                raise RuntimeError(f'Error in flatten_struct: {e}') from e
         result_df = flatten_struct(df_with_json, 'parsed_json', prefix,
             flatten_level)
     if explode_arrays:
@@ -436,7 +383,7 @@ def flatten_json_column_and_join_back_to_df(df: "DataFrame", json_column: str,
                 result_df = result_df.withColumn(array_column,
                     explode_outer(col(array_column)))
         except (_SparkAnalysisException, _Py4JError, AttributeError, TypeError) as e:
-            _log_error(f'Error exploding arrays: {e}')
+            raise RuntimeError(f'Error exploding arrays: {e}') from e
     columns_to_drop = ['parsed_json']
     if drop_original:
         columns_to_drop.append(json_column)
@@ -694,16 +641,10 @@ def export_pyspark_df_to_excel(df, file_name='output.xlsx', sheet_name='Sheet1'
         spark_df (pyspark.sql.DataFrame): The PySpark DataFrame to export.
         file_name (str): The name of the output Excel file.
         sheet_name (str): The sheet name in the Excel file.
-
-    Returns:
-        None
     """
-    try:
-        pandas_df = df.toPandas()
-        pandas_df.to_excel(file_name, sheet_name=sheet_name, index=False)
-        log_info(f'DataFrame successfully exported to {file_name}')
-    except (_SparkAnalysisException, _Py4JError, OSError, ImportError, ValueError, AttributeError) as e:
-        log_error(f'Error exporting DataFrame: {e}')
+    pandas_df = df.toPandas()
+    pandas_df.to_excel(file_name, sheet_name=sheet_name, index=False)
+    log_info(f'DataFrame successfully exported to {file_name}')
 
 
 def pivot_summary_table_for_bools(df, columns, spark):
@@ -792,27 +733,21 @@ def pivot_summary_with_metrics(df, group_col, pivot_col, spark):
 
 
 def export_prepared_df_as_csv_to_path_using_delimiter(df: "DataFrame",
-    write_path: pathlib.Path, delimiter: str=',') ->bool:
+    write_path: pathlib.Path, delimiter: str=',') -> None:
     """
     Exports DataFrame **with necessary transformations** to ensure Spark compatibility.
 
     :param df: Target DataFrame
     :param write_path: Pathlib object for export destination
     :param delimiter: CSV delimiter (default is comma)
-    :return: bool indicating success/failure
 
     Applies `prepare_dataframe_for_export()` to prevent Spark export issues.
     """
-    try:
-        prepared_df = prepare_dataframe_for_export(df)
-        prepared_df.coalesce(1).write.format(RESULTS_OUTPUT_FORMAT).option(
-            'header', 'true').option('delimiter', delimiter).mode('overwrite'
-            ).save(str(write_path))
-        log_info(f'Data successfully exported for step: {write_path.stem}')
-        return True
-    except (_SparkAnalysisException, _Py4JError, OSError, ValueError, TypeError, AttributeError) as e:
-        log_error(f'Error exporting DataFrame for {write_path.stem}: {e}')
-        return False
+    prepared_df = prepare_dataframe_for_export(df)
+    prepared_df.coalesce(1).write.format(RESULTS_OUTPUT_FORMAT).option(
+        'header', 'true').option('delimiter', delimiter).mode('overwrite'
+        ).save(str(write_path))
+    log_info(f'Data successfully exported for step: {write_path.stem}')
 
 
 def print_debug_table(spark_df, title):
@@ -853,23 +788,15 @@ def compute_walkability(distance) -> Optional[Dict[str, str]]:
     if distance is None:
         return None
     if distance < walkability_config['Trivial']['max']:
-        return {'grade': 'Trivial', 'label': walkability_config['Trivial'][
-            'label']}
+        return {'grade': 'Trivial', 'label': walkability_config['Trivial']['label']}
     elif distance < walkability_config['Tolerable']['max']:
-        if distance >= walkability_config['Tolerable'].get('min', 0):
-            return {'grade': 'Tolerable', 'label': walkability_config[
-                'Tolerable']['label']}
+        return {'grade': 'Tolerable', 'label': walkability_config['Tolerable']['label']}
     elif distance < walkability_config['Moderate']['max']:
-        if distance >= walkability_config['Moderate'].get('min', 0):
-            return {'grade': 'Moderate', 'label': walkability_config[
-                'Moderate']['label']}
+        return {'grade': 'Moderate', 'label': walkability_config['Moderate']['label']}
     elif distance < walkability_config['Borderline']['max']:
-        if distance >= walkability_config['Borderline'].get('min', 0):
-            return {'grade': 'Borderline', 'label': walkability_config[
-                'Borderline']['label']}
+        return {'grade': 'Borderline', 'label': walkability_config['Borderline']['label']}
     else:
-        return {'grade': 'Outside', 'label': walkability_config['Outside'][
-            'label']}
+        return {'grade': 'Outside', 'label': walkability_config['Outside']['label']}
 
 
 # UDF creation moved to function level to avoid module-level PySpark dependency
@@ -914,7 +841,7 @@ def backup_full_dataframe(df, step_name: str) -> None:
 
 def atomic_write_with_staging(df: "DataFrame", final_destination: str,
     staging_directory: str, file_format: str='csv', delimiter: str=',',
-    header: bool=True, mode: str='overwrite') ->bool:
+    header: bool=True, mode: str='overwrite') -> None:
     """
     Performs atomic write operations using a staging directory to prevent partial/corrupted files.
     """
@@ -961,10 +888,6 @@ def atomic_write_with_staging(df: "DataFrame", final_destination: str,
         log_info(f'Successfully moved {files_moved} items to final destination'
             )
         log_info('Atomic write operation completed successfully')
-        return True
-    except (_SparkAnalysisException, _Py4JError, OSError, ValueError, AttributeError) as e:
-        log_error(f'Error in atomic write operation: {e}')
-        return False
     finally:
         try:
             if os.path.exists(staging_directory):

--- a/siege_utilities/files/hashing.py
+++ b/siege_utilities/files/hashing.py
@@ -4,7 +4,6 @@ Provides standardized hash functions that actually exist and work properly
 """
 import hashlib
 import pathlib
-from typing import Optional
 
 from siege_utilities.core.logging import log_info, log_error
 
@@ -57,7 +56,7 @@ def _update_from_file(hash_obj, fp) -> None:
         hash_obj.update(chunk)
 
 
-def generate_sha256_hash_for_file(file_path) ->Optional[str]:
+def generate_sha256_hash_for_file(file_path) -> str:
     """Generate SHA256 hash for a file - chunked reading for large files.
 
     .. deprecated:: 3.19.0
@@ -71,16 +70,15 @@ def generate_sha256_hash_for_file(file_path) ->Optional[str]:
         file_path: Path to the file (str or Path object)
 
     Returns:
-        SHA256 hash as hexadecimal string, or None if error
+        SHA256 hash as hexadecimal string
 
     Raises:
+        FileNotFoundError: If file does not exist or is not a file
         PathSecurityError: If path fails security validation
+        OSError: If file cannot be read
 
     Example:
         >>> hash_val = generate_sha256_hash_for_file("data.txt")
-        >>>
-        >>> # This will raise PathSecurityError
-        >>> generate_sha256_hash_for_file("/etc/shadow")  # Sensitive file blocked
     """
     import warnings
     warnings.warn(
@@ -89,22 +87,12 @@ def generate_sha256_hash_for_file(file_path) ->Optional[str]:
         DeprecationWarning,
         stacklevel=2,
     )
-    try:
-        path_obj = _validated_path(file_path, must_exist=True)
-        if not path_obj.exists() or not path_obj.is_file():
-            return None
-        sha256_hash = hashlib.sha256()
-        with open(path_obj, 'rb') as f:
-            _update_from_file(sha256_hash, f)
-        return sha256_hash.hexdigest()
-    except (OSError, ValueError) as e:
-        log_error(f'Error generating SHA256 hash for {file_path}: {e}')
-        return None
+    return get_file_hash(file_path, 'sha256')
 
 
-def get_file_hash(file_path, algorithm='sha256') ->Optional[str]:
+def get_file_hash(file_path, algorithm='sha256') -> str:
     """
-    Generate hash for a file using specified algorithm
+    Generate hash for a file using specified algorithm.
 
     SECURITY: This function validates paths to prevent path traversal attacks
     and access to sensitive system files.
@@ -114,44 +102,40 @@ def get_file_hash(file_path, algorithm='sha256') ->Optional[str]:
         algorithm: Hash algorithm to use ('sha256', 'md5', 'sha1', etc.)
 
     Returns:
-        Hash as hexadecimal string, or None if error
+        Hash as hexadecimal string
 
     Raises:
+        FileNotFoundError: If file does not exist or is not a file
         PathSecurityError: If path fails security validation
+        OSError: If file cannot be read
+        ValueError: If algorithm is not supported
 
     Example:
         >>> hash_val = get_file_hash("data.txt", "sha256")
-        >>>
-        >>> # This will raise PathSecurityError
-        >>> get_file_hash("../../../etc/passwd")  # Path traversal blocked
-
-    Security Changes:
-        - Now validates paths to block path traversal
-        - Blocks access to sensitive system files
     """
-    try:
-        path_obj = _validated_path(file_path, must_exist=True)
-        if not path_obj.exists() or not path_obj.is_file():
-            return None
-        if algorithm.lower() == 'sha256':
-            hash_func = hashlib.sha256()
-        elif algorithm.lower() == 'md5':
-            hash_func = hashlib.md5()
-        elif algorithm.lower() == 'sha1':
-            hash_func = hashlib.sha1()
-        else:
-            hash_func = hashlib.new(algorithm)
-        with open(path_obj, 'rb') as f:
-            _update_from_file(hash_func, f)
-        return hash_func.hexdigest()
-    except (OSError, ValueError) as e:
-        log_error(f'Error generating {algorithm} hash for {file_path}: {e}')
-        return None
+    path_obj = _validated_path(file_path, must_exist=True)
+    if not path_obj.exists():
+        raise FileNotFoundError(f"File does not exist: {path_obj}")
+    if not path_obj.is_file():
+        raise FileNotFoundError(f"Path is not a file: {path_obj}")
+
+    if algorithm.lower() == 'sha256':
+        hash_func = hashlib.sha256()
+    elif algorithm.lower() == 'md5':
+        hash_func = hashlib.md5()
+    elif algorithm.lower() == 'sha1':
+        hash_func = hashlib.sha1()
+    else:
+        hash_func = hashlib.new(algorithm)
+
+    with open(path_obj, 'rb') as f:
+        _update_from_file(hash_func, f)
+    return hash_func.hexdigest()
 
 
-def calculate_file_hash(file_path) ->Optional[str]:
+def calculate_file_hash(file_path) -> str:
     """
-    Alias for get_file_hash with SHA256 - for backward compatibility
+    Alias for get_file_hash with SHA256 - for backward compatibility.
     """
     return get_file_hash(file_path, 'sha256')
 
@@ -192,7 +176,7 @@ def get_quick_file_signature(file_path) ->str:
             return 'missing'
         stat = path_obj.stat()
         if stat.st_size <= 1024 * 1024:
-            return get_file_hash(file_path) or f'stat_{stat.st_size}_{stat.st_mtime}'
+            return get_file_hash(file_path)
         # Past 1 MiB we always read both ends — the previous inner guard
         # `stat.st_size > 2 * _HASH_CHUNK_SIZE` was always true here
         # (2 * 64 KiB = 128 KiB < 1 MiB), so it was dead code.
@@ -218,9 +202,9 @@ def get_quick_file_signature(file_path) ->str:
             raise
 
 
-def verify_file_integrity(file_path, expected_hash, algorithm='sha256') ->bool:
+def verify_file_integrity(file_path, expected_hash, algorithm='sha256') -> bool:
     """
-    Verify file integrity by comparing with expected hash
+    Verify file integrity by comparing with expected hash.
 
     SECURITY: This function validates paths to prevent path traversal attacks
     and access to sensitive system files (through get_file_hash).
@@ -234,28 +218,17 @@ def verify_file_integrity(file_path, expected_hash, algorithm='sha256') ->bool:
         True if file matches expected hash, False if hash does not match
 
     Raises:
+        FileNotFoundError: If file does not exist
         PathSecurityError: If path fails security validation
-        Exception: If hash computation fails (logged before re-raise)
+        OSError: If file cannot be read
 
     Example:
         >>> expected = "abc123..."
         >>> if verify_file_integrity("data.txt", expected):
         ...     print("File integrity verified")
-        >>>
-        >>> # This will raise PathSecurityError
-        >>> verify_file_integrity("/etc/shadow", expected)  # Sensitive file blocked
-
-    Security Changes:
-        - Now validates paths via get_file_hash() to block path traversal
-        - Blocks access to sensitive system files
     """
-    try:
-        current_hash = get_file_hash(file_path, algorithm)
-        return current_hash is not None and current_hash.lower(
-            ) == expected_hash.lower()
-    except (OSError, ValueError) as exc:
-        log_error(f"Failed to verify hash for {file_path}: {exc}")
-        raise
+    current_hash = get_file_hash(file_path, algorithm)
+    return current_hash.lower() == expected_hash.lower()
 
 
 def test_hash_functions():
@@ -274,9 +247,8 @@ def test_hash_functions():
         log_info(f'MD5: {md5_hash}')
         quick_sig = get_quick_file_signature(test_file)
         log_info(f'Quick signature: {quick_sig}')
-        if sha256_hash:
-            verification = verify_file_integrity(test_file, sha256_hash)
-            log_info(f'Verification: {verification}')
+        verification = verify_file_integrity(test_file, sha256_hash)
+        log_info(f'Verification: {verification}')
         log_info('All hash functions working!')
     finally:
         os.unlink(test_file)

--- a/siege_utilities/files/operations.py
+++ b/siege_utilities/files/operations.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 # Type aliases
 FilePath = Union[str, Path]
 
-def remove_tree(path: FilePath) -> bool:
+def remove_tree(path: FilePath) -> None:
     """
     Remove a file or directory tree safely.
 
@@ -25,41 +25,29 @@ def remove_tree(path: FilePath) -> bool:
     Args:
         path: Path to file or directory to remove
 
-    Returns:
-        True if successful, False otherwise
-
     Raises:
+        FileNotFoundError: If path does not exist
         PathSecurityError: If path fails security validation
+        OSError: If removal fails
 
     Example:
         >>> remove_tree("temp_directory")
         >>> remove_tree(Path("old_files"))
     """
     try:
-        # Validate path
-        try:
-            from siege_utilities.files.validation import validate_safe_path, PathSecurityError
-            path_obj = validate_safe_path(path, allow_absolute=True)
-        except ImportError:
-            path_obj = Path(path)
+        from siege_utilities.files.validation import validate_safe_path, PathSecurityError
+        path_obj = validate_safe_path(path, allow_absolute=True)
+    except ImportError:
+        path_obj = Path(path)
 
-        if path_obj.is_file():
-            path_obj.unlink()
-            log.info(f"Removed file: {path_obj}")
-        elif path_obj.is_dir():
-            shutil.rmtree(path_obj)
-            log.info(f"Removed directory tree: {path_obj}")
-        else:
-            log.warning(f"Path does not exist: {path_obj}")
-            return False
-
-        return True
-
-    except PathSecurityError:
-        raise
-    except OSError as e:
-        log.error(f"Failed to remove {path}: {e}")
-        return False
+    if path_obj.is_file():
+        path_obj.unlink()
+        log.info(f"Removed file: {path_obj}")
+    elif path_obj.is_dir():
+        shutil.rmtree(path_obj)
+        log.info(f"Removed directory tree: {path_obj}")
+    else:
+        raise FileNotFoundError(f"Path does not exist: {path_obj}")
 
 def file_exists(path: FilePath) -> bool:
     """
@@ -115,7 +103,7 @@ def file_exists(path: FilePath) -> bool:
         log.error(f"Error checking file existence for {path}: {e}")
         return False
 
-def touch_file(path: FilePath, create_parents: bool = True) -> bool:
+def touch_file(path: FilePath, create_parents: bool = True) -> None:
     """
     Create an empty file, creating parent directories if needed.
 
@@ -125,38 +113,27 @@ def touch_file(path: FilePath, create_parents: bool = True) -> bool:
         path: Path to the file to create
         create_parents: Whether to create parent directories
 
-    Returns:
-        True if successful, False otherwise
-
     Raises:
         PathSecurityError: If path fails security validation
+        OSError: If file creation fails
 
     Example:
         >>> touch_file("logs/app.log")
         >>> touch_file(Path("data/output.txt"))
     """
     try:
-        # Validate path
-        try:
-            from siege_utilities.files.validation import validate_safe_path, PathSecurityError
-            path_obj = validate_safe_path(path, allow_absolute=True)
-        except ImportError:
-            path_obj = Path(path)
+        from siege_utilities.files.validation import validate_safe_path, PathSecurityError
+        path_obj = validate_safe_path(path, allow_absolute=True)
+    except ImportError:
+        path_obj = Path(path)
 
-        if create_parents:
-            path_obj.parent.mkdir(parents=True, exist_ok=True)
+    if create_parents:
+        path_obj.parent.mkdir(parents=True, exist_ok=True)
 
-        path_obj.touch(exist_ok=True)
-        log.info(f"Created/updated file: {path_obj}")
-        return True
+    path_obj.touch(exist_ok=True)
+    log.info(f"Created/updated file: {path_obj}")
 
-    except PathSecurityError:
-        raise
-    except OSError as e:
-        log.error(f"Failed to create file {path}: {e}")
-        return False
-
-def count_lines(file_path: FilePath, encoding: str = 'utf-8') -> Optional[int]:
+def count_lines(file_path: FilePath, encoding: str = 'utf-8') -> int:
     """
     Count the total number of lines in a text file.
 
@@ -168,61 +145,37 @@ def count_lines(file_path: FilePath, encoding: str = 'utf-8') -> Optional[int]:
         encoding: File encoding to use
 
     Returns:
-        Number of lines, or None if failed
+        Number of lines
 
     Raises:
-        PathSecurityError: If path fails security validation (from validation module)
+        FileNotFoundError: If file does not exist or is not a file
+        PathSecurityError: If path fails security validation
+        OSError: If file cannot be read
+        UnicodeDecodeError: If file cannot be decoded with given encoding
 
     Example:
         >>> line_count = count_lines("data.csv")
         >>> print(f"File has {line_count} lines")
-        >>>
-        >>> # This will raise PathSecurityError
-        >>> count_lines("../../../etc/passwd")  # Path traversal blocked
-
-    Security Changes:
-        - Now validates paths to block path traversal
-        - Blocks access to sensitive system files
-        - Resolves symlinks and validates final destination
     """
     try:
-        # Import validation function
-        try:
-            from siege_utilities.files.validation import validate_file_path, PathSecurityError
-        except ImportError:
-            # Fallback: use basic Path validation without security checks
-            log.warning("Path validation module not available - using basic validation")
-            path_obj = Path(file_path)
-        else:
-            # Validate path with security checks
-            try:
-                path_obj = validate_file_path(file_path, must_exist=True)
-            except PathSecurityError as e:
-                log.error(f"Path security validation failed: {e}")
-                raise  # Re-raise to caller
+        from siege_utilities.files.validation import validate_file_path, PathSecurityError
+        path_obj = validate_file_path(file_path, must_exist=True)
+    except ImportError:
+        path_obj = Path(file_path)
 
-        if not path_obj.exists():
-            log.warning(f"File does not exist: {path_obj}")
-            return None
+    if not path_obj.exists():
+        raise FileNotFoundError(f"File does not exist: {path_obj}")
 
-        if not path_obj.is_file():
-            log.warning(f"Path is not a file: {path_obj}")
-            return None
+    if not path_obj.is_file():
+        raise FileNotFoundError(f"Path is not a file: {path_obj}")
 
-        with open(path_obj, 'r', encoding=encoding) as f:
-            line_count = sum(1 for _ in f)
+    with open(path_obj, 'r', encoding=encoding) as f:
+        line_count = sum(1 for _ in f)
 
-        log.info(f"Counted {line_count} lines in {path_obj}")
-        return line_count
+    log.info(f"Counted {line_count} lines in {path_obj}")
+    return line_count
 
-    except PathSecurityError:
-        # Re-raise security errors
-        raise
-    except (OSError, UnicodeDecodeError) as e:
-        log.error(f"Failed to count lines in {file_path}: {e}")
-        return None
-
-def copy_file(source: FilePath, destination: FilePath, overwrite: bool = False) -> bool:
+def copy_file(source: FilePath, destination: FilePath, overwrite: bool = False) -> None:
     """
     Copy a file from source to destination.
 
@@ -233,53 +186,39 @@ def copy_file(source: FilePath, destination: FilePath, overwrite: bool = False) 
         destination: Destination file path
         overwrite: Whether to overwrite existing files
 
-    Returns:
-        True if successful, False otherwise
-
     Raises:
+        FileNotFoundError: If source does not exist or is not a file
+        FileExistsError: If destination exists and overwrite=False
         PathSecurityError: If paths fail security validation
+        OSError: If copy fails
 
     Example:
         >>> copy_file("source.txt", "backup/source.txt")
         >>> copy_file(Path("config.yaml"), Path("config.yaml.bak"))
     """
     try:
-        # Validate paths
-        try:
-            from siege_utilities.files.validation import validate_file_path, validate_safe_path, PathSecurityError
-            source_obj = validate_file_path(source, must_exist=True)
-            dest_obj = validate_safe_path(destination, allow_absolute=True)
-        except ImportError:
-            source_obj = Path(source)
-            dest_obj = Path(destination)
+        from siege_utilities.files.validation import validate_file_path, validate_safe_path, PathSecurityError
+        source_obj = validate_file_path(source, must_exist=True)
+        dest_obj = validate_safe_path(destination, allow_absolute=True)
+    except ImportError:
+        source_obj = Path(source)
+        dest_obj = Path(destination)
 
-        if not source_obj.exists():
-            log.error(f"Source file does not exist: {source_obj}")
-            return False
+    if not source_obj.exists():
+        raise FileNotFoundError(f"Source file does not exist: {source_obj}")
 
-        if not source_obj.is_file():
-            log.error(f"Source is not a file: {source_obj}")
-            return False
+    if not source_obj.is_file():
+        raise FileNotFoundError(f"Source is not a file: {source_obj}")
 
-        # Create destination directory if needed
-        dest_obj.parent.mkdir(parents=True, exist_ok=True)
+    dest_obj.parent.mkdir(parents=True, exist_ok=True)
 
-        # Check if destination exists
-        if dest_obj.exists() and not overwrite:
-            log.warning(f"Destination file exists and overwrite=False: {dest_obj}")
-            return False
+    if dest_obj.exists() and not overwrite:
+        raise FileExistsError(f"Destination file exists and overwrite=False: {dest_obj}")
 
-        shutil.copy2(source_obj, dest_obj)
-        log.info(f"Copied {source_obj} to {dest_obj}")
-        return True
+    shutil.copy2(source_obj, dest_obj)
+    log.info(f"Copied {source_obj} to {dest_obj}")
 
-    except PathSecurityError:
-        raise
-    except OSError as e:
-        log.error(f"Failed to copy {source} to {destination}: {e}")
-        return False
-
-def move_file(source: FilePath, destination: FilePath, overwrite: bool = False) -> bool:
+def move_file(source: FilePath, destination: FilePath, overwrite: bool = False) -> None:
     """
     Move a file from source to destination.
 
@@ -290,53 +229,39 @@ def move_file(source: FilePath, destination: FilePath, overwrite: bool = False) 
         destination: Destination file path
         overwrite: Whether to overwrite existing files
 
-    Returns:
-        True if successful, False otherwise
-
     Raises:
+        FileNotFoundError: If source does not exist or is not a file
+        FileExistsError: If destination exists and overwrite=False
         PathSecurityError: If paths fail security validation
+        OSError: If move fails
 
     Example:
         >>> move_file("temp.txt", "archive/temp.txt")
         >>> move_file(Path("old.log"), Path("logs/old.log"))
     """
     try:
-        # Validate paths
-        try:
-            from siege_utilities.files.validation import validate_file_path, validate_safe_path, PathSecurityError
-            source_obj = validate_file_path(source, must_exist=True)
-            dest_obj = validate_safe_path(destination, allow_absolute=True)
-        except ImportError:
-            source_obj = Path(source)
-            dest_obj = Path(destination)
+        from siege_utilities.files.validation import validate_file_path, validate_safe_path, PathSecurityError
+        source_obj = validate_file_path(source, must_exist=True)
+        dest_obj = validate_safe_path(destination, allow_absolute=True)
+    except ImportError:
+        source_obj = Path(source)
+        dest_obj = Path(destination)
 
-        if not source_obj.exists():
-            log.error(f"Source file does not exist: {source_obj}")
-            return False
+    if not source_obj.exists():
+        raise FileNotFoundError(f"Source file does not exist: {source_obj}")
 
-        if not source_obj.is_file():
-            log.error(f"Source is not a file: {source_obj}")
-            return False
+    if not source_obj.is_file():
+        raise FileNotFoundError(f"Source is not a file: {source_obj}")
 
-        # Create destination directory if needed
-        dest_obj.parent.mkdir(parents=True, exist_ok=True)
+    dest_obj.parent.mkdir(parents=True, exist_ok=True)
 
-        # Check if destination exists
-        if dest_obj.exists() and not overwrite:
-            log.warning(f"Destination file exists and overwrite=False: {dest_obj}")
-            return False
+    if dest_obj.exists() and not overwrite:
+        raise FileExistsError(f"Destination file exists and overwrite=False: {dest_obj}")
 
-        shutil.move(str(source_obj), str(dest_obj))
-        log.info(f"Moved {source_obj} to {dest_obj}")
-        return True
+    shutil.move(str(source_obj), str(dest_obj))
+    log.info(f"Moved {source_obj} to {dest_obj}")
 
-    except PathSecurityError:
-        raise
-    except OSError as e:
-        log.error(f"Failed to move {source} to {destination}: {e}")
-        return False
-
-def get_file_size(file_path: FilePath) -> Optional[int]:
+def get_file_size(file_path: FilePath) -> int:
     """
     Get the size of a file in bytes.
 
@@ -347,61 +272,37 @@ def get_file_size(file_path: FilePath) -> Optional[int]:
         file_path: Path to the file
 
     Returns:
-        File size in bytes, or None if failed
+        File size in bytes
 
     Raises:
+        FileNotFoundError: If file does not exist or is not a file
         PathSecurityError: If path fails security validation
+        OSError: If file size cannot be determined
 
     Example:
         >>> size = get_file_size("large_file.zip")
         >>> print(f"File size: {size} bytes")
-        >>>
-        >>> # This will raise PathSecurityError
-        >>> get_file_size("/etc/shadow")  # Sensitive file blocked
-
-    Security Changes:
-        - Now validates paths to block path traversal
-        - Blocks access to sensitive system files
     """
     try:
-        # Import validation function
-        try:
-            from siege_utilities.files.validation import validate_file_path, PathSecurityError
-        except ImportError:
-            # Fallback: use basic Path validation without security checks
-            log.warning("Path validation module not available - using basic validation")
-            path_obj = Path(file_path)
-        else:
-            # Validate path with security checks
-            try:
-                path_obj = validate_file_path(file_path, must_exist=True)
-            except PathSecurityError as e:
-                log.error(f"Path security validation failed: {e}")
-                raise  # Re-raise to caller
+        from siege_utilities.files.validation import validate_file_path, PathSecurityError
+        path_obj = validate_file_path(file_path, must_exist=True)
+    except ImportError:
+        path_obj = Path(file_path)
 
-        if not path_obj.exists():
-            log.warning(f"File does not exist: {path_obj}")
-            return None
+    if not path_obj.exists():
+        raise FileNotFoundError(f"File does not exist: {path_obj}")
 
-        if not path_obj.is_file():
-            log.warning(f"Path is not a file: {path_obj}")
-            return None
+    if not path_obj.is_file():
+        raise FileNotFoundError(f"Path is not a file: {path_obj}")
 
-        size = path_obj.stat().st_size
-        log.debug(f"File size for {path_obj}: {size} bytes")
-        return size
-
-    except PathSecurityError:
-        # Re-raise security errors
-        raise
-    except OSError as e:
-        log.error(f"Failed to get file size for {file_path}: {e}")
-        return None
+    size = path_obj.stat().st_size
+    log.debug(f"File size for {path_obj}: {size} bytes")
+    return size
 
 def list_directory(path: FilePath,
                   pattern: str = "*",
                   include_dirs: bool = True,
-                  include_files: bool = True) -> Optional[List[Path]]:
+                  include_files: bool = True) -> List[Path]:
     """
     List contents of a directory with optional filtering.
 
@@ -414,47 +315,39 @@ def list_directory(path: FilePath,
         include_files: Whether to include files
 
     Returns:
-        List of Path objects, or None if failed
+        List of Path objects
 
     Raises:
+        FileNotFoundError: If directory does not exist or is not a directory
         PathSecurityError: If path fails security validation
+        OSError: If directory cannot be read
 
     Example:
         >>> files = list_directory("data", "*.csv")
         >>> dirs = list_directory("logs", include_files=False)
     """
     try:
-        # Validate path
-        try:
-            from siege_utilities.files.validation import validate_directory_path, PathSecurityError
-            path_obj = validate_directory_path(path, must_exist=True)
-        except ImportError:
-            path_obj = Path(path)
+        from siege_utilities.files.validation import validate_directory_path, PathSecurityError
+        path_obj = validate_directory_path(path, must_exist=True)
+    except ImportError:
+        path_obj = Path(path)
 
-        if not path_obj.exists():
-            log.warning(f"Directory does not exist: {path_obj}")
-            return None
+    if not path_obj.exists():
+        raise FileNotFoundError(f"Directory does not exist: {path_obj}")
 
-        if not path_obj.is_dir():
-            log.warning(f"Path is not a directory: {path_obj}")
-            return None
+    if not path_obj.is_dir():
+        raise FileNotFoundError(f"Path is not a directory: {path_obj}")
 
-        items = []
+    items = []
 
-        for item in path_obj.glob(pattern):
-            if item.is_dir() and include_dirs:
-                items.append(item)
-            elif item.is_file() and include_files:
-                items.append(item)
+    for item in path_obj.glob(pattern):
+        if item.is_dir() and include_dirs:
+            items.append(item)
+        elif item.is_file() and include_files:
+            items.append(item)
 
-        log.debug(f"Listed {len(items)} items in {path_obj}")
-        return sorted(items)
-
-    except PathSecurityError:
-        raise
-    except OSError as e:
-        log.error(f"Failed to list directory {path}: {e}")
-        return None
+    log.debug(f"Listed {len(items)} items in {path_obj}")
+    return sorted(items)
 
 def run_command(command: Union[str, List[str]],
                 cwd: Optional[FilePath] = None,
@@ -513,14 +406,14 @@ def run_command(command: Union[str, List[str]],
         # Import validation function
         try:
             from siege_utilities.files.shell import validate_command_safety, SecurityError
-        except ImportError:
+        except ImportError as imp_err:
             # Fallback: define minimal SecurityError
             class SecurityError(Exception):
                 pass
             # If we can't import validation, we must be in unsafe mode or fail
             if not unsafe:
                 log.error("Cannot validate command: security module not available")
-                raise SecurityError("Security validation unavailable")
+                raise SecurityError("Security validation unavailable") from imp_err
 
         # Parse command. In unsafe mode we additionally reject string
         # commands that contain shell metacharacters — callers that
@@ -586,8 +479,10 @@ def run_command(command: Union[str, List[str]],
 
         return result
 
-    except subprocess.TimeoutExpired:
+    except subprocess.TimeoutExpired as e:
         log.error(f"Command timed out: {command}")
+        if not unsafe:
+            raise
         return None
     except (OSError, ValueError) as e:
         log.error(f"Failed to run command {command}: {e}")
@@ -615,7 +510,7 @@ def check_if_file_exists_at_path(path: FilePath) -> bool:
     return file_exists(path)
 
 
-def delete_existing_file_and_replace_it_with_an_empty_file(file_path: FilePath, create_parents: bool = True) -> bool:
+def delete_existing_file_and_replace_it_with_an_empty_file(file_path: FilePath, create_parents: bool = True) -> None:
     """Backward compatibility function that deletes existing file and replaces it with empty file.
 
     .. deprecated:: 3.19.0
@@ -660,15 +555,12 @@ def delete_existing_file_and_replace_it_with_an_empty_file(file_path: FilePath, 
         if path_obj.exists():
             path_obj.unlink()
 
-        # Create empty file
         path_obj.touch()
         log.info(f"Created/updated empty file: {path_obj}")
-        return True
     except PathSecurityError:
         raise
     except OSError as e:
-        log.error(f"Failed to create empty file {file_path}: {e}")
-        return False
+        raise OSError(f"Failed to create empty file {file_path}") from e
 
 count_total_rows_in_file_pythonically = count_lines
 

--- a/siege_utilities/files/paths.py
+++ b/siege_utilities/files/paths.py
@@ -61,7 +61,7 @@ def ensure_path_exists(desired_path: FilePath) -> Path:
 
 def unzip_file_to_directory(zip_file_path: FilePath,
                            extract_to: Optional[FilePath] = None,
-                           create_subdirectory: bool = True) -> Optional[Path]:
+                           create_subdirectory: bool = True) -> Path:
     """
     Extract a zip file to a directory.
 
@@ -73,83 +73,61 @@ def unzip_file_to_directory(zip_file_path: FilePath,
         create_subdirectory: Whether to create a subdirectory for extracted files
 
     Returns:
-        Path to the extraction directory, or None if failed
+        Path to the extraction directory
 
     Raises:
+        FileNotFoundError: If zip file does not exist or is not a file
+        zipfile.BadZipFile: If file is not a valid zip
         PathSecurityError: If paths fail security validation
+        OSError: If extraction fails
 
     Example:
         >>> extract_dir = unzip_file_to_directory("data.zip")
         >>> print(f"Files extracted to: {extract_dir}")
     """
     try:
-        # Validate paths
-        try:
-            from siege_utilities.files.validation import validate_file_path, validate_directory_path, PathSecurityError  # noqa: F401, F811
-            zip_path = validate_file_path(zip_file_path, must_exist=True)
-        except ImportError:
-            zip_path = Path(zip_file_path)
+        from siege_utilities.files.validation import validate_file_path, validate_directory_path, PathSecurityError  # noqa: F401, F811
+        zip_path = validate_file_path(zip_file_path, must_exist=True)
+    except ImportError:
+        zip_path = Path(zip_file_path)
 
-        if not zip_path.exists():
-            log.error(f"Zip file does not exist: {zip_path}")
-            return None
+    if not zip_path.exists():
+        raise FileNotFoundError(f"Zip file does not exist: {zip_path}")
 
-        if not zip_path.is_file():
-            log.error(f"Path is not a file: {zip_path}")
-            return None
+    if not zip_path.is_file():
+        raise FileNotFoundError(f"Path is not a file: {zip_path}")
 
-        # Determine extraction directory
-        if extract_to is None:
-            extract_to = zip_path.parent
+    if extract_to is None:
+        extract_to = zip_path.parent
 
-        try:
-            from siege_utilities.files.validation import validate_directory_path, PathSecurityError  # noqa: F401, F811
-            extract_dir = validate_directory_path(extract_to, must_exist=False)
-        except ImportError:
-            extract_dir = Path(extract_to)
+    try:
+        from siege_utilities.files.validation import validate_directory_path, PathSecurityError  # noqa: F401, F811
+        extract_dir = validate_directory_path(extract_to, must_exist=False)
+    except ImportError:
+        extract_dir = Path(extract_to)
 
-        if create_subdirectory:
-            # Create subdirectory based on zip file name
-            subdir_name = zip_path.stem
-            target_dir = extract_dir / subdir_name
-        else:
-            target_dir = extract_dir
+    if create_subdirectory:
+        subdir_name = zip_path.stem
+        target_dir = extract_dir / subdir_name
+    else:
+        target_dir = extract_dir
 
-        # Create target directory
-        target_dir.mkdir(parents=True, exist_ok=True)
+    target_dir.mkdir(parents=True, exist_ok=True)
 
-        # Extract files (with zip slip protection). Validate AND extract
-        # per-member — extractall() would ignore the validation loop
-        # below and re-process every entry without the guard.
-        with zipfile.ZipFile(zip_path, 'r') as zip_ref:
-            target_resolved = target_dir.resolve()
-            for member in zip_ref.namelist():
-                # Reject absolute paths and any traversal that escapes
-                # target_dir. Path.resolve() collapses '..' segments;
-                # if the result isn't a child of target_dir, it's
-                # malicious.
-                try:
-                    (target_dir / member).resolve().relative_to(target_resolved)
-                except ValueError:
-                    # Detected-and-skipped → recoverable anomaly, not a
-                    # user-visible failure. Use warning + lazy format.
-                    log.warning(
-                        "Zip slip attempt detected, skipping member: %r", member,
-                    )
-                    continue
-                zip_ref.extract(member, target_dir)
+    with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+        target_resolved = target_dir.resolve()
+        for member in zip_ref.namelist():
+            try:
+                (target_dir / member).resolve().relative_to(target_resolved)
+            except ValueError:
+                log.warning(
+                    "Zip slip attempt detected, skipping member: %r", member,
+                )
+                continue
+            zip_ref.extract(member, target_dir)
 
-        log.info(f"Extracted {zip_path} to {target_dir}")
-        return target_dir
-
-    except zipfile.BadZipFile:
-        log.error(f"Invalid zip file: {zip_file_path}")
-        return None
-    except PathSecurityError:
-        raise
-    except OSError as e:
-        log.error(f"Failed to extract {zip_file_path}: {e}")
-        return None
+    log.info(f"Extracted {zip_path} to {target_dir}")
+    return target_dir
 
 def get_file_extension(file_path: FilePath) -> str:
     """
@@ -262,7 +240,7 @@ def is_hidden_file(file_path: FilePath) -> bool:
         log.error(f"Failed to check if hidden: {file_path}: {e}")
         raise
 
-def get_relative_path(base_path: FilePath, target_path: FilePath) -> Optional[Path]:
+def get_relative_path(base_path: FilePath, target_path: FilePath) -> Path:
     """
     Get the relative path from base_path to target_path.
 
@@ -273,39 +251,28 @@ def get_relative_path(base_path: FilePath, target_path: FilePath) -> Optional[Pa
         target_path: Target file/directory path
 
     Returns:
-        Relative path from base to target, or None if failed
+        Relative path from base to target
 
     Raises:
+        ValueError: If target is not relative to base
         PathSecurityError: If paths fail security validation
 
     Example:
         >>> rel_path = get_relative_path("/home/user", "/home/user/documents/file.txt")
         >>> print(f"Relative path: {rel_path}")  # documents/file.txt
-        >>>
-        >>> # This will raise PathSecurityError
-        >>> get_relative_path("/etc", "/etc/passwd")  # Sensitive path blocked
     """
     try:
-        # Validate paths
-        try:
-            from siege_utilities.files.validation import validate_safe_path, PathSecurityError  # noqa: F401, F811
-            base = validate_safe_path(base_path, allow_absolute=True)
-            target = validate_safe_path(target_path, allow_absolute=True)
-        except ImportError:
-            base = Path(base_path).resolve()
-            target = Path(target_path).resolve()
+        from siege_utilities.files.validation import validate_safe_path, PathSecurityError  # noqa: F401, F811
+        base = validate_safe_path(base_path, allow_absolute=True)
+        target = validate_safe_path(target_path, allow_absolute=True)
+    except ImportError:
+        base = Path(base_path).resolve()
+        target = Path(target_path).resolve()
 
-        try:
-            relative = target.relative_to(base)
-            return relative
-        except ValueError:
-            log.warning(f"Target {target} is not relative to base {base}")
-            return None
-    except PathSecurityError:
-        raise
-    except (OSError, TypeError) as e:
-        log.error(f"Failed to get relative path: {e}")
-        return None
+    try:
+        return target.relative_to(base)
+    except ValueError as e:
+        raise ValueError(f"Target {target} is not relative to base {base}") from e
 
 def find_files_by_pattern(directory: FilePath,
                          pattern: str = "*",
@@ -342,9 +309,10 @@ def find_files_by_pattern(directory: FilePath,
         except ImportError:
             dir_path = Path(directory)
 
-        if not dir_path.exists() or not dir_path.is_dir():
-            log.warning(f"Directory does not exist or is not a directory: {dir_path}")
-            return []
+        if not dir_path.exists():
+            raise FileNotFoundError(f"Directory does not exist: {dir_path}")
+        if not dir_path.is_dir():
+            raise FileNotFoundError(f"Path is not a directory: {dir_path}")
 
         if recursive:
             files = list(dir_path.rglob(pattern))
@@ -356,7 +324,7 @@ def find_files_by_pattern(directory: FilePath,
 
         log.debug(f"Found {len(files)} files matching '{pattern}' in {dir_path}")
         return sorted(files)
-    except PathSecurityError:
+    except (PathSecurityError, FileNotFoundError):
         raise
     except OSError as e:
         raise OSError(f"Failed to find files in {directory}: {e}") from e

--- a/siege_utilities/files/remote.py
+++ b/siege_utilities/files/remote.py
@@ -7,7 +7,7 @@ import logging
 import os
 import platform
 from pathlib import Path
-from typing import Union, Optional
+from typing import Union
 
 try:
     import requests
@@ -92,7 +92,7 @@ def _get_progress_bar(*args, **kwargs):
 def download_file(url: str, local_filename: FilePath,
                  chunk_size: int = 8192,
                  timeout: int = 30,
-                 verify_ssl: bool = True) -> Union[str, bool]:
+                 verify_ssl: bool = True) -> str:
     """
     Download a file from a URL to a local file with progress bar.
 
@@ -106,57 +106,50 @@ def download_file(url: str, local_filename: FilePath,
         verify_ssl: Whether to verify SSL certificates
 
     Returns:
-        The local filename if successful, False otherwise
+        The local filename as a string
 
     Raises:
         PathSecurityError: If local path fails security validation
+        ConnectionError: If HTTP request fails (non-2xx status)
+        requests.exceptions.Timeout: If request times out
+        requests.exceptions.RequestException: If request fails
+        OSError: If file write fails
 
     Example:
         >>> result = download_file("https://example.com/file.zip", "downloads/file.zip")
-        >>> if result:
-        ...     print(f"Downloaded to {result}")
-        >>>
-        >>> # This will raise PathSecurityError
-        >>> download_file("https://example.com/file.zip", "../../../etc/passwd")  # Path traversal blocked
-
-    Security Changes:
-        - Now validates local file paths to block path traversal
-        - Blocks writing to sensitive system locations
+        >>> print(f"Downloaded to {result}")
     """
     _check_requests_dependency()
 
+    log.info(f'Downloading {url} to {local_filename}')
+
     try:
-        log.info(f'Downloading {url} to {local_filename}')
+        from siege_utilities.files.validation import validate_safe_path, PathSecurityError
+        local_path = validate_safe_path(local_filename, allow_absolute=True)
+    except ImportError:
+        local_path = Path(local_filename)
 
-        # Validate local file path
-        try:
-            from siege_utilities.files.validation import validate_safe_path, PathSecurityError
-            local_path = validate_safe_path(local_filename, allow_absolute=True)
-        except ImportError:
-            local_path = Path(local_filename)
+    local_path.parent.mkdir(parents=True, exist_ok=True)
 
-        local_path.parent.mkdir(parents=True, exist_ok=True)
-        
-        # Make the request with streaming, using smart SSL verification
-        ssl_verify = _get_ssl_verify_path() if verify_ssl else False
-        headers = {'User-Agent': 'siege_utilities/1.0 (Census/GIS data client)'}
+    ssl_verify = _get_ssl_verify_path() if verify_ssl else False
+    headers = {'User-Agent': 'siege_utilities/1.0 (Census/GIS data client)'}
+
+    try:
         with requests.get(url, stream=True, allow_redirects=True,
                          timeout=timeout, verify=ssl_verify,
                          headers=headers) as response:
-            
+
             if not response.ok:
-                log.error(f'Download failed: HTTP {response.status_code} - {response.reason}')
-                return False
-            
-            # Get total size for progress bar
+                raise ConnectionError(
+                    f"Download failed: HTTP {response.status_code} - {response.reason} for {url}"
+                )
+
             total_size = _safe_content_length(response)
-            
             if total_size > 0:
                 log.info(f'Download started, file size: {total_size} bytes')
             else:
                 log.info('Download started, file size unknown')
-            
-            # Download with progress bar
+
             with open(local_path, 'wb') as file:
                 with _get_progress_bar(
                     total=total_size,
@@ -165,71 +158,50 @@ def download_file(url: str, local_filename: FilePath,
                     desc=local_path.name,
                     ascii=True
                 ) as progress_bar:
-                    
                     for chunk in response.iter_content(chunk_size=chunk_size):
                         if chunk:
                             file.write(chunk)
                             progress_bar.update(len(chunk))
-            
+
             log.info(f'Successfully downloaded {url} to {local_path}')
             return str(local_path)
-    except PathSecurityError:
-        raise
+
     except requests.exceptions.SSLError as e:
         log.warning(f'SSL verification failed for {url}, retrying without verification: {e}')
-        # Retry without SSL verification
-        try:
-            headers = {'User-Agent': 'siege_utilities/1.0 (Census/GIS data client)'}
-            with requests.get(url, stream=True, allow_redirects=True,
-                           timeout=timeout, verify=False,
-                           headers=headers) as response:
-                
-                if not response.ok:
-                    log.error(f'Download failed without SSL: HTTP {response.status_code} - {response.reason}')
-                    return False
-                
-                # Get total size for progress bar
-                total_size = _safe_content_length(response)
-                
-                if total_size > 0:
-                    log.info(f'Download started without SSL, file size: {total_size} bytes')
-                else:
-                    log.info('Download started without SSL, file size unknown')
-                
-                # Download with progress bar
-                with open(local_path, 'wb') as file:
-                    with _get_progress_bar(
-                        total=total_size,
-                        unit='B',
-                        unit_scale=True,
-                        desc=f"{local_path.name} (no SSL)",
-                        ascii=True
-                    ) as progress_bar:
-                        
-                        for chunk in response.iter_content(chunk_size=chunk_size):
-                            if chunk:
-                                file.write(chunk)
-                                progress_bar.update(len(chunk))
-                
-                log.info(f'Successfully downloaded {url} to {local_path} without SSL verification')
-                return str(local_path)
-                
-        except (OSError, ValueError) as retry_error:
-            log.error(f'Download failed even without SSL verification: {retry_error}')
-            return False
+        with requests.get(url, stream=True, allow_redirects=True,
+                       timeout=timeout, verify=False,
+                       headers=headers) as response:
 
-    except requests.exceptions.Timeout:
-        log.error(f'Download timed out for {url}')
-        return False
-    except requests.exceptions.RequestException as e:
-        log.error(f'Request error downloading {url}: {e}')
-        return False
-    except (OSError, ValueError) as e:
-        log.error(f'Unexpected error downloading {url}: {e}')
-        return False
+            if not response.ok:
+                raise ConnectionError(
+                    f"Download failed without SSL: HTTP {response.status_code} - "
+                    f"{response.reason} for {url}"
+                ) from e
+
+            total_size = _safe_content_length(response)
+            if total_size > 0:
+                log.info(f'Download started without SSL, file size: {total_size} bytes')
+            else:
+                log.info('Download started without SSL, file size unknown')
+
+            with open(local_path, 'wb') as file:
+                with _get_progress_bar(
+                    total=total_size,
+                    unit='B',
+                    unit_scale=True,
+                    desc=f"{local_path.name} (no SSL)",
+                    ascii=True
+                ) as progress_bar:
+                    for chunk in response.iter_content(chunk_size=chunk_size):
+                        if chunk:
+                            file.write(chunk)
+                            progress_bar.update(len(chunk))
+
+            log.info(f'Successfully downloaded {url} to {local_path} without SSL verification')
+            return str(local_path)
 
 def generate_local_path_from_url(url: str, directory_path: FilePath,
-                                as_string: bool = True) -> Union[Path, str, bool]:
+                                as_string: bool = True) -> Union[Path, str]:
     """
     Generate a local file path from a URL.
 
@@ -241,165 +213,154 @@ def generate_local_path_from_url(url: str, directory_path: FilePath,
         as_string: Whether to return the result as a string
 
     Returns:
-        Path object, string, or False if failed
+        Path object or string
 
     Raises:
+        ValueError: If filename cannot be extracted from URL
         PathSecurityError: If directory path fails security validation
+        OSError: If directory creation fails
 
     Example:
         >>> path = generate_local_path_from_url("https://example.com/file.zip", "downloads")
         >>> print(f"Local path: {path}")
-        >>>
-        >>> # This will raise PathSecurityError
-        >>> generate_local_path_from_url("https://example.com/file.zip", "../../../etc")  # Path traversal blocked
-
-    Security Changes:
-        - Now validates directory paths to block path traversal
-        - Blocks writing to sensitive system locations
     """
+    parsed_url = urlparse(url)
+    remote_filename = parsed_url.path.split('/')[-1]
+
+    if not remote_filename:
+        raise ValueError(f"Could not extract filename from URL: {url}")
+
     try:
-        # Parse URL to get filename
-        parsed_url = urlparse(url)
-        remote_filename = parsed_url.path.split('/')[-1]
+        from siege_utilities.files.validation import validate_directory_path, PathSecurityError
+        dir_path = validate_directory_path(directory_path, must_exist=False)
+    except ImportError:
+        dir_path = Path(directory_path)
 
-        if not remote_filename:
-            log.warning(f'Could not extract filename from URL: {url}')
-            return False
+    dir_path.mkdir(parents=True, exist_ok=True)
 
-        # Validate directory path
-        try:
-            from siege_utilities.files.validation import validate_directory_path, PathSecurityError
-            dir_path = validate_directory_path(directory_path, must_exist=False)
-        except ImportError:
-            dir_path = Path(directory_path)
+    local_path = dir_path / remote_filename
+    log.info(f'Generated local path: {local_path}')
 
-        dir_path.mkdir(parents=True, exist_ok=True)
-        
-        # Create full local path
-        local_path = dir_path / remote_filename
-        
-        log.info(f'Generated local path: {local_path}')
-        
-        if as_string:
-            return str(local_path)
-        else:
-            return local_path
-    except PathSecurityError:
-        raise
-    except (OSError, ValueError) as e:
-        log.error(f'Error generating local path from {url}: {e}')
-        return False
+    if as_string:
+        return str(local_path)
+    else:
+        return local_path
 
 def download_file_with_retry(url: str, local_filename: FilePath,
                             max_retries: int = 3,
                             retry_delay: int = 5,
-                            **kwargs) -> Union[str, bool]:
+                            **kwargs) -> str:
     """
     Download a file with automatic retry on failure.
-    
+
     Args:
         url: The URL to download from
         local_filename: The local path where the file should be saved
         max_retries: Maximum number of retry attempts
         retry_delay: Delay between retries in seconds
         **kwargs: Additional arguments passed to download_file
-        
+
     Returns:
-        The local filename if successful, False otherwise
-        
+        The local filename as a string
+
+    Raises:
+        ConnectionError: If all retry attempts fail
+        requests.exceptions.RequestException: If all retry attempts fail
+
     Example:
         >>> result = download_file_with_retry("https://example.com/file.zip", "file.zip")
-        >>> if result:
-        ...     print("Download succeeded after retries")
+        >>> print(f"Downloaded to {result}")
     """
     import time
-    
+
+    last_error: Exception = RuntimeError("no attempts made")
     for attempt in range(max_retries + 1):
         try:
             if attempt > 0:
                 log.info(f'Retry attempt {attempt}/{max_retries} for {url}')
                 time.sleep(retry_delay)
-            
-            result = download_file(url, local_filename, **kwargs)
-            if result:
-                return result
-                
-        except (OSError, ValueError) as e:
-            log.warning(f'Download attempt {attempt + 1} failed: {e}')
-    
-    log.error(f'Download failed after {max_retries + 1} attempts for {url}')
-    return False
 
-def get_file_info(url: str, timeout: int = 10) -> Optional[dict]:
+            return download_file(url, local_filename, **kwargs)
+
+        except (OSError, ConnectionError, ValueError) as e:
+            log.warning(f'Download attempt {attempt + 1} failed: {e}')
+            last_error = e
+
+    raise ConnectionError(
+        f"Download failed after {max_retries + 1} attempts for {url}"
+    ) from last_error
+
+def get_file_info(url: str, timeout: int = 10) -> dict:
     """
     Get information about a remote file without downloading it.
-    
+
     Args:
         url: URL to get information about
         timeout: Request timeout in seconds
-        
+
     Returns:
-        Dictionary with file information, or None if failed
-        
+        Dictionary with file information
+
+    Raises:
+        ConnectionError: If HTTP request fails (non-2xx status)
+        requests.exceptions.RequestException: If request fails
+        ImportError: If requests library is not available
+
     Example:
         >>> info = get_file_info("https://example.com/file.zip")
-        >>> if info:
-        ...     print(f"File size: {info['size']} bytes")
+        >>> print(f"File size: {info['size']} bytes")
     """
-    try:
-        log.debug(f'Getting file info for {url}')
-        
-        response = requests.head(url, timeout=timeout, allow_redirects=True)
-        
-        if not response.ok:
-            log.warning(f'Failed to get file info: HTTP {response.status_code}')
-            return None
-        
-        info = {
-            'url': url,
-            'size': _safe_content_length(response),
-            'content_type': response.headers.get('content-type', 'unknown'),
-            'last_modified': response.headers.get('last-modified'),
-            'etag': response.headers.get('etag')
-        }
-        
-        log.debug(f'File info for {url}: {info}')
-        return info
-        
-    except (OSError, ValueError) as e:
-        log.error(f'Error getting file info for {url}: {e}')
-        return None
+    _check_requests_dependency()
+
+    log.debug(f'Getting file info for {url}')
+
+    response = requests.head(url, timeout=timeout, allow_redirects=True)
+
+    if not response.ok:
+        raise ConnectionError(
+            f"Failed to get file info: HTTP {response.status_code} for {url}"
+        )
+
+    info = {
+        'url': url,
+        'size': _safe_content_length(response),
+        'content_type': response.headers.get('content-type', 'unknown'),
+        'last_modified': response.headers.get('last-modified'),
+        'etag': response.headers.get('etag')
+    }
+
+    log.debug(f'File info for {url}: {info}')
+    return info
 
 def is_downloadable(url: str, timeout: int = 10) -> bool:
     """
     Check if a URL points to a downloadable file.
-    
+
     Args:
         url: URL to check
         timeout: Request timeout in seconds
-        
-    Returns:
-        True if the URL points to a downloadable file
 
-    Raises:
-        Exception: If the network request fails (logged before re-raise)
+    Returns:
+        True if the URL points to a downloadable file, False otherwise
 
     Example:
         >>> if is_downloadable("https://example.com/file.zip"):
         ...     print("URL is downloadable")
     """
+    _check_requests_dependency()
+
     try:
         info = get_file_info(url, timeout)
-        if info and info['size'] > 0:
+        if info['size'] > 0:
             return True
+    except (ConnectionError, OSError, ValueError):
+        pass
 
-        # Try a GET request to see if we can access the content
+    try:
         response = requests.get(url, stream=True, timeout=timeout)
         return response.ok
-        
-    except (OSError, ValueError) as exc:
-        log.warning("Could not check if URL is downloadable %s: %s", url, exc)
-        raise
+    except (OSError, ValueError):
+        return False
 
 __all__ = [
     'download_file',

--- a/siege_utilities/files/shell.py
+++ b/siege_utilities/files/shell.py
@@ -164,13 +164,13 @@ def run_subprocess(command_list: Union[str, List[str]],
 
         try:
             stdout, stderr = p.communicate(timeout=timeout)
-        except subprocess.TimeoutExpired:
+        except subprocess.TimeoutExpired as e:
             p.kill()
             stdout, stderr = p.communicate()
             raise subprocess.TimeoutExpired(
                 validated_command, timeout,
                 output=stdout, stderr=stderr
-            )
+            ) from e
 
         returncode = p.returncode
 

--- a/siege_utilities/files/validation.py
+++ b/siege_utilities/files/validation.py
@@ -229,10 +229,10 @@ def validate_safe_path(path: FilePath,
             try:
                 # This raises ValueError if resolved_path is not relative to base_path
                 resolved_path.relative_to(base_path)
-            except ValueError:
+            except ValueError as e:
                 raise PathSecurityError(
                     f"Path {resolved_path} is outside base directory {base_path}"
-                )
+                ) from e
 
         log.debug(f"Path validation passed: {path_str} -> {resolved_path}")
         return resolved_path

--- a/siege_utilities/geo/census/api.py
+++ b/siege_utilities/geo/census/api.py
@@ -127,6 +127,16 @@ class CensusAPI:
 
         Delegates variable resolution to VariableRegistry and geography
         validation to DatasetSelector, then handles the HTTP round-trip.
+
+        Args:
+            variables: Variable name(s) to fetch (resolved via VariableRegistry).
+            year: Census data year.
+            dataset: Census dataset identifier (e.g., 'acs5', 'dec/sf1').
+            geography: Geographic level (e.g., 'county', 'tract', 'zcta').
+            state_fips: State FIPS filter (required for sub-state geographies).
+            county_fips: County FIPS filter.
+            include_moe: If True and dataset is ACS, append margin-of-error
+                variables. Silently ignored for non-ACS datasets.
         """
         # Resolve variables via registry
         var_list = self._registry.resolve_variables(variables)
@@ -154,7 +164,7 @@ class CensusAPI:
         df = self._make_request_with_retry(url)
 
         # Process response
-        df = self._process_response(df, geography, state_fips, county_fips)
+        df = self._process_response(df, geography)
 
         # Cache
         self._save_to_cache(cache_key, df)
@@ -252,8 +262,6 @@ class CensusAPI:
         self,
         df: pd.DataFrame,
         geography: str,
-        state_fips: Optional[str],
-        county_fips: Optional[str],
     ) -> pd.DataFrame:
         if df.empty:
             return df
@@ -290,7 +298,10 @@ class CensusAPI:
             if zcta_col:
                 df['GEOID'] = df[zcta_col]
             else:
-                df['GEOID'] = ''
+                raise ValueError(
+                    f"Cannot construct GEOID for zcta: no column matching "
+                    f"'zip' or 'zcta' found in response columns {list(df.columns)}"
+                )
 
         cols_to_drop = ['state', 'county', 'tract', 'block group', 'place']
         cols_to_drop = [c for c in cols_to_drop if c in df.columns]
@@ -395,8 +406,14 @@ class CensusAPI:
             log.warning(f"Django cache set failed: {e}")
 
     def clear_cache(self) -> None:
-        """Clear all cached API responses."""
+        """Clear cached API responses from the parquet file cache.
+
+        Only clears the local parquet cache. Has no effect when
+        ``cache_backend='django'`` (Django cache must be cleared via
+        ``django.core.cache.cache.clear()``).
+        """
         if self.cache_dir is None:
+            log.debug("clear_cache called but no parquet cache_dir configured (django backend?)")
             return
         try:
             for cache_file in self.cache_dir.glob('*.parquet'):

--- a/siege_utilities/geo/census/dataset_selector.py
+++ b/siege_utilities/geo/census/dataset_selector.py
@@ -72,11 +72,11 @@ class DatasetSelector:
 
         try:
             canonical = resolve_geographic_level(geography)
-        except ValueError:
+        except ValueError as e:
             raise ValueError(
                 f"Invalid geography '{geography}'. "
                 f"Valid options: {sorted(cls.API_SUPPORTED_GEOGRAPHIES)}"
-            )
+            ) from e
 
         if canonical not in cls.API_SUPPORTED_GEOGRAPHIES:
             raise ValueError(
@@ -127,11 +127,15 @@ class DatasetSelector:
             return "for=county:*"
 
         elif geography == 'tract':
+            if not state_fips:
+                raise ValueError("state_fips is required for tract-level data")
             if county_fips:
                 return f"for=tract:*&in=state:{state_fips}%20county:{county_fips}"
             return f"for=tract:*&in=state:{state_fips}"
 
         elif geography == 'block_group':
+            if not state_fips:
+                raise ValueError("state_fips is required for block_group-level data")
             if county_fips:
                 return f"for=block%20group:*&in=state:{state_fips}%20county:{county_fips}"
             return f"for=block%20group:*&in=state:{state_fips}"

--- a/siege_utilities/geo/crs.py
+++ b/siege_utilities/geo/crs.py
@@ -60,7 +60,12 @@ def set_default_crs(crs: str) -> None:
     Args:
         crs: Any CRS string accepted by ``pyproj`` (e.g. ``"EPSG:4326"``,
             ``"EPSG:3857"``, ``"ESRI:102003"``).
+
+    Raises:
+        pyproj.exceptions.CRSError: If *crs* is not recognized by pyproj.
     """
+    from pyproj import CRS as _CRS
+    _CRS.from_user_input(crs)
     global _DEFAULT_CRS  # noqa: PLW0603
     _DEFAULT_CRS = crs
 
@@ -89,8 +94,10 @@ def reproject_if_needed(gdf, crs: str | None = None):
         )
         gdf = gdf.set_crs(target)
         return gdf
-    if str(gdf.crs).upper() != target.upper():
-        return gdf.to_crs(target)
+    from pyproj import CRS as _CRS
+    target_crs = _CRS.from_user_input(target)
+    if gdf.crs != target_crs:
+        return gdf.to_crs(target_crs)
     return gdf
 
 
@@ -172,7 +179,7 @@ def _normalize_crs(value: Any) -> str:
 def reproject_geom(
     geom,
     src_crs: Any,
-    dst_epsg: int = 4326,
+    dst_crs: Any = 4326,
     axis_order: str = AXIS_ORDER_TRAD_GIS,
 ):
     """Reproject a shapely geometry with explicit axis-order control.
@@ -183,7 +190,8 @@ def reproject_geom(
         src_crs: The geometry's source CRS, in any form
             :class:`pyproj.CRS.from_user_input` accepts (``"EPSG:4326"``,
             an integer EPSG code, a WKT string, a ``pyproj.CRS`` object).
-        dst_epsg: Target EPSG code. Defaults to ``4326``.
+        dst_crs: Target CRS, in any form :class:`pyproj.CRS.from_user_input`
+            accepts. Defaults to ``4326`` (WGS 84).
         axis_order: One of:
 
             * ``"trad_gis"`` (default) — ``pyproj`` ``always_xy=True``.
@@ -239,7 +247,7 @@ def reproject_geom(
         ) from exc
 
     src = CRS.from_user_input(src_crs)
-    dst = CRS.from_epsg(dst_epsg)
+    dst = CRS.from_user_input(dst_crs)
 
     # No-op if source equals target.
     if src == dst:

--- a/siege_utilities/geo/django/management/commands/classify_urbanicity.py
+++ b/siege_utilities/geo/django/management/commands/classify_urbanicity.py
@@ -67,11 +67,11 @@ class Command(BaseCommand):
 
         try:
             return normalize_state_identifier(state_input)
-        except ValueError:
+        except ValueError as e:
             raise CommandError(
                 f"Invalid state identifier: {state_input}. "
                 "Use FIPS code (e.g., 06) or abbreviation (e.g., CA)"
-            )
+            ) from e
 
     def handle(self, *args, **options):
         year = options["year"]

--- a/siege_utilities/geo/django/management/commands/populate_boundaries.py
+++ b/siege_utilities/geo/django/management/commands/populate_boundaries.py
@@ -93,11 +93,11 @@ class Command(BaseCommand):
 
         try:
             return normalize_state_identifier(state_input)
-        except (ValueError, KeyError):
+        except (ValueError, KeyError) as e:
             raise CommandError(
                 f"Invalid state identifier: {state_input}. "
                 "Use FIPS code (e.g., 06) or abbreviation (e.g., CA)"
-            )
+            ) from e
 
     def handle(self, *args, **options):
         year = options["year"]

--- a/siege_utilities/geo/django/management/commands/populate_crosswalks.py
+++ b/siege_utilities/geo/django/management/commands/populate_crosswalks.py
@@ -79,11 +79,11 @@ class Command(BaseCommand):
 
         try:
             return normalize_state_identifier(state_input)
-        except (ValueError, KeyError):
+        except (ValueError, KeyError) as e:
             raise CommandError(
                 f"Invalid state identifier: {state_input}. "
                 "Use FIPS code (e.g., 06) or abbreviation (e.g., CA)"
-            )
+            ) from e
 
     def handle(self, *args, **options):
         source_year = options["source_year"]

--- a/siege_utilities/geo/django/management/commands/populate_demographics.py
+++ b/siege_utilities/geo/django/management/commands/populate_demographics.py
@@ -90,11 +90,11 @@ class Command(BaseCommand):
 
         try:
             return normalize_state_identifier(state_input)
-        except (ValueError, KeyError):
+        except (ValueError, KeyError) as e:
             raise CommandError(
                 f"Invalid state identifier: {state_input}. "
                 "Use FIPS code (e.g., 06) or abbreviation (e.g., CA)"
-            )
+            ) from e
 
     def handle(self, *args, **options):
         year = options["year"]

--- a/siege_utilities/geo/django/services/rollup_service.py
+++ b/siege_utilities/geo/django/services/rollup_service.py
@@ -100,6 +100,13 @@ class DemographicRollupService:
         Returns:
             List of RollupResult (one per variable)
         """
+        _VALID_OPERATIONS = {'sum', 'avg', 'weighted_avg'}
+        if operation not in _VALID_OPERATIONS:
+            raise ValueError(
+                f"Unknown aggregation operation {operation!r}; "
+                f"expected one of {sorted(_VALID_OPERATIONS)}"
+            )
+
         from django.contrib.contenttypes.models import ContentType
 
         from ..models.demographics import DemographicSnapshot
@@ -271,9 +278,6 @@ class DemographicRollupService:
                             agg_value = sum(values) / len(values)
                     else:
                         agg_value = sum(values) / len(values)
-                else:
-                    result.errors.append(f"Unknown operation: {operation}")
-                    break
 
                 # Check if target snapshot already exists
                 existing = DemographicSnapshot.objects.filter(

--- a/siege_utilities/geo/geoid_utils.py
+++ b/siege_utilities/geo/geoid_utils.py
@@ -165,11 +165,11 @@ def normalize_geoid(
     # Zero-pad to expected length
     normalized = geoid_str.zfill(expected_length)
 
-    # Validate result
     if len(normalized) != expected_length:
-        log.warning(
+        raise ValueError(
             f"GEOID '{geoid}' is longer than expected for {geography_level} "
-            f"(expected {expected_length}, got {len(normalized)})"
+            f"(expected {expected_length} digits, got {len(geoid_str)}). "
+            f"Check that the geography_level is correct."
         )
 
     return normalized
@@ -395,13 +395,21 @@ def extract_parent_geoid(
     """
     Extract a parent GEOID from a child GEOID.
 
+    Supports extracting state, county, or tract as the parent level.
+    Other parent levels raise ValueError.
+
     Args:
         geoid: Child GEOID
         child_geography: Geography level of the input GEOID
-        parent_geography: Geography level to extract
+        parent_geography: Target parent level (``"state"``, ``"county"``,
+            or ``"tract"``)
 
     Returns:
         Parent GEOID
+
+    Raises:
+        ValueError: If *parent_geography* is not one of the supported
+            parent levels (state, county, tract).
 
     Example:
         >>> extract_parent_geoid("06037101100", "tract", "county")

--- a/siege_utilities/geo/overlay_registry.py
+++ b/siege_utilities/geo/overlay_registry.py
@@ -131,13 +131,9 @@ class OverlayRegistry:
             return self._overlays[name]
 
         if name in self._classes:
-            try:
-                instance = self._classes[name]()
-                self._overlays[name] = instance
-                return instance
-            except (RuntimeError, ValueError, TypeError, AttributeError, OSError) as exc:
-                log.error("Failed to instantiate overlay %s: %s", name, exc)
-                return None
+            instance = self._classes[name]()
+            self._overlays[name] = instance
+            return instance
 
         return None
 

--- a/siege_utilities/geo/overlays/demographics.py
+++ b/siege_utilities/geo/overlays/demographics.py
@@ -194,6 +194,3 @@ class DemographicsOverlay(PlaceHistoryOverlay):
         except ImportError:
             log.debug("Django demographics provider not available (Django not installed or not configured)")
             return None
-        except (RuntimeError, ValueError, TypeError, AttributeError, OSError) as exc:
-            log.warning("Failed to initialise Django demographics provider: %s", exc)
-            return None

--- a/siege_utilities/geo/overlays/events.py
+++ b/siege_utilities/geo/overlays/events.py
@@ -186,6 +186,3 @@ class EventsOverlay(PlaceHistoryOverlay):
         except ImportError:
             log.debug("Django events provider not available (Django not installed or not configured)")
             return None
-        except (RuntimeError, ValueError, TypeError, AttributeError, OSError) as exc:
-            log.warning("Failed to initialise Django events provider: %s", exc)
-            return None

--- a/siege_utilities/geo/overlays/seats.py
+++ b/siege_utilities/geo/overlays/seats.py
@@ -182,6 +182,3 @@ class SeatsOverlay(PlaceHistoryOverlay):
         except ImportError:
             log.debug("Django seats provider not available (Django not installed or not configured)")
             return None
-        except (RuntimeError, ValueError, TypeError, AttributeError, OSError) as exc:
-            log.warning("Failed to initialise Django seats provider: %s", exc)
-            return None

--- a/siege_utilities/geo/overlays/urbanicity.py
+++ b/siege_utilities/geo/overlays/urbanicity.py
@@ -180,6 +180,3 @@ class UrbanicityOverlay(PlaceHistoryOverlay):
         except ImportError:
             log.debug("Django urbanicity provider not available (Django not installed or not configured)")
             return None
-        except (RuntimeError, ValueError, TypeError, AttributeError, OSError) as exc:
-            log.warning("Failed to initialise Django urbanicity provider: %s", exc)
-            return None

--- a/siege_utilities/geo/providers/boundary_providers.py
+++ b/siege_utilities/geo/providers/boundary_providers.py
@@ -234,10 +234,10 @@ class GADMProvider(BoundaryProvider):
 
         try:
             import geopandas as gpd
-        except ImportError:
+        except ImportError as e:
             raise ImportError(
                 'GADMProvider requires geopandas. Install with: pip install siege_utilities[geo]'
-            )
+            ) from e
 
         logger.info('Downloading GADM boundaries: %s', url)
         return gpd.read_file(url)

--- a/siege_utilities/geo/providers/census_geocoder.py
+++ b/siege_utilities/geo/providers/census_geocoder.py
@@ -189,11 +189,11 @@ def _get_geocoder(vintage: CensusVintage = CensusVintage.CURRENT):
     """Get a censusgeocode.CensusGeocode instance with the specified vintage."""
     try:
         import censusgeocode
-    except ImportError:
+    except ImportError as e:
         raise ImportError(
             "censusgeocode is required for Census geocoding. "
             "Install it with: pip install 'siege-utilities[geo]' or pip install censusgeocode"
-        )
+        ) from e
     return censusgeocode.CensusGeocode(
         benchmark=vintage.benchmark,
         vintage=vintage.vintage,

--- a/siege_utilities/geo/providers/etter_to_geometry.py
+++ b/siege_utilities/geo/providers/etter_to_geometry.py
@@ -50,6 +50,8 @@ __all__ = [
     "EtterGeometryResult",
     "PointPredicate",
     "EtterToGeometryError",
+    "EtterReferenceNotFoundError",
+    "EtterUnknownRelationError",
     "etter_to_geometry",
 ]
 

--- a/siege_utilities/geo/providers/nces_download.py
+++ b/siege_utilities/geo/providers/nces_download.py
@@ -123,11 +123,12 @@ class NCESDownloader:
         zip_path = str(self.cache_dir / f"{data_type}_{year}.zip")
         log.info(f"Downloading {data_type} data for {year} from {url}")
 
-        result = download_file(url, zip_path, timeout=self.timeout)
-        if not result:
+        try:
+            download_file(url, zip_path, timeout=self.timeout)
+        except (OSError, ConnectionError) as e:
             raise NCESDownloadError(
                 f"Failed to download {data_type} for year {year} from {url}"
-            )
+            ) from e
 
         # Extract
         extract_dir.mkdir(parents=True, exist_ok=True)
@@ -284,7 +285,7 @@ class NCESDownloader:
         try:
             shp_path = self._find_shapefile(extract_dir)
             gdf = gpd.read_file(shp_path)
-        except NCESDownloadError:
+        except NCESDownloadError as shp_err:
             # Try CSV with lat/lon columns
             csv_path = self._find_csv(extract_dir)
             df = pd.read_csv(csv_path, dtype=str, low_memory=False)
@@ -299,7 +300,7 @@ class NCESDownloader:
                 raise NCESDownloadError(
                     f"Cannot find lat/lon columns in {csv_path}. "
                     f"Available: {list(df.columns)}"
-                )
+                ) from shp_err
 
             df[lat_col] = pd.to_numeric(df[lat_col], errors="coerce")
             df[lon_col] = pd.to_numeric(df[lon_col], errors="coerce")

--- a/siege_utilities/geo/providers/nlrb_clients.py
+++ b/siege_utilities/geo/providers/nlrb_clients.py
@@ -325,29 +325,34 @@ class NLRBLabordataClient:
         Downloads cases, elections, and ULP charges CSVs.
         """
         result = NLRBFetchResult(source="labordata")
+        _RequestException = _requests().exceptions.RequestException
 
-        cases_csv = self._download_csv("cases")
-        if cases_csv is not None:
+        try:
+            cases_csv = self._download_csv("cases")
             for row in cases_csv:
                 record = self._parse_case_row(row)
                 if record:
                     result.cases.append(record)
+        except (_RequestException, OSError) as exc:
+            result.errors.append(f"cases: {exc}")
 
-        elections_csv = self._download_csv("elections")
-        if elections_csv is not None:
+        try:
+            elections_csv = self._download_csv("elections")
             for row in elections_csv:
                 record = self._parse_election_row(row)
                 if record:
                     result.elections.append(record)
+        except (_RequestException, OSError) as exc:
+            result.errors.append(f"elections: {exc}")
 
-        charges_csv = self._download_csv("ulp_charges")
-        if charges_csv is not None:
+        try:
+            charges_csv = self._download_csv("ulp_charges")
             for row in charges_csv:
                 record = self._parse_ulp_row(row)
                 if record:
                     result.ulp_charges.append(record)
-        elif cases_csv is None:
-            result.errors.append("Failed to download any data from labordata")
+        except (_RequestException, OSError) as exc:
+            result.errors.append(f"ulp_charges: {exc}")
 
         log.info(
             "labordata: %d cases, %d elections, %d charges",
@@ -357,17 +362,13 @@ class NLRBLabordataClient:
         )
         return result
 
-    def _download_csv(self, dataset: str) -> Optional[list[dict]]:
+    def _download_csv(self, dataset: str) -> list[dict]:
         path = LABORDATA_FILES.get(dataset)
         if not path:
-            return None
+            raise ValueError(f"Unknown labordata dataset: {dataset!r}")
         url = self._base_url + path
-        try:
-            resp = self._get_session().get(url, timeout=self._timeout)
-            resp.raise_for_status()
-        except (_RequestException, OSError) as exc:
-            log.warning("labordata: failed to download %s: %s", dataset, exc)
-            return None
+        resp = self._get_session().get(url, timeout=self._timeout)
+        resp.raise_for_status()
 
         reader = csv.DictReader(io.StringIO(resp.text))
         return list(reader)

--- a/siege_utilities/geo/rdh_catalog.py
+++ b/siege_utilities/geo/rdh_catalog.py
@@ -250,8 +250,7 @@ class RDHCatalog:
             return len(self._entries)
 
         if self._provider is None:
-            log.warning("No provider configured; catalog is empty")
-            return 0
+            raise RuntimeError("No provider configured; cannot load catalog")
 
         entries = self._provider.fetch_all_datasets()
         self._entries = entries

--- a/siege_utilities/geo/spatial_data.py
+++ b/siege_utilities/geo/spatial_data.py
@@ -322,7 +322,11 @@ def update_census_inventory(
 
 
 def load_census_inventory(path: Optional[Path] = None) -> Optional[dict]:
-    """Load the saved Census inventory from disk.  Returns None if absent."""
+    """Load the saved Census inventory from disk.  Returns None if absent.
+
+    Raises:
+        SpatialDataError: If the file exists but cannot be parsed.
+    """
     import json
     p = Path(path or _DEFAULT_INVENTORY_PATH)
     if not p.exists():
@@ -331,8 +335,9 @@ def load_census_inventory(path: Optional[Path] = None) -> Optional[dict]:
         with open(p, encoding="utf-8") as fh:
             return json.load(fh)
     except (OSError, ValueError, UnicodeDecodeError) as exc:
-        log.warning("could not load census inventory from %s: %s", p, exc)
-        return None
+        raise SpatialDataError(
+            f"Census inventory file exists at {p} but cannot be parsed: {exc}"
+        ) from exc
 
 
 def _dirs_from_inventory(year: int, inventory: Optional[dict] = None) -> Optional[List[str]]:
@@ -1062,7 +1067,7 @@ class CensusDirectoryDiscovery:
                 raise BoundaryUrlValidationError(
                     f"URL returned HTTP {response.status_code} (SSL bypass): {url}",
                     context=ctx,
-                )
+                ) from ssl_err
             except BoundaryUrlValidationError:
                 raise
             except (requests.exceptions.RequestException, OSError) as e:
@@ -1430,13 +1435,16 @@ class CensusDataSource(SpatialDataSource):
         # Use centralized FIPS data
         return FIPS_TO_STATE.copy()
     
-    def normalize_state_identifier(self, state_input) -> Optional[str]:
-        """Convert any state identifier (FIPS, abbreviation, name) to FIPS code."""
-        # DEPRECATED: Use centralized normalize_state_identifier function instead
-        try:
-            return normalize_state_identifier(state_input)
-        except ValueError:
-            return None
+    def normalize_state_identifier(self, state_input) -> str:
+        """Convert any state identifier (FIPS, abbreviation, name) to FIPS code.
+
+        .. deprecated:: 3.16.0
+            Use the module-level :func:`normalize_state_identifier` directly.
+
+        Raises:
+            ValueError: If the input cannot be resolved to a valid state FIPS.
+        """
+        return normalize_state_identifier(state_input)
     
     def get_comprehensive_state_info(self) -> Dict[str, Dict[str, str]]:
         """Get comprehensive state information including FIPS, name, and abbreviation."""
@@ -1549,30 +1557,16 @@ class CensusDataSource(SpatialDataSource):
 
             # Generate local path using existing function
             zip_filename = generate_local_path_from_url(url, download_dir)
-            if not zip_filename:
-                raise BoundaryDownloadError(
-                    "Failed to generate local path for download",
-                    context={**ctx, "error_code": "LOCAL_PATH_FAILED"},
-                )
-
             ctx["local_path"] = str(zip_filename)
 
-            # Download file using existing function with SSL fallback
-            download_success = False
+            # Download file (download_file handles SSL retry internally)
             try:
-                download_success = download_file(url, zip_filename)
-            except (OSError, requests.exceptions.RequestException, ValueError) as ssl_error:
-                if "SSL" in str(ssl_error) or "certificate" in str(ssl_error).lower():
-                    log.warning(f"SSL verification failed, retrying without verification: {ssl_error}")
-                    download_success = download_file(url, zip_filename, verify_ssl=False)
-                    if download_success:
-                        log.info("Successfully downloaded without SSL verification")
-
-            if not download_success:
+                download_file(url, zip_filename)
+            except (OSError, ConnectionError) as dl_err:
                 raise BoundaryDownloadError(
                     f"Failed to download TIGER/Line data from {url}",
                     context={**ctx, "error_code": "DOWNLOAD_FAILED"},
-                )
+                ) from dl_err
 
             # Validate downloaded file is actually a zip (not an HTML challenge page)
             import zipfile
@@ -1585,8 +1579,11 @@ class CensusDataSource(SpatialDataSource):
                 )
                 zip_path.unlink(missing_ok=True)
                 # Retry once — the first attempt may have been an anti-bot challenge
-                download_success = download_file(url, zip_filename)
-                if not download_success or not zipfile.is_zipfile(zip_path):
+                try:
+                    download_file(url, zip_filename)
+                except (OSError, ConnectionError):
+                    pass
+                if not zipfile.is_zipfile(zip_path):
                     zip_path.unlink(missing_ok=True)
                     raise BoundaryDownloadError(
                         f"Downloaded file is not a valid zip after retry: {url}",
@@ -1600,11 +1597,6 @@ class CensusDataSource(SpatialDataSource):
 
             # Unzip using existing function
             unzip_dir = unzip_file_to_directory(Path(zip_filename))
-            if not unzip_dir:
-                raise BoundaryDownloadError(
-                    f"Failed to unzip TIGER/Line data from {zip_filename}",
-                    context={**ctx, "error_code": "UNZIP_FAILED"},
-                )
 
             # Find the shapefile
             shapefile_path = None
@@ -1709,16 +1701,19 @@ class GovernmentDataSource(SpatialDataSource):
             api_key=api_key
         )
     
-    def download_dataset(self, dataset_id: str, format_type: str = 'geojson') -> Optional[GeoDataFrame]:
+    def download_dataset(self, dataset_id: str, format_type: str = 'geojson') -> GeoDataFrame:
         """
         Download a dataset from the government data portal.
-        
+
         Args:
             dataset_id: Unique identifier for the dataset
             format_type: Preferred format (geojson, shapefile, kml)
-            
+
         Returns:
-            GeoDataFrame with spatial data or None if failed
+            GeoDataFrame with spatial data.
+
+        Raises:
+            SpatialDataError: On any download or processing failure.
         """
         try:
             # Construct download URL
@@ -1727,12 +1722,17 @@ class GovernmentDataSource(SpatialDataSource):
             # Get dataset metadata
             metadata = self._get_dataset_metadata(download_url)
             if not metadata:
-                return None
-            
+                raise SpatialDataError(
+                    f"Dataset {dataset_id} returned empty metadata"
+                )
+
             # Find best format
             resource_url = self._find_best_format(metadata, format_type)
             if not resource_url:
-                return None
+                raise SpatialDataError(
+                    f"No downloadable resource found for dataset {dataset_id} "
+                    f"(preferred format: {format_type})"
+                )
             
             # Download and process
             return self._download_and_process_dataset(resource_url, format_type)
@@ -1775,30 +1775,36 @@ class GovernmentDataSource(SpatialDataSource):
                 f"Error getting dataset metadata from {url}: {e}"
             ) from e
     
-    def _find_best_format(self, metadata: Dict[str, Any], preferred_format: str) -> Optional[str]:
-        """Find the best available format for download.
+    def _find_best_format(self, metadata: Dict[str, Any], preferred_format: str) -> str:
+        """Find the best available format URL for download.
 
-        Pure dict-manipulation; no I/O. The previous catch-all
-        ``except Exception: raise SpatialDataError(...)`` wrapper was
-        treating programming errors (a non-dict in ``resources``, a
-        ``metadata`` that wasn't a dict) as data errors. Let programming
-        errors propagate as themselves so the cause is visible.
+        Pure dict-manipulation; no I/O.
+
+        Raises:
+            SpatialDataError: If no downloadable resource URL is found.
         """
         resources = metadata.get('resources', [])
 
         # Look for preferred format first
         for resource in resources:
             if resource.get('format', '').lower() == preferred_format.lower():
-                return resource.get('url')
+                url = resource.get('url')
+                if url:
+                    return url
 
         # Fall back to any available format
         for resource in resources:
-            if resource.get('url'):
-                return resource.get('url')
+            url = resource.get('url')
+            if url:
+                return url
 
-        return None
+        raise SpatialDataError(
+            f"No downloadable resource URL in metadata "
+            f"(preferred format: {preferred_format}, "
+            f"resources checked: {len(resources)})"
+        )
     
-    def _download_and_process_dataset(self, url: str, format_type: str) -> Optional[GeoDataFrame]:
+    def _download_and_process_dataset(self, url: str, format_type: str) -> GeoDataFrame:
         """Download and process the dataset."""
         try:
             # Get user's download directory
@@ -1807,14 +1813,10 @@ class GovernmentDataSource(SpatialDataSource):
             
             # Generate local path
             local_filename = generate_local_path_from_url(url, download_dir)
-            if not local_filename:
-                return None
-            
+
             # Download file
-            download_success = download_file(url, local_filename)
-            if not download_success:
-                return None
-            
+            download_file(url, local_filename)
+
             # Process based on format
             if format_type.lower() == 'geojson':
                 gdf = gpd.read_file(local_filename)
@@ -1822,20 +1824,15 @@ class GovernmentDataSource(SpatialDataSource):
                 # Handle zip files
                 if str(local_filename).endswith('.zip'):
                     unzip_dir = unzip_file_to_directory(Path(local_filename))
-                    if unzip_dir:
-                        shp_files = list(unzip_dir.glob("*.shp"))
-                        if shp_files:
-                            gdf = gpd.read_file(shp_files[0])
-                        else:
-                            log.error("No shapefile found in zip")
-                            return None
+                    shp_files = list(unzip_dir.glob("*.shp"))
+                    if shp_files:
+                        gdf = gpd.read_file(shp_files[0])
                     else:
-                        return None
+                        raise ValueError(f"No shapefile found in zip: {local_filename}")
                 else:
                     gdf = gpd.read_file(local_filename)
             else:
-                log.error(f"Unsupported format: {format_type}")
-                return None
+                raise SpatialDataError(f"Unsupported format: {format_type}")
             
             # Best-effort cleanup of the downloaded file. Narrow to OSError
             # (the only family os.remove raises) and log at debug level so
@@ -1865,16 +1862,19 @@ class OpenStreetMapDataSource(SpatialDataSource):
             base_url="https://overpass-api.de/api/interpreter"
         )
     
-    def download_osm_data(self, query: str, bbox: Optional[List[float]] = None) -> Optional[GeoDataFrame]:
+    def download_osm_data(self, query: str, bbox: Optional[List[float]] = None) -> GeoDataFrame:
         """
         Download data from OpenStreetMap using Overpass QL.
-        
+
         Args:
             query: Overpass QL query string
             bbox: Bounding box [min_lat, min_lon, max_lat, max_lon]
-            
+
         Returns:
-            GeoDataFrame with OSM data or None if failed
+            GeoDataFrame with OSM data.
+
+        Raises:
+            SpatialDataError: On HTTP or processing failure.
         """
         try:
             # Construct Overpass query
@@ -1894,8 +1894,9 @@ class OpenStreetMapDataSource(SpatialDataSource):
             )
             
             if not response.ok:
-                log.error(f"Overpass API error: HTTP {response.status_code}")
-                return None
+                raise SpatialDataError(
+                    f"Overpass API error: HTTP {response.status_code}"
+                )
             
             # Parse response
             gdf = gpd.read_file(response.content, driver='GeoJSON')

--- a/siege_utilities/geo/spatial_transformations.py
+++ b/siege_utilities/geo/spatial_transformations.py
@@ -77,219 +77,140 @@ class SpatialDataTransformer:
         if DUCKDB_AVAILABLE:
             self.supported_formats['output'].append('duckdb')
     
-    def convert_format(self, gdf: GeoDataFrame, output_format: str, **kwargs) -> bool:
+    def convert_format(self, gdf: GeoDataFrame, output_format: str, **kwargs) -> None:
         """
         Convert GeoDataFrame to different format.
-        
+
         Args:
             gdf: Input GeoDataFrame
             output_format: Desired output format
             **kwargs: Additional format-specific parameters
-            
-        Returns:
-            True if successful, False otherwise
+
+        Raises:
+            ValueError: If output_format is unsupported
+            ImportError: If required dependency is not available
+            OSError: If file write fails
         """
-        try:
-            if output_format == 'shp':
-                return self._convert_to_shapefile(gdf, **kwargs)
-            elif output_format == 'geojson':
-                return self._convert_to_geojson(gdf, **kwargs)
-            elif output_format == 'gpkg':
-                return self._convert_to_geopackage(gdf, **kwargs)
-            elif output_format == 'kml':
-                return self._convert_to_kml(gdf, **kwargs)
-            elif output_format == 'gml':
-                return self._convert_to_gml(gdf, **kwargs)
-            elif output_format == 'wkt':
-                return self._convert_to_wkt(gdf, **kwargs)
-            elif output_format == 'wkb':
-                return self._convert_to_wkb(gdf, **kwargs)
-            elif output_format == 'postgis':
-                return self._convert_to_postgis(gdf, **kwargs)
-            elif output_format == 'duckdb':
-                if DUCKDB_AVAILABLE:
-                    return self._convert_to_duckdb(gdf, **kwargs)
-                else:
-                    log.error("DuckDB not available. Install with: pip install duckdb")
-                    return False
-            else:
-                log.error(f"Unsupported output format: {output_format}")
-                return False
-                
-        except (OSError, ValueError, TypeError, AttributeError, KeyError, ImportError) as e:
-            log.error(f"Format conversion failed: {e}")
-            return False
+        if output_format == 'shp':
+            self._convert_to_shapefile(gdf, **kwargs)
+        elif output_format == 'geojson':
+            self._convert_to_geojson(gdf, **kwargs)
+        elif output_format == 'gpkg':
+            self._convert_to_geopackage(gdf, **kwargs)
+        elif output_format == 'kml':
+            self._convert_to_kml(gdf, **kwargs)
+        elif output_format == 'gml':
+            self._convert_to_gml(gdf, **kwargs)
+        elif output_format == 'wkt':
+            self._convert_to_wkt(gdf, **kwargs)
+        elif output_format == 'wkb':
+            self._convert_to_wkb(gdf, **kwargs)
+        elif output_format == 'postgis':
+            self._convert_to_postgis(gdf, **kwargs)
+        elif output_format == 'duckdb':
+            if not DUCKDB_AVAILABLE:
+                raise ImportError("DuckDB not available. Install with: pip install duckdb")
+            self._convert_to_duckdb(gdf, **kwargs)
+        else:
+            raise ValueError(f"Unsupported output format: {output_format}")
     
-    def _convert_to_shapefile(self, gdf: GeoDataFrame, **kwargs) -> bool:
+    def _convert_to_shapefile(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to ESRI Shapefile format."""
-        try:
-            output_path = kwargs.get('output_path', 'output.shp')
-            gdf.to_file(output_path, driver='ESRI Shapefile')
-            log.info(f"Successfully converted to Shapefile: {output_path}")
-            return True
-        except (OSError, ValueError, TypeError, RuntimeError) as e:
-            log.error(f"Failed to convert to Shapefile: {e}")
-            return False
-    
-    def _convert_to_geojson(self, gdf: GeoDataFrame, **kwargs) -> bool:
+        output_path = kwargs.get('output_path', 'output.shp')
+        gdf.to_file(output_path, driver='ESRI Shapefile')
+        log.info(f"Successfully converted to Shapefile: {output_path}")
+
+    def _convert_to_geojson(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to GeoJSON format."""
-        try:
-            output_path = kwargs.get('output_path', 'output.geojson')
-            gdf.to_file(output_path, driver='GeoJSON')
-            log.info(f"Successfully converted to GeoJSON: {output_path}")
-            return True
-        except (OSError, ValueError, TypeError, RuntimeError) as e:
-            log.error(f"Failed to convert to GeoJSON: {e}")
-            return False
-    
-    def _convert_to_geopackage(self, gdf: GeoDataFrame, **kwargs) -> bool:
+        output_path = kwargs.get('output_path', 'output.geojson')
+        gdf.to_file(output_path, driver='GeoJSON')
+        log.info(f"Successfully converted to GeoJSON: {output_path}")
+
+    def _convert_to_geopackage(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to GeoPackage format."""
-        try:
-            output_path = kwargs.get('output_path', 'output.gpkg')
-            gdf.to_file(output_path, driver='GPKG')
-            log.info(f"Successfully converted to GeoPackage: {output_path}")
-            return True
-        except (OSError, ValueError, TypeError, RuntimeError) as e:
-            log.error(f"Failed to convert to GeoPackage: {e}")
-            return False
-    
-    def _convert_to_kml(self, gdf: GeoDataFrame, **kwargs) -> bool:
+        output_path = kwargs.get('output_path', 'output.gpkg')
+        gdf.to_file(output_path, driver='GPKG')
+        log.info(f"Successfully converted to GeoPackage: {output_path}")
+
+    def _convert_to_kml(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to KML format."""
-        try:
-            output_path = kwargs.get('output_path', 'output.kml')
-            gdf.to_file(output_path, driver='KML')
-            log.info(f"Successfully converted to KML: {output_path}")
-            return True
-        except (OSError, ValueError, TypeError, RuntimeError) as e:
-            log.error(f"Failed to convert to KML: {e}")
-            return False
-    
-    def _convert_to_gml(self, gdf: GeoDataFrame, **kwargs) -> bool:
+        output_path = kwargs.get('output_path', 'output.kml')
+        gdf.to_file(output_path, driver='KML')
+        log.info(f"Successfully converted to KML: {output_path}")
+
+    def _convert_to_gml(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to GML format."""
-        try:
-            output_path = kwargs.get('output_path', 'output.gml')
-            gdf.to_file(output_path, driver='GML')
-            log.info(f"Successfully converted to GML: {output_path}")
-            return True
-        except (OSError, ValueError, TypeError, RuntimeError) as e:
-            log.error(f"Failed to convert to GML: {e}")
-            return False
-    
-    def _convert_to_wkt(self, gdf: GeoDataFrame, **kwargs) -> bool:
+        output_path = kwargs.get('output_path', 'output.gml')
+        gdf.to_file(output_path, driver='GML')
+        log.info(f"Successfully converted to GML: {output_path}")
+
+    def _convert_to_wkt(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to WKT (Well-Known Text) format."""
-        try:
-            output_path = kwargs.get('output_path', 'output.wkt')
-            
-            # Convert geometries to WKT strings
-            wkt_data = gdf.copy()
-            wkt_data['geometry'] = wkt_data.geometry.astype(str)
-            
-            # Save as CSV with WKT geometries
-            wkt_data.to_csv(output_path, index=False)
-            log.info(f"Successfully converted to WKT: {output_path}")
-            return True
-        except (OSError, ValueError, TypeError, AttributeError) as e:
-            log.error(f"Failed to convert to WKT: {e}")
-            return False
-    
-    def _convert_to_wkb(self, gdf: GeoDataFrame, **kwargs) -> bool:
+        output_path = kwargs.get('output_path', 'output.wkt')
+        wkt_data = gdf.copy()
+        wkt_data['geometry'] = wkt_data.geometry.astype(str)
+        wkt_data.to_csv(output_path, index=False)
+        log.info(f"Successfully converted to WKT: {output_path}")
+
+    def _convert_to_wkb(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to WKB (Well-Known Binary) format."""
-        try:
-            output_path = kwargs.get('output_path', 'output.wkb')
-            
-            # Convert geometries to WKB bytes
-            wkb_data = gdf.copy()
-            wkb_data['geometry'] = wkb_data.geometry.apply(lambda geom: geom.wkb)
-            
-            # Save as pickle (WKB is binary data)
-            wkb_data.to_pickle(output_path)
-            log.info(f"Successfully converted to WKB: {output_path}")
-            return True
-        except (OSError, ValueError, TypeError, AttributeError) as e:
-            log.error(f"Failed to convert to WKB: {e}")
-            return False
+        output_path = kwargs.get('output_path', 'output.wkb')
+        wkb_data = gdf.copy()
+        wkb_data['geometry'] = wkb_data.geometry.apply(lambda geom: geom.wkb)
+        wkb_data.to_pickle(output_path)
+        log.info(f"Successfully converted to WKB: {output_path}")
     
-    def _convert_to_postgis(self, gdf: GeoDataFrame, **kwargs) -> bool:
-        """Convert to PostGIS format (upload to PostgreSQL database)."""
-        try:
-            # This would require psycopg2 and database connection
-            # For now, just save as SQL file that can be imported
-            output_path = kwargs.get('output_path', 'output.sql')
-            
-            # Generate SQL INSERT statements. WKT comes from shapely
-            # which can't normally produce single quotes, but the file
-            # is written for human inspection / re-import — escape
-            # defensively so a hand-edited row can't break out of the
-            # literal.
-            from siege_utilities.core.sql_safety import escape_sql_string_literal as escape_string_literal
-            # Vectorised: pull the geometry column into a Series of WKT
-            # strings in one pass and join with newlines. The previous
-            # row-at-a-time iterrows produced O(N) Python-level
-            # attribute lookups; on a 100K-row state file that was
-            # measurably slower than the IO it bookended.
-            wkt_series = gdf.geometry.apply(lambda g: escape_string_literal(g.wkt))
-            sql_lines = (
-                "INSERT INTO spatial_table (geom) VALUES (ST_GeomFromText('"
-                + wkt_series
-                + "'));"
-            )
+    def _convert_to_postgis(self, gdf: GeoDataFrame, **kwargs) -> None:
+        """Convert to PostGIS format (generate SQL file)."""
+        output_path = kwargs.get('output_path', 'output.sql')
 
-            with open(output_path, 'w', encoding='utf-8') as f:
-                f.write('\n'.join(sql_lines))
-            
-            log.info(f"Successfully generated PostGIS SQL: {output_path}")
-            return True
-        except (OSError, ValueError, TypeError, AttributeError, ImportError) as e:
-            log.error(f"Failed to convert to PostGIS: {e}")
-            return False
-    
-    def _convert_to_duckdb(self, gdf: GeoDataFrame, **kwargs) -> bool:
+        from siege_utilities.core.sql_safety import escape_sql_string_literal as escape_string_literal
+        wkt_series = gdf.geometry.apply(lambda g: escape_string_literal(g.wkt))
+        sql_lines = (
+            "INSERT INTO spatial_table (geom) VALUES (ST_GeomFromText('"
+            + wkt_series
+            + "'));"
+        )
+
+        with open(output_path, 'w', encoding='utf-8') as f:
+            f.write('\n'.join(sql_lines))
+
+        log.info(f"Successfully generated PostGIS SQL: {output_path}")
+
+    def _convert_to_duckdb(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to DuckDB format and save to database."""
-        if not DUCKDB_AVAILABLE:
-            log.error("DuckDB not available")
-            return False
-            
-        try:
-            # Get database parameters from user config or kwargs.
-            db_path = kwargs.get('db_path')
-            if db_path is None and self.user_config is not None:
-                try:
-                    db_path = self.user_config.get_database_connection('duckdb')
-                except (AttributeError, ValueError, KeyError, TypeError) as e:
-                    log.warning(f"user_config.get_database_connection('duckdb') failed: {e}")
-            db_path = db_path or ':memory:'
-            table_name = kwargs.get('table_name', 'spatial_data')
+        db_path = kwargs.get('db_path')
+        if db_path is None and self.user_config is not None:
+            try:
+                db_path = self.user_config.get_database_connection('duckdb')
+            except (AttributeError, ValueError, KeyError, TypeError) as e:
+                log.warning(f"user_config.get_database_connection('duckdb') failed: {e}")
+        db_path = db_path or ':memory:'
+        table_name = kwargs.get('table_name', 'spatial_data')
 
-            # DuckDB doesn't permit parameter-bound identifiers, so the
-            # table name has to be validated up front.
-            from siege_utilities.core.sql_safety import validate_sql_identifier as validate_identifier
-            validate_identifier(table_name, label="table name", allow_dotted=False)
+        from siege_utilities.core.sql_safety import validate_sql_identifier as validate_identifier
+        validate_identifier(table_name, label="table name", allow_dotted=False)
 
-            with duckdb.connect(db_path) as con:
-                df = gdf.copy()
-                df['geometry_wkt'] = df.geometry.apply(lambda geom: geom.wkt)
-                df = df.drop(columns=['geometry'])
-                con.register("siege_upload_df", df)
+        with duckdb.connect(db_path) as con:
+            df = gdf.copy()
+            df['geometry_wkt'] = df.geometry.apply(lambda geom: geom.wkt)
+            df = df.drop(columns=['geometry'])
+            con.register("siege_upload_df", df)
+            try:
+                con.execute(
+                    f"CREATE TABLE IF NOT EXISTS {table_name} "
+                    f"AS SELECT * FROM siege_upload_df"
+                )
+            finally:
                 try:
-                    con.execute(
-                        f"CREATE TABLE IF NOT EXISTS {table_name} "
-                        f"AS SELECT * FROM siege_upload_df"
+                    con.unregister("siege_upload_df")
+                except (_DuckDBError, RuntimeError) as cleanup_exc:
+                    log.warning(
+                        "Failed to unregister siege_upload_df: %s",
+                        cleanup_exc,
                     )
-                finally:
-                    try:
-                        con.unregister("siege_upload_df")
-                    except (_DuckDBError, RuntimeError) as cleanup_exc:
-                        log.warning(
-                            "Failed to unregister siege_upload_df: %s",
-                            cleanup_exc,
-                        )
 
-            log.info(f"Successfully uploaded to DuckDB table: {table_name}")
-            return True
-
-        except (_DuckDBError, OSError, ValueError, TypeError, AttributeError, KeyError) as e:
-            log.error(f"Failed to convert to DuckDB: {e}")
-            return False
+        log.info(f"Successfully uploaded to DuckDB table: {table_name}")
 
 
 class PostGISConnector:
@@ -350,7 +271,7 @@ class PostGISConnector:
     def __exit__(self, *exc_info):
         self.close()
 
-    def upload_spatial_data(self, gdf: GeoDataFrame, table_name: str, **kwargs) -> bool:
+    def upload_spatial_data(self, gdf: GeoDataFrame, table_name: str, **kwargs) -> None:
         """
         Upload spatial data to PostGIS with all columns preserved.
 
@@ -372,36 +293,28 @@ class PostGISConnector:
                     ``'replace'`` (default), or ``'append'``.
                 schema: PostgreSQL schema name (default ``'public'``).
 
-        Returns:
-            True if successful, False otherwise.
-
-        Note:
-            Requires ``geoalchemy2`` (declared in the ``geo`` optional
-            extra). If missing, the import error is logged and the
-            upload returns False with a clear remediation hint.
+        Raises:
+            RuntimeError: If no connection string is configured
+            ImportError: If geoalchemy2 is not available
+            SpatialQueryError: If the upload fails
         """
         if not self.connection_string:
-            log.error("No PostGIS connection_string available")
-            return False
+            raise RuntimeError("No PostGIS connection_string available")
 
         if_exists = kwargs.get('if_exists', 'replace')
         schema = kwargs.get('schema', 'public')
 
-        # Validate identifiers before they reach SQL. to_postgis itself
-        # uses parameterized SQL but defense-in-depth keeps the validation
-        # consistent with download_spatial_data + the prior implementation.
         from siege_utilities.core.sql_safety import validate_sql_identifier as validate_identifier
         validate_identifier(schema, label="schema name", allow_dotted=False)
         validate_identifier(table_name, label="table name", allow_dotted=False)
 
         try:
             import geoalchemy2  # noqa: F401  -- presence-check; to_postgis needs it
-        except ImportError:
-            log.error(
+        except ImportError as e:
+            raise ImportError(
                 "geoalchemy2 not available -- upload_spatial_data requires it "
                 "for full-column writes. Install with: pip install 'siege_utilities[geo]'"
-            )
-            return False
+            ) from e
 
         try:
             from sqlalchemy import create_engine
@@ -419,11 +332,9 @@ class PostGISConnector:
                 f"Successfully uploaded to PostGIS table: {schema}.{table_name} "
                 f"({len(gdf)} rows, {len(gdf.columns)} columns)"
             )
-            return True
 
         except (_Psycopg2Error, OSError, ValueError, TypeError, AttributeError, ImportError) as e:
-            log.error(f"Failed to upload to PostGIS: {e}")
-            return False
+            raise SpatialQueryError(f"Failed to upload to PostGIS: {e}") from e
     
     def download_spatial_data(self, table_name: str, *, crs: str | None = None, **kwargs) -> GeoDataFrame:
         """
@@ -619,15 +530,17 @@ class DuckDBConnector:
         self.db_path = db_path or ':memory:'
         self.connection = None
     
-    def connect(self):
-        """Establish database connection."""
+    def connect(self) -> None:
+        """Establish database connection.
+
+        Raises:
+            RuntimeError: If connection fails
+        """
         try:
             self.connection = duckdb.connect(self.db_path)
             log.info("Successfully connected to DuckDB")
-            return True
         except (_DuckDBError, OSError) as e:
-            log.error(f"Failed to connect to DuckDB: {e}")
-            return False
+            raise RuntimeError(f"Failed to connect to DuckDB: {e}") from e
 
     def close(self):
         """Close the database connection."""
@@ -644,22 +557,21 @@ class DuckDBConnector:
     def __exit__(self, *exc_info):
         self.close()
 
-    def upload_spatial_data(self, gdf: GeoDataFrame, table_name: str, **kwargs) -> bool:
+    def upload_spatial_data(self, gdf: GeoDataFrame, table_name: str, **kwargs) -> None:
         """
         Upload spatial data to DuckDB.
-        
+
         Args:
             gdf: GeoDataFrame to upload
             table_name: Target table name
             **kwargs: Additional parameters
-            
-        Returns:
-            True if successful, False otherwise
+
+        Raises:
+            RuntimeError: If connection or upload fails
         """
         if not self.connection:
-            if not self.connect():
-                return False
-        
+            self.connect()
+
         from siege_utilities.core.sql_safety import validate_sql_identifier
         validate_sql_identifier(table_name, "table name")
 
@@ -672,9 +584,6 @@ class DuckDBConnector:
             if if_exists == 'replace':
                 self.connection.execute(f"DROP TABLE IF EXISTS {table_name}")
 
-            # table_name validated above; pin the DataFrame under an
-            # explicit name rather than relying on duckdb's replacement
-            # scan picking it up from the caller frame.
             self.connection.register("siege_upload_df", df)
             try:
                 self.connection.execute(
@@ -690,11 +599,9 @@ class DuckDBConnector:
                     )
 
             log.info(f"Successfully uploaded to DuckDB: {table_name}")
-            return True
 
         except (_DuckDBError, OSError, ValueError, TypeError, AttributeError) as e:
-            log.error(f"Failed to upload to DuckDB: {e}")
-            return False
+            raise RuntimeError(f"Failed to upload to DuckDB: {e}") from e
     
     def download_spatial_data(self, table_name: str, *, crs: str | None = None, **kwargs) -> GeoDataFrame:
         """
@@ -716,8 +623,7 @@ class DuckDBConnector:
         from siege_utilities.geo.crs import reproject_if_needed
 
         if not self.connection:
-            if not self.connect():
-                raise SpatialQueryError("No DuckDB connection available")
+            self.connect()
 
         from siege_utilities.core.sql_safety import (
             validate_sql_identifier,
@@ -741,8 +647,17 @@ class DuckDBConnector:
                 df['geometry'] = df['geometry_wkt'].apply(wkt.loads)
                 df = df.drop(columns=['geometry_wkt'])
 
-            # Create GeoDataFrame — default to WGS84 since WKT lacks SRID
+            # WKT does not carry SRID metadata.  Assume WGS84 as the
+            # storage CRS, then reproject to the caller's target CRS if
+            # one was specified.  If the data was actually stored in a
+            # different CRS the coordinates will be wrong — there is no
+            # way to recover the SRID from bare WKT.
             gdf = gpd.GeoDataFrame(df, geometry='geometry', crs="EPSG:4326")
+            if crs is None:
+                log.warning(
+                    "DuckDB WKT geometries lack SRID metadata; assuming "
+                    "EPSG:4326.  Pass crs= to reproject to a target CRS."
+                )
 
             log.info(f"Successfully downloaded from DuckDB: {table_name}")
             return reproject_if_needed(gdf, crs)
@@ -776,8 +691,7 @@ class DuckDBConnector:
         from siege_utilities.geo.crs import reproject_if_needed
 
         if not self.connection:
-            if not self.connect():
-                raise SpatialQueryError("No DuckDB connection available")
+            self.connect()
 
         try:
             if query.strip().upper().startswith('SELECT'):
@@ -788,8 +702,12 @@ class DuckDBConnector:
                     df['geometry'] = df['geometry_wkt'].apply(wkt.loads)
                     df = df.drop(columns=['geometry_wkt'])
 
-                # Default to WGS84 since WKT lacks SRID metadata
                 gdf = gpd.GeoDataFrame(df, geometry='geometry', crs="EPSG:4326")
+                if crs is None:
+                    log.warning(
+                        "DuckDB WKT geometries lack SRID metadata; assuming "
+                        "EPSG:4326.  Pass crs= to reproject to a target CRS."
+                    )
 
                 log.info("Successfully executed DuckDB query")
                 return reproject_if_needed(gdf, crs)
@@ -809,16 +727,16 @@ class DuckDBConnector:
 
 
 # Convenience functions
-def convert_spatial_format(gdf: GeoDataFrame, output_format: str, **kwargs) -> bool:
+def convert_spatial_format(gdf: GeoDataFrame, output_format: str, **kwargs) -> None:
     """Convert spatial data to different format."""
     transformer = SpatialDataTransformer()
-    return transformer.convert_format(gdf, output_format, **kwargs)
+    transformer.convert_format(gdf, output_format, **kwargs)
 
 
-def upload_to_postgis(gdf: GeoDataFrame, table_name: str, connection_string: Optional[str] = None, **kwargs) -> bool:
+def upload_to_postgis(gdf: GeoDataFrame, table_name: str, connection_string: Optional[str] = None, **kwargs) -> None:
     """Upload spatial data to PostGIS."""
     with PostGISConnector(connection_string) as connector:
-        return connector.upload_spatial_data(gdf, table_name, **kwargs)
+        connector.upload_spatial_data(gdf, table_name, **kwargs)
 
 
 def download_from_postgis(table_name: str, connection_string: Optional[str] = None, **kwargs) -> GeoDataFrame:
@@ -843,17 +761,18 @@ def execute_postgis_query(query: str, connection_string: Optional[str] = None, *
         return connector.execute_spatial_query(query, **kwargs)
 
 
-def upload_to_duckdb(gdf: GeoDataFrame, table_name: str, db_path: Optional[str] = None, **kwargs) -> bool:
+def upload_to_duckdb(gdf: GeoDataFrame, table_name: str, db_path: Optional[str] = None, **kwargs) -> None:
     """Upload spatial data to DuckDB (optional).
 
     Raises:
         ImportError: If DuckDB is not installed.
+        RuntimeError: If upload fails.
     """
     if not DUCKDB_AVAILABLE:
         raise ImportError("DuckDB not available. Install with: pip install duckdb")
 
     with DuckDBConnector(db_path) as connector:
-        return connector.upload_spatial_data(gdf, table_name, **kwargs)
+        connector.upload_spatial_data(gdf, table_name, **kwargs)
 
 
 def download_from_duckdb(table_name: str, db_path: Optional[str] = None, **kwargs) -> GeoDataFrame:

--- a/siege_utilities/geo/timeseries/longitudinal_data.py
+++ b/siege_utilities/geo/timeseries/longitudinal_data.py
@@ -491,7 +491,10 @@ def get_available_years(
     elif dataset == 'dec':
         return DECENNIAL_YEARS.copy()
     else:
-        return []
+        raise ValueError(
+            f"Unknown dataset {dataset!r}. "
+            f"Supported: 'acs5', 'acs1', 'dec'"
+        )
 
 
 def validate_longitudinal_years(

--- a/siege_utilities/git/validation.py
+++ b/siege_utilities/git/validation.py
@@ -366,5 +366,6 @@ __all__ = [
     'validate_commit_hash',
     'validate_remote_name',
     'validate_repo_path',
+    'validate_git_ref_name',
     'has_dangerous_characters',
 ]

--- a/siege_utilities/hygiene/generate_docstrings.py
+++ b/siege_utilities/hygiene/generate_docstrings.py
@@ -157,48 +157,39 @@ Note:
 
 
 def process_python_file(file_path):
-    """Process a single Python file to add missing docstrings."""
+    """Process a single Python file to add missing docstrings.
+
+    Raises:
+        SyntaxError: If the file has invalid Python syntax.
+        ImportError: If astor is not installed.
+        OSError: If the file cannot be read or written.
+    """
     relative_path = file_path.relative_to(Path.cwd())
     log_info(f'\nProcessing {relative_path}')
-    try:
-        with open(file_path, 'r', encoding='utf-8') as f:
-            content = f.read()
-        try:
-            tree = ast.parse(content)
-        except SyntaxError as e:
-            log_error(f'Syntax error in {file_path}: {e}')
-            return False
-        module_name = str(relative_path).replace('.py', '').replace('/', '.')
-        transformer = DocstringAdder(module_name)
-        new_tree = transformer.visit(tree)
-        if transformer.functions_processed > 0:
-            try:
-                import astor
-                new_content = astor.to_source(new_tree)
-            except ImportError:
-                log_error(
-                    f'astor not available, install with: pip install astor'
-                    )
-                return False
-            except (ValueError, TypeError, AttributeError) as e:
-                log_error(f'Error converting AST back to source: {e}')
-                return False
-            with open(file_path, 'w', encoding='utf-8') as f:
-                f.write(new_content)
-            log_info(f'Updated {file_path}')
-            log_info(
-                f'Processed: {transformer.functions_processed}, Skipped: {transformer.functions_skipped}'
-                )
-        else:
-            log_info(f'No changes needed')
-        return True
-    except (OSError, UnicodeDecodeError, ValueError, TypeError, AttributeError) as e:
-        log_error(f'Error processing {file_path}: {e}')
-        return False
+
+    with open(file_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    tree = ast.parse(content)
+    module_name = str(relative_path).replace('.py', '').replace('/', '.')
+    transformer = DocstringAdder(module_name)
+    new_tree = transformer.visit(tree)
+
+    if transformer.functions_processed > 0:
+        import astor
+        new_content = astor.to_source(new_tree)
+        with open(file_path, 'w', encoding='utf-8') as f:
+            f.write(new_content)
+        log_info(f'Updated {file_path}')
+        log_info(
+            f'Processed: {transformer.functions_processed}, Skipped: {transformer.functions_skipped}'
+        )
+    else:
+        log_info(f'No changes needed')
 
 
 def find_python_files(base_path):
-    """Find all Python files to process."""
+    """Find Python files to process (excludes __init__.py and build artifacts)."""
     base_path = Path(base_path)
     python_files = []
     if (base_path / 'siege_utilities').exists():
@@ -214,43 +205,50 @@ def find_python_files(base_path):
 
 
 def main():
-    """Main function to process all Python files in siege_utilities."""
+    """Process all Python files in siege_utilities to add missing docstrings.
+
+    Raises:
+        ImportError: If astor is not installed.
+        FileNotFoundError: If no Python files are found in the working directory.
+    """
     log_info('Auto-generating docstrings for siege_utilities')
     log_info('=' * 60)
     try:
-        import astor
-    except ImportError:
-        log_error('Missing dependency: astor')
-        log_info('Install with: pip install astor')
-        return False
+        import astor  # noqa: F401
+    except ImportError as e:
+        raise ImportError(
+            'Missing dependency: astor. Install with: pip install astor'
+        ) from e
     base_path = Path.cwd()
     python_files = find_python_files(base_path)
     if not python_files:
-        log_error('No Python files found. Are you in the right directory?')
-        log_info(f'Current directory: {base_path}')
-        log_info('Expected: directory containing siege_utilities package')
-        return False
+        raise FileNotFoundError(
+            f'No Python files found in {base_path}. '
+            f'Expected: directory containing siege_utilities package'
+        )
     log_info(f'Found {len(python_files)} Python files to process')
     successful = 0
-    failed = 0
+    errors: list[tuple[Path, Exception]] = []
     for file_path in python_files:
-        if process_python_file(file_path):
+        try:
+            process_python_file(file_path)
             successful += 1
-        else:
-            failed += 1
+        except (SyntaxError, OSError, ImportError, ValueError, TypeError) as e:
+            log_error(f'Error processing {file_path}: {e}')
+            errors.append((file_path, e))
     log_info(f'\n' + '=' * 60)
     log_info(f'Docstring generation complete!')
     log_info(f'Summary:')
     log_info(f'Successfully processed: {successful} files')
-    if failed > 0:
-        log_error(f'Failed: {failed} files')
+    if errors:
+        log_error(f'Failed: {len(errors)} files')
     log_info(f'Next steps:')
     log_info(f'1. Review generated docstrings')
     log_info(f'2. Rebuild docs: cd docs && make html')
     log_info(
         f"3. Commit changes: git add -A && git commit -m 'Add auto-generated docstrings'"
         )
-    return failed == 0
+    return len(errors) == 0
 
 
 def cli():

--- a/siege_utilities/reference/sample_data.py
+++ b/siege_utilities/reference/sample_data.py
@@ -203,7 +203,7 @@ def get_dataset_info(dataset_name: str) -> Optional[Dict[str, Any]]:
     """
     return SAMPLE_DATASETS.get(dataset_name)
 
-def load_sample_data(dataset_name: str, **kwargs) -> Union[pd.DataFrame, "gpd.GeoDataFrame", None]:
+def load_sample_data(dataset_name: str, **kwargs) -> Union[pd.DataFrame, "gpd.GeoDataFrame"]:
     """
     Load a sample dataset by name.
 
@@ -250,7 +250,7 @@ def load_sample_data(dataset_name: str, **kwargs) -> Union[pd.DataFrame, "gpd.Ge
 def get_census_boundaries(year: int = 2020,
                          geographic_level: str = 'tract',
                          state_fips: Optional[str] = None,
-                         county_fips: Optional[str] = None) -> Optional[gpd.GeoDataFrame]:
+                         county_fips: Optional[str] = None) -> gpd.GeoDataFrame:
     """
     Download Census geographic boundaries.
 
@@ -261,45 +261,44 @@ def get_census_boundaries(year: int = 2020,
         county_fips: County FIPS code for filtering (if applicable)
 
     Returns:
-        GeoDataFrame with boundaries or None if failed
+        GeoDataFrame with boundaries.
+
+    Raises:
+        ImportError: If geo extras are not installed.
+        RuntimeError: If no boundaries are returned from Census source.
     """
     if not CENSUS_AVAILABLE:
         raise ImportError("Census utilities required. Install with: pip install siege-utilities[geo]")
 
-    try:
-        from siege_utilities.geo.spatial_data import census_source
+    from siege_utilities.geo.spatial_data import census_source
 
-        log_info(f"Downloading {geographic_level} boundaries for year {year}")
+    log_info(f"Downloading {geographic_level} boundaries for year {year}")
 
-        # Download boundaries
-        boundaries = census_source.get_geographic_boundaries(
-            year=year,
-            geographic_level=geographic_level,
-            state_fips=state_fips
+    boundaries = census_source.get_geographic_boundaries(
+        year=year,
+        geographic_level=geographic_level,
+        state_fips=state_fips
+    )
+
+    if boundaries is None or len(boundaries) == 0:
+        raise RuntimeError(
+            f"No {geographic_level} boundaries returned from Census source "
+            f"for year={year}, state_fips={state_fips!r}"
         )
 
-        if boundaries is None or len(boundaries) == 0:
-            log_error("No boundaries returned from Census source")
-            return None
+    log_info(f"Downloaded {len(boundaries)} {geographic_level} boundaries")
+    log_debug(f"Available columns: {list(boundaries.columns)}")
 
-        log_info(f"Downloaded {len(boundaries)} {geographic_level} boundaries")
-        log_debug(f"Available columns: {list(boundaries.columns)}")
+    if county_fips and geographic_level in ['tract', 'block_group']:
+        county_cols = boundaries.columns[boundaries.columns.str.lower() == 'countyfp']
+        if len(county_cols) > 0:
+            county_col = county_cols[0]
+            boundaries = boundaries[boundaries[county_col] == county_fips]
+            log_info(f"Filtered to {len(boundaries)} boundaries in county {county_fips}")
+        else:
+            log_warning("No county column found, skipping county filter")
 
-        # Filter by county if specified
-        if county_fips and geographic_level in ['tract', 'block_group']:
-            county_cols = boundaries.columns[boundaries.columns.str.lower() == 'countyfp']
-            if len(county_cols) > 0:
-                county_col = county_cols[0]
-                boundaries = boundaries[boundaries[county_col] == county_fips]
-                log_info(f"Filtered to {len(boundaries)} boundaries in county {county_fips}")
-            else:
-                log_warning("No county column found, skipping county filter")
-
-        return boundaries
-
-    except (OSError, ValueError, TypeError, AttributeError, KeyError) as e:
-        log_error(f"Error downloading boundaries: {e}")
-        return None
+    return boundaries
 
 
 def get_census_data(year: int = 2020,
@@ -332,7 +331,7 @@ def get_census_data(year: int = 2020,
 def join_boundaries_and_data(boundaries: gpd.GeoDataFrame,
                            data: pd.DataFrame,
                            boundary_id_col: str = 'geoid',
-                           data_id_col: str = 'geoid') -> Optional[gpd.GeoDataFrame]:
+                           data_id_col: str = 'geoid') -> gpd.GeoDataFrame:
     """
     Join geographic boundaries with attribute data.
 
@@ -343,49 +342,48 @@ def join_boundaries_and_data(boundaries: gpd.GeoDataFrame,
         data_id_col: Column name for data identifiers
 
     Returns:
-        GeoDataFrame with joined data or None if failed
+        GeoDataFrame with joined data.
+
+    Raises:
+        KeyError: If the specified ID columns do not exist.
+        ValueError: If the join produces zero records.
     """
-    try:
-        log_info(f"Joining boundaries ({len(boundaries)} records) with data ({len(data)} records)")
-        log_debug(f"Boundary ID column: {boundary_id_col}")
-        log_debug(f"Data ID column: {data_id_col}")
+    log_info(f"Joining boundaries ({len(boundaries)} records) with data ({len(data)} records)")
 
-        # Check if ID columns exist
-        if boundary_id_col not in boundaries.columns:
-            log_error(f"Boundary ID column '{boundary_id_col}' not found")
-            log_debug(f"Available columns: {list(boundaries.columns)}")
-            return None
-
-        if data_id_col not in data.columns:
-            log_error(f"Data ID column '{data_id_col}' not found")
-            log_debug(f"Available columns: {list(data.columns)}")
-            return None
-
-        # Perform the join
-        result = boundaries.merge(
-            data,
-            left_on=boundary_id_col,
-            right_on=data_id_col,
-            how='inner'
+    if boundary_id_col not in boundaries.columns:
+        raise KeyError(
+            f"Boundary ID column '{boundary_id_col}' not found. "
+            f"Available columns: {list(boundaries.columns)}"
         )
 
-        if len(result) == 0:
-            log_error("Join resulted in 0 records")
-            return None
+    if data_id_col not in data.columns:
+        raise KeyError(
+            f"Data ID column '{data_id_col}' not found. "
+            f"Available columns: {list(data.columns)}"
+        )
 
-        log_info(f"Successfully joined data: {len(result)} records")
-        return result
+    result = boundaries.merge(
+        data,
+        left_on=boundary_id_col,
+        right_on=data_id_col,
+        how='inner'
+    )
 
-    except (ValueError, TypeError, KeyError, AttributeError) as e:
-        log_error(f"Error joining boundaries and data: {e}")
-        return None
+    if len(result) == 0:
+        raise ValueError(
+            f"Join on {boundary_id_col!r}={data_id_col!r} produced 0 records. "
+            f"Check that ID formats match between boundaries and data."
+        )
+
+    log_info(f"Successfully joined data: {len(result)} records")
+    return result
 
 
 def create_sample_dataset(year: int = 2020,
                          geographic_level: str = 'tract',
                          state_fips: str = '06',
                          county_fips: str = '037',
-                         include_geometry: bool = True) -> Optional[Union[pd.DataFrame, gpd.GeoDataFrame]]:
+                         include_geometry: bool = True) -> Union[pd.DataFrame, gpd.GeoDataFrame]:
     """
     Create a real-world sample dataset by combining boundaries and data.
 
@@ -397,26 +395,22 @@ def create_sample_dataset(year: int = 2020,
         include_geometry: Whether to include geographic boundaries
 
     Returns:
-        Combined dataset or None if failed
+        Combined dataset.
+
+    Raises:
+        RuntimeError: If boundaries cannot be retrieved.
+        NotImplementedError: If Census data retrieval is not yet implemented.
     """
     log_info(f"Creating sample dataset: {geographic_level} level, year {year}, state {state_fips}")
 
-    # Step 1: Get boundaries
+    # Step 1: Get boundaries (raises RuntimeError on failure)
     boundaries = get_census_boundaries(year, geographic_level, state_fips, county_fips)
-    if boundaries is None:
-        return None
 
-    # Step 2: Get data (when implemented)
+    # Step 2: Get data (raises NotImplementedError until Census data API is wired up)
     data = get_census_data(year, 'demographics', geographic_level, state_fips, county_fips)
-    if data is None:
-        log_warning("No Census data available, returning boundaries only")
-        return boundaries if include_geometry else boundaries.drop(columns=['geometry'])
 
-    # Step 3: Join boundaries and data
+    # Step 3: Join boundaries and data (raises ValueError/KeyError on failure)
     result = join_boundaries_and_data(boundaries, data)
-    if result is None:
-        log_warning("Join failed, returning boundaries only")
-        return boundaries if include_geometry else boundaries.drop(columns=['geometry'])
 
     return result
 
@@ -806,6 +800,8 @@ def _generate_synthetic_housing_unit(property_type: str,
             lat_range, lon_range, area_unit, area_range, value_range, year_range
     """
     if faker_inst is None:
+        if not FAKER_AVAILABLE:
+            raise ImportError("Faker required. Install with: pip install Faker")
         faker_inst = faker_en
     if geo_config is None:
         geo_config = HOUSING_LOCALE_PRESETS["us"]
@@ -853,29 +849,38 @@ def _generate_synthetic_tract_info(state_fips: str, county_fips: str, tract_fips
 # Synthetic data generation removed from library - will be implemented separately if needed
 
 def _create_tract_geodataframe(population_data: pd.DataFrame, tract_info: Dict) -> gpd.GeoDataFrame:
-    """Create a GeoDataFrame with tract boundaries."""
+    """Create a GeoDataFrame with tract boundaries.
+
+    Raises:
+        ImportError: If geopandas is not installed.
+        ValueError: If latitude/longitude columns are missing from the data.
+    """
     if not GEOPANDAS_AVAILABLE:
-        return population_data
+        raise ImportError(
+            "geopandas is required to create tract GeoDataFrames. "
+            "Install with: pip install geopandas"
+        )
 
-    # Create simple tract boundary (rectangle around population points)
-    if 'latitude' in population_data.columns and 'longitude' in population_data.columns:
-        min_lat, max_lat = population_data['latitude'].min(), population_data['latitude'].max()
-        min_lon, max_lon = population_data['longitude'].min(), population_data['longitude'].max()
+    if 'latitude' not in population_data.columns or 'longitude' not in population_data.columns:
+        raise ValueError(
+            "population_data must contain 'latitude' and 'longitude' columns; "
+            f"got: {list(population_data.columns)}"
+        )
 
-        # Expand boundaries slightly
-        lat_buffer = (max_lat - min_lat) * 0.1
-        lon_buffer = (max_lon - min_lon) * 0.1
+    min_lat, max_lat = population_data['latitude'].min(), population_data['latitude'].max()
+    min_lon, max_lon = population_data['longitude'].min(), population_data['longitude'].max()
 
-        tract_boundary = Polygon([
-            (min_lon - lon_buffer, min_lat - lat_buffer),
-            (max_lon + lon_buffer, min_lat - lat_buffer),
-            (max_lon + lon_buffer, max_lat + lat_buffer),
-            (min_lon - lon_buffer, max_lat + lat_buffer)
-        ])
+    # Expand boundaries slightly
+    lat_buffer = (max_lat - min_lat) * 0.1
+    lon_buffer = (max_lon - min_lon) * 0.1
 
-        # Add tract boundary to population data
-        population_data['tract_geometry'] = tract_boundary
+    tract_boundary = Polygon([
+        (min_lon - lon_buffer, min_lat - lat_buffer),
+        (max_lon + lon_buffer, min_lat - lat_buffer),
+        (max_lon + lon_buffer, max_lat + lat_buffer),
+        (min_lon - lon_buffer, max_lat + lat_buffer)
+    ])
 
-        return gpd.GeoDataFrame(population_data, geometry='tract_geometry')
-    else:
-        return population_data
+    population_data['tract_geometry'] = tract_boundary
+
+    return gpd.GeoDataFrame(population_data, geometry='tract_geometry')

--- a/siege_utilities/reporting/__init__.py
+++ b/siege_utilities/reporting/__init__.py
@@ -99,6 +99,8 @@ __all__ = [
     'get_report_output_directory', 'create_report_generator',
     'create_powerpoint_generator',
     'export_branding_config', 'import_branding_config', 'export_chart_type_config',
+    # Errors
+    'ReportingConfigError',
 ]
 
 
@@ -159,7 +161,7 @@ class ReportingConfigError(RuntimeError):
     """Raised when a reporting configuration export / import cannot complete."""
 
 
-def export_branding_config(client_name: str, export_path: str) -> bool:
+def export_branding_config(client_name: str, export_path: str) -> None:
     """Export client branding configuration to a file.
 
     Parameters
@@ -169,11 +171,6 @@ def export_branding_config(client_name: str, export_path: str) -> bool:
     export_path : str
         Destination path for the export.
 
-    Returns
-    -------
-    bool
-        True on success. (Never returns False — failures raise.)
-
     Raises
     ------
     ReportingConfigError
@@ -182,7 +179,7 @@ def export_branding_config(client_name: str, export_path: str) -> bool:
     try:
         from .client_branding import ClientBrandingManager as _CBM
         branding_manager = _CBM()
-        return branding_manager.export_branding_config(client_name, Path(export_path))
+        branding_manager.export_branding_config(client_name, Path(export_path))
     except (OSError, ValueError, KeyError) as e:
         log.error(
             "export_branding_config failed (client=%s, path=%s): %s",
@@ -193,7 +190,7 @@ def export_branding_config(client_name: str, export_path: str) -> bool:
         ) from e
 
 
-def import_branding_config(import_path: str, client_name: str = None) -> bool:
+def import_branding_config(import_path: str, client_name: str = None) -> None:
     """Import client branding configuration from a file.
 
     Parameters
@@ -204,11 +201,6 @@ def import_branding_config(import_path: str, client_name: str = None) -> bool:
         Client to associate with the imported branding. When omitted, the
         implementation picks a name from the file.
 
-    Returns
-    -------
-    bool
-        True on success.
-
     Raises
     ------
     ReportingConfigError
@@ -217,7 +209,7 @@ def import_branding_config(import_path: str, client_name: str = None) -> bool:
     try:
         from .client_branding import ClientBrandingManager as _CBM
         branding_manager = _CBM()
-        return branding_manager.import_branding_config(Path(import_path), client_name)
+        branding_manager.import_branding_config(Path(import_path), client_name)
     except (OSError, ValueError, KeyError) as e:
         log.error(
             "import_branding_config failed (path=%s, client=%s): %s",

--- a/siege_utilities/reporting/analytics_reports.py
+++ b/siege_utilities/reporting/analytics_reports.py
@@ -776,6 +776,7 @@ class AnalyticsReportGenerator:
             
             # Create tables
             tables = []
+            summary_data = []
             if not df.empty:
                 # Sample data table
                 sample_data = df.head(20).values.tolist()
@@ -821,7 +822,7 @@ class AnalyticsReportGenerator:
                         'type': 'table',
                         'title': 'Summary Statistics',
                         'headers': ['Column', 'Mean', 'Std', 'Min', 'Max'],
-                        'data': summary_data if 'summary_data' in locals() else []
+                        'data': summary_data
                     }
                 ]
             }

--- a/siege_utilities/reporting/chart_types.py
+++ b/siege_utilities/reporting/chart_types.py
@@ -383,7 +383,7 @@ class ChartTypeRegistry:
 
         try:
             return chart_type.create_function(**kwargs)
-        except Exception as e:
+        except (OSError, ValueError, TypeError, KeyError, RuntimeError) as e:
             log.error("Create function for %s raised: %s", chart_type_name, e)
             raise ChartCreationError(
                 f"create function for chart type {chart_type_name!r} failed"

--- a/siege_utilities/reporting/client_branding.py
+++ b/siege_utilities/reporting/client_branding.py
@@ -270,70 +270,69 @@ class ClientBrandingManager:
 
             log.info(f"Created branding configuration for {client_name}: {config_file}")
             return config_file
-            
-        except Exception as e:
+
+        except (OSError, ValueError, KeyError, TypeError) as e:
             log.error(f"Error creating branding configuration for {client_name}: {e}")
             raise
 
-    def get_client_branding(self, client_name: str) -> Optional[Dict[str, Any]]:
+    def get_client_branding(self, client_name: str) -> Dict[str, Any]:
         """
         Get branding configuration for a specific client.
-        
+
         Args:
             client_name: Name of the client
-            
+
         Returns:
-            Branding configuration dictionary or None if not found
+            Branding configuration dictionary.
+
+        Raises:
+            ClientBrandingNotFoundError: If no branding configuration exists.
+            ClientBrandingError: If loading fails for another reason.
         """
         try:
-            # First check predefined templates
             if client_name.lower() in self.branding_templates:
                 return self.branding_templates[client_name.lower()]
-            
-            # Check for custom client configurations
+
             client_dir = self.config_dir / _slugify_client_name(client_name)
             if client_dir.exists():
-                # Look for branding config files
                 for config_file in client_dir.glob("*_branding.yaml"):
                     with open(config_file, 'r', encoding='utf-8') as f:
                         config = yaml.safe_load(f)
                         log.info(f"Loaded branding configuration from {config_file}")
                         return config
-            
-            log.warning(f"No branding configuration found for client: {client_name}")
-            return None
 
-        except Exception as e:
+            raise ClientBrandingNotFoundError(
+                f"No branding configuration found for client: {client_name}"
+            )
+
+        except (ClientBrandingNotFoundError, ClientBrandingError):
+            raise
+        except (OSError, ValueError, KeyError, TypeError) as e:
             raise ClientBrandingError(
                 f"Error loading branding configuration for {client_name}: {e}"
             ) from e
 
-    def update_client_branding(self, client_name: str, updates: Dict[str, Any]) -> bool:
+    def update_client_branding(self, client_name: str, updates: Dict[str, Any]) -> None:
         """
         Update an existing client branding configuration.
-        
+
         Args:
             client_name: Name of the client
             updates: Dictionary of updates to apply
-            
-        Returns:
-            True if successful, False otherwise
+
+        Raises:
+            ClientBrandingNotFoundError: If no existing branding exists.
+            ClientBrandingError: If the update fails.
         """
         current_config = self.get_client_branding(client_name)
-        if not current_config:
-            raise ClientBrandingNotFoundError(
-                f"No existing branding configuration found for {client_name}"
-            )
 
         try:
-            # Apply updates
             for key, value in updates.items():
                 if isinstance(value, dict) and key in current_config:
                     current_config[key].update(value)
                 else:
                     current_config[key] = value
 
-            # Save updated configuration
             client_dir = self.config_dir / _slugify_client_name(client_name)
             config_file = client_dir / f"{_slugify_client_name(client_name)}_branding.yaml"
 
@@ -341,9 +340,10 @@ class ClientBrandingManager:
                 yaml.dump(current_config, f, default_flow_style=False, indent=2)
 
             log.info(f"Updated branding configuration for {client_name}")
-            return True
 
-        except Exception as e:
+        except (ClientBrandingNotFoundError, ClientBrandingError):
+            raise
+        except (OSError, ValueError, KeyError, TypeError) as e:
             raise ClientBrandingError(
                 f"Error updating branding configuration for {client_name}: {e}"
             ) from e
@@ -367,32 +367,35 @@ class ClientBrandingManager:
         
         return sorted(clients)
 
-    def delete_client_branding(self, client_name: str) -> bool:
+    def delete_client_branding(self, client_name: str) -> None:
         """
         Delete a client branding configuration.
-        
+
         Args:
             client_name: Name of the client to delete
-            
-        Returns:
-            True if successful, False otherwise
+
+        Raises:
+            ClientBrandingError: If attempting to delete a predefined template.
+            ClientBrandingNotFoundError: If no configuration exists for the client.
         """
         try:
-            # Cannot delete predefined templates
             if client_name.lower() in self.branding_templates:
-                log.warning(f"Cannot delete predefined template: {client_name}")
-                return False
-            
+                raise ClientBrandingError(
+                    f"Cannot delete predefined template: {client_name}"
+                )
+
             client_dir = self.config_dir / _slugify_client_name(client_name)
-            if client_dir.exists():
-                shutil.rmtree(client_dir)
-                log.info(f"Deleted branding configuration for {client_name}")
-                return True
-            else:
-                log.warning(f"No branding configuration found for {client_name}")
-                return False
-                
-        except Exception as e:
+            if not client_dir.exists():
+                raise ClientBrandingNotFoundError(
+                    f"No branding configuration found for {client_name}"
+                )
+
+            shutil.rmtree(client_dir)
+            log.info(f"Deleted branding configuration for {client_name}")
+
+        except (ClientBrandingNotFoundError, ClientBrandingError):
+            raise
+        except OSError as e:
             raise ClientBrandingError(
                 f"Error deleting branding configuration for {client_name}: {e}"
             ) from e
@@ -428,7 +431,7 @@ class ClientBrandingManager:
             
             return self.create_client_branding(client_name, branding_config)
             
-        except Exception as e:
+        except (OSError, ValueError, KeyError, TypeError) as e:
             log.error(f"Error creating branding from template: {e}")
             raise
 
@@ -472,59 +475,54 @@ class ClientBrandingManager:
         
         return errors
 
-    def export_branding_config(self, client_name: str, export_path: Path) -> bool:
+    def export_branding_config(self, client_name: str, export_path: Path) -> None:
         """
         Export a client branding configuration to a file.
-        
+
         Args:
             client_name: Name of the client
             export_path: Path where to export the configuration
-            
-        Returns:
-            True if successful, False otherwise
+
+        Raises:
+            ClientBrandingNotFoundError: If no branding configuration exists.
+            ClientBrandingError: If the export fails.
         """
         branding_config = self.get_client_branding(client_name)
-        if not branding_config:
-            raise ClientBrandingNotFoundError(
-                f"No branding configuration found for {client_name}"
-            )
 
         try:
-            # Export as YAML
             if export_path.suffix.lower() in ['.yaml', '.yml']:
                 with open(export_path, 'w', encoding='utf-8') as f:
                     yaml.dump(branding_config, f, default_flow_style=False, indent=2)
-            # Export as JSON
             elif export_path.suffix.lower() == '.json':
                 with open(export_path, 'w', encoding='utf-8') as f:
                     json.dump(branding_config, f, indent=2)
             else:
-                # Default to YAML
                 export_path = export_path.with_suffix('.yaml')
                 with open(export_path, 'w', encoding='utf-8') as f:
                     yaml.dump(branding_config, f, default_flow_style=False, indent=2)
 
             log.info(f"Exported branding configuration for {client_name} to {export_path}")
-            return True
 
-        except Exception as e:
+        except (ClientBrandingNotFoundError, ClientBrandingError):
+            raise
+        except (OSError, ValueError, TypeError) as e:
             raise ClientBrandingError(
                 f"Error exporting branding configuration for {client_name}: {e}"
             ) from e
 
-    def import_branding_config(self, import_path: Path, client_name: Optional[str] = None) -> bool:
+    def import_branding_config(self, import_path: Path, client_name: Optional[str] = None) -> None:
         """
         Import a branding configuration from a file.
-        
+
         Args:
             import_path: Path to the configuration file
             client_name: Name for the client (if not specified in config)
-            
-        Returns:
-            True if successful, False otherwise
+
+        Raises:
+            ValueError: If the file format is unsupported or validation fails.
+            ClientBrandingError: If the import fails.
         """
         try:
-            # Load configuration
             if import_path.suffix.lower() in ['.yaml', '.yml']:
                 with open(import_path, 'r', encoding='utf-8') as f:
                     branding_config = yaml.safe_load(f)
@@ -532,28 +530,22 @@ class ClientBrandingManager:
                 with open(import_path, 'r', encoding='utf-8') as f:
                     branding_config = json.load(f)
             else:
-                log.error(f"Unsupported file format: {import_path.suffix}")
-                return False
-            
-            # Validate configuration
+                raise ValueError(f"Unsupported file format: {import_path.suffix}")
+
             errors = self.validate_branding_config(branding_config)
             if errors:
-                log.error(f"Invalid branding configuration: {errors}")
-                return False
-            
-            # Use specified client name or name from config
+                raise ValueError(f"Invalid branding configuration: {errors}")
+
             if client_name:
                 branding_config['name'] = client_name
             elif 'name' not in branding_config:
                 branding_config['name'] = import_path.stem
-            
-            # Create client branding
-            self.create_client_branding(branding_config['name'], branding_config)
-            return True
 
-        except ClientBrandingError:
+            self.create_client_branding(branding_config['name'], branding_config)
+
+        except (ClientBrandingError, ValueError):
             raise
-        except Exception as e:
+        except (OSError, KeyError, TypeError) as e:
             raise ClientBrandingError(
                 f"Error importing branding configuration: {e}"
             ) from e
@@ -570,10 +562,8 @@ class ClientBrandingManager:
         """
         try:
             branding_config = self.get_client_branding(client_name)
-            if not branding_config:
-                return {}
-            
-            summary = {
+
+            return {
                 'client_name': branding_config.get('name', client_name),
                 'colors': list(branding_config.get('colors', {}).keys()),
                 'fonts': list(branding_config.get('fonts', {}).keys()),
@@ -583,10 +573,10 @@ class ClientBrandingManager:
                 'header_text': branding_config.get('header', {}).get('left_text', ''),
                 'footer_text': branding_config.get('footer', {}).get('left_text', '')
             }
-            
-            return summary
-            
-        except Exception as e:
+
+        except (ClientBrandingNotFoundError, ClientBrandingError):
+            raise
+        except (OSError, ValueError, KeyError, TypeError) as e:
             raise ClientBrandingError(
                 f"Error getting branding summary for {client_name}: {e}"
             ) from e

--- a/siege_utilities/reporting/engines/bar_engine.py
+++ b/siege_utilities/reporting/engines/bar_engine.py
@@ -88,7 +88,7 @@ class BarChartMixin:
                     y_column = numeric_cols[0]
                     y_values = df[y_column].tolist()
                 else:
-                    return self._create_placeholder_chart(width, height, "No numeric data found")
+                    raise ValueError("No numeric columns found in data for bar chart")
 
             # Create figure with very conservative sizing to prevent ReportLab crashes
             fig, ax = plt.subplots(figsize=(width, height), dpi=self.default_dpi)
@@ -131,8 +131,15 @@ class BarChartMixin:
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
         except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-            log.error(f"Error creating bar chart: {e}")
-            return self._create_placeholder_chart(width, height, f"Chart Error: {str(e)}")
+
+
+            raise RuntimeError(
+
+
+                f"Chart Error: {e}"
+
+
+            ) from e
 
     def create_line_chart(self, data: Union[pd.DataFrame, Dict[str, Any]],
                          x_column: str = None, y_columns: List[str] = None,
@@ -216,8 +223,15 @@ class BarChartMixin:
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
         except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-            log.error(f"Error creating line chart: {e}")
-            return self._create_placeholder_chart(width, height, f"Chart Error: {str(e)}")
+
+
+            raise RuntimeError(
+
+
+                f"Chart Error: {e}"
+
+
+            ) from e
 
     def create_pie_chart(self, data: Union[pd.DataFrame, Dict[str, Any]],
                         labels_column: str = None, values_column: str = None,
@@ -258,7 +272,7 @@ class BarChartMixin:
                     labels = df[cols[0]].tolist()
                     values = df[cols[1]].tolist()
                 else:
-                    return self._create_placeholder_chart(width, height, "Need at least 2 columns for pie chart")
+                    raise ValueError("Need at least 2 columns for pie chart")
 
             # Create figure with larger size for dominant appearance
             fig, ax = plt.subplots(figsize=(width, height), dpi=self.default_dpi)
@@ -325,8 +339,15 @@ class BarChartMixin:
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
         except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-            log.error(f"Error creating pie chart: {e}")
-            return self._create_placeholder_chart(width, height, f"Chart Error: {str(e)}")
+
+
+            raise RuntimeError(
+
+
+                f"Chart Error: {e}"
+
+
+            ) from e
 
     def create_proportional_text_bar_chart(self,
                                          data: 'pd.DataFrame',

--- a/siege_utilities/reporting/engines/base_engine.py
+++ b/siege_utilities/reporting/engines/base_engine.py
@@ -217,7 +217,7 @@ class BaseChartEngine:
         return self._create_placeholder_chart(width, height, f"{label} — saved to {map_path}")
 
     def save_figure_as_vector(self, fig, output_path: Union[str, Path],
-                              fmt: str = 'svg') -> Optional[Path]:
+                              fmt: str = 'svg') -> Path:
         """Save a matplotlib figure as a vector file (SVG, EPS, or PDF).
 
         Args:
@@ -226,23 +226,24 @@ class BaseChartEngine:
             fmt: Vector format — ``'svg'``, ``'eps'``, or ``'pdf'``.
 
         Returns:
-            Path to the saved file, or ``None`` on error.
+            Path to the saved file.
+
+        Raises:
+            ValueError: If *fmt* is not a supported vector format.
+            OSError: If the file cannot be written.
         """
         allowed = {'svg', 'eps', 'pdf'}
         if fmt not in allowed:
-            log.error(f"Unsupported vector format '{fmt}'; expected one of {allowed}")
-            return None
+            raise ValueError(
+                f"Unsupported vector format {fmt!r}; expected one of {sorted(allowed)}"
+            )
 
-        try:
-            out = Path(output_path).with_suffix(f'.{fmt}')
-            out.parent.mkdir(parents=True, exist_ok=True)
-            fig.savefig(str(out), format=fmt, bbox_inches='tight',
-                        facecolor='white', edgecolor='none', pad_inches=0.1)
-            log.info(f"Saved vector chart: {out}")
-            return out
-        except (OSError, ValueError, TypeError) as e:
-            log.error(f"Error saving vector chart to {output_path}: {e}")
-            return None
+        out = Path(output_path).with_suffix(f'.{fmt}')
+        out.parent.mkdir(parents=True, exist_ok=True)
+        fig.savefig(str(out), format=fmt, bbox_inches='tight',
+                    facecolor='white', edgecolor='none', pad_inches=0.1)
+        log.info(f"Saved vector chart: {out}")
+        return out
 
     def _matplotlib_to_reportlab_image(self, fig, width: float, height: float,
                                        max_width: Optional[float] = None,
@@ -315,8 +316,9 @@ class BaseChartEngine:
             return rl_image
 
         except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
-            log.error(f"Error converting matplotlib figure to ReportLab Image: {e}")
-            return self._create_placeholder_chart(width, height, "Image Conversion Error")
+            raise RuntimeError(
+                f"Image Conversion Error: {e}"
+            ) from e
 
     def _create_placeholder_chart(self, width: float, height: float,
                                 text: str = "Chart Placeholder") -> Image:
@@ -442,13 +444,14 @@ class BaseChartEngine:
                 if y_columns and len(y_columns) >= 2:
                     return self.create_bivariate_choropleth(df, x_column, y_columns[0], y_columns[1], title, width, height)
                 else:
-                    return self._create_placeholder_chart(width, height, "Bivariate choropleth requires at least 2 value columns")
+                    raise ValueError("Bivariate choropleth requires at least 2 value columns")
             else:
                 return self.create_bar_chart(df, x_column, y_columns[0] if y_columns else None, title, width, height)
 
         except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-            log.error(f"Error generating chart from DataFrame: {e}")
-            return self._create_placeholder_chart(width, height, "DataFrame Chart Error")
+            raise RuntimeError(
+                f"DataFrame Chart Error: {e}"
+            ) from e
 
     def create_custom_chart(self, chart_config: Dict[str, Any],
                            width: float = 6.0, height: float = 4.0) -> Image:
@@ -496,10 +499,11 @@ class BaseChartEngine:
                         height=height
                     )
                 else:
-                    return self._create_placeholder_chart(width, height, "Bivariate choropleth requires location_column and value_columns configuration")
+                    raise ValueError("Bivariate choropleth requires location_column and value_columns configuration")
             else:
                 return self.create_bar_chart(chart_config['data'], title=chart_config.get('title', ''), width=width, height=height)
 
         except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-            log.error(f"Error creating custom chart: {e}")
-            return self._create_placeholder_chart(width, height, "Custom Chart Error")
+            raise RuntimeError(
+                f"Custom Chart Error: {e}"
+            ) from e

--- a/siege_utilities/reporting/engines/composite_engine.py
+++ b/siege_utilities/reporting/engines/composite_engine.py
@@ -76,7 +76,7 @@ class CompositeChartMixin:
 
         try:
             if not sources:
-                return self._create_placeholder_chart(width, height, "No sources provided")
+                raise ValueError("No sources provided for convergence diagram")
 
             out_nodes = outputs or []
             src_nodes = sources[:arrow_count] if arrow_count else sources
@@ -190,8 +190,15 @@ class CompositeChartMixin:
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
         except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-            log.error(f"Error creating convergence diagram: {e}")
-            return self._create_placeholder_chart(width, height, f"Convergence Diagram Error: {str(e)}")
+
+
+            raise RuntimeError(
+
+
+                f"Convergence Diagram Error: {e}"
+
+
+            ) from e
 
     def create_dashboard(self, charts: List[Dict[str, Any]],
                         layout: str = "2x2", width: float = 12.0, height: float = 8.0) -> Image:
@@ -257,8 +264,15 @@ class CompositeChartMixin:
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
         except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-            log.error(f"Error creating dashboard: {e}")
-            return self._create_placeholder_chart(width, height, f"Dashboard Error: {str(e)}")
+
+
+            raise RuntimeError(
+
+
+                f"Dashboard Error: {e}"
+
+
+            ) from e
 
     def create_dataframe_summary_charts(self, df: 'pd.DataFrame',
                                      title: str = "", width: float = 8.0, height: float = 6.0) -> Image:
@@ -282,7 +296,7 @@ class CompositeChartMixin:
             numeric_cols = df.select_dtypes(include=[np.number]).columns
 
             if len(numeric_cols) == 0:
-                return self._create_placeholder_chart(width, height, "No numeric columns found")
+                raise ValueError("No numeric columns found for summary charts")
 
             # Create subplots
             fig, axes = plt.subplots(2, 2, figsize=(width, height), dpi=self.default_dpi)
@@ -309,8 +323,15 @@ class CompositeChartMixin:
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
         except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-            log.error(f"Error creating DataFrame summary charts: {e}")
-            return self._create_placeholder_chart(width, height, f"Summary Charts Error: {str(e)}")
+
+
+            raise RuntimeError(
+
+
+                f"Summary Charts Error: {e}"
+
+
+            ) from e
 
     def _create_bar_subplot(self, ax, chart_config: Dict[str, Any], title: str):
         """Create a bar chart in a subplot."""

--- a/siege_utilities/reporting/engines/map_engine.py
+++ b/siege_utilities/reporting/engines/map_engine.py
@@ -99,7 +99,7 @@ class MapChartMixin:
             return self._create_placeholder_chart(width, height, "Folium not available")
 
         if geo_data is None:
-            return self._create_placeholder_chart(width, height, "geo_data is required for choropleth map")
+            raise ValueError("geo_data is required for choropleth map")
 
         try:
             # Convert data to DataFrame if needed
@@ -141,8 +141,15 @@ class MapChartMixin:
                                         "Choropleth Map", width, height)
 
         except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
-            log.error(f"Error creating choropleth map: {e}")
-            return self._create_placeholder_chart(width, height, f"Map Error: {str(e)}")
+
+
+            raise RuntimeError(
+
+
+                f"Map Error: {e}"
+
+
+            ) from e
 
     def _resolve_geo_data(self, geo_data) -> Union[str, Dict]:
         """Convert geo_data argument to a format Folium accepts (GeoJSON dict or path string)."""
@@ -232,8 +239,15 @@ class MapChartMixin:
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
         except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-            log.error(f"Error creating bivariate choropleth with matplotlib: {e}")
-            return self._create_placeholder_chart(width, height, f"Bivariate Choropleth Error: {str(e)}")
+
+
+            raise RuntimeError(
+
+
+                f"Bivariate Choropleth Error: {e}"
+
+
+            ) from e
 
     def _create_bivariate_color_matrix(self, scheme: str = "default") -> 'np.ndarray':
         """
@@ -424,8 +438,15 @@ class MapChartMixin:
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
         except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-            log.error(f"Error creating advanced choropleth: {e}")
-            return self._create_placeholder_chart(width, height, f"Advanced Choropleth Error: {str(e)}")
+
+
+            raise RuntimeError(
+
+
+                f"Advanced Choropleth Error: {e}"
+
+
+            ) from e
 
     def create_marker_map(self, data: Union[pd.DataFrame, Dict[str, Any]],
                           latitude_column: str, longitude_column: str,
@@ -524,8 +545,15 @@ class MapChartMixin:
                                         "Marker Map", width, height)
 
         except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
-            log.error(f"Error creating marker map: {e}")
-            return self._create_placeholder_chart(width, height, f"Marker Map Error: {str(e)}")
+
+
+            raise RuntimeError(
+
+
+                f"Marker Map Error: {e}"
+
+
+            ) from e
 
     def create_3d_map(self, data: Union[pd.DataFrame, Dict[str, Any]],
                       latitude_column: str, longitude_column: str, elevation_column: str,
@@ -597,8 +625,15 @@ class MapChartMixin:
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
         except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-            log.error(f"Error creating 3D map: {e}")
-            return self._create_placeholder_chart(width, height, f"3D Map Error: {str(e)}")
+
+
+            raise RuntimeError(
+
+
+                f"3D Map Error: {e}"
+
+
+            ) from e
 
     def create_heatmap_map(self, data: Union[pd.DataFrame, Dict[str, Any]],
                            latitude_column: str, longitude_column: str, value_column: str,
@@ -670,8 +705,15 @@ class MapChartMixin:
                                         "Heatmap", width, height)
 
         except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
-            log.error(f"Error creating heatmap: {e}")
-            return self._create_placeholder_chart(width, height, f"Heatmap Error: {str(e)}")
+
+
+            raise RuntimeError(
+
+
+                f"Heatmap Error: {e}"
+
+
+            ) from e
 
     def create_cluster_map(self, data: Union[pd.DataFrame, Dict[str, Any]],
                            latitude_column: str, longitude_column: str,
@@ -766,8 +808,15 @@ class MapChartMixin:
                                         "Cluster Map", width, height)
 
         except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
-            log.error(f"Error creating cluster map: {e}")
-            return self._create_placeholder_chart(width, height, f"Cluster Map Error: {str(e)}")
+
+
+            raise RuntimeError(
+
+
+                f"Cluster Map Error: {e}"
+
+
+            ) from e
 
     def create_flow_map(self, data: Union[pd.DataFrame, Dict[str, Any]],
                         origin_lat_column: str, origin_lon_column: str,
@@ -869,8 +918,15 @@ class MapChartMixin:
                                         "Flow Map", width, height)
 
         except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
-            log.error(f"Error creating flow map: {e}")
-            return self._create_placeholder_chart(width, height, f"Flow Map Error: {str(e)}")
+
+
+            raise RuntimeError(
+
+
+                f"Flow Map Error: {e}"
+
+
+            ) from e
 
     def create_bivariate_choropleth(self, data: Union[pd.DataFrame, Dict[str, Any]],
                                   geo_data: Union['gpd.GeoDataFrame', str, Path, Dict, None] = None,
@@ -930,8 +986,9 @@ class MapChartMixin:
             elif hasattr(df, 'geometry'):
                 gdf = df
             else:
-                return self._create_placeholder_chart(width, height,
-                    "geo_data is required (GeoDataFrame, GeoJSON path, or dict)")
+                raise ValueError(
+                    "geo_data is required (GeoDataFrame, GeoJSON path, or dict)"
+                )
 
             # Apply bivariate classification using existing helpers
             color_matrix = self._create_bivariate_color_matrix(color_scheme)
@@ -972,5 +1029,12 @@ class MapChartMixin:
                                         "Bivariate Choropleth", width, height)
 
         except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
-            log.error(f"Error creating bivariate choropleth map: {e}")
-            return self._create_placeholder_chart(width, height, f"Bivariate Choropleth Error: {str(e)}")
+
+
+            raise RuntimeError(
+
+
+                f"Bivariate Choropleth Error: {e}"
+
+
+            ) from e

--- a/siege_utilities/reporting/engines/stats_engine.py
+++ b/siege_utilities/reporting/engines/stats_engine.py
@@ -78,7 +78,7 @@ class StatsChartMixin:
                 if len(numeric_cols) > 1:
                     pivot_data = df[numeric_cols].corr()
                 else:
-                    return self._create_placeholder_chart(width, height, "Need numeric data for heatmap")
+                    raise ValueError("Need at least 2 numeric columns for heatmap")
 
             # Create figure
             fig, ax = plt.subplots(figsize=(width, height), dpi=self.default_dpi)
@@ -95,8 +95,15 @@ class StatsChartMixin:
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
         except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-            log.error(f"Error creating heatmap: {e}")
-            return self._create_placeholder_chart(width, height, f"Heatmap Error: {str(e)}")
+
+
+            raise RuntimeError(
+
+
+                f"Heatmap Error: {e}"
+
+
+            ) from e
 
     def create_scatter_plot(self, data: Union[pd.DataFrame, Dict[str, Any]],
                            x_column: str, y_column: str, color_column: str = None,
@@ -149,8 +156,15 @@ class StatsChartMixin:
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
         except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-            log.error(f"Error creating scatter plot: {e}")
-            return self._create_placeholder_chart(width, height, f"Scatter Plot Error: {str(e)}")
+
+
+            raise RuntimeError(
+
+
+                f"Scatter Plot Error: {e}"
+
+
+            ) from e
 
     def create_heatmap_text_chart(self,
                                 data: 'pd.DataFrame',

--- a/siege_utilities/reporting/examples/bivariate_choropleth_example.py
+++ b/siege_utilities/reporting/examples/bivariate_choropleth_example.py
@@ -14,12 +14,20 @@ Examples include:
 Based on the approach from: https://github.com/mikhailsirenko/bivariate-choropleth
 """
 
-import pandas as pd
-import geopandas as gpd
-from pathlib import Path
-import logging
+from __future__ import annotations
 
-# Import the ChartGenerator
+import logging
+from pathlib import Path
+
+import pandas as pd
+
+try:
+    import geopandas as gpd
+    _GEOPANDAS_AVAILABLE = True
+except ImportError:
+    gpd = None  # type: ignore[assignment]
+    _GEOPANDAS_AVAILABLE = False
+
 from ..chart_generator import ChartGenerator
 
 log = logging.getLogger(__name__)
@@ -27,141 +35,115 @@ log = logging.getLogger(__name__)
 def create_sample_data():
     """
     Create sample data for bivariate choropleth examples.
-    
+
     Returns:
         pandas.DataFrame: Sample data with location and two value columns
     """
-    # Sample data - population density and median income by state
     sample_data = {
-        'state': ['California', 'Texas', 'New York', 'Florida', 'Illinois', 
+        'state': ['California', 'Texas', 'New York', 'Florida', 'Illinois',
                   'Pennsylvania', 'Ohio', 'Georgia', 'Michigan', 'North Carolina'],
-        'population_density': [251.3, 108.4, 421.0, 384.3, 231.1, 
+        'population_density': [251.3, 108.4, 421.0, 384.3, 231.1,
                               285.3, 287.7, 175.1, 174.8, 200.6],
-        'median_income': [75235, 64034, 72741, 59227, 69234, 
+        'median_income': [75235, 64034, 72741, 59227, 69234,
                           63240, 58642, 61820, 59234, 57216]
     }
-    
+
     return pd.DataFrame(sample_data)
 
 def create_sample_geodata():
     """
     Create sample geographic data for examples.
     In practice, you would load real GeoJSON files.
-    
+
     Returns:
         geopandas.GeoDataFrame: Sample geographic data
     """
-    # This is a simplified example - in practice you'd load real GeoJSON
-    # For demonstration, we'll create a simple GeoDataFrame
     from shapely.geometry import Point
-    
-    # Create simple point geometries for demonstration
+
     sample_geodata = {
         'state': ['California', 'Texas', 'New York', 'Florida', 'Illinois'],
         'geometry': [
-            Point(-119.4179, 36.7783),  # California
-            Point(-99.9018, 31.9686),    # Texas
-            Point(-74.2179, 43.2994),    # New York
-            Point(-81.5158, 27.6648),    # Florida
-            Point(-88.9861, 40.3495)     # Illinois
+            Point(-119.4179, 36.7783),
+            Point(-99.9018, 31.9686),
+            Point(-74.2179, 43.2994),
+            Point(-81.5158, 27.6648),
+            Point(-88.9861, 40.3495)
         ]
     }
-    
+
     return gpd.GeoDataFrame(sample_geodata, crs="EPSG:4326")
 
 def example_basic_bivariate_choropleth():
     """
     Example 1: Basic bivariate choropleth using Folium.
-    
+
     This example shows how to create a simple bivariate choropleth map
     using the Folium-based method.
     """
     print("=== Example 1: Basic Bivariate Choropleth (Folium) ===")
-    
-    # Initialize chart generator
+
     chart_gen = ChartGenerator()
-    
-    # Create sample data
     data = create_sample_data()
-    
-    try:
-        # Create bivariate choropleth
-        chart = chart_gen.create_bivariate_choropleth(
-            data=data,
-            location_column='state',
-            value_column1='population_density',
-            value_column2='median_income',
-            title="Population Density vs Median Income by State",
-            width=10.0,
-            height=8.0
-        )
-        
-        print("✓ Basic bivariate choropleth created successfully")
-        print(f"Chart type: {type(chart)}")
-        print(f"Chart dimensions: {chart.drawWidth} x {chart.drawHeight}")
-        
-        return chart
-        
-    except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-        print(f"✗ Error creating basic bivariate choropleth: {e}")
-        return None
+
+    chart = chart_gen.create_bivariate_choropleth(
+        data=data,
+        location_column='state',
+        value_column1='population_density',
+        value_column2='median_income',
+        title="Population Density vs Median Income by State",
+        width=10.0,
+        height=8.0
+    )
+
+    print("✓ Basic bivariate choropleth created successfully")
+    print(f"Chart type: {type(chart)}")
+    print(f"Chart dimensions: {chart.drawWidth} x {chart.drawHeight}")
+
+    return chart
 
 def example_advanced_bivariate_choropleth():
     """
     Example 2: Advanced bivariate choropleth using matplotlib and geopandas.
-    
+
     This example demonstrates the more sophisticated approach using matplotlib
     for better control over styling and legends.
     """
     print("\n=== Example 2: Advanced Bivariate Choropleth (Matplotlib) ===")
-    
-    # Initialize chart generator
+
     chart_gen = ChartGenerator()
-    
-    # Create sample data
     data = create_sample_data()
     geodata = create_sample_geodata()
-    
-    try:
-        # Create advanced bivariate choropleth
-        chart = chart_gen.create_bivariate_choropleth_matplotlib(
-            data=data,
-            geodata=geodata,
-            location_column='state',
-            value_column1='population_density',
-            value_column2='median_income',
-            title="Advanced Bivariate Choropleth: Population Density vs Income",
-            width=12.0,
-            height=10.0,
-            color_scheme='custom'
-        )
-        
-        print("✓ Advanced bivariate choropleth created successfully")
-        print(f"Chart type: {type(chart)}")
-        print(f"Chart dimensions: {chart.drawWidth} x {chart.drawHeight}")
-        
-        return chart
-        
-    except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-        print(f"✗ Error creating advanced bivariate choropleth: {e}")
-        return None
+
+    chart = chart_gen.create_bivariate_choropleth_matplotlib(
+        data=data,
+        geodata=geodata,
+        location_column='state',
+        value_column1='population_density',
+        value_column2='median_income',
+        title="Advanced Bivariate Choropleth: Population Density vs Income",
+        width=12.0,
+        height=10.0,
+        color_scheme='custom'
+    )
+
+    print("✓ Advanced bivariate choropleth created successfully")
+    print(f"Chart type: {type(chart)}")
+    print(f"Chart dimensions: {chart.drawWidth} x {chart.drawHeight}")
+
+    return chart
 
 def example_custom_chart_configuration():
     """
     Example 3: Using custom chart configuration for bivariate choropleth.
-    
+
     This example shows how to use the custom chart configuration
     system with bivariate choropleth maps.
     """
     print("\n=== Example 3: Custom Chart Configuration ===")
-    
-    # Initialize chart generator
+
     chart_gen = ChartGenerator()
-    
-    # Create sample data
     data = create_sample_data()
-    
-    # Custom chart configuration
+
     chart_config = {
         'type': 'bivariate_choropleth',
         'title': 'Custom Bivariate Choropleth Configuration',
@@ -169,116 +151,91 @@ def example_custom_chart_configuration():
         'location_column': 'state',
         'value_columns': ['population_density', 'median_income']
     }
-    
-    try:
-        # Create chart using custom configuration
-        chart = chart_gen.create_custom_chart(
-            chart_config=chart_config,
-            width=10.0,
-            height=8.0
-        )
-        
-        print("✓ Custom chart configuration bivariate choropleth created successfully")
-        print(f"Chart type: {type(chart)}")
-        print(f"Chart dimensions: {chart.drawWidth} x {chart.drawHeight}")
-        
-        return chart
-        
-    except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-        print(f"✗ Error creating custom chart configuration: {e}")
-        return None
+
+    chart = chart_gen.create_custom_chart(
+        chart_config=chart_config,
+        width=10.0,
+        height=8.0
+    )
+
+    print("✓ Custom chart configuration bivariate choropleth created successfully")
+    print(f"Chart type: {type(chart)}")
+    print(f"Chart dimensions: {chart.drawWidth} x {chart.drawHeight}")
+
+    return chart
 
 def example_dataframe_integration():
     """
     Example 4: Integration with DataFrame-based chart generation.
-    
+
     This example shows how to use the DataFrame integration methods
     with bivariate choropleth maps.
     """
     print("\n=== Example 4: DataFrame Integration ===")
-    
-    # Initialize chart generator
+
     chart_gen = ChartGenerator()
-    
-    # Create sample data
     data = create_sample_data()
-    
-    try:
-        # Create bivariate choropleth using DataFrame method
-        chart = chart_gen.generate_chart_from_dataframe(
-            df=data,
-            chart_type='bivariate_choropleth',
-            x_column='state',
-            y_columns=['population_density', 'median_income'],
-            title="DataFrame Integration Example",
-            width=10.0,
-            height=8.0
-        )
-        
-        print("✓ DataFrame integration bivariate choropleth created successfully")
-        print(f"Chart type: {type(chart)}")
-        print(f"Chart dimensions: {chart.drawWidth} x {chart.drawHeight}")
-        
-        return chart
-        
-    except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-        print(f"✗ Error creating DataFrame integration chart: {e}")
-        return None
+
+    chart = chart_gen.generate_chart_from_dataframe(
+        df=data,
+        chart_type='bivariate_choropleth',
+        x_column='state',
+        y_columns=['population_density', 'median_income'],
+        title="DataFrame Integration Example",
+        width=10.0,
+        height=8.0
+    )
+
+    print("✓ DataFrame integration bivariate choropleth created successfully")
+    print(f"Chart type: {type(chart)}")
+    print(f"Chart dimensions: {chart.drawWidth} x {chart.drawHeight}")
+
+    return chart
 
 def example_advanced_choropleth():
     """
     Example 5: Advanced choropleth with classification options.
-    
+
     This example demonstrates the advanced choropleth functionality
     with different classification methods.
     """
     print("\n=== Example 5: Advanced Choropleth with Classification ===")
-    
-    # Initialize chart generator
+
     chart_gen = ChartGenerator()
-    
-    # Create sample data
     data = create_sample_data()
     geodata = create_sample_geodata()
-    
-    try:
-        # Create advanced choropleth with quantile classification
-        chart = chart_gen.create_advanced_choropleth(
-            data=data,
-            geodata=geodata,
-            location_column='state',
-            value_column='population_density',
-            title="Advanced Choropleth: Population Density (Quantile Classification)",
-            width=12.0,
-            height=10.0,
-            classification='quantiles',
-            bins=5,
-            color_scheme='YlOrRd'
-        )
-        
-        print("✓ Advanced choropleth with classification created successfully")
-        print(f"Chart type: {type(chart)}")
-        print(f"Chart dimensions: {chart.drawWidth} x {chart.drawHeight}")
-        
-        return chart
-        
-    except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-        print(f"✗ Error creating advanced choropleth: {e}")
-        return None
+
+    chart = chart_gen.create_advanced_choropleth(
+        data=data,
+        geodata=geodata,
+        location_column='state',
+        value_column='population_density',
+        title="Advanced Choropleth: Population Density (Quantile Classification)",
+        width=12.0,
+        height=10.0,
+        classification='quantiles',
+        bins=5,
+        color_scheme='YlOrRd'
+    )
+
+    print("✓ Advanced choropleth with classification created successfully")
+    print(f"Chart type: {type(chart)}")
+    print(f"Chart dimensions: {chart.drawWidth} x {chart.drawHeight}")
+
+    return chart
 
 def run_all_examples():
     """
     Run all bivariate choropleth examples and return results.
-    
+
     Returns:
         list: List of successfully created charts
     """
     print("🚀 Running Bivariate Choropleth Examples")
     print("=" * 50)
-    
+
     charts = []
-    
-    # Run all examples
+
     examples = [
         example_basic_bivariate_choropleth,
         example_advanced_bivariate_choropleth,
@@ -286,77 +243,61 @@ def run_all_examples():
         example_dataframe_integration,
         example_advanced_choropleth
     ]
-    
+
     for example_func in examples:
-        try:
-            chart = example_func()
-            if chart:
-                charts.append(chart)
-        except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-            print(f"✗ Example {example_func.__name__} failed: {e}")
-    
+        chart = example_func()
+        charts.append(chart)
+
     print(f"\n📊 Summary: {len(charts)} out of {len(examples)} examples completed successfully")
-    
+
     return charts
 
 def create_report_with_bivariate_maps():
     """
     Example 6: Create a complete report section with bivariate choropleth maps.
-    
+
     This example shows how to integrate bivariate choropleth maps
     into the complete reporting system.
     """
     print("\n=== Example 6: Report Integration ===")
-    
-    # Initialize chart generator
+
     chart_gen = ChartGenerator()
-    
-    # Create sample data
     data = create_sample_data()
-    
-    try:
-        # Create multiple charts for the report
-        charts = []
-        
-        # Chart 1: Basic bivariate choropleth
-        chart1 = chart_gen.create_bivariate_choropleth(
-            data=data,
-            location_column='state',
-            value_column1='population_density',
-            value_column2='median_income',
-            title="Population Density vs Median Income",
-            width=8.0,
-            height=6.0
-        )
-        charts.append(chart1)
-        
-        # Chart 2: Scatter plot for comparison
-        chart2 = chart_gen.create_scatter_plot(
-            data=data,
-            x_column='population_density',
-            y_column='median_income',
-            title="Population Density vs Median Income (Scatter)",
-            width=8.0,
-            height=6.0
-        )
-        charts.append(chart2)
-        
-        # Create report section
-        report_section = chart_gen.create_chart_section(
-            title="Geographic Analysis: Population and Income Patterns",
-            charts=charts,
-            description="This section analyzes the relationship between population density and median income across different states using bivariate choropleth maps and supporting visualizations."
-        )
-        
-        print("✓ Report section with bivariate maps created successfully")
-        print(f"Number of charts in section: {len(charts)}")
-        print(f"Report section length: {len(report_section)} elements")
-        
-        return report_section
-        
-    except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-        print(f"✗ Error creating report section: {e}")
-        return None
+
+    charts = []
+
+    chart1 = chart_gen.create_bivariate_choropleth(
+        data=data,
+        location_column='state',
+        value_column1='population_density',
+        value_column2='median_income',
+        title="Population Density vs Median Income",
+        width=8.0,
+        height=6.0
+    )
+    charts.append(chart1)
+
+    chart2 = chart_gen.create_scatter_plot(
+        data=data,
+        x_column='population_density',
+        y_column='median_income',
+        title="Population Density vs Median Income (Scatter)",
+        width=8.0,
+        height=6.0
+    )
+    charts.append(chart2)
+
+    report_section = chart_gen.create_chart_section(
+        title="Geographic Analysis: Population and Income Patterns",
+        charts=charts,
+        description="This section analyzes the relationship between population density and median income across different states using bivariate choropleth maps and supporting visualizations."
+    )
+
+    print("✓ Report section with bivariate maps created successfully")
+    print(f"Number of charts in section: {len(charts)}")
+    print(f"Report section length: {len(report_section)} elements")
+
+    return report_section
 
 if __name__ == "__main__":
     """
@@ -365,21 +306,6 @@ if __name__ == "__main__":
     print("🎯 Bivariate Choropleth Map Examples for siege_utilities")
     print("Based on: https://github.com/mikhailsirenko/bivariate-choropleth")
     print()
-    
-    # Run all examples
+
     charts = run_all_examples()
-    
-    # Create report integration example
     report_section = create_report_with_bivariate_maps()
-    
-    print("\n🎉 Examples completed!")
-    print(f"Total charts created: {len(charts)}")
-    print(f"Report section created: {'Yes' if report_section else 'No'}")
-    
-    # Print usage tips
-    print("\n💡 Usage Tips:")
-    print("1. Install required dependencies: pip install geopandas folium matplotlib")
-    print("2. Use GeoJSON files for real geographic data")
-    print("3. Experiment with different color schemes and classification methods")
-    print("4. Combine with other chart types for comprehensive analysis")
-    print("5. Integrate with the full reporting system for professional reports")

--- a/siege_utilities/reporting/examples/comprehensive_mapping_example.py
+++ b/siege_utilities/reporting/examples/comprehensive_mapping_example.py
@@ -21,14 +21,10 @@ import pandas as pd
 import numpy as np
 from pathlib import Path
 from datetime import datetime, timedelta
-import geopandas as gpd
-from shapely.geometry import Point
-
 # Import siege_utilities components
 from siege_utilities.reporting.chart_generator import ChartGenerator
 from siege_utilities.reporting.report_generator import ReportGenerator
 from siege_utilities.reporting.powerpoint_generator import PowerPointGenerator
-from siege_utilities.reporting.client_branding import ClientBrandingManager
 
 def create_sample_geographic_data():
     """Create sample geographic data for demonstration."""
@@ -354,14 +350,10 @@ def create_comprehensive_pdf_report(maps_dict):
     
     # Generate PDF report
     output_path = "comprehensive_geographic_report.pdf"
-    success = report_gen.generate_pdf_report(report_content, output_path)
-    
-    if success:
-        print(f"✅ PDF report generated successfully: {output_path}")
-    else:
-        print("❌ Error generating PDF report")
-    
-    return success
+    report_gen.generate_pdf_report(report_content, output_path)
+    print(f"PDF report generated successfully: {output_path}")
+
+    return output_path
 
 def create_comprehensive_powerpoint(maps_dict):
     """Create a comprehensive PowerPoint presentation."""

--- a/siege_utilities/reporting/examples/ga_geographic_analysis.py
+++ b/siege_utilities/reporting/examples/ga_geographic_analysis.py
@@ -169,67 +169,54 @@ def create_state_choropleth(state_data: pd.DataFrame, value_column: str = 'sessi
         log.warning("GeoPandas or matplotlib not available for choropleth")
         return None
 
-    try:
-        # Load US states shapefile (from Census TIGER/Line)
-        if GEO_AVAILABLE:
-            states_gdf = get_geographic_boundaries(
-                boundary_type='state',
-                year=2020,
-                state=None  # All states
-            )
-        else:
-            log.warning("siege_utilities geo module not available")
-            return None
-
-        if states_gdf is None or states_gdf.empty:
-            log.warning("Could not load state boundaries")
-            return None
-
-        # Merge with GA data
-        merged = states_gdf.merge(
-            state_data,
-            left_on='STATEFP',
-            right_on='state_fips',
-            how='left'
-        )
-
-        # Create figure
-        fig, ax = plt.subplots(1, 1, figsize=(14, 8))
-
-        # Plot states
-        merged.plot(
-            column=value_column,
-            ax=ax,
-            legend=True,
-            cmap='Blues',
-            missing_kwds={'color': 'lightgray', 'label': 'No data'},
-            legend_kwds={'label': value_column.replace('_', ' ').title()}
-        )
-
-        # Styling
-        ax.set_title(title, fontsize=16, fontweight='bold')
-        ax.set_axis_off()
-
-        # Crop to continental US
-        ax.set_xlim(-130, -65)
-        ax.set_ylim(24, 50)
-
-        plt.tight_layout()
-
-        # Save or return path
-        if output_path:
-            plt.savefig(output_path, dpi=150, bbox_inches='tight')
-            plt.close()
-            return output_path
-        else:
-            with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as tmp:
-                plt.savefig(tmp.name, dpi=150, bbox_inches='tight')
-                plt.close()
-                return tmp.name
-
-    except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
-        log.error(f"Error creating state choropleth: {e}")
+    if not GEO_AVAILABLE:
+        log.warning("siege_utilities geo module not available")
         return None
+
+    states_gdf = get_geographic_boundaries(
+        boundary_type='state',
+        year=2020,
+        state=None
+    )
+
+    if states_gdf is None or states_gdf.empty:
+        log.warning("Could not load state boundaries")
+        return None
+
+    merged = states_gdf.merge(
+        state_data,
+        left_on='STATEFP',
+        right_on='state_fips',
+        how='left'
+    )
+
+    fig, ax = plt.subplots(1, 1, figsize=(14, 8))
+
+    merged.plot(
+        column=value_column,
+        ax=ax,
+        legend=True,
+        cmap='Blues',
+        missing_kwds={'color': 'lightgray', 'label': 'No data'},
+        legend_kwds={'label': value_column.replace('_', ' ').title()}
+    )
+
+    ax.set_title(title, fontsize=16, fontweight='bold')
+    ax.set_axis_off()
+    ax.set_xlim(-130, -65)
+    ax.set_ylim(24, 50)
+
+    plt.tight_layout()
+
+    if output_path:
+        plt.savefig(output_path, dpi=150, bbox_inches='tight')
+        plt.close()
+        return output_path
+    else:
+        with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as tmp:
+            plt.savefig(tmp.name, dpi=150, bbox_inches='tight')
+            plt.close()
+            return tmp.name
 
 
 def create_city_heatmap(ga_city_df: pd.DataFrame, value_column: str = 'sessions',
@@ -241,53 +228,42 @@ def create_city_heatmap(ga_city_df: pd.DataFrame, value_column: str = 'sessions'
         log.warning("Folium not available for heatmap")
         return None
 
-    try:
-        # Filter to geocoded cities
-        valid = ga_city_df[ga_city_df['latitude'].notna()].copy()
+    valid = ga_city_df[ga_city_df['latitude'].notna()].copy()
 
-        if valid.empty:
-            log.warning("No geocoded cities for heatmap")
-            return None
-
-        # Create base map centered on US
-        center_lat = valid['latitude'].mean()
-        center_lon = valid['longitude'].mean()
-        m = folium.Map(location=[center_lat, center_lon], zoom_start=4)
-
-        # Prepare heatmap data
-        heat_data = []
-        for _, row in valid.iterrows():
-            col_max = valid[value_column].max()
-            weight = (row[value_column] / col_max) if col_max else 0
-            heat_data.append([row['latitude'], row['longitude'], weight])
-
-        # Add heatmap layer
-        HeatMap(heat_data, radius=25, blur=15).add_to(m)
-
-        # Add markers for top cities
-        top_cities = valid.nlargest(10, value_column)
-        for _, row in top_cities.iterrows():
-            folium.CircleMarker(
-                location=[row['latitude'], row['longitude']],
-                radius=8,
-                popup=f"{row['city']}: {row[value_column]:,} {value_column}",
-                color='red',
-                fill=True,
-                fill_opacity=0.7
-            ).add_to(m)
-
-        # Save map
-        if output_path:
-            m.save(output_path)
-            return output_path
-        else:
-            with tempfile.NamedTemporaryFile(suffix='.html', delete=False) as tmp:
-                m.save(tmp.name)
-                return tmp.name
-
-    except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
-        log.error(f"Error creating city heatmap: {e}")
+    if valid.empty:
+        log.warning("No geocoded cities for heatmap")
         return None
+
+    center_lat = valid['latitude'].mean()
+    center_lon = valid['longitude'].mean()
+    m = folium.Map(location=[center_lat, center_lon], zoom_start=4)
+
+    heat_data = []
+    for _, row in valid.iterrows():
+        col_max = valid[value_column].max()
+        weight = (row[value_column] / col_max) if col_max else 0
+        heat_data.append([row['latitude'], row['longitude'], weight])
+
+    HeatMap(heat_data, radius=25, blur=15).add_to(m)
+
+    top_cities = valid.nlargest(10, value_column)
+    for _, row in top_cities.iterrows():
+        folium.CircleMarker(
+            location=[row['latitude'], row['longitude']],
+            radius=8,
+            popup=f"{row['city']}: {row[value_column]:,} {value_column}",
+            color='red',
+            fill=True,
+            fill_opacity=0.7
+        ).add_to(m)
+
+    if output_path:
+        m.save(output_path)
+        return output_path
+    else:
+        with tempfile.NamedTemporaryFile(suffix='.html', delete=False) as tmp:
+            m.save(tmp.name)
+            return tmp.name
 
 
 def create_traffic_demographics_comparison(ga_state_data: pd.DataFrame,
@@ -298,47 +274,37 @@ def create_traffic_demographics_comparison(ga_state_data: pd.DataFrame,
     Returns a DataFrame with both traffic metrics and demographic data.
     """
     if not GEO_AVAILABLE:
-        log.warning("siege_utilities geo module not available for Census data")
-        return ga_state_data
+        raise ImportError("siege_utilities geo module not available for Census data")
 
-    try:
-        # Fetch state-level demographics
-        census_client = CensusAPIClient()
+    census_client = CensusAPIClient()
 
-        demographics = census_client.fetch_data(
-            year=census_year,
-            dataset='acs5',
-            geography='state',
-            variables=['B01001_001E', 'B19013_001E', 'B15003_022E'],  # Pop, Income, Bachelor's
-            state='*'
-        )
+    demographics = census_client.fetch_data(
+        year=census_year,
+        dataset='acs5',
+        geography='state',
+        variables=['B01001_001E', 'B19013_001E', 'B15003_022E'],
+        state='*'
+    )
 
-        if demographics.empty:
-            return ga_state_data
+    if demographics.empty:
+        raise ValueError("Census API returned no data for the requested variables")
 
-        # Rename columns
-        demographics = demographics.rename(columns={
-            'B01001_001E': 'total_population',
-            'B19013_001E': 'median_income',
-            'B15003_022E': 'bachelors_degree'
-        })
+    demographics = demographics.rename(columns={
+        'B01001_001E': 'total_population',
+        'B19013_001E': 'median_income',
+        'B15003_022E': 'bachelors_degree'
+    })
 
-        # Merge with GA data
-        merged = ga_state_data.merge(
-            demographics[['state', 'total_population', 'median_income', 'bachelors_degree']],
-            on='state',
-            how='left'
-        )
+    merged = ga_state_data.merge(
+        demographics[['state', 'total_population', 'median_income', 'bachelors_degree']],
+        on='state',
+        how='left'
+    )
 
-        # Calculate derived metrics
-        if 'total_population' in merged.columns and 'users' in merged.columns:
-            merged['users_per_capita'] = merged['users'] / merged['total_population'] * 100000
+    if 'total_population' in merged.columns and 'users' in merged.columns:
+        merged['users_per_capita'] = merged['users'] / merged['total_population'] * 100000
 
-        return merged
-
-    except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
-        log.error(f"Error fetching Census demographics: {e}")
-        return ga_state_data
+    return merged
 
 
 def create_bivariate_traffic_income_map(merged_data: pd.DataFrame,
@@ -347,94 +313,85 @@ def create_bivariate_traffic_income_map(merged_data: pd.DataFrame,
     Create a bivariate choropleth showing traffic vs income.
     """
     if not GEOPANDAS_AVAILABLE or not MATPLOTLIB_AVAILABLE:
+        log.warning("geopandas or matplotlib not available; cannot create bivariate map")
         return None
 
-    try:
-        if GEO_AVAILABLE:
-            states_gdf = get_geographic_boundaries(
-                boundary_type='state',
-                year=2020,
-                state=None
-            )
-        else:
-            return None
+    if not GEO_AVAILABLE:
+        log.warning("siege_utilities.geo not available; cannot create bivariate map")
+        return None
 
-        if states_gdf is None or states_gdf.empty:
-            return None
+    states_gdf = get_geographic_boundaries(
+        boundary_type='state',
+        year=2020,
+        state=None
+    )
 
-        # Merge data
-        gdf = states_gdf.merge(
-            merged_data,
-            left_on='STATEFP',
-            right_on='state_fips',
-            how='left'
-        )
+    if states_gdf is None or states_gdf.empty:
+        log.warning("No state boundary data available; cannot create bivariate map")
+        return None
 
-        # Create quantile bins for both variables
-        gdf['traffic_bin'] = pd.qcut(gdf['sessions'].fillna(0), q=3, labels=['Low', 'Medium', 'High'])
-        gdf['income_bin'] = pd.qcut(gdf['median_income'].fillna(0), q=3, labels=['Low', 'Medium', 'High'])
+    gdf = states_gdf.merge(
+        merged_data,
+        left_on='STATEFP',
+        right_on='state_fips',
+        how='left'
+    )
 
-        # Create bivariate color matrix
-        bivariate_colors = {
-            ('Low', 'Low'): '#e8e8e8',
-            ('Low', 'Medium'): '#b8d6be',
-            ('Low', 'High'): '#73ae80',
-            ('Medium', 'Low'): '#b5c0da',
-            ('Medium', 'Medium'): '#90b2b3',
-            ('Medium', 'High'): '#5a9178',
-            ('High', 'Low'): '#6c83b5',
-            ('High', 'Medium'): '#567994',
-            ('High', 'High'): '#2a5a5b',
-        }
+    gdf['traffic_bin'] = pd.qcut(gdf['sessions'].fillna(0), q=3, labels=['Low', 'Medium', 'High'])
+    gdf['income_bin'] = pd.qcut(gdf['median_income'].fillna(0), q=3, labels=['Low', 'Medium', 'High'])
 
-        def get_color(row):
-            if pd.isna(row['traffic_bin']) or pd.isna(row['income_bin']):
-                return '#ffffff'
-            return bivariate_colors.get((row['traffic_bin'], row['income_bin']), '#ffffff')
+    bivariate_colors = {
+        ('Low', 'Low'): '#e8e8e8',
+        ('Low', 'Medium'): '#b8d6be',
+        ('Low', 'High'): '#73ae80',
+        ('Medium', 'Low'): '#b5c0da',
+        ('Medium', 'Medium'): '#90b2b3',
+        ('Medium', 'High'): '#5a9178',
+        ('High', 'Low'): '#6c83b5',
+        ('High', 'Medium'): '#567994',
+        ('High', 'High'): '#2a5a5b',
+    }
 
-        gdf['color'] = gdf.apply(get_color, axis=1)
+    def get_color(row):
+        if pd.isna(row['traffic_bin']) or pd.isna(row['income_bin']):
+            return '#ffffff'
+        return bivariate_colors.get((row['traffic_bin'], row['income_bin']), '#ffffff')
 
-        # Create figure
-        fig, ax = plt.subplots(1, 1, figsize=(14, 10))
+    gdf['color'] = gdf.apply(get_color, axis=1)
 
-        # Plot with custom colors
-        gdf.plot(
-            ax=ax,
-            color=gdf['color'],
-            edgecolor='white',
-            linewidth=0.5
-        )
+    fig, ax = plt.subplots(1, 1, figsize=(14, 10))
 
-        # Title and styling
-        ax.set_title('Website Traffic vs. Median Income by State', fontsize=16, fontweight='bold')
-        ax.set_axis_off()
-        ax.set_xlim(-130, -65)
-        ax.set_ylim(24, 50)
+    gdf.plot(
+        ax=ax,
+        color=gdf['color'],
+        edgecolor='white',
+        linewidth=0.5
+    )
 
-        # Add legend
-        legend_elements = [
-            Patch(facecolor='#73ae80', label='High Income, Low Traffic'),
-            Patch(facecolor='#2a5a5b', label='High Income, High Traffic'),
-            Patch(facecolor='#e8e8e8', label='Low Income, Low Traffic'),
-            Patch(facecolor='#6c83b5', label='Low Income, High Traffic'),
-        ]
-        ax.legend(handles=legend_elements, loc='lower right', fontsize=9)
+    ax.set_title('Website Traffic vs. Median Income by State', fontsize=16, fontweight='bold')
+    ax.set_axis_off()
+    ax.set_xlim(-130, -65)
+    ax.set_ylim(24, 50)
 
-        plt.tight_layout()
+    legend_elements = [
+        Patch(facecolor='#73ae80', label='High Income, Low Traffic'),
+        Patch(facecolor='#2a5a5b', label='High Income, High Traffic'),
+        Patch(facecolor='#e8e8e8', label='Low Income, Low Traffic'),
+        Patch(facecolor='#6c83b5', label='Low Income, High Traffic'),
+    ]
+    ax.legend(handles=legend_elements, loc='lower right', fontsize=9)
 
-        if output_path:
-            plt.savefig(output_path, dpi=150, bbox_inches='tight')
+    plt.tight_layout()
+
+    if output_path:
+        plt.savefig(output_path, dpi=150, bbox_inches='tight')
+        plt.close()
+        return output_path
+    else:
+        with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as tmp:
+            plt.savefig(tmp.name, dpi=150, bbox_inches='tight')
             plt.close()
-            return output_path
-        else:
-            with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as tmp:
-                plt.savefig(tmp.name, dpi=150, bbox_inches='tight')
-                plt.close()
-                return tmp.name
-
-    except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
-        log.error(f"Error creating bivariate map: {e}")
-        return None
+            return tmp.name
 
 
 def generate_geographic_insights(merged_data: pd.DataFrame) -> List[str]:
@@ -525,8 +482,7 @@ def main():
 
     print("\n5. Adding Census demographics...")
     merged = create_traffic_demographics_comparison(state_df)
-    if 'median_income' in merged.columns:
-        print("   Census data merged successfully")
+    print("   Census data merged successfully")
 
     print("\n6. Generating geographic insights...")
     insights = generate_geographic_insights(merged)
@@ -534,7 +490,6 @@ def main():
         print(f"   - {insight}")
 
     print("\nDone!")
-    return True
 
 
 if __name__ == "__main__":

--- a/siege_utilities/reporting/examples/google_analytics_report_example.py
+++ b/siege_utilities/reporting/examples/google_analytics_report_example.py
@@ -14,6 +14,7 @@ Requirements:
 - siege_utilities with reporting extras
 - Google Analytics credentials (service account or OAuth)
 """
+from __future__ import annotations
 
 import pandas as pd
 import numpy as np
@@ -22,6 +23,7 @@ from datetime import datetime, timedelta
 from typing import Dict, List, Any, Optional, Tuple
 import logging
 import io
+import subprocess
 import tempfile
 
 # ReportLab imports
@@ -69,6 +71,11 @@ def _safe_int(value, default: int = 0) -> int:
         return int(value)
     except (ValueError, TypeError):
         return default
+
+
+if not REPORTLAB_AVAILABLE:
+    Flowable = object
+    inch = 72.0
 
 
 class KPICard(Flowable):
@@ -498,26 +505,28 @@ def fetch_real_ga4_data(property_id: str, start_date: str, end_date: str,
 
         # Strategy 1: Try service account credentials from 1Password
         if connector is None:
-            sa_data = get_google_service_account_from_1password(
-                item_title=credential_item_name, vault=vault, account=account,
-            )
-            if sa_data:
+            try:
+                sa_data = get_google_service_account_from_1password(
+                    item_title=credential_item_name, vault=vault, account=account,
+                )
                 connector = GoogleAnalyticsConnector(
                     auth_method="service_account",
                     service_account_data=sa_data,
                 )
+            except (subprocess.CalledProcessError, OSError):
+                log.info("Service account not found in 1Password — trying OAuth2")
 
         # Strategy 2: Try OAuth2 credentials from 1Password
         if connector is None:
-            log.info("No service account found — trying OAuth2 credentials")
             try:
                 from siege_utilities.config import get_google_oauth_from_1password
             except ImportError:
                 log.warning("get_google_oauth_from_1password not available")
                 return None
 
-            oauth_creds = get_google_oauth_from_1password(vault=vault, account=account)
-            if not oauth_creds:
+            try:
+                oauth_creds = get_google_oauth_from_1password(vault=vault, account=account)
+            except (subprocess.CalledProcessError, ValueError, OSError):
                 log.warning("No GA credentials found in 1Password (service account or OAuth2)")
                 return None
 
@@ -528,8 +537,10 @@ def fetch_real_ga4_data(property_id: str, start_date: str, end_date: str,
             )
             token_path = Path.home() / '.siege_utilities' / 'ga_token.json'
             token_path.parent.mkdir(parents=True, exist_ok=True)
-            if not connector.authenticate(token_file=str(token_path)):
-                log.warning("OAuth2 authentication failed")
+            try:
+                connector.authenticate(token_file=str(token_path))
+            except (OSError, ValueError, RuntimeError) as e:
+                log.warning("OAuth2 authentication failed: %s", e)
                 return None
 
         # Fetch daily metrics
@@ -778,8 +789,7 @@ def fetch_real_ga4_data(property_id: str, start_date: str, end_date: str,
         return result
 
     except (ValueError, TypeError, KeyError, AttributeError, OSError) as e:
-        log.warning(f"Could not fetch real GA4 data: {e}")
-        return None
+        raise RuntimeError(f"Could not fetch real GA4 data: {e}") from e
 
 
 def create_kpi_dashboard(ga_data: Dict[str, Any]) -> List[Flowable]:
@@ -1649,7 +1659,7 @@ def generate_ga_report_pdf(ga_data: Dict[str, Any], output_path: str,
                            vector_export_dir: Optional[str] = None,
                            raster_export_dir: Optional[str] = None,
                            client_logo_path: Optional[str] = None,
-                           company_logo_path: Optional[str] = None) -> bool:
+                           company_logo_path: Optional[str] = None) -> None:
     """
     Generate a comprehensive Google Analytics PDF report with professional styling.
 
@@ -1671,740 +1681,732 @@ def generate_ga_report_pdf(ga_data: Dict[str, Any], output_path: str,
         client_logo_path: Path to client logo image for the cover page (upper right).
         company_logo_path: Path to company/agency logo for the cover page footer.
 
-    Returns:
-        True if successful
+    Raises:
+        ImportError: If ReportLab is not installed.
+        OSError: If file I/O fails.
     """
     if not REPORTLAB_AVAILABLE:
-        log.error("ReportLab not available - cannot generate PDF")
-        return False
+        raise ImportError("ReportLab not available - cannot generate PDF (pip install reportlab)")
 
-    try:
-        # Load branding colors
-        primary_color = '#1E3A5F'
-        secondary_color = '#2E7D32'
-        if branding_key:
+    # Load branding colors
+    primary_color = '#1E3A5F'
+    secondary_color = '#2E7D32'
+    if branding_key:
+        try:
+            from siege_utilities.reporting.client_branding import ClientBrandingManager
+            mgr = ClientBrandingManager()
+            branding = mgr.get_client_branding(branding_key)
+            if branding:
+                primary_color = branding.get('colors', {}).get('primary', primary_color)
+                secondary_color = branding.get('colors', {}).get('secondary', secondary_color)
+                client_name = branding.get('name', client_name)
+                prepared_by = branding.get('footer', {}).get('left_text', f"Prepared by: {prepared_by}").replace('Prepared by: ', '')
+        except (ImportError, LookupError, ValueError, KeyError, AttributeError) as e:
+            log.debug(f"Could not load branding '{branding_key}': {e}")
+
+    date_range = ga_data['date_range']
+    totals = ga_data['totals']
+    changes = ga_data['changes']
+
+    # Header/footer callback
+    def _header_footer(canvas_obj, doc_obj):
+        canvas_obj.saveState()
+        canvas_obj.setFont('Helvetica-Bold', 8)
+        canvas_obj.setFillColor(colors.HexColor(primary_color))
+        canvas_obj.drawString(0.75*inch, letter[1] - 0.4*inch, report_title)
+        canvas_obj.setFont('Helvetica', 7)
+        canvas_obj.setFillColor(colors.HexColor('#666666'))
+        canvas_obj.drawString(0.75*inch, letter[1] - 0.52*inch, f"{client_name}  |  {date_range['start']} to {date_range['end']}")
+        # Footer
+        canvas_obj.setFont('Helvetica', 7)
+        canvas_obj.drawString(0.75*inch, 0.4*inch, f"Page {doc_obj.page}")
+        canvas_obj.drawRightString(letter[0] - 0.75*inch, 0.4*inch, prepared_by)
+        canvas_obj.restoreState()
+
+    # Create document with room for header/footer
+    doc = SimpleDocTemplate(
+        output_path,
+        pagesize=letter,
+        rightMargin=0.75*inch,
+        leftMargin=0.75*inch,
+        topMargin=0.85*inch,
+        bottomMargin=0.7*inch
+    )
+
+    styles = getSampleStyleSheet()
+
+    # Branding-aware styles
+    title_style = ParagraphStyle(
+        'CustomTitle', parent=styles['Title'],
+        fontSize=28, spaceAfter=8, alignment=TA_CENTER,
+        textColor=colors.HexColor(primary_color), fontName='Helvetica-Bold'
+    )
+    subtitle_style = ParagraphStyle(
+        'CustomSubtitle', parent=styles['Normal'],
+        fontSize=14, alignment=TA_CENTER, textColor=colors.HexColor('#666666'),
+        spaceAfter=20
+    )
+    heading_style = ParagraphStyle(
+        'CustomHeading', parent=styles['Heading1'],
+        fontSize=16, spaceBefore=20, spaceAfter=10,
+        textColor=colors.HexColor(primary_color)
+    )
+    subheading_style = ParagraphStyle(
+        'CustomSubheading', parent=styles['Heading2'],
+        fontSize=13, spaceBefore=15, spaceAfter=8,
+        textColor=colors.HexColor('#34495e')
+    )
+    body_style = ParagraphStyle(
+        'CustomBody', parent=styles['Normal'],
+        fontSize=10, leading=14, spaceBefore=6, spaceAfter=6
+    )
+    bullet_style = ParagraphStyle(
+        'CustomBullet', parent=styles['Normal'],
+        fontSize=10, leading=14, leftIndent=20, bulletIndent=10,
+        spaceBefore=3, spaceAfter=3
+    )
+    details_style = ParagraphStyle(
+        'Details', parent=styles['Normal'],
+        fontSize=11, spaceAfter=6, alignment=TA_LEFT
+    )
+
+    # Standard table styles
+    primary_table_style = [
+        ('BACKGROUND', (0, 0), (-1, 0), colors.HexColor(primary_color)),
+        ('TEXTCOLOR', (0, 0), (-1, 0), colors.whitesmoke),
+        ('ALIGN', (0, 0), (-1, -1), 'LEFT'),
+        ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
+        ('FONTSIZE', (0, 0), (-1, -1), 9),
+        ('BOTTOMPADDING', (0, 0), (-1, 0), 10),
+        ('BACKGROUND', (0, 1), (-1, -1), colors.HexColor('#F8F9FA')),
+        ('GRID', (0, 0), (-1, -1), 0.5, colors.HexColor('#E9ECEF')),
+        ('ROWBACKGROUNDS', (0, 1), (-1, -1), [colors.HexColor('#F8F9FA'), colors.white]),
+    ]
+
+    green_table_style = list(primary_table_style)
+    green_table_style[0] = ('BACKGROUND', (0, 0), (-1, 0), colors.HexColor(secondary_color))
+
+    story = []
+
+    # ── TITLE PAGE ──
+    # Client logo (upper right)
+    if client_logo_path and Path(client_logo_path).exists():
+        _logo_path = client_logo_path
+        # ReportLab can't render SVG directly; convert to PNG first
+        if Path(client_logo_path).suffix.lower() == '.svg':
             try:
-                from siege_utilities.reporting.client_branding import ClientBrandingManager
-                mgr = ClientBrandingManager()
-                branding = mgr.get_client_branding(branding_key)
-                if branding:
-                    primary_color = branding.get('colors', {}).get('primary', primary_color)
-                    secondary_color = branding.get('colors', {}).get('secondary', secondary_color)
-                    client_name = branding.get('name', client_name)
-                    prepared_by = branding.get('footer', {}).get('left_text', f"Prepared by: {prepared_by}").replace('Prepared by: ', '')
-            except (ImportError, ValueError, KeyError, AttributeError) as e:
-                log.debug(f"Could not load branding '{branding_key}': {e}")
-
-        date_range = ga_data['date_range']
-        totals = ga_data['totals']
-        changes = ga_data['changes']
-
-        # Header/footer callback
-        def _header_footer(canvas_obj, doc_obj):
-            canvas_obj.saveState()
-            canvas_obj.setFont('Helvetica-Bold', 8)
-            canvas_obj.setFillColor(colors.HexColor(primary_color))
-            canvas_obj.drawString(0.75*inch, letter[1] - 0.4*inch, report_title)
-            canvas_obj.setFont('Helvetica', 7)
-            canvas_obj.setFillColor(colors.HexColor('#666666'))
-            canvas_obj.drawString(0.75*inch, letter[1] - 0.52*inch, f"{client_name}  |  {date_range['start']} to {date_range['end']}")
-            # Footer
-            canvas_obj.setFont('Helvetica', 7)
-            canvas_obj.drawString(0.75*inch, 0.4*inch, f"Page {doc_obj.page}")
-            canvas_obj.drawRightString(letter[0] - 0.75*inch, 0.4*inch, prepared_by)
-            canvas_obj.restoreState()
-
-        # Create document with room for header/footer
-        doc = SimpleDocTemplate(
-            output_path,
-            pagesize=letter,
-            rightMargin=0.75*inch,
-            leftMargin=0.75*inch,
-            topMargin=0.85*inch,
-            bottomMargin=0.7*inch
-        )
-
-        styles = getSampleStyleSheet()
-
-        # Branding-aware styles
-        title_style = ParagraphStyle(
-            'CustomTitle', parent=styles['Title'],
-            fontSize=28, spaceAfter=8, alignment=TA_CENTER,
-            textColor=colors.HexColor(primary_color), fontName='Helvetica-Bold'
-        )
-        subtitle_style = ParagraphStyle(
-            'CustomSubtitle', parent=styles['Normal'],
-            fontSize=14, alignment=TA_CENTER, textColor=colors.HexColor('#666666'),
-            spaceAfter=20
-        )
-        heading_style = ParagraphStyle(
-            'CustomHeading', parent=styles['Heading1'],
-            fontSize=16, spaceBefore=20, spaceAfter=10,
-            textColor=colors.HexColor(primary_color)
-        )
-        subheading_style = ParagraphStyle(
-            'CustomSubheading', parent=styles['Heading2'],
-            fontSize=13, spaceBefore=15, spaceAfter=8,
-            textColor=colors.HexColor('#34495e')
-        )
-        body_style = ParagraphStyle(
-            'CustomBody', parent=styles['Normal'],
-            fontSize=10, leading=14, spaceBefore=6, spaceAfter=6
-        )
-        bullet_style = ParagraphStyle(
-            'CustomBullet', parent=styles['Normal'],
-            fontSize=10, leading=14, leftIndent=20, bulletIndent=10,
-            spaceBefore=3, spaceAfter=3
-        )
-        details_style = ParagraphStyle(
-            'Details', parent=styles['Normal'],
-            fontSize=11, spaceAfter=6, alignment=TA_LEFT
-        )
-
-        # Standard table styles
-        primary_table_style = [
-            ('BACKGROUND', (0, 0), (-1, 0), colors.HexColor(primary_color)),
-            ('TEXTCOLOR', (0, 0), (-1, 0), colors.whitesmoke),
-            ('ALIGN', (0, 0), (-1, -1), 'LEFT'),
-            ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
-            ('FONTSIZE', (0, 0), (-1, -1), 9),
-            ('BOTTOMPADDING', (0, 0), (-1, 0), 10),
-            ('BACKGROUND', (0, 1), (-1, -1), colors.HexColor('#F8F9FA')),
-            ('GRID', (0, 0), (-1, -1), 0.5, colors.HexColor('#E9ECEF')),
-            ('ROWBACKGROUNDS', (0, 1), (-1, -1), [colors.HexColor('#F8F9FA'), colors.white]),
-        ]
-
-        green_table_style = list(primary_table_style)
-        green_table_style[0] = ('BACKGROUND', (0, 0), (-1, 0), colors.HexColor(secondary_color))
-
-        story = []
-
-        # ── TITLE PAGE ──
-        # Client logo (upper right)
-        if client_logo_path and Path(client_logo_path).exists():
-            _logo_path = client_logo_path
-            # ReportLab can't render SVG directly; convert to PNG first
-            if Path(client_logo_path).suffix.lower() == '.svg':
-                try:
-                    import cairosvg
-                    _tmp_logo = tempfile.NamedTemporaryFile(suffix='.png', delete=False)
-                    _tmp_logo.close()
-                    cairosvg.svg2png(url=str(Path(client_logo_path).resolve()),
-                                    write_to=_tmp_logo.name, output_width=300)
-                    _logo_path = _tmp_logo.name
-                except ImportError:
-                    log.debug("cairosvg not installed; skipping SVG logo (install cairosvg for SVG support)")
-                    _logo_path = None
-                except (OSError, ValueError, TypeError) as e:
-                    log.debug(f"Could not convert SVG logo: {e}")
-                    _logo_path = None
-            if _logo_path:
-                logo_img = RLImage(_logo_path, width=1.5*inch, height=1.0*inch)
-                logo_img.hAlign = 'RIGHT'
-                story.append(logo_img)
-            story.append(Spacer(1, 0.5*inch))
-        else:
-            story.append(Spacer(1, 1.5*inch))
-
-        story.append(Paragraph(client_name, title_style))
-        story.append(Paragraph("Comprehensive Website Performance Analysis", subtitle_style))
-        story.append(Spacer(1, 0.3*inch))
-        story.append(Paragraph(report_title, ParagraphStyle(
-            'ReportTitle', parent=styles['Heading1'],
-            fontSize=20, alignment=TA_CENTER, fontName='Helvetica-Bold'
-        )))
+                import cairosvg
+                _tmp_logo = tempfile.NamedTemporaryFile(suffix='.png', delete=False)
+                _tmp_logo.close()
+                cairosvg.svg2png(url=str(Path(client_logo_path).resolve()),
+                                write_to=_tmp_logo.name, output_width=300)
+                _logo_path = _tmp_logo.name
+            except ImportError:
+                log.debug("cairosvg not installed; skipping SVG logo (install cairosvg for SVG support)")
+                _logo_path = None
+            except (OSError, ValueError, TypeError) as e:
+                log.debug(f"Could not convert SVG logo: {e}")
+                _logo_path = None
+        if _logo_path:
+            logo_img = RLImage(_logo_path, width=1.5*inch, height=1.0*inch)
+            logo_img.hAlign = 'RIGHT'
+            story.append(logo_img)
         story.append(Spacer(1, 0.5*inch))
-        story.append(Paragraph(f"<b>Report Date:</b> {datetime.now().strftime('%B %d, %Y')}", details_style))
-        story.append(Paragraph(f"<b>Period Covered:</b> {date_range['start']} to {date_range['end']}", details_style))
-        story.append(Paragraph(f"<b>Prepared By:</b> {prepared_by}", details_style))
-        data_source = ga_data.get('data_source', 'sample')
-        story.append(Paragraph(f"<b>Data Source:</b> {'GA4 API (Live)' if data_source == 'ga4_api' else 'Sample Data'}", details_style))
+    else:
+        story.append(Spacer(1, 1.5*inch))
 
-        # Company logo (bottom of title page)
-        if company_logo_path and Path(company_logo_path).exists():
-            story.append(Spacer(1, 1.0*inch))
-            company_logo = RLImage(company_logo_path, width=1.2*inch, height=0.6*inch)
-            company_logo.hAlign = 'RIGHT'
-            story.append(company_logo)
-        story.append(PageBreak())
+    story.append(Paragraph(client_name, title_style))
+    story.append(Paragraph("Comprehensive Website Performance Analysis", subtitle_style))
+    story.append(Spacer(1, 0.3*inch))
+    story.append(Paragraph(report_title, ParagraphStyle(
+        'ReportTitle', parent=styles['Heading1'],
+        fontSize=20, alignment=TA_CENTER, fontName='Helvetica-Bold'
+    )))
+    story.append(Spacer(1, 0.5*inch))
+    story.append(Paragraph(f"<b>Report Date:</b> {datetime.now().strftime('%B %d, %Y')}", details_style))
+    story.append(Paragraph(f"<b>Period Covered:</b> {date_range['start']} to {date_range['end']}", details_style))
+    story.append(Paragraph(f"<b>Prepared By:</b> {prepared_by}", details_style))
+    data_source = ga_data.get('data_source', 'sample')
+    story.append(Paragraph(f"<b>Data Source:</b> {'GA4 API (Live)' if data_source == 'ga4_api' else 'Sample Data'}", details_style))
 
-        # ── TABLE OF CONTENTS ──
-        story.append(Paragraph("Table of Contents", heading_style))
+    # Company logo (bottom of title page)
+    if company_logo_path and Path(company_logo_path).exists():
+        story.append(Spacer(1, 1.0*inch))
+        company_logo = RLImage(company_logo_path, width=1.2*inch, height=0.6*inch)
+        company_logo.hAlign = 'RIGHT'
+        story.append(company_logo)
+    story.append(PageBreak())
+
+    # ── TABLE OF CONTENTS ──
+    story.append(Paragraph("Table of Contents", heading_style))
+    story.append(Spacer(1, 12))
+    toc_items = [
+        "1. Executive Summary",
+        "2. Key Performance Indicators",
+        "3. Traffic Trends",
+        "4. Traffic Sources Analysis",
+        "5. Device Analysis",
+        "6. Top Pages Performance",
+        "7. Geographic Distribution",
+        "    7.1 Country Analysis",
+        "    7.2 Regional Analysis",
+        "    7.3 City Analysis",
+        "    7.4 Continental Analysis",
+        "    7.5 Geographic Summary",
+    ]
+    next_section = 8
+    if ga_data.get('prior_daily_data', {}).get('sessions'):
+        toc_items.append(f"{next_section}. Period-over-Period Comparison")
+        next_section += 1
+    if ga_data.get('longitudinal'):
+        toc_items.append(f"{next_section}. Year-over-Year Analysis")
+        next_section += 1
+    if ga_data.get('best_day'):
+        toc_items.append(f"{next_section}. Performance Highlights")
+        next_section += 1
+    toc_items.append(f"{next_section}. Key Insights")
+    next_section += 1
+    toc_items.append(f"{next_section}. Recommendations")
+    next_section += 1
+    toc_items.append("")
+    toc_items.append("APPENDICES")
+    toc_items.append("    A. Complete Daily Performance Data")
+    toc_items.append("    B. Complete Traffic Sources Data")
+    toc_items.append("    C. Complete Device Category Data")
+    toc_items.append("    D. Complete Geographic Data")
+
+    toc_style = ParagraphStyle(
+        'TOC', parent=styles['Normal'], fontSize=12, spaceBefore=4, spaceAfter=4,
+        leftIndent=20
+    )
+    for item in toc_items:
+        story.append(Paragraph(item, toc_style))
+    story.append(PageBreak())
+
+    # ── 1. EXECUTIVE SUMMARY ──
+    story.append(Paragraph("1. Executive Summary", heading_style))
+    summary_text = (
+        f"This report provides a comprehensive analysis of website performance for the period "
+        f"{date_range['start']} to {date_range['end']}. During this period, the website received "
+        f"<b>{totals['users']:,}</b> unique users and <b>{totals['sessions']:,}</b> sessions, "
+        f"representing a <b>{changes['users']:+.1f}%</b> change in users compared to the prior period."
+    )
+    story.append(Paragraph(summary_text, body_style))
+    story.append(Spacer(1, 8))
+    summary_text2 = (
+        f"Key performance indicators show an average bounce rate of <b>{totals['avg_bounce_rate']:.1f}%</b> "
+        f"and average session duration of <b>{totals['avg_session_duration']:.0f} seconds</b>. "
+        f"Users viewed an average of <b>{totals['pages_per_session']:.1f} pages</b> per session."
+    )
+    story.append(Paragraph(summary_text2, body_style))
+    story.append(Spacer(1, 15))
+
+    # Key Performance Highlights table
+    avg_daily = totals['sessions'] / max(1, len(ga_data['daily_data']['sessions']))
+    kph_data = [
+        ["Metric", "Value", "Details"],
+        ["Total Sessions", f"{totals['sessions']:,}", f"Average: {avg_daily:.0f} per day"],
+        ["Total Users", f"{totals['users']:,}", "Unique visitors"],
+        ["Total Pageviews", f"{totals['pageviews']:,}", f"{totals['pages_per_session']:.1f} pages/session"],
+        ["Avg Bounce Rate", f"{totals['avg_bounce_rate']:.1f}%", f"{changes['bounce_rate']:+.1f}% vs prior"],
+        ["Avg Session Duration", f"{totals['avg_session_duration']:.0f}s", f"{changes['duration']:+.1f}% vs prior"],
+    ]
+    if ga_data.get('best_day'):
+        kph_data.append(["Best Day", f"{ga_data['best_day']['sessions']:,} sessions", ga_data['best_day']['date']])
+    if ga_data.get('worst_day'):
+        kph_data.append(["Lowest Day", f"{ga_data['worst_day']['sessions']:,} sessions", ga_data['worst_day']['date']])
+
+    kph_table = Table(kph_data, colWidths=[2*inch, 1.5*inch, 2.8*inch])
+    kph_table.setStyle(TableStyle(primary_table_style))
+    story.append(kph_table)
+    fn = create_footnote_paragraph(['sessions', 'users', 'bounce_rate', 'pageviews', 'avg_session_duration'])
+    if fn:
+        story.append(fn)
+    story.append(Spacer(1, 20))
+
+    # ── 2. KPI DASHBOARD ──
+    story.append(Paragraph("2. Key Performance Indicators", heading_style))
+    story.extend(create_kpi_dashboard(ga_data))
+    story.append(PageBreak())
+
+    # Resolve export paths
+    _vec_dir = Path(vector_export_dir) if vector_export_dir else None
+    if _vec_dir:
+        _vec_dir.mkdir(parents=True, exist_ok=True)
+        log.info(f"Vector chart export enabled: {_vec_dir}")
+
+    _ras_dir = Path(raster_export_dir) if raster_export_dir else None
+    if _ras_dir:
+        _ras_dir.mkdir(parents=True, exist_ok=True)
+        log.info(f"Raster chart export enabled: {_ras_dir}")
+
+    def _save_raster(chart_path: Optional[str], name: str) -> None:
+        """Copy a chart's temp PNG to the raster export directory."""
+        if _ras_dir and chart_path and Path(chart_path).exists():
+            import shutil
+            dest = _ras_dir / f"{name}.png"
+            shutil.copy2(chart_path, dest)
+            log.info(f"Saved raster chart: {dest}")
+
+    # ── 3. TRAFFIC TRENDS ──
+    story.append(Paragraph("3. Traffic Trends", heading_style))
+    trend_chart = create_traffic_trend_chart(
+        ga_data,
+        vector_export_path=str(_vec_dir / 'traffic_trends.svg') if _vec_dir else None,
+    )
+    _save_raster(trend_chart, 'traffic_trends')
+    if trend_chart:
+        story.append(RLImage(trend_chart, width=5.5*inch, height=3.5*inch))
         story.append(Spacer(1, 12))
-        toc_items = [
-            "1. Executive Summary",
-            "2. Key Performance Indicators",
-            "3. Traffic Trends",
-            "4. Traffic Sources Analysis",
-            "5. Device Analysis",
-            "6. Top Pages Performance",
-            "7. Geographic Distribution",
-            "    7.1 Country Analysis",
-            "    7.2 Regional Analysis",
-            "    7.3 City Analysis",
-            "    7.4 Continental Analysis",
-            "    7.5 Geographic Summary",
-        ]
-        next_section = 8
-        if ga_data.get('prior_daily_data', {}).get('sessions'):
-            toc_items.append(f"{next_section}. Period-over-Period Comparison")
-            next_section += 1
-        if ga_data.get('longitudinal'):
-            toc_items.append(f"{next_section}. Year-over-Year Analysis")
-            next_section += 1
-        if ga_data.get('best_day'):
-            toc_items.append(f"{next_section}. Performance Highlights")
-            next_section += 1
-        toc_items.append(f"{next_section}. Key Insights")
-        next_section += 1
-        toc_items.append(f"{next_section}. Recommendations")
-        next_section += 1
-        toc_items.append("")
-        toc_items.append("APPENDICES")
-        toc_items.append("    A. Complete Daily Performance Data")
-        toc_items.append("    B. Complete Traffic Sources Data")
-        toc_items.append("    C. Complete Device Category Data")
-        toc_items.append("    D. Complete Geographic Data")
+    else:
+        story.append(Paragraph("Traffic trend chart unavailable (matplotlib not installed).", body_style))
+    story.append(PageBreak())
 
-        toc_style = ParagraphStyle(
-            'TOC', parent=styles['Normal'], fontSize=12, spaceBefore=4, spaceAfter=4,
-            leftIndent=20
-        )
-        for item in toc_items:
-            story.append(Paragraph(item, toc_style))
-        story.append(PageBreak())
+    # ── 4. TRAFFIC SOURCES ──
+    story.append(Paragraph("4. Traffic Sources Analysis", heading_style))
+    source_chart = create_traffic_sources_chart(
+        ga_data,
+        vector_export_path=str(_vec_dir / 'traffic_sources.svg') if _vec_dir else None,
+    )
+    _save_raster(source_chart, 'traffic_sources')
+    if source_chart:
+        story.append(RLImage(source_chart, width=5.5*inch, height=3.5*inch))
+        story.append(Spacer(1, 12))
 
-        # ── 1. EXECUTIVE SUMMARY ──
-        story.append(Paragraph("1. Executive Summary", heading_style))
-        summary_text = (
-            f"This report provides a comprehensive analysis of website performance for the period "
-            f"{date_range['start']} to {date_range['end']}. During this period, the website received "
-            f"<b>{totals['users']:,}</b> unique users and <b>{totals['sessions']:,}</b> sessions, "
-            f"representing a <b>{changes['users']:+.1f}%</b> change in users compared to the prior period."
-        )
-        story.append(Paragraph(summary_text, body_style))
+    source_table_data = create_traffic_sources_table(ga_data)
+    # Heatmap the sessions column (index 2)
+    source_table = Table(source_table_data, colWidths=[1.2*inch, 1*inch, 1*inch, 1*inch, 1*inch, 1.2*inch])
+    source_table.setStyle(create_heatmapped_table_style(
+        source_table_data, value_column_index=2,
+        base_style=primary_table_style, color_scheme='blue'
+    ))
+    story.append(source_table)
+    fn = create_footnote_paragraph(['source', 'medium', 'sessions', 'bounce_rate'])
+    if fn:
+        story.append(fn)
+    story.append(Spacer(1, 20))
+
+    # ── 5. DEVICE ANALYSIS ──
+    story.append(Paragraph("5. Device Analysis", heading_style))
+    device_chart = create_device_breakdown_chart(
+        ga_data,
+        vector_export_path=str(_vec_dir / 'device_breakdown.svg') if _vec_dir else None,
+    )
+    _save_raster(device_chart, 'device_breakdown')
+    if device_chart:
+        story.append(RLImage(device_chart, width=5.5*inch, height=3.5*inch))
+    else:
+        story.append(Paragraph("Device analysis chart unavailable (matplotlib not installed).", body_style))
+    story.append(PageBreak())
+
+    # ── 6. TOP PAGES ──
+    story.append(Paragraph("6. Top Pages Performance", heading_style))
+    pages_table_data = create_top_pages_table(ga_data)
+    pages_table = Table(pages_table_data, colWidths=[2.2*inch, 0.9*inch, 0.9*inch, 0.8*inch, 0.9*inch, 0.8*inch])
+    pages_table.setStyle(create_heatmapped_table_style(
+        pages_table_data, value_column_index=1,
+        base_style=[
+            ('BACKGROUND', (0, 0), (-1, 0), colors.HexColor(primary_color)),
+            ('TEXTCOLOR', (0, 0), (-1, 0), colors.white),
+            ('ALIGN', (0, 0), (0, -1), 'LEFT'),
+            ('ALIGN', (1, 0), (-1, -1), 'CENTER'),
+            ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
+            ('FONTSIZE', (0, 0), (-1, 0), 9),
+            ('FONTSIZE', (0, 1), (-1, -1), 8),
+            ('BOTTOMPADDING', (0, 0), (-1, 0), 8),
+            ('GRID', (0, 0), (-1, -1), 0.5, colors.HexColor('#bdc3c7')),
+        ],
+        color_scheme='blue'
+    ))
+    story.append(pages_table)
+    story.append(Spacer(1, 20))
+
+    # ── 7. GEOGRAPHIC DISTRIBUTION ──
+    story.append(Paragraph("7. Geographic Distribution", heading_style))
+
+    # 7.1 Country Analysis
+    story.append(Paragraph("7.1 Country Analysis", subheading_style))
+    country_chart = create_geo_country_chart(
+        ga_data,
+        vector_export_path=str(_vec_dir / 'geo_country.svg') if _vec_dir else None,
+    )
+    _save_raster(country_chart, 'geo_country')
+    if country_chart:
+        story.append(RLImage(country_chart, width=5.5*inch, height=3.5*inch))
         story.append(Spacer(1, 8))
-        summary_text2 = (
-            f"Key performance indicators show an average bounce rate of <b>{totals['avg_bounce_rate']:.1f}%</b> "
-            f"and average session duration of <b>{totals['avg_session_duration']:.0f} seconds</b>. "
-            f"Users viewed an average of <b>{totals['pages_per_session']:.1f} pages</b> per session."
-        )
-        story.append(Paragraph(summary_text2, body_style))
-        story.append(Spacer(1, 15))
 
-        # Key Performance Highlights table
-        avg_daily = totals['sessions'] / max(1, len(ga_data['daily_data']['sessions']))
-        kph_data = [
-            ["Metric", "Value", "Details"],
-            ["Total Sessions", f"{totals['sessions']:,}", f"Average: {avg_daily:.0f} per day"],
-            ["Total Users", f"{totals['users']:,}", "Unique visitors"],
-            ["Total Pageviews", f"{totals['pageviews']:,}", f"{totals['pages_per_session']:.1f} pages/session"],
-            ["Avg Bounce Rate", f"{totals['avg_bounce_rate']:.1f}%", f"{changes['bounce_rate']:+.1f}% vs prior"],
-            ["Avg Session Duration", f"{totals['avg_session_duration']:.0f}s", f"{changes['duration']:+.1f}% vs prior"],
-        ]
-        if ga_data.get('best_day'):
-            kph_data.append(["Best Day", f"{ga_data['best_day']['sessions']:,} sessions", ga_data['best_day']['date']])
-        if ga_data.get('worst_day'):
-            kph_data.append(["Lowest Day", f"{ga_data['worst_day']['sessions']:,} sessions", ga_data['worst_day']['date']])
-
-        kph_table = Table(kph_data, colWidths=[2*inch, 1.5*inch, 2.8*inch])
-        kph_table.setStyle(TableStyle(primary_table_style))
-        story.append(kph_table)
-        fn = create_footnote_paragraph(['sessions', 'users', 'bounce_rate', 'pageviews', 'avg_session_duration'])
-        if fn:
-            story.append(fn)
-        story.append(Spacer(1, 20))
-
-        # ── 2. KPI DASHBOARD ──
-        story.append(Paragraph("2. Key Performance Indicators", heading_style))
-        story.extend(create_kpi_dashboard(ga_data))
-        story.append(PageBreak())
-
-        # Resolve export paths
-        _vec_dir = Path(vector_export_dir) if vector_export_dir else None
-        if _vec_dir:
-            _vec_dir.mkdir(parents=True, exist_ok=True)
-            log.info(f"Vector chart export enabled: {_vec_dir}")
-
-        _ras_dir = Path(raster_export_dir) if raster_export_dir else None
-        if _ras_dir:
-            _ras_dir.mkdir(parents=True, exist_ok=True)
-            log.info(f"Raster chart export enabled: {_ras_dir}")
-
-        def _save_raster(chart_path: Optional[str], name: str) -> None:
-            """Copy a chart's temp PNG to the raster export directory."""
-            if _ras_dir and chart_path and Path(chart_path).exists():
-                import shutil
-                dest = _ras_dir / f"{name}.png"
-                shutil.copy2(chart_path, dest)
-                log.info(f"Saved raster chart: {dest}")
-
-        # ── 3. TRAFFIC TRENDS ──
-        story.append(Paragraph("3. Traffic Trends", heading_style))
-        trend_chart = create_traffic_trend_chart(
-            ga_data,
-            vector_export_path=str(_vec_dir / 'traffic_trends.svg') if _vec_dir else None,
-        )
-        _save_raster(trend_chart, 'traffic_trends')
-        if trend_chart:
-            story.append(RLImage(trend_chart, width=5.5*inch, height=3.5*inch))
-            story.append(Spacer(1, 12))
-        else:
-            story.append(Paragraph("Traffic trend chart unavailable (matplotlib not installed).", body_style))
-        story.append(PageBreak())
-
-        # ── 4. TRAFFIC SOURCES ──
-        story.append(Paragraph("4. Traffic Sources Analysis", heading_style))
-        source_chart = create_traffic_sources_chart(
-            ga_data,
-            vector_export_path=str(_vec_dir / 'traffic_sources.svg') if _vec_dir else None,
-        )
-        _save_raster(source_chart, 'traffic_sources')
-        if source_chart:
-            story.append(RLImage(source_chart, width=5.5*inch, height=3.5*inch))
-            story.append(Spacer(1, 12))
-
-        source_table_data = create_traffic_sources_table(ga_data)
-        # Heatmap the sessions column (index 2)
-        source_table = Table(source_table_data, colWidths=[1.2*inch, 1*inch, 1*inch, 1*inch, 1*inch, 1.2*inch])
-        source_table.setStyle(create_heatmapped_table_style(
-            source_table_data, value_column_index=2,
-            base_style=primary_table_style, color_scheme='blue'
-        ))
-        story.append(source_table)
-        fn = create_footnote_paragraph(['source', 'medium', 'sessions', 'bounce_rate'])
-        if fn:
-            story.append(fn)
-        story.append(Spacer(1, 20))
-
-        # ── 5. DEVICE ANALYSIS ──
-        story.append(Paragraph("5. Device Analysis", heading_style))
-        device_chart = create_device_breakdown_chart(
-            ga_data,
-            vector_export_path=str(_vec_dir / 'device_breakdown.svg') if _vec_dir else None,
-        )
-        _save_raster(device_chart, 'device_breakdown')
-        if device_chart:
-            story.append(RLImage(device_chart, width=5.5*inch, height=3.5*inch))
-        else:
-            story.append(Paragraph("Device analysis chart unavailable (matplotlib not installed).", body_style))
-        story.append(PageBreak())
-
-        # ── 6. TOP PAGES ──
-        story.append(Paragraph("6. Top Pages Performance", heading_style))
-        pages_table_data = create_top_pages_table(ga_data)
-        pages_table = Table(pages_table_data, colWidths=[2.2*inch, 0.9*inch, 0.9*inch, 0.8*inch, 0.9*inch, 0.8*inch])
-        pages_table.setStyle(create_heatmapped_table_style(
-            pages_table_data, value_column_index=1,
-            base_style=[
-                ('BACKGROUND', (0, 0), (-1, 0), colors.HexColor(primary_color)),
-                ('TEXTCOLOR', (0, 0), (-1, 0), colors.white),
-                ('ALIGN', (0, 0), (0, -1), 'LEFT'),
-                ('ALIGN', (1, 0), (-1, -1), 'CENTER'),
-                ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
-                ('FONTSIZE', (0, 0), (-1, 0), 9),
-                ('FONTSIZE', (0, 1), (-1, -1), 8),
-                ('BOTTOMPADDING', (0, 0), (-1, 0), 8),
-                ('GRID', (0, 0), (-1, -1), 0.5, colors.HexColor('#bdc3c7')),
-            ],
-            color_scheme='blue'
-        ))
-        story.append(pages_table)
-        story.append(Spacer(1, 20))
-
-        # ── 7. GEOGRAPHIC DISTRIBUTION ──
-        story.append(Paragraph("7. Geographic Distribution", heading_style))
-
-        # 7.1 Country Analysis
-        story.append(Paragraph("7.1 Country Analysis", subheading_style))
-        country_chart = create_geo_country_chart(
-            ga_data,
-            vector_export_path=str(_vec_dir / 'geo_country.svg') if _vec_dir else None,
-        )
-        _save_raster(country_chart, 'geo_country')
-        if country_chart:
-            story.append(RLImage(country_chart, width=5.5*inch, height=3.5*inch))
-            story.append(Spacer(1, 8))
-
-        # Country heatmapped table
-        geo = ga_data.get('geo_data', [])
-        country_sessions = {}
-        for loc in geo:
-            c = loc.get('country', 'Unknown')
-            country_sessions[c] = country_sessions.get(c, 0) + loc.get('sessions', 0)
-        if country_sessions:
-            total_geo_sessions = sum(country_sessions.values())
-            country_table_data = [['Country', 'Sessions', '% of Total']]
-            for country, sessions in sorted(country_sessions.items(), key=lambda x: x[1], reverse=True):
-                pct = (sessions / total_geo_sessions * 100) if total_geo_sessions else 0
-                country_table_data.append([country, f'{sessions:,}', f'{pct:.1f}%'])
-            country_table = Table(country_table_data, colWidths=[2.5*inch, 1.5*inch, 1.5*inch])
-            country_table.setStyle(create_heatmapped_table_style(
-                country_table_data, value_column_index=1,
-                base_style=green_table_style, color_scheme='green'
-            ))
-            story.append(country_table)
-        story.append(Spacer(1, 12))
-
-        # 7.2 Regional Analysis
-        story.append(Paragraph("7.2 Regional Analysis", subheading_style))
-        region_chart = create_geo_region_chart(
-            ga_data,
-            vector_export_path=str(_vec_dir / 'geo_region.svg') if _vec_dir else None,
-        )
-        _save_raster(region_chart, 'geo_region')
-        if region_chart:
-            story.append(RLImage(region_chart, width=5.5*inch, height=3.5*inch))
-            story.append(Spacer(1, 8))
-
-        region_sessions = {}
-        for loc in geo:
-            r = loc.get('region', 'Unknown')
-            region_sessions[r] = region_sessions.get(r, 0) + loc.get('sessions', 0)
-        if region_sessions:
-            total_region = sum(region_sessions.values())
-            region_table_data = [['Region', 'Sessions', '% of Total']]
-            for region, sessions in sorted(region_sessions.items(), key=lambda x: x[1], reverse=True):
-                pct = (sessions / total_region * 100) if total_region else 0
-                region_table_data.append([region, f'{sessions:,}', f'{pct:.1f}%'])
-            region_table = Table(region_table_data, colWidths=[2.5*inch, 1.5*inch, 1.5*inch])
-            region_table.setStyle(create_heatmapped_table_style(
-                region_table_data, value_column_index=1,
-                base_style=green_table_style, color_scheme='green'
-            ))
-            story.append(region_table)
-        story.append(PageBreak())
-
-        # 7.3 City Analysis
-        story.append(Paragraph("7.3 City Analysis", subheading_style))
-        city_chart = create_geo_city_scatter(
-            ga_data,
-            vector_export_path=str(_vec_dir / 'geo_city.svg') if _vec_dir else None,
-        )
-        _save_raster(city_chart, 'geo_city')
-        if city_chart:
-            story.append(RLImage(city_chart, width=5.5*inch, height=3.5*inch))
-            story.append(Spacer(1, 8))
-
-        # City heatmapped table (original geo table)
-        geo_table_data = create_geo_table(ga_data)
-        geo_table = Table(geo_table_data, colWidths=[1.8*inch, 1.5*inch, 1.2*inch, 1.2*inch])
-        geo_table.setStyle(create_heatmapped_table_style(
-            geo_table_data, value_column_index=2,
+    # Country heatmapped table
+    geo = ga_data.get('geo_data', [])
+    country_sessions = {}
+    for loc in geo:
+        c = loc.get('country', 'Unknown')
+        country_sessions[c] = country_sessions.get(c, 0) + loc.get('sessions', 0)
+    if country_sessions:
+        total_geo_sessions = sum(country_sessions.values())
+        country_table_data = [['Country', 'Sessions', '% of Total']]
+        for country, sessions in sorted(country_sessions.items(), key=lambda x: x[1], reverse=True):
+            pct = (sessions / total_geo_sessions * 100) if total_geo_sessions else 0
+            country_table_data.append([country, f'{sessions:,}', f'{pct:.1f}%'])
+        country_table = Table(country_table_data, colWidths=[2.5*inch, 1.5*inch, 1.5*inch])
+        country_table.setStyle(create_heatmapped_table_style(
+            country_table_data, value_column_index=1,
             base_style=green_table_style, color_scheme='green'
         ))
-        story.append(geo_table)
-        story.append(PageBreak())
+        story.append(country_table)
+    story.append(Spacer(1, 12))
 
-        # 7.4 Continental Analysis
-        story.append(Paragraph("7.4 Continental Analysis", subheading_style))
-        continent_chart = create_continent_donut_chart(
+    # 7.2 Regional Analysis
+    story.append(Paragraph("7.2 Regional Analysis", subheading_style))
+    region_chart = create_geo_region_chart(
+        ga_data,
+        vector_export_path=str(_vec_dir / 'geo_region.svg') if _vec_dir else None,
+    )
+    _save_raster(region_chart, 'geo_region')
+    if region_chart:
+        story.append(RLImage(region_chart, width=5.5*inch, height=3.5*inch))
+        story.append(Spacer(1, 8))
+
+    region_sessions = {}
+    for loc in geo:
+        r = loc.get('region', 'Unknown')
+        region_sessions[r] = region_sessions.get(r, 0) + loc.get('sessions', 0)
+    if region_sessions:
+        total_region = sum(region_sessions.values())
+        region_table_data = [['Region', 'Sessions', '% of Total']]
+        for region, sessions in sorted(region_sessions.items(), key=lambda x: x[1], reverse=True):
+            pct = (sessions / total_region * 100) if total_region else 0
+            region_table_data.append([region, f'{sessions:,}', f'{pct:.1f}%'])
+        region_table = Table(region_table_data, colWidths=[2.5*inch, 1.5*inch, 1.5*inch])
+        region_table.setStyle(create_heatmapped_table_style(
+            region_table_data, value_column_index=1,
+            base_style=green_table_style, color_scheme='green'
+        ))
+        story.append(region_table)
+    story.append(PageBreak())
+
+    # 7.3 City Analysis
+    story.append(Paragraph("7.3 City Analysis", subheading_style))
+    city_chart = create_geo_city_scatter(
+        ga_data,
+        vector_export_path=str(_vec_dir / 'geo_city.svg') if _vec_dir else None,
+    )
+    _save_raster(city_chart, 'geo_city')
+    if city_chart:
+        story.append(RLImage(city_chart, width=5.5*inch, height=3.5*inch))
+        story.append(Spacer(1, 8))
+
+    # City heatmapped table (original geo table)
+    geo_table_data = create_geo_table(ga_data)
+    geo_table = Table(geo_table_data, colWidths=[1.8*inch, 1.5*inch, 1.2*inch, 1.2*inch])
+    geo_table.setStyle(create_heatmapped_table_style(
+        geo_table_data, value_column_index=2,
+        base_style=green_table_style, color_scheme='green'
+    ))
+    story.append(geo_table)
+    story.append(PageBreak())
+
+    # 7.4 Continental Analysis
+    story.append(Paragraph("7.4 Continental Analysis", subheading_style))
+    continent_chart = create_continent_donut_chart(
+        ga_data,
+        vector_export_path=str(_vec_dir / 'geo_continent.svg') if _vec_dir else None,
+    )
+    _save_raster(continent_chart, 'geo_continent')
+    if continent_chart:
+        story.append(RLImage(continent_chart, width=5.5*inch, height=3.5*inch))
+        story.append(Spacer(1, 8))
+
+    continent_sessions = {}
+    for loc in geo:
+        c = loc.get('continent')
+        if c:
+            continent_sessions[c] = continent_sessions.get(c, 0) + loc.get('sessions', 0)
+    if continent_sessions:
+        total_cont = sum(continent_sessions.values())
+        cont_table_data = [['Continent', 'Sessions', '% of Total']]
+        for cont, sessions in sorted(continent_sessions.items(), key=lambda x: x[1], reverse=True):
+            pct = (sessions / total_cont * 100) if total_cont else 0
+            cont_table_data.append([cont, f'{sessions:,}', f'{pct:.1f}%'])
+        cont_table = Table(cont_table_data, colWidths=[2.5*inch, 1.5*inch, 1.5*inch])
+        cont_table.setStyle(create_heatmapped_table_style(
+            cont_table_data, value_column_index=1,
+            base_style=green_table_style, color_scheme='green'
+        ))
+        story.append(cont_table)
+    story.append(Spacer(1, 12))
+
+    # 7.5 Geographic Summary
+    story.append(Paragraph("7.5 Geographic Summary", subheading_style))
+    geo_summary_data = create_geo_summary_table(ga_data)
+    if geo_summary_data:
+        summary_table = Table(geo_summary_data, colWidths=[1.5*inch, 2*inch, 1.2*inch, 1.3*inch])
+        summary_table.setStyle(TableStyle(primary_table_style))
+        story.append(summary_table)
+    story.append(PageBreak())
+
+    # ── PERIOD-OVER-PERIOD COMPARISON (if prior daily data available) ──
+    pop_section = 8
+    has_pop = bool(ga_data.get('prior_daily_data', {}).get('sessions'))
+    if has_pop:
+        story.append(Paragraph(f"{pop_section}. Period-over-Period Comparison", heading_style))
+        story.append(Paragraph(
+            "Daily sessions for the current period compared against the equivalent prior period.",
+            body_style
+        ))
+        story.append(Spacer(1, 10))
+
+        pop_chart = create_period_comparison_chart(
             ga_data,
-            vector_export_path=str(_vec_dir / 'geo_continent.svg') if _vec_dir else None,
+            vector_export_path=str(_vec_dir / 'period_comparison.svg') if _vec_dir else None,
         )
-        _save_raster(continent_chart, 'geo_continent')
-        if continent_chart:
-            story.append(RLImage(continent_chart, width=5.5*inch, height=3.5*inch))
+        _save_raster(pop_chart, 'period_comparison')
+        if pop_chart:
+            story.append(RLImage(pop_chart, width=5.5*inch, height=4.0*inch))
             story.append(Spacer(1, 8))
 
-        continent_sessions = {}
-        for loc in geo:
-            c = loc.get('continent')
-            if c:
-                continent_sessions[c] = continent_sessions.get(c, 0) + loc.get('sessions', 0)
-        if continent_sessions:
-            total_cont = sum(continent_sessions.values())
-            cont_table_data = [['Continent', 'Sessions', '% of Total']]
-            for cont, sessions in sorted(continent_sessions.items(), key=lambda x: x[1], reverse=True):
-                pct = (sessions / total_cont * 100) if total_cont else 0
-                cont_table_data.append([cont, f'{sessions:,}', f'{pct:.1f}%'])
-            cont_table = Table(cont_table_data, colWidths=[2.5*inch, 1.5*inch, 1.5*inch])
-            cont_table.setStyle(create_heatmapped_table_style(
-                cont_table_data, value_column_index=1,
-                base_style=green_table_style, color_scheme='green'
-            ))
-            story.append(cont_table)
-        story.append(Spacer(1, 12))
-
-        # 7.5 Geographic Summary
-        story.append(Paragraph("7.5 Geographic Summary", subheading_style))
-        geo_summary_data = create_geo_summary_table(ga_data)
-        if geo_summary_data:
-            summary_table = Table(geo_summary_data, colWidths=[1.5*inch, 2*inch, 1.2*inch, 1.3*inch])
-            summary_table.setStyle(TableStyle(primary_table_style))
-            story.append(summary_table)
+        # Summary table
+        prior_p = ga_data.get('prior_period', {})
+        pop_table_data = [
+            ['Metric', 'Current Period', 'Prior Period', 'Change'],
+            ['Sessions', f"{totals['sessions']:,}", f"{prior_p.get('sessions', 0):,}",
+             f"{changes['sessions']:+.1f}%"],
+            ['Users', f"{totals['users']:,}", f"{prior_p.get('users', 0):,}",
+             f"{changes['users']:+.1f}%"],
+            ['Bounce Rate', f"{totals['avg_bounce_rate']:.1f}%",
+             f"{prior_p.get('avg_bounce_rate', 0):.1f}%",
+             f"{changes['bounce_rate']:+.1f} pts"],
+            ['Avg Duration', f"{totals['avg_session_duration']:.0f}s",
+             f"{prior_p.get('avg_session_duration', 0):.0f}s",
+             f"{changes['duration']:+.1f}%"],
+        ]
+        pop_table = Table(pop_table_data, colWidths=[1.5*inch, 1.5*inch, 1.5*inch, 1.5*inch])
+        pop_table.setStyle(TableStyle(primary_table_style))
+        story.append(pop_table)
+        fn = create_footnote_paragraph(['sessions', 'users', 'bounce_rate', 'avg_session_duration'])
+        if fn:
+            story.append(fn)
         story.append(PageBreak())
 
-        # ── PERIOD-OVER-PERIOD COMPARISON (if prior daily data available) ──
-        pop_section = 8
-        has_pop = bool(ga_data.get('prior_daily_data', {}).get('sessions'))
-        if has_pop:
-            story.append(Paragraph(f"{pop_section}. Period-over-Period Comparison", heading_style))
-            story.append(Paragraph(
-                "Daily sessions for the current period compared against the equivalent prior period.",
-                body_style
-            ))
-            story.append(Spacer(1, 10))
+    # ── YEAR-OVER-YEAR ANALYSIS (if available) ──
+    yoy_section = (pop_section + 1) if has_pop else pop_section
+    longitudinal = ga_data.get('longitudinal', {})
+    if longitudinal:
+        story.append(Paragraph(f"{yoy_section}. Year-over-Year Analysis", heading_style))
+        story.append(Paragraph(
+            "Longitudinal comparison of website performance across years.",
+            body_style
+        ))
+        story.append(Spacer(1, 10))
 
-            pop_chart = create_period_comparison_chart(
-                ga_data,
-                vector_export_path=str(_vec_dir / 'period_comparison.svg') if _vec_dir else None,
-            )
-            _save_raster(pop_chart, 'period_comparison')
-            if pop_chart:
-                story.append(RLImage(pop_chart, width=5.5*inch, height=4.0*inch))
-                story.append(Spacer(1, 8))
+        yoy_header = ["Year", "Sessions", "Users", "Pageviews", "Growth Rate"]
+        yoy_rows = []
+        years_sorted = sorted(longitudinal.keys())
+        prev_sessions = None
+        for year in years_sorted:
+            year_data = longitudinal[year]
+            sessions = year_data['sessions']
+            growth = "Baseline"
+            if prev_sessions and prev_sessions > 0:
+                rate = ((sessions - prev_sessions) / prev_sessions) * 100
+                growth = f"{rate:+.1f}%"
+            yoy_rows.append([
+                year if year == years_sorted[-1] else year,
+                f"{sessions:,}",
+                f"{year_data['users']:,}",
+                f"{year_data['pageviews']:,}",
+                growth,
+            ])
+            prev_sessions = sessions
 
-            # Summary table
-            prior_p = ga_data.get('prior_period', {})
-            pop_table_data = [
-                ['Metric', 'Current Period', 'Prior Period', 'Change'],
-                ['Sessions', f"{totals['sessions']:,}", f"{prior_p.get('sessions', 0):,}",
-                 f"{changes['sessions']:+.1f}%"],
-                ['Users', f"{totals['users']:,}", f"{prior_p.get('users', 0):,}",
-                 f"{changes['users']:+.1f}%"],
-                ['Bounce Rate', f"{totals['avg_bounce_rate']:.1f}%",
-                 f"{prior_p.get('avg_bounce_rate', 0):.1f}%",
-                 f"{changes['bounce_rate']:+.1f} pts"],
-                ['Avg Duration', f"{totals['avg_session_duration']:.0f}s",
-                 f"{prior_p.get('avg_session_duration', 0):.0f}s",
-                 f"{changes['duration']:+.1f}%"],
-            ]
-            pop_table = Table(pop_table_data, colWidths=[1.5*inch, 1.5*inch, 1.5*inch, 1.5*inch])
-            pop_table.setStyle(TableStyle(primary_table_style))
-            story.append(pop_table)
-            fn = create_footnote_paragraph(['sessions', 'users', 'bounce_rate', 'avg_session_duration'])
-            if fn:
-                story.append(fn)
-            story.append(PageBreak())
-
-        # ── YEAR-OVER-YEAR ANALYSIS (if available) ──
-        yoy_section = (pop_section + 1) if has_pop else pop_section
-        longitudinal = ga_data.get('longitudinal', {})
-        if longitudinal:
-            story.append(Paragraph(f"{yoy_section}. Year-over-Year Analysis", heading_style))
-            story.append(Paragraph(
-                "Longitudinal comparison of website performance across years.",
-                body_style
-            ))
-            story.append(Spacer(1, 10))
-
-            yoy_header = ["Year", "Sessions", "Users", "Pageviews", "Growth Rate"]
-            yoy_rows = []
-            years_sorted = sorted(longitudinal.keys())
-            prev_sessions = None
-            for year in years_sorted:
-                year_data = longitudinal[year]
-                sessions = year_data['sessions']
-                growth = "Baseline"
-                if prev_sessions and prev_sessions > 0:
-                    rate = ((sessions - prev_sessions) / prev_sessions) * 100
-                    growth = f"{rate:+.1f}%"
-                yoy_rows.append([
-                    year if year == years_sorted[-1] else year,
-                    f"{sessions:,}",
-                    f"{year_data['users']:,}",
-                    f"{year_data['pageviews']:,}",
-                    growth,
-                ])
-                prev_sessions = sessions
-
-            yoy_table_data = [yoy_header] + yoy_rows
-            yoy_table = Table(yoy_table_data, colWidths=[1.2*inch, 1.4*inch, 1.4*inch, 1.4*inch, 1.2*inch])
-            yoy_table.setStyle(create_heatmapped_table_style(
-                yoy_table_data, value_column_index=1,
-                base_style=green_table_style, color_scheme='green'
-            ))
-            story.append(yoy_table)
-            story.append(Spacer(1, 20))
-
-        # ── PERFORMANCE HIGHLIGHTS (best/worst) ──
-        best_day = ga_data.get('best_day')
-        worst_day = ga_data.get('worst_day')
-        best_week = ga_data.get('best_week')
-        worst_week = ga_data.get('worst_week')
-        if best_day or best_week:
-            highlight_section = yoy_section + (1 if longitudinal else 0)
-            story.append(Paragraph(f"{highlight_section}. Performance Highlights", heading_style))
-
-            highlights = [["Metric", "Value", "Details"]]
-            if best_day:
-                highlights.append(["Best Day", f"{best_day['sessions']:,} sessions", best_day['date']])
-            if worst_day:
-                highlights.append(["Lowest Day", f"{worst_day['sessions']:,} sessions", worst_day['date']])
-            if best_week:
-                highlights.append(["Best Week", f"{best_week['sessions']:,} sessions", f"Week {best_week['week']}"])
-            if worst_week:
-                highlights.append(["Lowest Week", f"{worst_week['sessions']:,} sessions", f"Week {worst_week['week']}"])
-
-            hl_table = Table(highlights, colWidths=[2*inch, 2*inch, 2.3*inch])
-            hl_table.setStyle(TableStyle(primary_table_style))
-            story.append(hl_table)
-            story.append(Spacer(1, 20))
-            story.append(PageBreak())
-
-        if not (best_day or best_week):
-            story.append(PageBreak())
-
-        # ── INSIGHTS ──
-        insights_num = yoy_section + (1 if longitudinal else 0) + (1 if (best_day or best_week) else 0)
-        story.append(Paragraph(f"{insights_num}. Key Insights", heading_style))
-        insights = generate_insights(ga_data)
-        for insight in insights:
-            story.append(Paragraph(f"-- {insight}", bullet_style))
+        yoy_table_data = [yoy_header] + yoy_rows
+        yoy_table = Table(yoy_table_data, colWidths=[1.2*inch, 1.4*inch, 1.4*inch, 1.4*inch, 1.2*inch])
+        yoy_table.setStyle(create_heatmapped_table_style(
+            yoy_table_data, value_column_index=1,
+            base_style=green_table_style, color_scheme='green'
+        ))
+        story.append(yoy_table)
         story.append(Spacer(1, 20))
 
-        # ── RECOMMENDATIONS ──
-        story.append(Paragraph(f"{insights_num + 1}. Recommendations", heading_style))
-        recommendations = generate_recommendations(ga_data)
-        for i, rec in enumerate(recommendations, 1):
-            story.append(Paragraph(f"<b>{i}.</b> {rec}", bullet_style))
-        story.append(Spacer(1, 30))
+    # ── PERFORMANCE HIGHLIGHTS (best/worst) ──
+    best_day = ga_data.get('best_day')
+    worst_day = ga_data.get('worst_day')
+    best_week = ga_data.get('best_week')
+    worst_week = ga_data.get('worst_week')
+    if best_day or best_week:
+        highlight_section = yoy_section + (1 if longitudinal else 0)
+        story.append(Paragraph(f"{highlight_section}. Performance Highlights", heading_style))
 
-        # ── APPENDICES ──
-        appendix_table_style = [
-            ('BACKGROUND', (0, 0), (-1, 0), colors.HexColor(primary_color)),
-            ('TEXTCOLOR', (0, 0), (-1, 0), colors.whitesmoke),
-            ('ALIGN', (0, 0), (-1, -1), 'LEFT'),
-            ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
-            ('FONTSIZE', (0, 0), (-1, 0), 8),
-            ('FONTSIZE', (0, 1), (-1, -1), 8),
-            ('BOTTOMPADDING', (0, 0), (-1, 0), 6),
-            ('TOPPADDING', (0, 1), (-1, -1), 3),
-            ('BOTTOMPADDING', (0, 1), (-1, -1), 3),
-            ('GRID', (0, 0), (-1, -1), 0.5, colors.HexColor('#E9ECEF')),
-            ('ROWBACKGROUNDS', (0, 1), (-1, -1), [colors.HexColor('#F8F9FA'), colors.white]),
-        ]
+        highlights = [["Metric", "Value", "Details"]]
+        if best_day:
+            highlights.append(["Best Day", f"{best_day['sessions']:,} sessions", best_day['date']])
+        if worst_day:
+            highlights.append(["Lowest Day", f"{worst_day['sessions']:,} sessions", worst_day['date']])
+        if best_week:
+            highlights.append(["Best Week", f"{best_week['sessions']:,} sessions", f"Week {best_week['week']}"])
+        if worst_week:
+            highlights.append(["Lowest Week", f"{worst_week['sessions']:,} sessions", f"Week {worst_week['week']}"])
 
-        story.append(PageBreak())
-        story.append(Paragraph("APPENDICES", heading_style))
-        story.append(Spacer(1, 12))
-
-        # Appendix A: Complete Daily Performance Data
-        story.append(Paragraph("Appendix A: Complete Daily Performance Data", subheading_style))
-        daily = ga_data['daily_data']
-        daily_table_data = [['Date', 'Sessions', 'Users', 'Pageviews', 'Bounce Rate', 'Avg Duration']]
-        # Sort by sessions descending
-        daily_rows = list(zip(
-            daily['dates'], daily['sessions'], daily['users'],
-            daily['pageviews'], daily['bounce_rate'], daily['avg_duration']
-        ))
-        daily_rows.sort(key=lambda x: x[1], reverse=True)
-        for date, sessions, users, pvs, bounce, duration in daily_rows:
-            daily_table_data.append([
-                date, f'{sessions:,}', f'{users:,}', f'{pvs:,}',
-                f'{bounce:.1f}%', f'{duration:.0f}s'
-            ])
-        daily_app_table = Table(daily_table_data, colWidths=[1.2*inch, 0.9*inch, 0.9*inch, 0.9*inch, 1*inch, 1*inch])
-        daily_app_table.setStyle(TableStyle(appendix_table_style))
-        story.append(daily_app_table)
+        hl_table = Table(highlights, colWidths=[2*inch, 2*inch, 2.3*inch])
+        hl_table.setStyle(TableStyle(primary_table_style))
+        story.append(hl_table)
+        story.append(Spacer(1, 20))
         story.append(PageBreak())
 
-        # Appendix B: Complete Traffic Sources Data
-        story.append(Paragraph("Appendix B: Complete Traffic Sources Data", subheading_style))
-        sources = ga_data['traffic_sources']
-        total_src_sessions = sum(s['sessions'] for s in sources)
-        src_table_data = [['Source', 'Medium', 'Sessions', '% of Total', 'Bounce Rate', 'Avg Duration']]
-        for src in sorted(sources, key=lambda x: x['sessions'], reverse=True):
-            pct = (src['sessions'] / total_src_sessions * 100) if total_src_sessions else 0
-            src_table_data.append([
-                src['source'], src['medium'], f"{src['sessions']:,}",
-                f'{pct:.1f}%', f"{src['bounce_rate']:.1f}%", f"{src['avg_duration']:.1f}s"
-            ])
-        src_app_table = Table(src_table_data, colWidths=[1.2*inch, 0.9*inch, 0.9*inch, 0.8*inch, 1*inch, 1*inch])
-        src_app_table.setStyle(TableStyle(appendix_table_style))
-        story.append(src_app_table)
+    if not (best_day or best_week):
         story.append(PageBreak())
 
-        # Appendix C: Complete Device Category Data
-        story.append(Paragraph("Appendix C: Complete Device Category Data", subheading_style))
-        devices = ga_data['devices']
-        total_dev_sessions = sum(d['sessions'] for d in devices)
-        dev_table_data = [['Device', 'Sessions', '% of Total', 'Bounce Rate']]
-        for dev in sorted(devices, key=lambda x: x['sessions'], reverse=True):
-            pct = (dev['sessions'] / total_dev_sessions * 100) if total_dev_sessions else 0
-            dev_table_data.append([
-                dev['device'].title(), f"{dev['sessions']:,}",
-                f'{pct:.1f}%', f"{dev['bounce_rate']:.1f}%"
-            ])
-        dev_app_table = Table(dev_table_data, colWidths=[1.5*inch, 1.5*inch, 1.5*inch, 1.5*inch])
-        dev_app_table.setStyle(TableStyle(appendix_table_style))
-        story.append(dev_app_table)
-        story.append(PageBreak())
+    # ── INSIGHTS ──
+    insights_num = yoy_section + (1 if longitudinal else 0) + (1 if (best_day or best_week) else 0)
+    story.append(Paragraph(f"{insights_num}. Key Insights", heading_style))
+    insights = generate_insights(ga_data)
+    for insight in insights:
+        story.append(Paragraph(f"-- {insight}", bullet_style))
+    story.append(Spacer(1, 20))
 
-        # Appendix D: Complete Geographic Data
-        story.append(Paragraph("Appendix D: Complete Geographic Data", subheading_style))
-        geo = ga_data.get('geo_data', [])
+    # ── RECOMMENDATIONS ──
+    story.append(Paragraph(f"{insights_num + 1}. Recommendations", heading_style))
+    recommendations = generate_recommendations(ga_data)
+    for i, rec in enumerate(recommendations, 1):
+        story.append(Paragraph(f"<b>{i}.</b> {rec}", bullet_style))
+    story.append(Spacer(1, 30))
 
-        # D.1 All Countries
-        story.append(Paragraph("All Countries", ParagraphStyle(
-            'AppendixSub', parent=styles['Normal'], fontSize=10, spaceBefore=10,
-            spaceAfter=6, fontName='Helvetica-Bold'
-        )))
-        country_agg = {}
-        for loc in geo:
-            c = loc.get('country', 'Unknown')
-            country_agg[c] = country_agg.get(c, 0) + loc.get('sessions', 0)
-        total_geo = sum(country_agg.values())
-        country_app_data = [['Country', 'Sessions', '% of Total']]
-        for country, sessions in sorted(country_agg.items(), key=lambda x: x[1], reverse=True):
-            pct = (sessions / total_geo * 100) if total_geo else 0
-            country_app_data.append([country, f'{sessions:,}', f'{pct:.1f}%'])
-        country_app_table = Table(country_app_data, colWidths=[2.5*inch, 1.5*inch, 1.5*inch])
-        country_app_table.setStyle(TableStyle(appendix_table_style))
-        story.append(country_app_table)
-        story.append(Spacer(1, 12))
+    # ── APPENDICES ──
+    appendix_table_style = [
+        ('BACKGROUND', (0, 0), (-1, 0), colors.HexColor(primary_color)),
+        ('TEXTCOLOR', (0, 0), (-1, 0), colors.whitesmoke),
+        ('ALIGN', (0, 0), (-1, -1), 'LEFT'),
+        ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
+        ('FONTSIZE', (0, 0), (-1, 0), 8),
+        ('FONTSIZE', (0, 1), (-1, -1), 8),
+        ('BOTTOMPADDING', (0, 0), (-1, 0), 6),
+        ('TOPPADDING', (0, 1), (-1, -1), 3),
+        ('BOTTOMPADDING', (0, 1), (-1, -1), 3),
+        ('GRID', (0, 0), (-1, -1), 0.5, colors.HexColor('#E9ECEF')),
+        ('ROWBACKGROUNDS', (0, 1), (-1, -1), [colors.HexColor('#F8F9FA'), colors.white]),
+    ]
 
-        # D.2 All Regions
-        story.append(Paragraph("All Regions", ParagraphStyle(
-            'AppendixSub2', parent=styles['Normal'], fontSize=10, spaceBefore=10,
-            spaceAfter=6, fontName='Helvetica-Bold'
-        )))
-        region_agg = {}
-        for loc in geo:
-            r = loc.get('region', 'Unknown')
-            region_agg[r] = region_agg.get(r, 0) + loc.get('sessions', 0)
-        region_app_data = [['Region', 'Sessions', '% of Total']]
-        for region, sessions in sorted(region_agg.items(), key=lambda x: x[1], reverse=True):
-            pct = (sessions / total_geo * 100) if total_geo else 0
-            region_app_data.append([region, f'{sessions:,}', f'{pct:.1f}%'])
-        region_app_table = Table(region_app_data, colWidths=[2.5*inch, 1.5*inch, 1.5*inch])
-        region_app_table.setStyle(TableStyle(appendix_table_style))
-        story.append(region_app_table)
-        story.append(Spacer(1, 12))
+    story.append(PageBreak())
+    story.append(Paragraph("APPENDICES", heading_style))
+    story.append(Spacer(1, 12))
 
-        # D.3 All Cities
-        story.append(Paragraph("All Cities", ParagraphStyle(
-            'AppendixSub3', parent=styles['Normal'], fontSize=10, spaceBefore=10,
-            spaceAfter=6, fontName='Helvetica-Bold'
-        )))
-        city_app_data = [['City', 'Region', 'Country', 'Sessions']]
-        for loc in sorted(geo, key=lambda x: x.get('sessions', 0), reverse=True):
-            city_app_data.append([
-                loc.get('city', 'Unknown'), loc.get('region', 'Unknown'),
-                loc.get('country', 'Unknown'), f"{loc.get('sessions', 0):,}"
-            ])
-        city_app_table = Table(city_app_data, colWidths=[1.5*inch, 1.5*inch, 1.5*inch, 1.5*inch])
-        city_app_table.setStyle(TableStyle(appendix_table_style))
-        story.append(city_app_table)
+    # Appendix A: Complete Daily Performance Data
+    story.append(Paragraph("Appendix A: Complete Daily Performance Data", subheading_style))
+    daily = ga_data['daily_data']
+    daily_table_data = [['Date', 'Sessions', 'Users', 'Pageviews', 'Bounce Rate', 'Avg Duration']]
+    # Sort by sessions descending
+    daily_rows = list(zip(
+        daily['dates'], daily['sessions'], daily['users'],
+        daily['pageviews'], daily['bounce_rate'], daily['avg_duration']
+    ))
+    daily_rows.sort(key=lambda x: x[1], reverse=True)
+    for date, sessions, users, pvs, bounce, duration in daily_rows:
+        daily_table_data.append([
+            date, f'{sessions:,}', f'{users:,}', f'{pvs:,}',
+            f'{bounce:.1f}%', f'{duration:.0f}s'
+        ])
+    daily_app_table = Table(daily_table_data, colWidths=[1.2*inch, 0.9*inch, 0.9*inch, 0.9*inch, 1*inch, 1*inch])
+    daily_app_table.setStyle(TableStyle(appendix_table_style))
+    story.append(daily_app_table)
+    story.append(PageBreak())
 
-        # Build with header/footer
-        doc.build(story, onFirstPage=lambda c, d: None, onLaterPages=_header_footer)
+    # Appendix B: Complete Traffic Sources Data
+    story.append(Paragraph("Appendix B: Complete Traffic Sources Data", subheading_style))
+    sources = ga_data['traffic_sources']
+    total_src_sessions = sum(s['sessions'] for s in sources)
+    src_table_data = [['Source', 'Medium', 'Sessions', '% of Total', 'Bounce Rate', 'Avg Duration']]
+    for src in sorted(sources, key=lambda x: x['sessions'], reverse=True):
+        pct = (src['sessions'] / total_src_sessions * 100) if total_src_sessions else 0
+        src_table_data.append([
+            src['source'], src['medium'], f"{src['sessions']:,}",
+            f'{pct:.1f}%', f"{src['bounce_rate']:.1f}%", f"{src['avg_duration']:.1f}s"
+        ])
+    src_app_table = Table(src_table_data, colWidths=[1.2*inch, 0.9*inch, 0.9*inch, 0.8*inch, 1*inch, 1*inch])
+    src_app_table.setStyle(TableStyle(appendix_table_style))
+    story.append(src_app_table)
+    story.append(PageBreak())
 
-        log.info(f"Google Analytics report generated: {output_path}")
-        return True
+    # Appendix C: Complete Device Category Data
+    story.append(Paragraph("Appendix C: Complete Device Category Data", subheading_style))
+    devices = ga_data['devices']
+    total_dev_sessions = sum(d['sessions'] for d in devices)
+    dev_table_data = [['Device', 'Sessions', '% of Total', 'Bounce Rate']]
+    for dev in sorted(devices, key=lambda x: x['sessions'], reverse=True):
+        pct = (dev['sessions'] / total_dev_sessions * 100) if total_dev_sessions else 0
+        dev_table_data.append([
+            dev['device'].title(), f"{dev['sessions']:,}",
+            f'{pct:.1f}%', f"{dev['bounce_rate']:.1f}%"
+        ])
+    dev_app_table = Table(dev_table_data, colWidths=[1.5*inch, 1.5*inch, 1.5*inch, 1.5*inch])
+    dev_app_table.setStyle(TableStyle(appendix_table_style))
+    story.append(dev_app_table)
+    story.append(PageBreak())
 
-    except (OSError, ValueError, TypeError, KeyError, AttributeError) as e:
-        log.error(f"Error generating GA report: {e}")
-        import traceback
-        traceback.print_exc()
-        return False
+    # Appendix D: Complete Geographic Data
+    story.append(Paragraph("Appendix D: Complete Geographic Data", subheading_style))
+    geo = ga_data.get('geo_data', [])
+
+    # D.1 All Countries
+    story.append(Paragraph("All Countries", ParagraphStyle(
+        'AppendixSub', parent=styles['Normal'], fontSize=10, spaceBefore=10,
+        spaceAfter=6, fontName='Helvetica-Bold'
+    )))
+    country_agg = {}
+    for loc in geo:
+        c = loc.get('country', 'Unknown')
+        country_agg[c] = country_agg.get(c, 0) + loc.get('sessions', 0)
+    total_geo = sum(country_agg.values())
+    country_app_data = [['Country', 'Sessions', '% of Total']]
+    for country, sessions in sorted(country_agg.items(), key=lambda x: x[1], reverse=True):
+        pct = (sessions / total_geo * 100) if total_geo else 0
+        country_app_data.append([country, f'{sessions:,}', f'{pct:.1f}%'])
+    country_app_table = Table(country_app_data, colWidths=[2.5*inch, 1.5*inch, 1.5*inch])
+    country_app_table.setStyle(TableStyle(appendix_table_style))
+    story.append(country_app_table)
+    story.append(Spacer(1, 12))
+
+    # D.2 All Regions
+    story.append(Paragraph("All Regions", ParagraphStyle(
+        'AppendixSub2', parent=styles['Normal'], fontSize=10, spaceBefore=10,
+        spaceAfter=6, fontName='Helvetica-Bold'
+    )))
+    region_agg = {}
+    for loc in geo:
+        r = loc.get('region', 'Unknown')
+        region_agg[r] = region_agg.get(r, 0) + loc.get('sessions', 0)
+    region_app_data = [['Region', 'Sessions', '% of Total']]
+    for region, sessions in sorted(region_agg.items(), key=lambda x: x[1], reverse=True):
+        pct = (sessions / total_geo * 100) if total_geo else 0
+        region_app_data.append([region, f'{sessions:,}', f'{pct:.1f}%'])
+    region_app_table = Table(region_app_data, colWidths=[2.5*inch, 1.5*inch, 1.5*inch])
+    region_app_table.setStyle(TableStyle(appendix_table_style))
+    story.append(region_app_table)
+    story.append(Spacer(1, 12))
+
+    # D.3 All Cities
+    story.append(Paragraph("All Cities", ParagraphStyle(
+        'AppendixSub3', parent=styles['Normal'], fontSize=10, spaceBefore=10,
+        spaceAfter=6, fontName='Helvetica-Bold'
+    )))
+    city_app_data = [['City', 'Region', 'Country', 'Sessions']]
+    for loc in sorted(geo, key=lambda x: x.get('sessions', 0), reverse=True):
+        city_app_data.append([
+            loc.get('city', 'Unknown'), loc.get('region', 'Unknown'),
+            loc.get('country', 'Unknown'), f"{loc.get('sessions', 0):,}"
+        ])
+    city_app_table = Table(city_app_data, colWidths=[1.5*inch, 1.5*inch, 1.5*inch, 1.5*inch])
+    city_app_table.setStyle(TableStyle(appendix_table_style))
+    story.append(city_app_table)
+
+    # Build with header/footer
+    doc.build(story, onFirstPage=lambda c, d: None, onLaterPages=_header_footer)
+
+    log.info(f"Google Analytics report generated: {output_path}")
 
 
 def export_design_kit(ga_data: Dict[str, Any], output_dir: str,
                       client_name: str = "Client",
                       prepared_by: str = "Siege Analytics",
-                      branding_key: Optional[str] = None) -> bool:
+                      branding_key: Optional[str] = None) -> None:
     """
     Export a complete design kit for InDesign/Illustrator handoff.
 
@@ -2425,8 +2427,9 @@ def export_design_kit(ga_data: Dict[str, Any], output_dir: str,
         prepared_by: Preparer name for metadata
         branding_key: Optional branding template key
 
-    Returns:
-        True if successful
+    Raises:
+        OSError: If directory creation or file I/O fails.
+        KeyError: If expected keys are missing from ga_data.
     """
     import csv
     try:
@@ -2435,234 +2438,225 @@ def export_design_kit(ga_data: Dict[str, Any], output_dir: str,
     except ImportError:
         _has_yaml = False
 
-    try:
-        kit = Path(output_dir)
-        charts_dir = kit / 'charts'
-        charts_png_dir = kit / 'charts-png'
-        tables_dir = kit / 'tables'
-        text_dir = kit / 'text'
+    kit = Path(output_dir)
+    charts_dir = kit / 'charts'
+    charts_png_dir = kit / 'charts-png'
+    tables_dir = kit / 'tables'
+    text_dir = kit / 'text'
 
-        for d in [charts_dir, charts_png_dir, tables_dir, text_dir]:
-            d.mkdir(parents=True, exist_ok=True)
+    for d in [charts_dir, charts_png_dir, tables_dir, text_dir]:
+        d.mkdir(parents=True, exist_ok=True)
 
-        date_range = ga_data['date_range']
-        totals = ga_data['totals']
-        changes = ga_data['changes']
+    date_range = ga_data['date_range']
+    totals = ga_data['totals']
+    changes = ga_data['changes']
 
-        # ── 1. Charts (SVG + PNG) ──
-        chart_funcs = [
-            ('traffic_trends', create_traffic_trend_chart),
-            ('traffic_sources', create_traffic_sources_chart),
-            ('device_breakdown', create_device_breakdown_chart),
-            ('geo_country', create_geo_country_chart),
-            ('geo_region', create_geo_region_chart),
-            ('geo_city', create_geo_city_scatter),
-            ('geo_continent', create_continent_donut_chart),
-        ]
-        if ga_data.get('prior_daily_data', {}).get('sessions'):
-            chart_funcs.append(('period_comparison', create_period_comparison_chart))
+    # ── 1. Charts (SVG + PNG) ──
+    chart_funcs = [
+        ('traffic_trends', create_traffic_trend_chart),
+        ('traffic_sources', create_traffic_sources_chart),
+        ('device_breakdown', create_device_breakdown_chart),
+        ('geo_country', create_geo_country_chart),
+        ('geo_region', create_geo_region_chart),
+        ('geo_city', create_geo_city_scatter),
+        ('geo_continent', create_continent_donut_chart),
+    ]
+    if ga_data.get('prior_daily_data', {}).get('sessions'):
+        chart_funcs.append(('period_comparison', create_period_comparison_chart))
 
-        for name, func in chart_funcs:
-            chart_path = func(ga_data, vector_export_path=str(charts_dir / f'{name}.svg'))
-            if chart_path and Path(chart_path).exists():
-                import shutil
-                shutil.copy2(chart_path, charts_png_dir / f'{name}.png')
+    for name, func in chart_funcs:
+        chart_path = func(ga_data, vector_export_path=str(charts_dir / f'{name}.svg'))
+        if chart_path and Path(chart_path).exists():
+            import shutil
+            shutil.copy2(chart_path, charts_png_dir / f'{name}.png')
 
-        # ── 2. Tables (CSV) ──
-        # Daily performance
-        daily = ga_data['daily_data']
-        with open(tables_dir / 'daily_performance.csv', 'w', newline='', encoding='utf-8') as f:
+    # ── 2. Tables (CSV) ──
+    # Daily performance
+    daily = ga_data['daily_data']
+    with open(tables_dir / 'daily_performance.csv', 'w', newline='', encoding='utf-8') as f:
+        w = csv.writer(f)
+        w.writerow(['Date', 'Sessions', 'Users', 'Pageviews', 'Bounce Rate (%)', 'Avg Duration (s)'])
+        for i in range(len(daily['dates'])):
+            w.writerow([daily['dates'][i], daily['sessions'][i], daily['users'][i],
+                        daily['pageviews'][i], f"{daily['bounce_rate'][i]:.1f}",
+                        f"{daily['avg_duration'][i]:.0f}"])
+
+    # Traffic sources
+    with open(tables_dir / 'traffic_sources.csv', 'w', newline='', encoding='utf-8') as f:
+        w = csv.writer(f)
+        w.writerow(['Source', 'Medium', 'Sessions', 'Users', 'Bounce Rate (%)', 'Avg Duration (s)'])
+        for src in sorted(ga_data['traffic_sources'], key=lambda x: x['sessions'], reverse=True):
+            w.writerow([src['source'], src['medium'], src['sessions'], src['users'],
+                        f"{src['bounce_rate']:.1f}", f"{src['avg_duration']:.1f}"])
+
+    # Top pages
+    with open(tables_dir / 'top_pages.csv', 'w', newline='', encoding='utf-8') as f:
+        w = csv.writer(f)
+        w.writerow(['Page', 'Pageviews', 'Unique Views', 'Avg Time (s)', 'Bounce Rate (%)', 'Exit Rate (%)'])
+        for p in ga_data['top_pages']:
+            w.writerow([p['page'], p['pageviews'], p['unique_views'],
+                        f"{p['avg_time']:.1f}", f"{p['bounce_rate']:.1f}", f"{p['exit_rate']:.1f}"])
+
+    # Geographic data
+    with open(tables_dir / 'geographic.csv', 'w', newline='', encoding='utf-8') as f:
+        w = csv.writer(f)
+        w.writerow(['Country', 'Region', 'City', 'Continent', 'Sessions', 'Users'])
+        for loc in sorted(ga_data['geo_data'], key=lambda x: x.get('sessions', 0), reverse=True):
+            w.writerow([loc.get('country', ''), loc.get('region', ''), loc.get('city', ''),
+                        loc.get('continent', ''), loc.get('sessions', 0), loc.get('users', 0)])
+
+    # Device breakdown
+    with open(tables_dir / 'devices.csv', 'w', newline='', encoding='utf-8') as f:
+        w = csv.writer(f)
+        w.writerow(['Device', 'Sessions', 'Bounce Rate (%)'])
+        for d in ga_data['devices']:
+            w.writerow([d['device'], d['sessions'], f"{d['bounce_rate']:.1f}"])
+
+    # KPI summary
+    with open(tables_dir / 'kpi_summary.csv', 'w', newline='', encoding='utf-8') as f:
+        w = csv.writer(f)
+        w.writerow(['Metric', 'Value', 'Change vs Prior (%)'])
+        w.writerow(['Sessions', totals['sessions'], f"{changes['sessions']:+.1f}"])
+        w.writerow(['Users', totals['users'], f"{changes['users']:+.1f}"])
+        w.writerow(['Pageviews', totals['pageviews'], f"{changes.get('pageviews', 0):+.1f}"])
+        w.writerow(['Avg Bounce Rate', f"{totals['avg_bounce_rate']:.1f}%", f"{changes['bounce_rate']:+.1f}"])
+        w.writerow(['Avg Session Duration', f"{totals['avg_session_duration']:.0f}s", f"{changes['duration']:+.1f}"])
+        w.writerow(['Pages per Session', f"{totals['pages_per_session']:.2f}", ""])
+
+    # Period comparison (if available)
+    prior = ga_data.get('prior_period')
+    if prior:
+        with open(tables_dir / 'period_comparison.csv', 'w', newline='', encoding='utf-8') as f:
             w = csv.writer(f)
-            w.writerow(['Date', 'Sessions', 'Users', 'Pageviews', 'Bounce Rate (%)', 'Avg Duration (s)'])
-            for i in range(len(daily['dates'])):
-                w.writerow([daily['dates'][i], daily['sessions'][i], daily['users'][i],
-                            daily['pageviews'][i], f"{daily['bounce_rate'][i]:.1f}",
-                            f"{daily['avg_duration'][i]:.0f}"])
+            w.writerow(['Metric', 'Current Period', 'Prior Period', 'Change'])
+            w.writerow(['Sessions', totals['sessions'], prior.get('sessions', 0), f"{changes['sessions']:+.1f}%"])
+            w.writerow(['Users', totals['users'], prior.get('users', 0), f"{changes['users']:+.1f}%"])
+            w.writerow(['Bounce Rate', f"{totals['avg_bounce_rate']:.1f}%",
+                        f"{prior.get('avg_bounce_rate', 0):.1f}%", f"{changes['bounce_rate']:+.1f} pts"])
+            w.writerow(['Avg Duration', f"{totals['avg_session_duration']:.0f}s",
+                        f"{prior.get('avg_session_duration', 0):.0f}s", f"{changes['duration']:+.1f}%"])
 
-        # Traffic sources
-        with open(tables_dir / 'traffic_sources.csv', 'w', newline='', encoding='utf-8') as f:
+    # Longitudinal / YoY
+    longitudinal = ga_data.get('longitudinal', {})
+    if longitudinal:
+        with open(tables_dir / 'year_over_year.csv', 'w', newline='', encoding='utf-8') as f:
             w = csv.writer(f)
-            w.writerow(['Source', 'Medium', 'Sessions', 'Users', 'Bounce Rate (%)', 'Avg Duration (s)'])
-            for src in sorted(ga_data['traffic_sources'], key=lambda x: x['sessions'], reverse=True):
-                w.writerow([src['source'], src['medium'], src['sessions'], src['users'],
-                            f"{src['bounce_rate']:.1f}", f"{src['avg_duration']:.1f}"])
+            w.writerow(['Year', 'Sessions', 'Users', 'Pageviews'])
+            for year in sorted(longitudinal.keys()):
+                yd = longitudinal[year]
+                w.writerow([year, yd['sessions'], yd['users'], yd['pageviews']])
 
-        # Top pages
-        with open(tables_dir / 'top_pages.csv', 'w', newline='', encoding='utf-8') as f:
-            w = csv.writer(f)
-            w.writerow(['Page', 'Pageviews', 'Unique Views', 'Avg Time (s)', 'Bounce Rate (%)', 'Exit Rate (%)'])
-            for p in ga_data['top_pages']:
-                w.writerow([p['page'], p['pageviews'], p['unique_views'],
-                            f"{p['avg_time']:.1f}", f"{p['bounce_rate']:.1f}", f"{p['exit_rate']:.1f}"])
+    # ── 3. Report text (Markdown) ──
+    insights = generate_insights(ga_data)
+    recommendations = generate_recommendations(ga_data)
 
-        # Geographic data
-        with open(tables_dir / 'geographic.csv', 'w', newline='', encoding='utf-8') as f:
-            w = csv.writer(f)
-            w.writerow(['Country', 'Region', 'City', 'Continent', 'Sessions', 'Users'])
-            for loc in sorted(ga_data['geo_data'], key=lambda x: x.get('sessions', 0), reverse=True):
-                w.writerow([loc.get('country', ''), loc.get('region', ''), loc.get('city', ''),
-                            loc.get('continent', ''), loc.get('sessions', 0), loc.get('users', 0)])
+    lines = [
+        f"# {client_name}",
+        "## Google Analytics Performance Report",
+        "",
+        f"**Date Range:** {date_range['start']} to {date_range['end']}",
+        f"**Prepared by:** {prepared_by}",
+        "",
+        "---",
+        "",
+        "## Executive Summary",
+        "",
+        "| Metric | Value | Change vs Prior |",
+        "|--------|-------|-----------------|",
+        f"| Sessions | {totals['sessions']:,} | {changes['sessions']:+.1f}% |",
+        f"| Users | {totals['users']:,} | {changes['users']:+.1f}% |",
+        f"| Pageviews | {totals['pageviews']:,} | {changes.get('pageviews', 0):+.1f}% |",
+        f"| Bounce Rate | {totals['avg_bounce_rate']:.1f}% | {changes['bounce_rate']:+.1f} pts |",
+        f"| Avg Duration | {totals['avg_session_duration']:.0f}s | {changes['duration']:+.1f}% |",
+        f"| Pages/Session | {totals['pages_per_session']:.2f} | |",
+        "",
+    ]
 
-        # Device breakdown
-        with open(tables_dir / 'devices.csv', 'w', newline='', encoding='utf-8') as f:
-            w = csv.writer(f)
-            w.writerow(['Device', 'Sessions', 'Bounce Rate (%)'])
-            for d in ga_data['devices']:
-                w.writerow([d['device'], d['sessions'], f"{d['bounce_rate']:.1f}"])
+    best_day = ga_data.get('best_day')
+    worst_day = ga_data.get('worst_day')
+    if best_day:
+        lines.append(f"**Best Day:** {best_day['date']} ({best_day['sessions']:,} sessions)")
+    if worst_day:
+        lines.append(f"**Lowest Day:** {worst_day['date']} ({worst_day['sessions']:,} sessions)")
+    lines.append("")
 
-        # KPI summary
-        with open(tables_dir / 'kpi_summary.csv', 'w', newline='', encoding='utf-8') as f:
-            w = csv.writer(f)
-            w.writerow(['Metric', 'Value', 'Change vs Prior (%)'])
-            w.writerow(['Sessions', totals['sessions'], f"{changes['sessions']:+.1f}"])
-            w.writerow(['Users', totals['users'], f"{changes['users']:+.1f}"])
-            w.writerow(['Pageviews', totals['pageviews'], f"{changes.get('pageviews', 0):+.1f}"])
-            w.writerow(['Avg Bounce Rate', f"{totals['avg_bounce_rate']:.1f}%", f"{changes['bounce_rate']:+.1f}"])
-            w.writerow(['Avg Session Duration', f"{totals['avg_session_duration']:.0f}s", f"{changes['duration']:+.1f}"])
-            w.writerow(['Pages per Session', f"{totals['pages_per_session']:.2f}", ""])
+    lines.append("## Key Insights")
+    lines.append("")
+    for insight in insights:
+        lines.append(f"- {insight}")
+    lines.append("")
 
-        # Period comparison (if available)
-        prior = ga_data.get('prior_period')
-        if prior:
-            with open(tables_dir / 'period_comparison.csv', 'w', newline='', encoding='utf-8') as f:
-                w = csv.writer(f)
-                w.writerow(['Metric', 'Current Period', 'Prior Period', 'Change'])
-                w.writerow(['Sessions', totals['sessions'], prior.get('sessions', 0), f"{changes['sessions']:+.1f}%"])
-                w.writerow(['Users', totals['users'], prior.get('users', 0), f"{changes['users']:+.1f}%"])
-                w.writerow(['Bounce Rate', f"{totals['avg_bounce_rate']:.1f}%",
-                            f"{prior.get('avg_bounce_rate', 0):.1f}%", f"{changes['bounce_rate']:+.1f} pts"])
-                w.writerow(['Avg Duration', f"{totals['avg_session_duration']:.0f}s",
-                            f"{prior.get('avg_session_duration', 0):.0f}s", f"{changes['duration']:+.1f}%"])
+    lines.append("## Recommendations")
+    lines.append("")
+    for i, rec in enumerate(recommendations, 1):
+        lines.append(f"{i}. {rec}")
+    lines.append("")
 
-        # Longitudinal / YoY
-        longitudinal = ga_data.get('longitudinal', {})
-        if longitudinal:
-            with open(tables_dir / 'year_over_year.csv', 'w', newline='', encoding='utf-8') as f:
-                w = csv.writer(f)
-                w.writerow(['Year', 'Sessions', 'Users', 'Pageviews'])
-                for year in sorted(longitudinal.keys()):
-                    yd = longitudinal[year]
-                    w.writerow([year, yd['sessions'], yd['users'], yd['pageviews']])
+    lines.append("---")
+    lines.append("")
+    lines.append("## Chart Inventory")
+    lines.append("")
+    lines.append("| File | Description |")
+    lines.append("|------|-------------|")
+    lines.append("| traffic_trends | Daily sessions and users over the date range |")
+    lines.append("| traffic_sources | Top traffic sources (organic, direct, social, etc.) |")
+    lines.append("| device_breakdown | Desktop vs mobile vs tablet split |")
+    lines.append("| geo_country | Sessions by country |")
+    lines.append("| geo_region | Sessions by state/region |")
+    lines.append("| geo_city | City-level session distribution |")
+    lines.append("| geo_continent | Continental traffic breakdown |")
+    if ga_data.get('prior_daily_data', {}).get('sessions'):
+        lines.append("| period_comparison | Current vs prior period daily overlay |")
+    lines.append("")
+    lines.append("Charts are available as SVG (vector, editable) in `charts/` and PNG (raster, 300 DPI) in `charts-png/`.")
 
-        # ── 3. Report text (Markdown) ──
-        insights = generate_insights(ga_data)
-        recommendations = generate_recommendations(ga_data)
+    with open(text_dir / 'report_text.md', 'w', encoding='utf-8') as f:
+        f.write('\n'.join(lines))
 
-        lines = [
-            f"# {client_name}",
-            "## Google Analytics Performance Report",
-            "",
-            f"**Date Range:** {date_range['start']} to {date_range['end']}",
-            f"**Prepared by:** {prepared_by}",
-            "",
-            "---",
-            "",
-            "## Executive Summary",
-            "",
-            "| Metric | Value | Change vs Prior |",
-            "|--------|-------|-----------------|",
-            f"| Sessions | {totals['sessions']:,} | {changes['sessions']:+.1f}% |",
-            f"| Users | {totals['users']:,} | {changes['users']:+.1f}% |",
-            f"| Pageviews | {totals['pageviews']:,} | {changes.get('pageviews', 0):+.1f}% |",
-            f"| Bounce Rate | {totals['avg_bounce_rate']:.1f}% | {changes['bounce_rate']:+.1f} pts |",
-            f"| Avg Duration | {totals['avg_session_duration']:.0f}s | {changes['duration']:+.1f}% |",
-            f"| Pages/Session | {totals['pages_per_session']:.2f} | |",
-            "",
-        ]
+    # ── 4. Metadata (YAML or plain text) ──
+    metadata = {
+        'client_name': client_name,
+        'prepared_by': prepared_by,
+        'branding_key': branding_key,
+        'date_range': {'start': date_range['start'], 'end': date_range['end']},
+        'totals': {
+            'sessions': _safe_int(totals.get('sessions', 0)),
+            'users': _safe_int(totals.get('users', 0)),
+            'pageviews': _safe_int(totals.get('pageviews', 0)),
+            'avg_bounce_rate': float(round(totals['avg_bounce_rate'], 1)),
+            'avg_session_duration': float(round(totals['avg_session_duration'], 0)),
+            'pages_per_session': float(round(totals['pages_per_session'], 2)),
+        },
+        'changes_vs_prior': {
+            'sessions': float(round(changes['sessions'], 1)),
+            'users': float(round(changes['users'], 1)),
+            'pageviews': float(round(changes.get('pageviews', 0), 1)),
+            'bounce_rate': float(round(changes['bounce_rate'], 1)),
+            'duration': float(round(changes['duration'], 1)),
+        },
+        'chart_files': [name for name, _ in chart_funcs],
+        'table_files': [f.name for f in sorted(tables_dir.glob('*.csv'))],
+    }
 
-        best_day = ga_data.get('best_day')
-        worst_day = ga_data.get('worst_day')
-        if best_day:
-            lines.append(f"**Best Day:** {best_day['date']} ({best_day['sessions']:,} sessions)")
-        if worst_day:
-            lines.append(f"**Lowest Day:** {worst_day['date']} ({worst_day['sessions']:,} sessions)")
-        lines.append("")
+    if _has_yaml:
+        with open(kit / 'metadata.yaml', 'w', encoding='utf-8') as f:
+            yaml.dump(metadata, f, default_flow_style=False, sort_keys=False)
+    else:
+        # Fallback: write as readable text
+        with open(kit / 'metadata.txt', 'w', encoding='utf-8') as f:
+            for k, v in metadata.items():
+                if isinstance(v, dict):
+                    f.write(f"\n{k}:\n")
+                    for kk, vv in v.items():
+                        f.write(f"  {kk}: {vv}\n")
+                elif isinstance(v, list):
+                    f.write(f"\n{k}:\n")
+                    for item in v:
+                        f.write(f"  - {item}\n")
+                else:
+                    f.write(f"{k}: {v}\n")
 
-        lines.append("## Key Insights")
-        lines.append("")
-        for insight in insights:
-            lines.append(f"- {insight}")
-        lines.append("")
-
-        lines.append("## Recommendations")
-        lines.append("")
-        for i, rec in enumerate(recommendations, 1):
-            lines.append(f"{i}. {rec}")
-        lines.append("")
-
-        lines.append("---")
-        lines.append("")
-        lines.append("## Chart Inventory")
-        lines.append("")
-        lines.append("| File | Description |")
-        lines.append("|------|-------------|")
-        lines.append("| traffic_trends | Daily sessions and users over the date range |")
-        lines.append("| traffic_sources | Top traffic sources (organic, direct, social, etc.) |")
-        lines.append("| device_breakdown | Desktop vs mobile vs tablet split |")
-        lines.append("| geo_country | Sessions by country |")
-        lines.append("| geo_region | Sessions by state/region |")
-        lines.append("| geo_city | City-level session distribution |")
-        lines.append("| geo_continent | Continental traffic breakdown |")
-        if ga_data.get('prior_daily_data', {}).get('sessions'):
-            lines.append("| period_comparison | Current vs prior period daily overlay |")
-        lines.append("")
-        lines.append("Charts are available as SVG (vector, editable) in `charts/` and PNG (raster, 300 DPI) in `charts-png/`.")
-
-        with open(text_dir / 'report_text.md', 'w', encoding='utf-8') as f:
-            f.write('\n'.join(lines))
-
-        # ── 4. Metadata (YAML or plain text) ──
-        metadata = {
-            'client_name': client_name,
-            'prepared_by': prepared_by,
-            'branding_key': branding_key,
-            'date_range': {'start': date_range['start'], 'end': date_range['end']},
-            'totals': {
-                'sessions': _safe_int(totals.get('sessions', 0)),
-                'users': _safe_int(totals.get('users', 0)),
-                'pageviews': _safe_int(totals.get('pageviews', 0)),
-                'avg_bounce_rate': float(round(totals['avg_bounce_rate'], 1)),
-                'avg_session_duration': float(round(totals['avg_session_duration'], 0)),
-                'pages_per_session': float(round(totals['pages_per_session'], 2)),
-            },
-            'changes_vs_prior': {
-                'sessions': float(round(changes['sessions'], 1)),
-                'users': float(round(changes['users'], 1)),
-                'pageviews': float(round(changes.get('pageviews', 0), 1)),
-                'bounce_rate': float(round(changes['bounce_rate'], 1)),
-                'duration': float(round(changes['duration'], 1)),
-            },
-            'chart_files': [name for name, _ in chart_funcs],
-            'table_files': [f.name for f in sorted(tables_dir.glob('*.csv'))],
-        }
-
-        if _has_yaml:
-            with open(kit / 'metadata.yaml', 'w', encoding='utf-8') as f:
-                yaml.dump(metadata, f, default_flow_style=False, sort_keys=False)
-        else:
-            # Fallback: write as readable text
-            with open(kit / 'metadata.txt', 'w', encoding='utf-8') as f:
-                for k, v in metadata.items():
-                    if isinstance(v, dict):
-                        f.write(f"\n{k}:\n")
-                        for kk, vv in v.items():
-                            f.write(f"  {kk}: {vv}\n")
-                    elif isinstance(v, list):
-                        f.write(f"\n{k}:\n")
-                        for item in v:
-                            f.write(f"  - {item}\n")
-                    else:
-                        f.write(f"{k}: {v}\n")
-
-        log.info(f"Design kit exported: {kit}")
-        return True
-
-    except (OSError, ValueError, TypeError, KeyError) as e:
-        log.error(f"Error exporting design kit: {e}")
-        import traceback
-        traceback.print_exc()
-        return False
-
+    log.info(f"Design kit exported: {kit}")
 
 def main():
     """Main demonstration function."""
@@ -2685,29 +2679,24 @@ def main():
     output_path = "ga_performance_report.pdf"
     print(f"\nGenerating PDF report: {output_path}...")
 
-    success = generate_ga_report_pdf(
+    generate_ga_report_pdf(
         ga_data=ga_data,
         output_path=output_path,
         client_name="Demo Company",
         report_title="Website Analytics Report"
     )
 
-    if success:
-        print(f"\n Report generated successfully: {output_path}")
-        print("\nReport includes:")
-        print("  - Executive Summary")
-        print("  - KPI Dashboard with metric cards")
-        print("  - Traffic Trends chart")
-        print("  - Traffic Sources analysis")
-        print("  - Device breakdown")
-        print("  - Top Pages performance table")
-        print("  - Geographic distribution")
-        print("  - Automated Insights")
-        print("  - Actionable Recommendations")
-    else:
-        print("\n Report generation failed. Check logs for details.")
-
-    return success
+    print(f"\nReport generated successfully: {output_path}")
+    print("\nReport includes:")
+    print("  - Executive Summary")
+    print("  - KPI Dashboard with metric cards")
+    print("  - Traffic Trends chart")
+    print("  - Traffic Sources analysis")
+    print("  - Device breakdown")
+    print("  - Top Pages performance table")
+    print("  - Geographic distribution")
+    print("  - Automated Insights")
+    print("  - Actionable Recommendations")
 
 
 if __name__ == "__main__":

--- a/siege_utilities/reporting/hex_cartogram/components.py
+++ b/siege_utilities/reporting/hex_cartogram/components.py
@@ -29,6 +29,8 @@ log = logging.getLogger(__name__)
 
 __all__ = [
     "find_components",
+    "offset_layout",
+    "stitch_components",
 ]
 
 

--- a/siege_utilities/reporting/hex_cartogram/coords.py
+++ b/siege_utilities/reporting/hex_cartogram/coords.py
@@ -24,6 +24,7 @@ __all__ = [
     "axial_distance",
     "axial_neighbors",
     "axial_to_cartesian",
+    "bounding_grid",
     "hexagon_polygon",
 ]
 

--- a/siege_utilities/reporting/legend_manager.py
+++ b/siege_utilities/reporting/legend_manager.py
@@ -3,6 +3,8 @@ Legend management utilities for siege_utilities reporting system.
 Provides comprehensive legend generation and management for charts, tables, and visualizations.
 """
 
+from __future__ import annotations
+
 import logging
 from typing import Dict, List, Any, Optional, Union, Tuple
 from enum import Enum
@@ -15,6 +17,7 @@ try:
 except ImportError:
     MATPLOTLIB_AVAILABLE = False
     plt = None
+    mpatches = None
 
 # ReportLab for PDF generation
 try:

--- a/siege_utilities/reporting/powerpoint_generator.py
+++ b/siege_utilities/reporting/powerpoint_generator.py
@@ -526,7 +526,7 @@ class PowerPointGenerator:
             # Process each section
             for section in presentation_content.get('sections', []):
                 slide = self._create_slide_from_section(section, prs)
-                if slide and section.get('notes'):
+                if section.get('notes'):
                     notes_slide = slide.notes_slide
                     notes_slide.notes_text_frame.text = section['notes']
 
@@ -1193,8 +1193,9 @@ class PowerPointGenerator:
                 return self._create_text_slide(section, prs)
                 
         except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-            log.error(f"Error creating slide for section {section_type}: {e}")
-            return None
+            raise RuntimeError(
+                f"Failed to create slide for section {section_type!r}: {e}"
+            ) from e
 
     def _create_title_slide(self, section: Dict[str, Any], prs: Presentation) -> Any:
         """Create a title slide."""

--- a/siege_utilities/reporting/report_generator.py
+++ b/siege_utilities/reporting/report_generator.py
@@ -31,7 +31,7 @@ except ImportError:
 
 from .templates.base_template import BaseReportTemplate
 from .chart_generator import ChartGenerator
-from .client_branding import ClientBrandingManager
+from .client_branding import ClientBrandingManager, ClientBrandingNotFoundError
 
 log = logging.getLogger(__name__)
 
@@ -68,11 +68,10 @@ class ReportGenerator:
         self.output_dir = output_dir or Path.cwd() / "reports"
         self.output_dir.mkdir(parents=True, exist_ok=True)
         
-        # Initialize components
         self.branding_manager = ClientBrandingManager()
-        self.branding_config = self.branding_manager.get_client_branding(client_name)
-        
-        if not self.branding_config:
+        try:
+            self.branding_config = self.branding_manager.get_client_branding(client_name)
+        except ClientBrandingNotFoundError:
             log.warning(f"No branding configuration found for {client_name}, using defaults")
             self.branding_config = {}
         
@@ -429,53 +428,34 @@ class ReportGenerator:
         )
 
     def generate_pdf_report(self, report_content: Dict[str, Any],
-                           output_path: str, template_config: str = None) -> bool:
+                           output_path: str, template_config: str = None) -> None:
         """
         Generate a comprehensive PDF report with full document structure.
-        
+
         Args:
             report_content: Report content structure
             output_path: Output PDF file path
             template_config: Template configuration file path
-            
-        Returns:
-            True if successful, False otherwise
+
+        Raises:
+            OSError: If the output directory cannot be created or is not writable,
+                or if the final rename fails.
         """
+        final = Path(output_path)
+        parent = final.parent if str(final.parent) else Path(".")
+        parent.mkdir(parents=True, exist_ok=True)
+        if not os.access(parent, os.W_OK):
+            raise OSError(
+                f"generate_pdf_report: output directory {parent} is not writable"
+            )
+
+        tmp_path = parent / f".{final.name}.{uuid.uuid4().hex[:8]}.part"
+
         try:
-            # Pre-check writability: ReportLab buffers the entire PDF in
-            # memory and only attempts disk I/O at the very end. A
-            # missing parent dir or a read-only mount that was
-            # discoverable up-front would otherwise burn a full
-            # generation pass (slow on multi-hundred-page reports)
-            # before failing. Build to a sibling temp file and rename
-            # atomically so a partial PDF never appears at *output_path*.
-            final = Path(output_path)
-            parent = final.parent if str(final.parent) else Path(".")
-            try:
-                parent.mkdir(parents=True, exist_ok=True)
-            except OSError as exc:
-                log.error(
-                    "generate_pdf_report: cannot create output directory "
-                    "%s: %s", parent, exc,
-                )
-                return False
-            if not os.access(parent, os.W_OK):
-                log.error(
-                    "generate_pdf_report: output directory %s is not "
-                    "writable", parent,
-                )
-                return False
-
-            tmp_path = parent / f".{final.name}.{uuid.uuid4().hex[:8]}.part"
-
-            # Initialize template with the temp path; we rename to the
-            # final name only after a successful build.
             template = self._get_template(str(tmp_path), template_config)
 
-            # Build document content
             story = []
 
-            # Add title page if metadata present
             metadata = report_content.get('metadata', {})
             if metadata.get('title'):
                 title_flowables = template.add_title_page(
@@ -486,48 +466,37 @@ class ReportGenerator:
                 )
                 story.extend(title_flowables)
 
-            # Process each section
             for section in report_content.get('sections', []):
                 section_story = self._build_section_content(section, template)
                 story.extend(section_story)
 
-                # Add page breaks if requested
                 if section.get('page_break_after', False):
                     story.append(PageBreak())
 
-            # Build PDF using the template's build_document method
             template.build_document(story)
 
-            # Atomic rename. os.replace is atomic on POSIX and on Windows
-            # (per docs) when source and dest live on the same FS — which
-            # they do, since we created the temp alongside the target.
             try:
                 os.replace(tmp_path, final)
             except OSError as exc:
-                log.error(
-                    "generate_pdf_report: built %s but could not rename "
-                    "to %s: %s", tmp_path, final, exc,
-                )
                 try:
                     if tmp_path.exists():
                         tmp_path.unlink()
                 except OSError:
                     pass
-                return False
+                raise OSError(
+                    f"generate_pdf_report: built {tmp_path} but could not "
+                    f"rename to {final}: {exc}"
+                ) from exc
 
-            log.info(f"PDF report generated successfully: {output_path}")
-            return True
-
-        except (OSError, ValueError, TypeError, KeyError, AttributeError) as e:
-            log.error(f"Error generating PDF report: {e}")
-            # Best-effort cleanup of the partial file. The variable may
-            # not be bound yet if we failed before assigning it.
+        except BaseException:
             try:
-                if 'tmp_path' in locals() and tmp_path.exists():
+                if tmp_path.exists():
                     tmp_path.unlink()
             except OSError:
                 pass
-            return False
+            raise
+
+        log.info(f"PDF report generated successfully: {output_path}")
 
     def _process_chart_list(self, charts: List[Any], width: float = 6,
                              height: float = 4) -> List:

--- a/siege_utilities/reporting/templates/content_page_template.py
+++ b/siege_utilities/reporting/templates/content_page_template.py
@@ -5,6 +5,8 @@ Creates structured content pages with headers, footers, and proper layout
 Adapted from working GA project implementation
 """
 
+from __future__ import annotations
+
 try:
     from reportlab.pdfgen import canvas
     from reportlab.lib.pagesizes import letter

--- a/siege_utilities/reporting/templates/page_templates.py
+++ b/siege_utilities/reporting/templates/page_templates.py
@@ -290,55 +290,54 @@ class PageTemplateManager:
         """
         template = self.templates.get(template_name)
         if not template:
-            log.warning(f"Template not found: {template_name}")
-            return
-        
+            raise KeyError(f"Template not found: {template_name!r}")
+
         for key, value in kwargs.items():
             if hasattr(template, key):
                 setattr(template, key, value)
             else:
                 log.warning(f"Unknown template field: {key}")
-        
+
         # Save if it's a custom template
         if template_name.startswith('custom_'):
             self._save_custom_template(template)
-    
+
     def delete_template(self, template_name: str):
         """
         Delete a custom template.
-        
+
         Args:
             template_name: Name of the template to delete
         """
         if template_name in self.templates:
             del self.templates[template_name]
-            
+
             # Remove file if it's a custom template
             custom_templates_dir = self.templates_dir / "custom"
             template_file = custom_templates_dir / f"{template_name}.yaml"
             if template_file.exists():
                 template_file.unlink()
                 log.info(f"Deleted custom template: {template_name}")
-    
+
     def export_template(self, template_name: str, output_path: str):
         """
         Export a template to a file.
-        
+
         Args:
             template_name: Name of the template to export
             output_path: Path to export the template
+
+        Raises:
+            KeyError: If template_name does not exist.
+            OSError: If the file cannot be written.
         """
         template = self.templates.get(template_name)
         if not template:
-            log.warning(f"Template not found: {template_name}")
-            return
-        
-        try:
-            with open(output_path, 'w', encoding='utf-8') as f:
-                yaml.dump(template.__dict__, f, default_flow_style=False)
-            log.info(f"Exported template to: {output_path}")
-        except (OSError, yaml.YAMLError) as e:
-            log.error(f"Failed to export template: {e}")
+            raise KeyError(f"Template not found: {template_name!r}")
+
+        with open(output_path, 'w', encoding='utf-8') as f:
+            yaml.dump(template.__dict__, f, default_flow_style=False)
+        log.info(f"Exported template to: {output_path}")
     
     def import_template(self, input_path: str, template_name: Optional[str] = None):
         """

--- a/siege_utilities/reporting/templates/table_of_contents_template.py
+++ b/siege_utilities/reporting/templates/table_of_contents_template.py
@@ -5,6 +5,8 @@ Creates clean, organized TOCs with proper typography and page numbering
 Adapted from working GA project implementation
 """
 
+from __future__ import annotations
+
 try:
     from reportlab.pdfgen import canvas
     from reportlab.lib.pagesizes import letter

--- a/siege_utilities/reporting/templates/title_page_template.py
+++ b/siege_utilities/reporting/templates/title_page_template.py
@@ -5,6 +5,8 @@ Creates beautiful, branded title pages with proper typography and layout
 Adapted from working GA project implementation
 """
 
+from __future__ import annotations
+
 try:
     from reportlab.pdfgen import canvas
     from reportlab.lib.pagesizes import letter, A4

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -464,9 +464,8 @@ class TestAnalyzePackageStructure:
     @patch("siege_utilities.development.architecture.importlib.import_module")
     def test_generic_exception(self, mock_import):
         mock_import.side_effect = RuntimeError("kaboom")
-        result = analyze_package_structure("boom_pkg")
-        assert "error" in result
-        assert "kaboom" in result["error"]
+        with pytest.raises(RuntimeError, match="kaboom"):
+            analyze_package_structure("boom_pkg")
 
     @patch("siege_utilities.development.architecture.importlib.import_module")
     def test_synthetic_package(self, mock_import):

--- a/tests/test_config_errors.py
+++ b/tests/test_config_errors.py
@@ -116,38 +116,33 @@ class TestConfigurationMigratorErrors:
 # ===========================================================================
 
 class TestLegacyLoadErrors:
-    def test_load_user_profile_missing_file_returns_none(self, tmp_path):
-        result = load_user_profile("nonexistent", config_dir=tmp_path)
-        assert result is None
+    def test_load_user_profile_missing_file_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            load_user_profile("nonexistent", config_dir=tmp_path)
 
-    def test_load_user_profile_non_mapping_returns_none(self, tmp_path):
+    def test_load_user_profile_non_mapping_raises(self, tmp_path):
         bad_file = tmp_path / "baduser.yaml"
         bad_file.write_text("- not a mapping\n")
-        result = load_user_profile("baduser", config_dir=tmp_path)
-        assert result is None
+        with pytest.raises(ValueError, match="not a YAML mapping"):
+            load_user_profile("baduser", config_dir=tmp_path)
 
-    def test_load_client_profile_missing_file_returns_none(self, tmp_path):
-        result = load_client_profile("NOPE", config_dir=tmp_path)
-        assert result is None
+    def test_load_client_profile_missing_file_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            load_client_profile("NOPE", config_dir=tmp_path)
 
-    def test_load_client_profile_non_mapping_returns_none(self, tmp_path):
+    def test_load_client_profile_non_mapping_raises(self, tmp_path):
         bad_file = tmp_path / "BAD.yaml"
         bad_file.write_text("42\n")
-        result = load_client_profile("BAD", config_dir=tmp_path)
-        assert result is None
+        with pytest.raises(ValueError, match="not a YAML mapping"):
+            load_client_profile("BAD", config_dir=tmp_path)
 
-    def test_save_user_profile_invalid_dir_returns_false(self):
+    def test_save_user_profile_invalid_dir_raises(self):
         profile = UserProfile()
-        with patch("siege_utilities.config.enhanced_config.Path") as mock_path:
-            mock_path.home.return_value = Path("/nonexistent_root_9999")
-            # This will fail because the directory creation will fail
-            result = save_user_profile(
+        with pytest.raises(OSError):
+            save_user_profile(
                 profile, "user",
                 config_dir=Path("/proc/nonexistent_9999/profiles")
             )
-            # On most systems writing to /proc will fail
-            # If it doesn't fail, it still returns bool
-            assert isinstance(result, bool)
 
 
 # ===========================================================================
@@ -159,16 +154,16 @@ class TestUtilityErrors:
         result = list_client_profiles(config_dir=tmp_path / "nonexistent")
         assert result == []
 
-    def test_export_config_yaml_invalid_path_returns_false(self):
-        result = export_config_yaml(
-            {"key": "value"},
-            Path("/proc/nonexistent_9999/out.yaml"),
-        )
-        assert result is False
+    def test_export_config_yaml_invalid_path_raises(self):
+        with pytest.raises(OSError):
+            export_config_yaml(
+                {"key": "value"},
+                Path("/proc/nonexistent_9999/out.yaml"),
+            )
 
-    def test_import_config_yaml_missing_file_returns_none(self, tmp_path):
-        result = import_config_yaml(tmp_path / "nonexistent.yaml")
-        assert result is None
+    def test_import_config_yaml_missing_file_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            import_config_yaml(tmp_path / "nonexistent.yaml")
 
     def test_import_config_yaml_valid_file_returns_data(self, tmp_path):
         f = tmp_path / "config.yaml"
@@ -187,21 +182,21 @@ class TestHydraManagerErrors:
         with pytest.raises(FileNotFoundError, match="not found"):
             HydraConfigManager(config_dir=tmp_path / "nonexistent")
 
-    def test_load_user_missing_file_returns_none(self, tmp_path):
+    def test_load_user_missing_file_raises(self, tmp_path):
         config_dir = tmp_path / "configs"
         config_dir.mkdir()
         from siege_utilities.config.hydra_manager import HydraConfigManager
         mgr = HydraConfigManager(config_dir=config_dir)
-        result = mgr.load_user("nonexistent", profiles_dir=tmp_path / "profiles")
-        assert result is None
+        with pytest.raises(FileNotFoundError):
+            mgr.load_user("nonexistent", profiles_dir=tmp_path / "profiles")
 
-    def test_load_client_missing_file_returns_none(self, tmp_path):
+    def test_load_client_missing_file_raises(self, tmp_path):
         config_dir = tmp_path / "configs"
         config_dir.mkdir()
         from siege_utilities.config.hydra_manager import HydraConfigManager
         mgr = HydraConfigManager(config_dir=config_dir)
-        result = mgr.load_client("NOPE", profiles_dir=tmp_path / "profiles")
-        assert result is None
+        with pytest.raises(FileNotFoundError):
+            mgr.load_client("NOPE", profiles_dir=tmp_path / "profiles")
 
 
 # ===========================================================================
@@ -209,12 +204,12 @@ class TestHydraManagerErrors:
 # ===========================================================================
 
 class TestSiegeConfigErrors:
-    def test_get_user_profile_missing_returns_none(self, tmp_path):
+    def test_get_user_profile_missing_raises(self, tmp_path):
         cfg = SiegeConfig(config_dir=tmp_path)
-        result = cfg.get_user_profile("nonexistent")
-        assert result is None
+        with pytest.raises(FileNotFoundError):
+            cfg.get_user_profile("nonexistent")
 
-    def test_get_client_profile_missing_returns_none(self, tmp_path):
+    def test_get_client_profile_missing_raises(self, tmp_path):
         cfg = SiegeConfig(config_dir=tmp_path)
-        result = cfg.get_client_profile("NONEXISTENT")
-        assert result is None
+        with pytest.raises(FileNotFoundError):
+            cfg.get_client_profile("NONEXISTENT")

--- a/tests/test_credential_manager.py
+++ b/tests/test_credential_manager.py
@@ -525,12 +525,21 @@ class TestGetFromKeychain:
         result = manager._get_from_keychain('my-service', 'my-user')
         assert result is None
 
-    def test_returns_none_on_exception(self, mock_op_available):
+    def test_raises_on_transport_error(self, mock_op_available):
         manager = CredentialManager()
         mock_op_available.side_effect = OSError("keychain error")
 
-        result = manager._get_from_keychain('my-service', 'my-user')
-        assert result is None
+        with pytest.raises(OSError, match="keychain error"):
+            manager._get_from_keychain('my-service', 'my-user')
+
+    def test_raises_on_unexpected_exit_code(self, mock_op_available):
+        manager = CredentialManager()
+        mock_op_available.return_value = Mock(
+            returncode=2, stdout='', stderr='permission denied',
+        )
+
+        with pytest.raises(RuntimeError, match="exit code 2"):
+            manager._get_from_keychain('my-service', 'my-user')
 
 
 # =============================================================================
@@ -1150,17 +1159,17 @@ class TestGetGoogleSAFrom1Password:
                     assert not any(f.startswith('--vault=') for f in cmd)
                     assert not any(f.startswith('--account=') for f in cmd)
 
-    def test_returns_none_on_called_process_error(self):
+    def test_raises_on_called_process_error(self):
         with patch('siege_utilities.config.credential_manager.subprocess.run') as mock_run:
             mock_run.side_effect = subprocess.CalledProcessError(1, 'op')
-            result = get_google_service_account_from_1password()
-            assert result is None
+            with pytest.raises(subprocess.CalledProcessError):
+                get_google_service_account_from_1password()
 
-    def test_returns_none_on_general_exception(self):
+    def test_raises_on_general_exception(self):
         with patch('siege_utilities.config.credential_manager.subprocess.run') as mock_run:
             mock_run.side_effect = ValueError("unexpected")
-            result = get_google_service_account_from_1password()
-            assert result is None
+            with pytest.raises(ValueError):
+                get_google_service_account_from_1password()
 
     def test_private_key_cleanup(self):
         """Private key should have quotes stripped and escaped newlines fixed."""
@@ -1219,25 +1228,25 @@ class TestGetGoogleOAuthFrom1Password:
             assert result['client_secret'] == 'test-secret-xyz'
             assert result['redirect_uri'] == 'http://localhost:8080'
 
-    def test_returns_none_when_client_id_missing(self):
+    def test_raises_when_client_id_missing(self):
         with patch('siege_utilities.config.credential_manager.subprocess.run') as mock_run:
             mock_run.side_effect = _make_op_side_effect({
                 'client_id': None,
                 'client_secret': 'test-secret',
             })
 
-            result = get_google_oauth_from_1password()
-            assert result is None
+            with pytest.raises(ValueError, match="client_id"):
+                get_google_oauth_from_1password()
 
-    def test_returns_none_when_client_secret_missing(self):
+    def test_raises_when_client_secret_missing(self):
         with patch('siege_utilities.config.credential_manager.subprocess.run') as mock_run:
             mock_run.side_effect = _make_op_side_effect({
                 'client_id': 'test-client-id-1234567890',
                 'client_secret': None,
             })
 
-            result = get_google_oauth_from_1password()
-            assert result is None
+            with pytest.raises(ValueError, match="client_secret"):
+                get_google_oauth_from_1password()
 
     def test_includes_vault_and_account_flags(self):
         with patch('siege_utilities.config.credential_manager.subprocess.run') as mock_run:
@@ -1311,11 +1320,11 @@ class TestGetGoogleOAuthFrom1Password:
             assert result is not None
             assert 'project_id' not in result
 
-    def test_handles_subprocess_error(self):
+    def test_raises_on_subprocess_error(self):
         with patch('siege_utilities.config.credential_manager.subprocess.run') as mock_run:
             mock_run.side_effect = subprocess.CalledProcessError(1, 'op')
-            result = get_google_oauth_from_1password()
-            assert result is None
+            with pytest.raises(subprocess.CalledProcessError):
+                get_google_oauth_from_1password()
 
 
 # =============================================================================
@@ -1358,27 +1367,27 @@ class TestGetGoogleOAuthDocumentFrom1Password:
             assert not any(f.startswith('--vault=') for f in cmd)
             assert not any(f.startswith('--account=') for f in cmd)
 
-    def test_returns_none_on_called_process_error(self):
+    def test_raises_on_called_process_error(self):
         with patch('siege_utilities.config.credential_manager.subprocess.run') as mock_run:
             mock_run.side_effect = subprocess.CalledProcessError(
                 1, 'op', stderr='not found'
             )
-            result = get_google_oauth_document_from_1password()
-            assert result is None
+            with pytest.raises(subprocess.CalledProcessError):
+                get_google_oauth_document_from_1password()
 
-    def test_returns_none_on_invalid_json(self):
+    def test_raises_on_invalid_json(self):
         with patch('siege_utilities.config.credential_manager.subprocess.run') as mock_run:
             mock_run.return_value = Mock(
                 returncode=0, stdout='not json at all', stderr=''
             )
-            result = get_google_oauth_document_from_1password()
-            assert result is None
+            with pytest.raises(json.JSONDecodeError):
+                get_google_oauth_document_from_1password()
 
-    def test_returns_none_on_general_exception(self):
+    def test_raises_on_os_error(self):
         with patch('siege_utilities.config.credential_manager.subprocess.run') as mock_run:
             mock_run.side_effect = OSError("unexpected")
-            result = get_google_oauth_document_from_1password()
-            assert result is None
+            with pytest.raises(OSError):
+                get_google_oauth_document_from_1password()
 
 
 # =============================================================================
@@ -1407,11 +1416,11 @@ class TestCreateTemporaryServiceAccountFile:
         assert result.endswith('.json')
         os.unlink(result)
 
-    def test_returns_none_on_error(self):
+    def test_raises_on_error(self):
         with patch('siege_utilities.config.credential_manager.tempfile.NamedTemporaryFile',
                    side_effect=OSError("no space")):
-            result = create_temporary_service_account_file({"type": "sa"})
-            assert result is None
+            with pytest.raises(OSError):
+                create_temporary_service_account_file({"type": "sa"})
 
 
 # =============================================================================

--- a/tests/test_cross_tabulation.py
+++ b/tests/test_cross_tabulation.py
@@ -132,6 +132,21 @@ class TestRateTable:
         with pytest.raises(ValueError, match="normalize"):
             rate_table(ct, normalize="invalid")
 
+    def test_zero_grand_total(self):
+        ct = pd.DataFrame({"A": [0, 0], "B": [0, 0]}, index=["X", "Y"])
+        with pytest.raises(ZeroDivisionError, match="grand total"):
+            rate_table(ct, normalize="all")
+
+    def test_zero_row_sum(self):
+        ct = pd.DataFrame({"A": [10, 0], "B": [20, 0]}, index=["X", "Y"])
+        with pytest.raises(ZeroDivisionError, match="rows sum to zero"):
+            rate_table(ct, normalize="index")
+
+    def test_zero_col_sum(self):
+        ct = pd.DataFrame({"A": [10, 20], "B": [0, 0]}, index=["X", "Y"])
+        with pytest.raises(ZeroDivisionError, match="columns sum to zero"):
+            rate_table(ct, normalize="columns")
+
 
 # ---------------------------------------------------------------------------
 # chi_square_test

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -428,15 +428,14 @@ class TestSanitiseDataframeColumnNames:
         assert result is sanitised_df
         mock_df.toDF.assert_called_once_with('first_name', 'last_name', 'age')
 
-    def test_returns_none_on_error(self):
-        """Returns None when an exception occurs."""
+    def test_raises_on_error(self):
+        """Raises when an exception occurs."""
         from siege_utilities.distributed.spark_utils import sanitise_dataframe_column_names
         mock_df = Mock()
         mock_df.toDF.side_effect = Exception("test error")
-        # columns is accessed in the log message format string before toDF
         mock_df.columns = ['col1']
-        result = sanitise_dataframe_column_names(mock_df)
-        assert result is None
+        with pytest.raises(Exception, match="test error"):
+            sanitise_dataframe_column_names(mock_df)
 
 
 class TestGetRowCount:
@@ -449,12 +448,13 @@ class TestGetRowCount:
         mock_df.count.return_value = 42
         assert get_row_count(mock_df) == 42
 
-    def test_returns_none_on_error(self):
-        """Returns None when an exception occurs."""
+    def test_raises_on_error(self):
+        """Raises when an exception occurs."""
         from siege_utilities.distributed.spark_utils import get_row_count
         mock_df = Mock()
         mock_df.count.side_effect = Exception("count failed")
-        assert get_row_count(mock_df) is None
+        with pytest.raises(Exception, match="count failed"):
+            get_row_count(mock_df)
 
 
 class TestRepartitionAndCache:
@@ -480,12 +480,13 @@ class TestRepartitionAndCache:
         mock_df.repartition.assert_called_once_with(100)
         assert result is cached
 
-    def test_returns_none_on_error(self):
-        """Returns None when an exception occurs."""
+    def test_raises_on_error(self):
+        """Raises when an exception occurs."""
         from siege_utilities.distributed.spark_utils import repartition_and_cache
         mock_df = Mock()
         mock_df.repartition.side_effect = Exception("repartition failed")
-        assert repartition_and_cache(mock_df) is None
+        with pytest.raises(Exception, match="repartition failed"):
+            repartition_and_cache(mock_df)
 
 
 class TestRegisterTempTable:
@@ -495,16 +496,16 @@ class TestRegisterTempTable:
         """Calls createOrReplaceTempView with correct name."""
         from siege_utilities.distributed.spark_utils import register_temp_table
         mock_df = Mock()
-        result = register_temp_table(mock_df, 'my_table')
+        register_temp_table(mock_df, 'my_table')
         mock_df.createOrReplaceTempView.assert_called_once_with('my_table')
-        assert result is True
 
-    def test_returns_false_on_error(self):
-        """Returns False when an exception occurs."""
+    def test_raises_on_error(self):
+        """Raises when an exception occurs."""
         from siege_utilities.distributed.spark_utils import register_temp_table
         mock_df = Mock()
         mock_df.createOrReplaceTempView.side_effect = Exception("failed")
-        assert register_temp_table(mock_df, 'table') is False
+        with pytest.raises(Exception, match="failed"):
+            register_temp_table(mock_df, 'table')
 
 
 class TestMoveColumnToFront:
@@ -522,14 +523,14 @@ class TestMoveColumnToFront:
         mock_df.select.assert_called_once_with('target', 'a', 'b', 'c')
         assert result is reordered
 
-    def test_returns_none_on_error(self):
-        """Returns None on error."""
+    def test_raises_on_error(self):
+        """Raises on error."""
         from siege_utilities.distributed.spark_utils import move_column_to_front_of_dataframe
         mock_df = Mock()
         mock_df.columns = ['a', 'b']
         mock_df.select.side_effect = Exception("fail")
-        result = move_column_to_front_of_dataframe(mock_df, 'a')
-        assert result is None
+        with pytest.raises(Exception, match="fail"):
+            move_column_to_front_of_dataframe(mock_df, 'a')
 
     def test_column_already_first(self):
         """Column already at front still works."""
@@ -551,17 +552,17 @@ class TestWriteDfToParquet:
         """Calls df.write.mode().parquet()."""
         from siege_utilities.distributed.spark_utils import write_df_to_parquet
         mock_df = Mock()
-        result = write_df_to_parquet(mock_df, '/output/path', mode='overwrite')
+        write_df_to_parquet(mock_df, '/output/path', mode='overwrite')
         mock_df.write.mode.assert_called_once_with('overwrite')
         mock_df.write.mode.return_value.parquet.assert_called_once_with('/output/path')
-        assert result is True
 
-    def test_returns_false_on_error(self):
-        """Returns False on error."""
+    def test_raises_on_error(self):
+        """Raises on error."""
         from siege_utilities.distributed.spark_utils import write_df_to_parquet
         mock_df = Mock()
         mock_df.write.mode.side_effect = Exception("write failed")
-        assert write_df_to_parquet(mock_df, '/path') is False
+        with pytest.raises(Exception, match="write failed"):
+            write_df_to_parquet(mock_df, '/path')
 
 
 class TestReadParquetToDf:
@@ -576,11 +577,12 @@ class TestReadParquetToDf:
         mock_spark_session.read.parquet.assert_called_once_with('/input/path')
         assert result is expected_df
 
-    def test_returns_none_on_error(self, mock_spark_session):
-        """Returns None on error."""
+    def test_raises_on_error(self, mock_spark_session):
+        """Raises on error."""
         from siege_utilities.distributed.spark_utils import read_parquet_to_df
         mock_spark_session.read.parquet.side_effect = Exception("read failed")
-        assert read_parquet_to_df(mock_spark_session, '/bad/path') is None
+        with pytest.raises(Exception, match="read failed"):
+            read_parquet_to_df(mock_spark_session, '/bad/path')
 
 
 class TestValidateGeocodeData:
@@ -648,14 +650,13 @@ class TestExportPysparkDfToExcel:
         # Function returns None on success (no return value)
         assert result is None
 
-    def test_handles_error_gracefully(self):
-        """Does not raise on error (logs instead)."""
+    def test_raises_on_error(self):
+        """Raises when conversion fails."""
         from siege_utilities.distributed.spark_utils import export_pyspark_df_to_excel
         mock_df = Mock()
         mock_df.toPandas.side_effect = Exception("conversion failed")
-        # Should not raise; returns None on error
-        result = export_pyspark_df_to_excel(mock_df, 'output.xlsx')
-        assert result is None
+        with pytest.raises(Exception, match="conversion failed"):
+            export_pyspark_df_to_excel(mock_df, 'output.xlsx')
 
 
 # ================================================================

--- a/tests/test_facebook_business_connector.py
+++ b/tests/test_facebook_business_connector.py
@@ -50,10 +50,9 @@ def test_init_falls_back_to_token_only(_patch_fb):
     _patch_fb["api"].init.assert_called_once_with(access_token="tok")
 
 
-def test_get_ad_accounts_translates_errors_to_empty_list(_patch_fb):
-    """Errors during ``me.get_ad_accounts()`` must translate to ``[]``
-    not propagate raw facebook_business exceptions to callers -- the
-    rest of the codebase assumes List[Dict] from this method."""
+def test_get_ad_accounts_propagates_errors(_patch_fb):
+    """Errors during ``me.get_ad_accounts()`` must propagate — SU-1
+    forbids returning valid-shaped empty results on failure."""
     from siege_utilities.analytics.facebook_business import FacebookBusinessConnector
 
     user_inst = MagicMock()
@@ -61,7 +60,8 @@ def test_get_ad_accounts_translates_errors_to_empty_list(_patch_fb):
     _patch_fb["pkg"].adobjects.user.User.return_value = user_inst
 
     c = FacebookBusinessConnector(access_token="tok")
-    assert c.get_ad_accounts() == []
+    with pytest.raises(RuntimeError, match="rate limited"):
+        c.get_ad_accounts()
 
 
 def test_get_ad_accounts_maps_sdk_records_to_dicts(_patch_fb):

--- a/tests/test_file_hashing.py
+++ b/tests/test_file_hashing.py
@@ -37,9 +37,9 @@ class TestGenerateSha256:
         expected = hashlib.sha256(sample_file.read_bytes()).hexdigest()
         assert generate_sha256_hash_for_file(str(sample_file)) == expected
 
-    def test_nonexistent_returns_none(self):
-        result = generate_sha256_hash_for_file("/tmp/nonexistent_file_abc123.txt")
-        assert result is None
+    def test_nonexistent_raises(self):
+        with pytest.raises(FileNotFoundError):
+            generate_sha256_hash_for_file("/tmp/nonexistent_file_abc123.txt")
 
     def test_path_object(self, sample_file):
         result = generate_sha256_hash_for_file(sample_file)
@@ -67,8 +67,9 @@ class TestGetFileHash:
         expected = hashlib.sha256(sample_file.read_bytes()).hexdigest()
         assert result == expected
 
-    def test_nonexistent_returns_none(self):
-        assert get_file_hash("/tmp/no_such_file_xyz.txt") is None
+    def test_nonexistent_raises(self):
+        with pytest.raises(FileNotFoundError):
+            get_file_hash("/tmp/no_such_file_xyz.txt")
 
 
 class TestCalculateFileHash:
@@ -110,8 +111,9 @@ class TestVerifyFileIntegrity:
         h = get_file_hash(str(sample_file), "sha256")
         assert verify_file_integrity(str(sample_file), h.upper()) is True
 
-    def test_nonexistent_file(self):
-        assert verify_file_integrity("/tmp/no_file.txt", "abc") is False
+    def test_nonexistent_file_raises(self):
+        with pytest.raises(FileNotFoundError):
+            verify_file_integrity("/tmp/no_file.txt", "abc")
 
     def test_md5(self, sample_file):
         h = get_file_hash(str(sample_file), "md5")

--- a/tests/test_file_operations.py
+++ b/tests/test_file_operations.py
@@ -1,5 +1,7 @@
 """Tests for siege_utilities.files.operations — file manipulation utilities."""
 
+import pytest
+
 from siege_utilities.files.operations import (
     remove_tree,
     file_exists,
@@ -24,18 +26,19 @@ class TestRemoveTree:
     def test_remove_file(self, tmp_path):
         f = tmp_path / "test.txt"
         f.write_text("hello")
-        assert remove_tree(str(f)) is True
+        remove_tree(str(f))
         assert not f.exists()
 
     def test_remove_directory(self, tmp_path):
         d = tmp_path / "subdir"
         d.mkdir()
         (d / "file.txt").write_text("data")
-        assert remove_tree(str(d)) is True
+        remove_tree(str(d))
         assert not d.exists()
 
-    def test_nonexistent(self, tmp_path):
-        assert remove_tree(str(tmp_path / "nope")) is False
+    def test_nonexistent_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            remove_tree(str(tmp_path / "nope"))
 
 
 class TestFileExists:
@@ -51,18 +54,19 @@ class TestFileExists:
 class TestTouchFile:
     def test_create(self, tmp_path):
         f = tmp_path / "new.txt"
-        assert touch_file(str(f)) is True
+        touch_file(str(f))
         assert f.exists()
 
     def test_create_with_parents(self, tmp_path):
         f = tmp_path / "a" / "b" / "c.txt"
-        assert touch_file(str(f)) is True
+        touch_file(str(f))
         assert f.exists()
 
     def test_existing_file(self, tmp_path):
         f = tmp_path / "existing.txt"
         f.write_text("data")
-        assert touch_file(str(f)) is True
+        touch_file(str(f))
+        assert f.exists()
 
 
 class TestCountLines:
@@ -76,9 +80,9 @@ class TestCountLines:
         f.write_text("")
         assert count_lines(str(f)) == 0
 
-    def test_nonexistent(self, tmp_path):
-        result = count_lines(str(tmp_path / "nope.txt"))
-        assert result == 0 or result is None
+    def test_nonexistent_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            count_lines(str(tmp_path / "nope.txt"))
 
 
 class TestCopyFile:
@@ -86,8 +90,20 @@ class TestCopyFile:
         src = tmp_path / "src.txt"
         src.write_text("content")
         dst = tmp_path / "dst.txt"
-        assert copy_file(str(src), str(dst)) is True
+        copy_file(str(src), str(dst))
         assert dst.read_text() == "content"
+
+    def test_copy_nonexistent_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            copy_file(str(tmp_path / "nope.txt"), str(tmp_path / "dst.txt"))
+
+    def test_copy_no_overwrite_raises(self, tmp_path):
+        src = tmp_path / "src.txt"
+        src.write_text("content")
+        dst = tmp_path / "dst.txt"
+        dst.write_text("existing")
+        with pytest.raises(FileExistsError):
+            copy_file(str(src), str(dst))
 
 
 class TestMoveFile:
@@ -95,9 +111,21 @@ class TestMoveFile:
         src = tmp_path / "src.txt"
         src.write_text("content")
         dst = tmp_path / "dst.txt"
-        assert move_file(str(src), str(dst)) is True
+        move_file(str(src), str(dst))
         assert not src.exists()
         assert dst.read_text() == "content"
+
+    def test_move_nonexistent_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            move_file(str(tmp_path / "nope.txt"), str(tmp_path / "dst.txt"))
+
+    def test_move_no_overwrite_raises(self, tmp_path):
+        src = tmp_path / "src.txt"
+        src.write_text("content")
+        dst = tmp_path / "dst.txt"
+        dst.write_text("existing")
+        with pytest.raises(FileExistsError):
+            move_file(str(src), str(dst))
 
 
 class TestGetFileSize:
@@ -107,6 +135,10 @@ class TestGetFileSize:
         size = get_file_size(str(f))
         assert size == 5
 
+    def test_nonexistent_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            get_file_size(str(tmp_path / "nope.txt"))
+
 
 class TestListDirectory:
     def test_list(self, tmp_path):
@@ -114,6 +146,10 @@ class TestListDirectory:
         (tmp_path / "b.txt").write_text("b")
         result = list_directory(str(tmp_path))
         assert len(result) >= 2
+
+    def test_nonexistent_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            list_directory(str(tmp_path / "nope"))
 
 
 class TestEnsureDirectoryExists:

--- a/tests/test_files_paths.py
+++ b/tests/test_files_paths.py
@@ -87,12 +87,13 @@ class TestGetRelativePath:
         result = get_relative_path(base, target)
         assert result == Path("sub/file.txt")
 
-    def test_target_outside_base_returns_none(self, tmp_path):
+    def test_target_outside_base_raises(self, tmp_path):
         base = tmp_path / "a"
         base.mkdir()
         other = tmp_path / "b"
         other.mkdir()
-        assert get_relative_path(base, other) is None
+        with pytest.raises(ValueError):
+            get_relative_path(base, other)
 
 
 class TestFindFilesByPattern:
@@ -114,11 +115,9 @@ class TestFindFilesByPattern:
         result = find_files_by_pattern(tmp_path, "*.csv", recursive=True)
         assert len(result) == 2
 
-    def test_missing_directory_returns_empty(self, tmp_path):
-        # validation.validate_directory_path may raise on must_exist; fall
-        # back behavior returns []
-        result = find_files_by_pattern(tmp_path / "nope", "*", recursive=False)
-        assert result == []
+    def test_missing_directory_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            find_files_by_pattern(tmp_path / "nope", "*", recursive=False)
 
     def test_result_is_sorted(self, tmp_path):
         for name in ["c.txt", "a.txt", "b.txt"]:
@@ -170,15 +169,16 @@ class TestUnzipFileToDirectory:
         assert (result / "inner" / "hello.txt").read_text() == "hi"
         assert (result / "outer.txt").read_text() == "outside"
 
-    def test_missing_archive_returns_none(self, tmp_path):
-        result = unzip_file_to_directory(tmp_path / "nope.zip")
-        assert result is None
+    def test_missing_archive_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            unzip_file_to_directory(tmp_path / "nope.zip")
 
-    def test_bad_zip_returns_none(self, tmp_path):
+    def test_bad_zip_raises(self, tmp_path):
+        import zipfile
         fake = tmp_path / "bad.zip"
         fake.write_text("not a real zip")
-        result = unzip_file_to_directory(fake)
-        assert result is None
+        with pytest.raises(zipfile.BadZipFile):
+            unzip_file_to_directory(fake)
 
     def test_zip_slip_member_skipped(self, tmp_path):
         """Zip-slip member with traversal must NOT escape target_dir."""

--- a/tests/test_google_analytics_connector.py
+++ b/tests/test_google_analytics_connector.py
@@ -241,20 +241,17 @@ class TestGA4ResponseParsing:
         assert df.iloc[0]["users"] == 14950
 
     def test_not_authenticated_raises(self, connector):
-        """get_ga4_data should fail gracefully when not authenticated."""
+        """get_ga4_data must raise ValueError when not authenticated (SU-1)."""
         conn, ga_mod = connector
         conn.ga4_client = None
 
-        df = conn.get_ga4_data(
-            property_id="123456",
-            start_date="2025-06-01",
-            end_date="2025-06-30",
-            metrics=["sessions"],
-        )
-
-        # Should return empty DataFrame, not raise
-        assert isinstance(df, pd.DataFrame)
-        assert len(df) == 0
+        with pytest.raises(ValueError, match="Not authenticated"):
+            conn.get_ga4_data(
+                property_id="123456",
+                start_date="2025-06-01",
+                end_date="2025-06-30",
+                metrics=["sessions"],
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hygiene_generate_docstrings.py
+++ b/tests/test_hygiene_generate_docstrings.py
@@ -161,16 +161,17 @@ class TestFindPythonFiles:
 
 
 class TestProcessPythonFile:
-    def test_syntax_error_returns_false(self, tmp_path, monkeypatch):
+    def test_syntax_error_propagates(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         bad = tmp_path / "bad.py"
         bad.write_text("def :\n    pass\n")
-        assert process_python_file(bad) is False
+        with pytest.raises(SyntaxError):
+            process_python_file(bad)
 
-    def test_no_changes_needed_returns_true(self, tmp_path, monkeypatch):
+    def test_no_changes_needed(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         f = tmp_path / "ok.py"
         f.write_text('def greet():\n    """already."""\n    return 1\n')
-        assert process_python_file(f) is True
+        process_python_file(f)
         # Should not have been rewritten
         assert "already" in f.read_text()

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -127,9 +127,8 @@ class TestMoeProportion:
     def test_zero_denominator(self):
         num = Estimate(value=50, moe=10)
         den = Estimate(value=0, moe=0)
-        result = moe_proportion(num, den)
-        assert result.value == 0.0
-        assert result.moe == 0.0
+        with pytest.raises(ZeroDivisionError, match="denominator"):
+            moe_proportion(num, den)
 
 
 # ---------------------------------------------------------------------------
@@ -148,8 +147,8 @@ class TestMoeRatio:
     def test_zero_denominator(self):
         a = Estimate(value=200, moe=20)
         b = Estimate(value=0, moe=10)
-        result = moe_ratio(a, b)
-        assert result.value == 0.0
+        with pytest.raises(ZeroDivisionError, match="denominator"):
+            moe_ratio(a, b)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_person_actor.py
+++ b/tests/test_person_actor.py
@@ -442,35 +442,33 @@ class TestHydraConfigManagerModern:
     def test_save_and_load_user(self, manager, tmp_path):
         profiles = tmp_path / "profiles" / "users"
         u = make_user()
-        assert manager.save_user(u, profiles_dir=profiles) is True
+        manager.save_user(u, profiles_dir=profiles)
         u2 = manager.load_user("dheeraj", profiles_dir=profiles)
-        assert u2 is not None
         assert u2.person_id == "dheeraj"
 
     def test_save_and_load_client(self, manager, tmp_path):
         profiles = tmp_path / "profiles" / "clients"
         c = make_client()
-        assert manager.save_client(c, profiles_dir=profiles) is True
+        manager.save_client(c, profiles_dir=profiles)
         c2 = manager.load_client("HILL", profiles_dir=profiles)
-        assert c2 is not None
         assert c2.client_code == "HILL"
 
     def test_load_user_not_found(self, manager, tmp_path):
         profiles = tmp_path / "profiles" / "users"
         profiles.mkdir(parents=True)
-        result = manager.load_user("nonexistent", profiles_dir=profiles)
-        assert result is None
+        with pytest.raises(FileNotFoundError):
+            manager.load_user("nonexistent", profiles_dir=profiles)
 
     def test_load_client_not_found(self, manager, tmp_path):
         profiles = tmp_path / "profiles" / "clients"
         profiles.mkdir(parents=True)
-        result = manager.load_client("NOPE", profiles_dir=profiles)
-        assert result is None
+        with pytest.raises(FileNotFoundError):
+            manager.load_client("NOPE", profiles_dir=profiles)
 
     def test_save_user_creates_directory(self, manager, tmp_path):
         profiles = tmp_path / "new" / "path" / "users"
         u = make_user()
-        assert manager.save_user(u, profiles_dir=profiles) is True
+        manager.save_user(u, profiles_dir=profiles)
         assert profiles.exists()
 
 
@@ -485,7 +483,8 @@ class TestDeprecationWarnings:
         from siege_utilities.config.enhanced_config import load_user_profile
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            load_user_profile("nonexistent")
+            with pytest.raises(FileNotFoundError):
+                load_user_profile("nonexistent")
             assert len(w) >= 1
             assert any(issubclass(x.category, DeprecationWarning) for x in w)
 
@@ -493,7 +492,8 @@ class TestDeprecationWarnings:
         from siege_utilities.config.enhanced_config import load_client_profile
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            load_client_profile("NONEXISTENT")
+            with pytest.raises(FileNotFoundError):
+                load_client_profile("NONEXISTENT")
             assert len(w) >= 1
             assert any(issubclass(x.category, DeprecationWarning) for x in w)
 

--- a/tests/test_sample_data.py
+++ b/tests/test_sample_data.py
@@ -8,6 +8,14 @@ External-service functions (Census boundaries/data) are not tested here.
 import pytest
 import pandas as pd
 
+try:
+    import faker as _faker  # noqa: F401
+    _FAKER_AVAILABLE = True
+except ImportError:
+    _FAKER_AVAILABLE = False
+
+_needs_faker = pytest.mark.skipif(not _FAKER_AVAILABLE, reason="Faker not installed")
+
 from siege_utilities.reference.sample_data import (
     HOUSING_LOCALE_PRESETS,
     SAMPLE_DATASETS,
@@ -143,16 +151,19 @@ class TestLoadSampleData:
         with pytest.raises(ValueError, match="Unknown dataset"):
             load_sample_data("totally_fake_dataset")
 
+    @_needs_faker
     def test_synthetic_population_routing(self):
         df = load_sample_data("synthetic_population", size=20)
         assert isinstance(df, pd.DataFrame)
         assert len(df) > 0
 
+    @_needs_faker
     def test_synthetic_businesses_routing(self):
         df = load_sample_data("synthetic_businesses", business_count=15)
         assert isinstance(df, pd.DataFrame)
         assert len(df) > 0
 
+    @_needs_faker
     def test_synthetic_housing_routing(self):
         df = load_sample_data("synthetic_housing", housing_count=10)
         assert isinstance(df, pd.DataFrame)
@@ -164,6 +175,7 @@ class TestLoadSampleData:
 # ---------------------------------------------------------------------------
 
 
+@_needs_faker
 class TestGenerateSyntheticPopulation:
     def test_returns_dataframe(self, small_population):
         assert isinstance(small_population, pd.DataFrame)
@@ -230,6 +242,7 @@ class TestGenerateSyntheticPopulation:
 # ---------------------------------------------------------------------------
 
 
+@_needs_faker
 class TestGenerateSyntheticBusinesses:
     def test_returns_dataframe(self, small_businesses):
         assert isinstance(small_businesses, pd.DataFrame)
@@ -263,6 +276,7 @@ class TestGenerateSyntheticBusinesses:
 # ---------------------------------------------------------------------------
 
 
+@_needs_faker
 class TestGenerateSyntheticHousing:
     def test_returns_dataframe(self, small_housing):
         assert isinstance(small_housing, pd.DataFrame)
@@ -357,6 +371,7 @@ class TestGenerateSyntheticHousing:
 # ---------------------------------------------------------------------------
 
 
+@_needs_faker
 class TestGenerateSyntheticPerson:
     def test_hispanic_person_gets_spanish_name(self):
         person = _generate_synthetic_person("Hispanic or Latino")
@@ -411,6 +426,7 @@ class TestGenerateSyntheticPerson:
 # ---------------------------------------------------------------------------
 
 
+@_needs_faker
 class TestGenerateSyntheticBusiness:
     def test_basic_fields(self):
         biz = _generate_synthetic_business("retail")
@@ -437,6 +453,7 @@ class TestGenerateSyntheticBusiness:
 # ---------------------------------------------------------------------------
 
 
+@_needs_faker
 class TestGenerateSyntheticHousingUnit:
     def test_default_us_config(self):
         unit = _generate_synthetic_housing_unit("single_family")
@@ -517,19 +534,19 @@ class TestJoinBoundariesAndData:
 
     def test_missing_boundary_id_col(self):
         boundaries, data = _make_boundaries_and_data()
-        result = join_boundaries_and_data(boundaries, data, boundary_id_col="missing_col")
-        assert result is None
+        with pytest.raises(KeyError, match="missing_col"):
+            join_boundaries_and_data(boundaries, data, boundary_id_col="missing_col")
 
     def test_missing_data_id_col(self):
         boundaries, data = _make_boundaries_and_data()
-        result = join_boundaries_and_data(boundaries, data, data_id_col="missing_col")
-        assert result is None
+        with pytest.raises(KeyError, match="missing_col"):
+            join_boundaries_and_data(boundaries, data, data_id_col="missing_col")
 
     def test_no_matching_ids(self):
         boundaries, _ = _make_boundaries_and_data()
         data = pd.DataFrame({"geoid": ["99", "98"], "pop": [100, 200]})
-        result = join_boundaries_and_data(boundaries, data)
-        assert result is None
+        with pytest.raises(ValueError, match="produced 0 records"):
+            join_boundaries_and_data(boundaries, data)
 
     def test_custom_id_columns(self):
         boundaries = pd.DataFrame(
@@ -572,10 +589,12 @@ class TestCreateTractGeoDataFrame:
         assert "tract_geometry" in result.columns
 
     def test_no_lat_lon_returns_dataframe(self):
-        from siege_utilities.reference.sample_data import _create_tract_geodataframe
+        from siege_utilities.reference.sample_data import _create_tract_geodataframe, GEOPANDAS_AVAILABLE
 
         pop_df = pd.DataFrame({"name": ["A", "B"]})
-        result = _create_tract_geodataframe(pop_df, {})
-        # Should return the input DataFrame unchanged
-        assert isinstance(result, pd.DataFrame)
-        assert "tract_geometry" not in result.columns
+        if not GEOPANDAS_AVAILABLE:
+            with pytest.raises(ImportError, match="geopandas"):
+                _create_tract_geodataframe(pop_df, {})
+        else:
+            with pytest.raises(ValueError, match="latitude"):
+                _create_tract_geodataframe(pop_df, {})

--- a/tests/test_snowflake_connector.py
+++ b/tests/test_snowflake_connector.py
@@ -97,9 +97,8 @@ def test_connect_passes_only_non_none_params(_patch_snowflake):
     assert kwargs["password"] == "p"
 
 
-def test_execute_query_returns_none_on_driver_error(_patch_snowflake):
-    """Driver-side failures must be translated to ``None``, not propagate
-    a raw snowflake.connector exception -- callers expect Optional[list]."""
+def test_execute_query_raises_on_driver_error(_patch_snowflake):
+    """Driver-side failures must raise RuntimeError, not return None."""
     from siege_utilities.analytics.snowflake_connector import SnowflakeConnector
 
     c = SnowflakeConnector(account="acc", user="u", password="p")
@@ -108,7 +107,8 @@ def test_execute_query_returns_none_on_driver_error(_patch_snowflake):
     c.connection = MagicMock()
     c.cursor = cursor
 
-    assert c.execute_query("SELECT 1") is None
+    with pytest.raises(RuntimeError, match="boom"):
+        c.execute_query("SELECT 1")
 
 
 def test_upload_dataframe_validates_table_identifier(_patch_snowflake):

--- a/tests/test_spatial_transformations.py
+++ b/tests/test_spatial_transformations.py
@@ -15,6 +15,8 @@ import geopandas as gpd
 import pytest
 from shapely.geometry import Point, Polygon
 
+from siege_utilities.geo.spatial_transformations import SpatialQueryError
+
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -86,66 +88,61 @@ class TestSpatialDataTransformerInit:
 
 class TestConvertFormat:
 
-    def test_unsupported_format_returns_false(self, transformer, sample_gdf):
-        assert transformer.convert_format(sample_gdf, "xyz123") is False
+    def test_unsupported_format_raises(self, transformer, sample_gdf):
+        with pytest.raises(ValueError, match="Unsupported output format"):
+            transformer.convert_format(sample_gdf, "xyz123")
 
     def test_routes_to_shapefile(self, transformer, sample_gdf):
-        with patch.object(transformer, "_convert_to_shapefile", return_value=True) as mock:
-            result = transformer.convert_format(sample_gdf, "shp", output_path="/tmp/t.shp")
-            assert result is True
+        with patch.object(transformer, "_convert_to_shapefile") as mock:
+            transformer.convert_format(sample_gdf, "shp", output_path="/tmp/t.shp")
             mock.assert_called_once()
 
     def test_routes_to_geojson(self, transformer, sample_gdf):
-        with patch.object(transformer, "_convert_to_geojson", return_value=True) as mock:
-            result = transformer.convert_format(sample_gdf, "geojson")
-            assert result is True
+        with patch.object(transformer, "_convert_to_geojson") as mock:
+            transformer.convert_format(sample_gdf, "geojson")
             mock.assert_called_once()
 
     def test_routes_to_gpkg(self, transformer, sample_gdf):
-        with patch.object(transformer, "_convert_to_geopackage", return_value=True) as mock:
-            result = transformer.convert_format(sample_gdf, "gpkg")
-            assert result is True
+        with patch.object(transformer, "_convert_to_geopackage") as mock:
+            transformer.convert_format(sample_gdf, "gpkg")
             mock.assert_called_once()
 
     def test_routes_to_kml(self, transformer, sample_gdf):
-        with patch.object(transformer, "_convert_to_kml", return_value=True) as mock:
-            result = transformer.convert_format(sample_gdf, "kml")
-            assert result is True
+        with patch.object(transformer, "_convert_to_kml") as mock:
+            transformer.convert_format(sample_gdf, "kml")
             mock.assert_called_once()
 
     def test_routes_to_gml(self, transformer, sample_gdf):
-        with patch.object(transformer, "_convert_to_gml", return_value=True) as mock:
-            result = transformer.convert_format(sample_gdf, "gml")
-            assert result is True
+        with patch.object(transformer, "_convert_to_gml") as mock:
+            transformer.convert_format(sample_gdf, "gml")
             mock.assert_called_once()
 
     def test_routes_to_wkt(self, transformer, sample_gdf):
-        with patch.object(transformer, "_convert_to_wkt", return_value=True) as mock:
-            result = transformer.convert_format(sample_gdf, "wkt")
-            assert result is True
+        with patch.object(transformer, "_convert_to_wkt") as mock:
+            transformer.convert_format(sample_gdf, "wkt")
             mock.assert_called_once()
 
     def test_routes_to_wkb(self, transformer, sample_gdf):
-        with patch.object(transformer, "_convert_to_wkb", return_value=True) as mock:
-            result = transformer.convert_format(sample_gdf, "wkb")
-            assert result is True
+        with patch.object(transformer, "_convert_to_wkb") as mock:
+            transformer.convert_format(sample_gdf, "wkb")
             mock.assert_called_once()
 
     def test_routes_to_postgis(self, transformer, sample_gdf):
-        with patch.object(transformer, "_convert_to_postgis", return_value=True) as mock:
-            result = transformer.convert_format(sample_gdf, "postgis")
-            assert result is True
+        with patch.object(transformer, "_convert_to_postgis") as mock:
+            transformer.convert_format(sample_gdf, "postgis")
             mock.assert_called_once()
 
-    def test_duckdb_unavailable_returns_false(self, transformer, sample_gdf):
+    def test_duckdb_unavailable_raises(self, transformer, sample_gdf):
         with patch("siege_utilities.geo.spatial_transformations.DUCKDB_AVAILABLE", False):
-            assert transformer.convert_format(sample_gdf, "duckdb") is False
+            with pytest.raises(ImportError):
+                transformer.convert_format(sample_gdf, "duckdb")
 
-    def test_exception_in_converter_returns_false(self, transformer, sample_gdf):
+    def test_exception_in_converter_propagates(self, transformer, sample_gdf):
         with patch.object(
             transformer, "_convert_to_shapefile", side_effect=RuntimeError("boom")
         ):
-            assert transformer.convert_format(sample_gdf, "shp") is False
+            with pytest.raises(RuntimeError, match="boom"):
+                transformer.convert_format(sample_gdf, "shp")
 
 
 # ---------------------------------------------------------------------------
@@ -156,8 +153,7 @@ class TestShapefileConversion:
 
     def test_convert_to_shapefile(self, transformer, sample_gdf, tmp_path):
         out = str(tmp_path / "out.shp")
-        result = transformer._convert_to_shapefile(sample_gdf, output_path=out)
-        assert result is True
+        transformer._convert_to_shapefile(sample_gdf, output_path=out)
         assert Path(out).exists()
 
     def test_convert_to_shapefile_roundtrip(self, transformer, sample_gdf, tmp_path):
@@ -171,8 +167,7 @@ class TestGeoJSONConversion:
 
     def test_convert_to_geojson(self, transformer, sample_gdf, tmp_path):
         out = str(tmp_path / "out.geojson")
-        result = transformer._convert_to_geojson(sample_gdf, output_path=out)
-        assert result is True
+        transformer._convert_to_geojson(sample_gdf, output_path=out)
         assert Path(out).exists()
 
     def test_geojson_roundtrip(self, transformer, sample_gdf, tmp_path):
@@ -187,8 +182,7 @@ class TestGeoPackageConversion:
 
     def test_convert_to_geopackage(self, transformer, sample_gdf, tmp_path):
         out = str(tmp_path / "out.gpkg")
-        result = transformer._convert_to_geopackage(sample_gdf, output_path=out)
-        assert result is True
+        transformer._convert_to_geopackage(sample_gdf, output_path=out)
         assert Path(out).exists()
 
     def test_geopackage_roundtrip(self, transformer, sample_gdf, tmp_path):
@@ -202,8 +196,7 @@ class TestWKTConversion:
 
     def test_convert_to_wkt(self, transformer, sample_gdf, tmp_path):
         out = str(tmp_path / "out.wkt")
-        result = transformer._convert_to_wkt(sample_gdf, output_path=out)
-        assert result is True
+        transformer._convert_to_wkt(sample_gdf, output_path=out)
         assert Path(out).exists()
 
     def test_wkt_csv_content(self, transformer, sample_gdf, tmp_path):
@@ -221,8 +214,7 @@ class TestWKBConversion:
 
     def test_convert_to_wkb(self, transformer, sample_gdf, tmp_path):
         out = str(tmp_path / "out.wkb")
-        result = transformer._convert_to_wkb(sample_gdf, output_path=out)
-        assert result is True
+        transformer._convert_to_wkb(sample_gdf, output_path=out)
         assert Path(out).exists()
 
     def test_wkb_pickle_roundtrip(self, transformer, sample_gdf, tmp_path):
@@ -240,8 +232,7 @@ class TestPostGISConversion:
 
     def test_convert_to_postgis_sql(self, transformer, sample_gdf, tmp_path):
         out = str(tmp_path / "out.sql")
-        result = transformer._convert_to_postgis(sample_gdf, output_path=out)
-        assert result is True
+        transformer._convert_to_postgis(sample_gdf, output_path=out)
         assert Path(out).exists()
 
     def test_postgis_sql_content(self, transformer, sample_gdf, tmp_path):
@@ -258,21 +249,20 @@ class TestPostGISConversion:
 
 class TestKMLConversion:
 
-    def test_convert_to_kml_failure_returns_false(self, transformer, sample_gdf, tmp_path):
-        """KML driver may not be available in all GDAL builds; test graceful failure."""
+    def test_convert_to_kml_may_raise_if_driver_missing(self, transformer, sample_gdf, tmp_path):
+        """KML driver may not be available in all GDAL builds."""
         out = str(tmp_path / "out.kml")
-        # Regardless of outcome (True if KML driver exists, False if not), no exception
-        result = transformer._convert_to_kml(sample_gdf, output_path=out)
-        assert isinstance(result, bool)
+        try:
+            transformer._convert_to_kml(sample_gdf, output_path=out)
+        except (OSError, RuntimeError):
+            pass  # driver not available — expected
 
 
 class TestGMLConversion:
 
     def test_convert_to_gml(self, transformer, sample_gdf, tmp_path):
         out = str(tmp_path / "out.gml")
-        result = transformer._convert_to_gml(sample_gdf, output_path=out)
-        # GML driver should be universally available
-        assert result is True
+        transformer._convert_to_gml(sample_gdf, output_path=out)
         assert Path(out).exists()
 
 
@@ -306,13 +296,11 @@ class TestPostGISConnector:
                 connector.connection = mock_conn
                 return connector
 
-    def test_upload_no_connection_string_returns_false(self, sample_gdf):
-        # Post-#516: upload_spatial_data requires self.connection_string
-        # (used to build the SQLAlchemy engine for to_postgis), not the
-        # raw psycopg2 connection.
+    def test_upload_no_connection_string_raises(self, sample_gdf):
         connector = self._make_connector()
         connector.connection_string = None
-        assert connector.upload_spatial_data(sample_gdf, "test_table") is False
+        with pytest.raises(RuntimeError, match="No PostGIS connection_string"):
+            connector.upload_spatial_data(sample_gdf, "test_table")
 
     def _mock_geoalchemy2_available(self):
         """Patch sys.modules so the upload's `import geoalchemy2` succeeds
@@ -322,9 +310,7 @@ class TestPostGISConnector:
     def test_upload_calls_to_postgis_with_all_columns(self, sample_gdf):
         """Post-#516 regression: upload_spatial_data must delegate to
         gpd.GeoDataFrame.to_postgis, which writes ALL columns from the
-        input GeoDataFrame -- not just geom. Pre-#516 the implementation
-        manually built an INSERT for just geom and silently dropped every
-        attribute column."""
+        input GeoDataFrame -- not just geom."""
         connector = self._make_connector()
         with self._mock_geoalchemy2_available(), \
              patch("sqlalchemy.create_engine") as mock_engine_factory, \
@@ -332,26 +318,20 @@ class TestPostGISConnector:
             mock_engine = MagicMock()
             mock_engine_factory.return_value = mock_engine
 
-            result = connector.upload_spatial_data(sample_gdf, "test_table")
+            connector.upload_spatial_data(sample_gdf, "test_table")
 
-            assert result is True
-            # to_postgis must be called exactly once with the engine + schema + if_exists.
             mock_to_postgis.assert_called_once()
             kwargs = mock_to_postgis.call_args.kwargs
             assert kwargs["name"] == "test_table"
             assert kwargs["con"] is mock_engine
             assert kwargs["schema"] == "public"
             assert kwargs["if_exists"] == "replace"
-            # Engine must be disposed even on success.
             mock_engine.dispose.assert_called_once()
 
-    def test_upload_geoalchemy2_missing_returns_false(self, sample_gdf):
-        """If geoalchemy2 is not installed, upload returns False with a
-        clear log error rather than failing inside to_postgis."""
+    def test_upload_geoalchemy2_missing_raises(self, sample_gdf):
+        """If geoalchemy2 is not installed, upload raises ImportError."""
         connector = self._make_connector()
         with patch.dict("sys.modules", {"geoalchemy2": None}):
-            # Force the import attempt to fail by removing it from sys.modules
-            # and patching the import. Simpler: use builtins.__import__.
             import builtins
             real_import = builtins.__import__
 
@@ -361,18 +341,20 @@ class TestPostGISConnector:
                 return real_import(name, *args, **kw)
 
             with patch("builtins.__import__", side_effect=fake_import):
-                result = connector.upload_spatial_data(sample_gdf, "test_table")
-        assert result is False
+                with pytest.raises(ImportError, match="geoalchemy2"):
+                    connector.upload_spatial_data(sample_gdf, "test_table")
 
-    def test_download_no_connection_returns_none(self):
+    def test_download_no_connection_raises(self):
         connector = self._make_connector()
         connector.connection = None
-        assert connector.download_spatial_data("test_table") is None
+        with pytest.raises(SpatialQueryError, match="No PostGIS connection"):
+            connector.download_spatial_data("test_table")
 
-    def test_execute_spatial_query_no_connection_returns_none(self):
+    def test_execute_spatial_query_no_connection_raises(self):
         connector = self._make_connector()
         connector.connection = None
-        assert connector.execute_spatial_query("SELECT 1") is None
+        with pytest.raises(SpatialQueryError, match="No PostGIS connection"):
+            connector.execute_spatial_query("SELECT 1")
 
     def test_create_spatial_table_single_geom_type(self, sample_gdf):
         mock_conn = MagicMock()
@@ -484,8 +466,8 @@ class TestPostGISConnector:
                           side_effect=RuntimeError("simulated db error")):
             mock_engine = MagicMock()
             mock_engine_factory.return_value = mock_engine
-            result = connector.upload_spatial_data(sample_gdf, "test_table")
-        assert result is False
+            with pytest.raises(SpatialQueryError):
+                connector.upload_spatial_data(sample_gdf, "test_table")
         mock_engine.dispose.assert_called_once()
 
 
@@ -528,8 +510,7 @@ class TestDuckDBConnector:
         import siege_utilities.geo.spatial_transformations as st_mod
         st_mod.duckdb = mock_duckdb
         try:
-            result = connector.connect()
-            assert result is True
+            connector.connect()
             assert connector.connection is not None
         finally:
             if not hasattr(st_mod, '_orig_duckdb'):
@@ -542,8 +523,8 @@ class TestDuckDBConnector:
         import siege_utilities.geo.spatial_transformations as st_mod
         st_mod.duckdb = mock_duckdb
         try:
-            result = connector.connect()
-            assert result is False
+            with pytest.raises(RuntimeError, match="Failed to connect"):
+                connector.connect()
         finally:
             del st_mod.duckdb
 
@@ -556,8 +537,8 @@ class TestDuckDBConnector:
         import siege_utilities.geo.spatial_transformations as st_mod
         st_mod.duckdb = mock_duckdb
         try:
-            result = connector.upload_spatial_data(sample_gdf, "test_table")
-            assert result is True
+            connector.upload_spatial_data(sample_gdf, "test_table")
+            assert connector.connection is not None
         finally:
             del st_mod.duckdb
 
@@ -585,8 +566,8 @@ class TestDuckDBConnector:
         import siege_utilities.geo.spatial_transformations as st_mod
         st_mod.duckdb = mock_duckdb
         try:
-            result = connector.download_spatial_data("tbl")
-            assert result is None
+            with pytest.raises(RuntimeError, match="Failed to connect"):
+                connector.download_spatial_data("tbl")
         finally:
             del st_mod.duckdb
 
@@ -598,8 +579,8 @@ class TestDuckDBConnector:
         import siege_utilities.geo.spatial_transformations as st_mod
         st_mod.duckdb = mock_duckdb
         try:
-            result = connector.execute_spatial_query("SELECT 1")
-            assert result is None
+            with pytest.raises(RuntimeError, match="Failed to connect"):
+                connector.execute_spatial_query("SELECT 1")
         finally:
             del st_mod.duckdb
 


### PR DESCRIPTION
Systematic audit of all 290 modules against the four SU rules.\n\n## SU-1 (errors are not data)\n- analytics connectors (vista_social, google_analytics, facebook_business) returning empty dicts/lists on API failures → raise TypeError/RuntimeError\n- spark_utils silently swallowing Spark errors → raise RuntimeError\n- cross_tabulation rate_table returning zeros on zero denominators → raise ZeroDivisionError\n- config loaders returning None/False on failure → raise RuntimeError\n- files/operations returning None on failure → raise\n- distributed/hdfs_operations returning None on failure → raise\n- reporting engines returning placeholder images on render failure → raise\n- geo/spatial_data, geo/rdh_catalog, geo/spatial_transformations → raise\n\n## SU-2 (does it do what it says)\n- __all__ completeness: 6+ modules missing public names\n- Type annotation fixes (lowercase any → Any)\n- PostGISConnector.upload_spatial_data documented bool return but returned None\n- geo/crs, census/api, geoid_utils name/behavior mismatches\n\n## SU-3 (no demo exemptions)\n- examples/ code: unguarded imports, bare excepts, hardcoded paths\n- google_analytics_report_example made importable without reportlab\n\n## Cross-cutting\n- Exception chaining (raise X from e) added to all unchained raises\n- from __future__ import annotations on 4 modules that crashed on import when optional deps (reportlab, matplotlib) not installed\n- Tests updated for all contract changes; 213 pass, 0 regressions\n\nIndividual commit history preserved on fix/su1-su3-connectors-examples (45 commits).