### PR TITLE
chore: bump version to 3.20.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siege-utilities"
-version = "3.18.1-dev"
+version = "3.20.0"
 description = "A comprehensive Python utilities package with enhanced auto-discovery"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Bump pyproject.toml version from 3.18.1-dev to 3.20.0 for the SU enforcement release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 3.20.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->