### PR TITLE
fix(SU-2): document undocumented **kwargs and complete spatial_data __all__

### DIFF
--- a/siege_utilities/analytics/datadotworld_connector.py
+++ b/siege_utilities/analytics/datadotworld_connector.py
@@ -507,7 +507,14 @@ def get_datadotworld_connector(config_file: Optional[Union[str, Path]] = None) -
 def search_datadotworld_datasets(query: str,
                                 config_file: Optional[Union[str, Path]] = None,
                                 **kwargs) -> List[Dict[str, Any]]:
-    """Convenience function to search for datasets."""
+    """Convenience function to search for datasets.
+
+    Args:
+        query: Search query string.
+        config_file: Path to configuration file (optional).
+        **kwargs: Forwarded to DataDotWorldConnector.search_datasets().
+            See that method for accepted parameters.
+    """
     with get_datadotworld_connector(config_file) as conn:
         return conn.search_datasets(query, **kwargs)
 
@@ -515,7 +522,14 @@ def search_datadotworld_datasets(query: str,
 def load_datadotworld_dataset(dataset_id: str,
                              config_file: Optional[Union[str, Path]] = None,
                              **kwargs) -> 'pd.DataFrame':
-    """Convenience function to load a dataset as DataFrame."""
+    """Convenience function to load a dataset as DataFrame.
+
+    Args:
+        dataset_id: Dataset identifier (format: owner/dataset).
+        config_file: Path to configuration file (optional).
+        **kwargs: Forwarded to DataDotWorldConnector.load_dataset_as_dataframe().
+            See that method for accepted parameters.
+    """
     with get_datadotworld_connector(config_file) as conn:
         return conn.load_dataset_as_dataframe(dataset_id, **kwargs)
 
@@ -524,7 +538,15 @@ def query_datadotworld_dataset(dataset_id: str,
                               query: str,
                               config_file: Optional[Union[str, Path]] = None,
                               **kwargs) -> 'pd.DataFrame':
-    """Convenience function to query a dataset."""
+    """Convenience function to query a dataset.
+
+    Args:
+        dataset_id: Dataset identifier (format: owner/dataset).
+        query: Query string (SQL or SPARQL).
+        config_file: Path to configuration file (optional).
+        **kwargs: Forwarded to DataDotWorldConnector.query_dataset().
+            See that method for accepted parameters.
+    """
     with get_datadotworld_connector(config_file) as conn:
         return conn.query_dataset(dataset_id, query, **kwargs)
 

--- a/siege_utilities/analytics/snowflake_connector.py
+++ b/siege_utilities/analytics/snowflake_connector.py
@@ -443,7 +443,15 @@ def upload_to_snowflake(df: 'pd.DataFrame',
                         table_name: str,
                         config_file: Optional[Union[str, Path]] = None,
                         **kwargs) -> None:
-    """Convenience function to upload DataFrame to Snowflake."""
+    """Convenience function to upload DataFrame to Snowflake.
+
+    Args:
+        df: Pandas DataFrame to upload.
+        table_name: Target table name.
+        config_file: Path to configuration file (optional).
+        **kwargs: Forwarded to SnowflakeConnector.upload_dataframe().
+            See that method for accepted parameters.
+    """
     with get_snowflake_connector(config_file) as snow:
         snow.upload_dataframe(df, table_name, **kwargs)
 
@@ -451,7 +459,14 @@ def upload_to_snowflake(df: 'pd.DataFrame',
 def download_from_snowflake(query: str,
                            config_file: Optional[Union[str, Path]] = None,
                            **kwargs) -> 'pd.DataFrame':
-    """Convenience function to download DataFrame from Snowflake."""
+    """Convenience function to download DataFrame from Snowflake.
+
+    Args:
+        query: SQL query to execute.
+        config_file: Path to configuration file (optional).
+        **kwargs: Forwarded to SnowflakeConnector.download_dataframe().
+            See that method for accepted parameters.
+    """
     with get_snowflake_connector(config_file) as snow:
         return snow.download_dataframe(query, **kwargs)
 
@@ -459,7 +474,14 @@ def download_from_snowflake(query: str,
 def execute_snowflake_query(query: str,
                            config_file: Optional[Union[str, Path]] = None,
                            **kwargs) -> List[tuple]:
-    """Convenience function to execute Snowflake query."""
+    """Convenience function to execute Snowflake query.
+
+    Args:
+        query: SQL query string.
+        config_file: Path to configuration file (optional).
+        **kwargs: Forwarded to SnowflakeConnector.execute_query().
+            See that method for accepted parameters.
+    """
     with get_snowflake_connector(config_file) as snow:
         return snow.execute_query(query, **kwargs)
 

--- a/siege_utilities/distributed/hdfs_config.py
+++ b/siege_utilities/distributed/hdfs_config.py
@@ -124,12 +124,24 @@ class HDFSConfig:
 
 
 def create_hdfs_config(**kwargs) ->HDFSConfig:
-    """Factory function to create HDFS configuration"""
+    """Factory function to create HDFS configuration.
+
+    Args:
+        **kwargs: Forwarded to HDFSConfig(). See HDFSConfig for accepted fields
+            (e.g. data_path, master, executor_memory, enable_sedona, etc.).
+    """
     return HDFSConfig(**kwargs)
 
 
 def create_local_config(data_path: str, **kwargs) ->HDFSConfig:
-    """Create config optimized for local development"""
+    """Create config optimized for local development.
+
+    Args:
+        data_path: Path to data directory.
+        **kwargs: Override any HDFSConfig default. Merged on top of local-mode
+            defaults (num_executors=2, executor_cores=1, executor_memory='1g',
+            enable_sedona=False). See HDFSConfig for accepted fields.
+    """
     defaults = {'data_path': data_path, 'num_executors': 2,
         'executor_cores': 1, 'executor_memory': '1g', 'enable_sedona': 
         False, 'spark_log_level': 'WARN'}
@@ -138,7 +150,14 @@ def create_local_config(data_path: str, **kwargs) ->HDFSConfig:
 
 
 def create_cluster_config(data_path: str, **kwargs) ->HDFSConfig:
-    """Create config optimized for cluster deployment"""
+    """Create config optimized for cluster deployment.
+
+    Args:
+        data_path: Path to data directory.
+        **kwargs: Override any HDFSConfig default. Merged on top of cluster
+            defaults (num_executors=8, executor_cores=4, executor_memory='4g',
+            enable_sedona=True). See HDFSConfig for accepted fields.
+    """
     defaults = {'data_path': data_path, 'num_executors': 8,
         'executor_cores': 4, 'executor_memory': '4g', 'enable_sedona': True,
         'spark_log_level': 'WARN'}
@@ -147,7 +166,15 @@ def create_cluster_config(data_path: str, **kwargs) ->HDFSConfig:
 
 
 def create_geocoding_config(data_path: str, **kwargs) ->HDFSConfig:
-    """Create config optimized for geocoding workloads"""
+    """Create config optimized for geocoding workloads.
+
+    Args:
+        data_path: Path to data directory.
+        **kwargs: Override any HDFSConfig default. Merged on top of geocoding
+            defaults (app_name='GeocodingPipeline', num_executors=4,
+            executor_memory='2g', enable_sedona=True, network_timeout='1200s').
+            See HDFSConfig for accepted fields.
+    """
     defaults = {'data_path': data_path, 'app_name': 'GeocodingPipeline',
         'num_executors': 4, 'executor_cores': 2, 'executor_memory': '2g',
         'enable_sedona': True, 'network_timeout': '1200s',

--- a/siege_utilities/files/remote.py
+++ b/siege_utilities/files/remote.py
@@ -83,7 +83,13 @@ class _DummyProgressBar:
         pass
 
 def _get_progress_bar(*args, **kwargs):
-    """Get progress bar, using tqdm if available, dummy otherwise."""
+    """Get progress bar, using tqdm if available, dummy otherwise.
+
+    Args:
+        *args: Positional arguments forwarded to tqdm.tqdm().
+        **kwargs: Forwarded to tqdm.tqdm(). Common keys: total, unit,
+            unit_scale, desc, ascii. See tqdm.tqdm for all accepted parameters.
+    """
     if TQDM_AVAILABLE:
         return tqdm.tqdm(*args, **kwargs)
     else:

--- a/siege_utilities/geo/spatial_data.py
+++ b/siege_utilities/geo/spatial_data.py
@@ -2350,6 +2350,8 @@ def __getattr__(name: str):
 
 
 __all__ = [
+    # Errors
+    'SpatialDataError',
     # Classes
     'SpatialDataSource',
     'CensusDataSource',
@@ -2363,19 +2365,36 @@ __all__ = [
     'get_year_directory_contents',
     'discover_boundary_types',
     'download_data',
+    'download_dataset',
     'get_geographic_boundaries',
+    'fetch_geographic_boundaries',
+    'load_census_inventory',
+    'update_census_inventory',
+    'refresh_discovery_cache',
+    'construct_download_url',
+    'validate_download_url',
+    'get_optimal_year',
+    'get_available_boundary_types',
     # State normalization
     'normalize_state_identifier',
+    'normalize_state_identifier_standalone',
     'normalize_state_input',
     'normalize_state_name',
     'normalize_state_abbreviation',
     'normalize_fips_code',
     'get_state_by_abbreviation',
     'get_state_by_name',
+    'get_state_name',
+    'get_state_abbreviation',
+    'get_state_abbreviations',
+    'get_available_state_fips',
+    'get_unified_fips_data',
+    'get_comprehensive_state_info',
+    'validate_state_fips',
     # OSM
     'download_osm_data',
     # Global instances
     'census_source',
     'government_source',
-    'osm_source'
+    'osm_source',
 ]

--- a/siege_utilities/geo/spatial_transformations.py
+++ b/siege_utilities/geo/spatial_transformations.py
@@ -728,19 +728,63 @@ class DuckDBConnector:
 
 # Convenience functions
 def convert_spatial_format(gdf: GeoDataFrame, output_format: str, **kwargs) -> None:
-    """Convert spatial data to different format."""
+    """Convert spatial data to different format.
+
+    Args:
+        gdf: Input GeoDataFrame.
+        output_format: Target format (``'shp'``, ``'geojson'``, ``'gpkg'``,
+            ``'kml'``, ``'gml'``, ``'wkt'``, ``'wkb'``, ``'postgis'``,
+            ``'duckdb'``).
+        **kwargs: Format-specific parameters:
+            output_path (str): Output file path (default varies by format).
+            db_path (str): DuckDB database path (``'duckdb'`` format only).
+            table_name (str): DuckDB table name (``'duckdb'`` format only,
+                default ``'spatial_data'``).
+
+    Raises:
+        ValueError: If *output_format* is unsupported.
+        ImportError: If a required dependency is not available.
+    """
     transformer = SpatialDataTransformer()
     transformer.convert_format(gdf, output_format, **kwargs)
 
 
 def upload_to_postgis(gdf: GeoDataFrame, table_name: str, connection_string: Optional[str] = None, **kwargs) -> None:
-    """Upload spatial data to PostGIS."""
+    """Upload spatial data to PostGIS.
+
+    Args:
+        gdf: GeoDataFrame to upload.
+        table_name: Target table name.
+        connection_string: PostgreSQL connection string (uses user config
+            when omitted).
+        **kwargs: Forwarded to
+            :meth:`PostGISConnector.upload_spatial_data`. Accepts
+            ``if_exists`` (``'fail'``, ``'replace'``, ``'append'``;
+            default ``'replace'``) and ``schema`` (default ``'public'``).
+
+    Raises:
+        RuntimeError: If no connection string is configured.
+        ImportError: If geoalchemy2 is not available.
+        SpatialQueryError: If the upload fails.
+    """
     with PostGISConnector(connection_string) as connector:
         connector.upload_spatial_data(gdf, table_name, **kwargs)
 
 
 def download_from_postgis(table_name: str, connection_string: Optional[str] = None, **kwargs) -> GeoDataFrame:
     """Download spatial data from PostGIS.
+
+    Args:
+        table_name: Source table name (may be schema-qualified, e.g.
+            ``'public.my_table'``).
+        connection_string: PostgreSQL connection string (uses user config
+            when omitted).
+        **kwargs: Forwarded to
+            :meth:`PostGISConnector.download_spatial_data`. Accepts
+            ``geom_col`` (default ``'geom'``) and ``crs`` (output CRS).
+
+    Returns:
+        GeoDataFrame with spatial data.
 
     Raises:
         SpatialQueryError: If the connection is unavailable or the
@@ -753,6 +797,18 @@ def download_from_postgis(table_name: str, connection_string: Optional[str] = No
 def execute_postgis_query(query: str, connection_string: Optional[str] = None, **kwargs) -> Union[GeoDataFrame, int]:
     """Execute a spatial SQL query on PostGIS.
 
+    Args:
+        query: SQL query string.
+        connection_string: PostgreSQL connection string (uses user config
+            when omitted).
+        **kwargs: Forwarded to
+            :meth:`PostGISConnector.execute_spatial_query`. Accepts
+            ``geom_col`` (default ``'geometry'``) and ``crs`` (output CRS,
+            applies to SELECT queries only).
+
+    Returns:
+        GeoDataFrame for SELECT queries, int rowcount for others.
+
     Raises:
         SpatialQueryError: If the connection is unavailable or the
             query fails.
@@ -763,6 +819,15 @@ def execute_postgis_query(query: str, connection_string: Optional[str] = None, *
 
 def upload_to_duckdb(gdf: GeoDataFrame, table_name: str, db_path: Optional[str] = None, **kwargs) -> None:
     """Upload spatial data to DuckDB (optional).
+
+    Args:
+        gdf: GeoDataFrame to upload.
+        table_name: Target table name.
+        db_path: Path to DuckDB database file (uses user config or
+            in-memory when omitted).
+        **kwargs: Forwarded to
+            :meth:`DuckDBConnector.upload_spatial_data`. Accepts
+            ``if_exists`` (``'replace'`` by default).
 
     Raises:
         ImportError: If DuckDB is not installed.
@@ -778,6 +843,18 @@ def upload_to_duckdb(gdf: GeoDataFrame, table_name: str, db_path: Optional[str] 
 def download_from_duckdb(table_name: str, db_path: Optional[str] = None, **kwargs) -> GeoDataFrame:
     """Download spatial data from DuckDB (optional).
 
+    Args:
+        table_name: Source table name.
+        db_path: Path to DuckDB database file (uses user config or
+            in-memory when omitted).
+        **kwargs: Forwarded to
+            :meth:`DuckDBConnector.download_spatial_data`. Accepts
+            ``where_clause`` (optional SQL WHERE fragment) and ``crs``
+            (output CRS).
+
+    Returns:
+        GeoDataFrame with spatial data.
+
     Raises:
         SpatialQueryError: If the connection is unavailable or the
             query fails.
@@ -792,6 +869,17 @@ def download_from_duckdb(table_name: str, db_path: Optional[str] = None, **kwarg
 
 def execute_duckdb_query(query: str, db_path: Optional[str] = None, **kwargs) -> Union[GeoDataFrame, int]:
     """Execute a spatial SQL query on DuckDB (optional).
+
+    Args:
+        query: SQL query string.
+        db_path: Path to DuckDB database file (uses user config or
+            in-memory when omitted).
+        **kwargs: Forwarded to
+            :meth:`DuckDBConnector.execute_spatial_query`. Accepts
+            ``crs`` (output CRS, applies to SELECT queries only).
+
+    Returns:
+        GeoDataFrame for SELECT queries, int rowcount for others.
 
     Raises:
         SpatialQueryError: If the connection is unavailable or the

--- a/siege_utilities/geo/temporal/store.py
+++ b/siege_utilities/geo/temporal/store.py
@@ -295,7 +295,15 @@ def save_boundaries(
     vintage_year: int,
     **kwargs,
 ) -> Path:
-    """Save boundaries via the default store."""
+    """Save boundaries via the default store.
+
+    Args:
+        gdf: GeoDataFrame of boundaries to persist.
+        geography_type: Type of geography (e.g. "county", "tract").
+        vintage_year: Census vintage year.
+        **kwargs: Forwarded to get_temporal_store(). Accepts root_dir
+            and format.
+    """
     return get_temporal_store(**kwargs).save_boundaries(gdf, geography_type, vintage_year)
 
 
@@ -305,7 +313,15 @@ def load_boundaries(
     state_fips: str | None = None,
     **kwargs,
 ) -> "gpd.GeoDataFrame":
-    """Load boundaries via the default store."""
+    """Load boundaries via the default store.
+
+    Args:
+        geography_type: Type of geography (e.g. "county", "tract").
+        vintage_year: Census vintage year.
+        state_fips: Optional state FIPS code to filter results.
+        **kwargs: Forwarded to get_temporal_store(). Accepts root_dir
+            and format.
+    """
     return get_temporal_store(**kwargs).load_boundaries(
         geography_type, vintage_year, state_fips
     )
@@ -317,7 +333,15 @@ def query_boundaries_at_date(
     state_fips: str | None = None,
     **kwargs,
 ) -> "gpd.GeoDataFrame":
-    """Query boundaries at a date via the default store."""
+    """Query boundaries at a date via the default store.
+
+    Args:
+        geography_type: Type of geography (e.g. "county", "tract").
+        query_date: Date for which to find matching boundaries.
+        state_fips: Optional state FIPS code to filter results.
+        **kwargs: Forwarded to get_temporal_store(). Accepts root_dir
+            and format.
+    """
     return get_temporal_store(**kwargs).query_boundaries_at_date(
         geography_type, query_date, state_fips
     )
@@ -330,7 +354,16 @@ def save_demographics(
     year: int | None = None,
     **kwargs,
 ) -> Path:
-    """Save demographics via the default store."""
+    """Save demographics via the default store.
+
+    Args:
+        snapshots: DataFrame of demographic snapshot data.
+        geography_type: Type of geography (e.g. "county", "tract").
+        dataset: Dataset identifier (default "acs5").
+        year: Year of the snapshot. Inferred from DataFrame if omitted.
+        **kwargs: Forwarded to get_temporal_store(). Accepts root_dir
+            and format.
+    """
     return get_temporal_store(**kwargs).save_demographics(
         snapshots, geography_type, dataset, year
     )
@@ -342,7 +375,15 @@ def load_demographics(
     dataset: str = "acs5",
     **kwargs,
 ) -> "pd.DataFrame":
-    """Load demographics via the default store."""
+    """Load demographics via the default store.
+
+    Args:
+        geography_type: Type of geography (e.g. "county", "tract").
+        year: Year to load. If None, loads all available years.
+        dataset: Dataset identifier (default "acs5").
+        **kwargs: Forwarded to get_temporal_store(). Accepts root_dir
+            and format.
+    """
     return get_temporal_store(**kwargs).load_demographics(
         geography_type, year, dataset
     )

--- a/siege_utilities/reporting/chart_generator.py
+++ b/siege_utilities/reporting/chart_generator.py
@@ -366,8 +366,24 @@ def create_convergence_diagram(sources: List[Dict[str, Any]],
                                width: float = 10.0,
                                height: float = 6.0,
                                **kwargs) -> Optional['Image']:
-    """
-    Standalone function to create a convergence diagram.
+    """Standalone function to create a convergence diagram.
+
+    Args:
+        sources: Source node dicts with keys ``label`` (required),
+            ``color`` (optional), and an optional magnitude key.
+        hub_label: Center node label.
+        outputs: Optional output node dicts (same schema as *sources*).
+        title: Diagram title.
+        width: Figure width in inches.
+        height: Figure height in inches.
+        **kwargs: Forwarded to
+            :meth:`CompositeChartMixin.create_convergence_diagram`.
+            Accepts ``arrow_style`` (``'curved'``, ``'radial'``, or
+            ``'orthogonal'``), ``arrow_count``, ``arrow_color``,
+            ``show_magnitudes``, and ``magnitude_key``.
+
+    Returns:
+        ReportLab Image object or None if error.
     """
     generator = ChartGenerator()
     return generator.create_convergence_diagram(

--- a/siege_utilities/reporting/chart_types.py
+++ b/siege_utilities/reporting/chart_types.py
@@ -532,5 +532,13 @@ def register_chart_type(chart_type: ChartType):
     get_chart_registry().register_chart_type(chart_type)
 
 def create_chart(chart_type_name: str, **kwargs) -> Optional[Figure]:
-    """Create a chart using the specified chart type."""
+    """Create a chart using the specified chart type.
+
+    Args:
+        chart_type_name: Name of a registered chart type.
+        **kwargs: Forwarded to the chart type's create function. Must include
+            all of the chart type's required_parameters. Optional parameters
+            are filled from the chart type's defaults. See
+            ChartTypeRegistry.create_chart() for details.
+    """
     return get_chart_registry().create_chart(chart_type_name, **kwargs)


### PR DESCRIPTION
kwargs documentation added to 22 public functions across 8 files. spatial_data.py __all__ expanded by 18 missing public names.\n\nDjango model save/handle methods excluded — framework convention, not SU-2 violations.