### PR TITLE
fix(SU-1, SU-2): error visibility and module export completeness

### DIFF
--- a/siege_utilities/conf/__init__.py
+++ b/siege_utilities/conf/__init__.py
@@ -146,7 +146,11 @@ class Settings:
 
     @contextmanager
     def override(self, **kwargs):
-        """Temporarily override settings (thread-local, safe for concurrent use)."""
+        """Temporarily override settings (thread-local, safe for concurrent use).
+
+        **kwargs: Setting names and their override values, stored in
+            thread-local context.
+        """
         overrides = getattr(self._local, "overrides", {})
         previous = {k: overrides.get(k, _SENTINEL) for k in kwargs}
         overrides = {**overrides, **kwargs}

--- a/siege_utilities/core/logging.py
+++ b/siege_utilities/core/logging.py
@@ -382,6 +382,8 @@ def temporary_logging_config(config: LoggingConfig) -> Generator[None, None, Non
         _logger_manager._shared_config = original_config
 
 __all__ = [
+    'LogLevel',
+    'LoggerName',
     'LoggerManager',
     'LoggingConfig',
     'configure_shared_logging',

--- a/siege_utilities/engines/dataframe_engine.py
+++ b/siege_utilities/engines/dataframe_engine.py
@@ -696,10 +696,18 @@ class PandasEngine(DataFrameEngine):
     # -- I/O ----------------------------------------------------------------
 
     def read_csv(self, path: str, **kwargs: Any) -> Any:
+        """Read a CSV file.
+
+        **kwargs: Forwarded to :func:`pandas.read_csv`.
+        """
         import pandas as pd
         return pd.read_csv(path, **kwargs)
 
     def read_parquet(self, path: str, **kwargs: Any) -> Any:
+        """Read a Parquet file.
+
+        **kwargs: Forwarded to :func:`pandas.read_parquet`.
+        """
         import pandas as pd
         return pd.read_parquet(path, **kwargs)
 
@@ -755,6 +763,10 @@ class PandasEngine(DataFrameEngine):
     # -- Spatial -----------------------------------------------------------
 
     def read_spatial(self, path: str, *, crs: Optional[str] = None, **kwargs: Any) -> Any:
+        """Read a spatial file.
+
+        **kwargs: Forwarded to :func:`geopandas.read_file`.
+        """
         import geopandas as gpd
         from siege_utilities.geo.crs import get_default_crs, reproject_if_needed
         gdf = gpd.read_file(path, **kwargs)
@@ -944,6 +956,11 @@ class DuckDBEngine(DataFrameEngine):
             self._spatial_loaded = True
 
     def read_spatial(self, path: str, *, crs: Optional[str] = None, **kwargs: Any) -> Any:
+        """Read a spatial file via DuckDB's ``ST_Read``.
+
+        **kwargs: Forwarded to :func:`geopandas.read_file` (unused in the
+        current DuckDB path but accepted for interface compatibility).
+        """
         import geopandas as gpd
         from siege_utilities.geo.crs import get_default_crs, reproject_if_needed
         self._ensure_spatial()
@@ -1066,6 +1083,10 @@ class SparkEngine(DataFrameEngine):
     # -- I/O ----------------------------------------------------------------
 
     def read_csv(self, path: str, **kwargs: Any) -> Any:
+        """Read a CSV file via Spark.
+
+        **kwargs: Forwarded to Spark's ``DataFrameReader.csv()``.
+        """
         header = kwargs.pop("header", True)
         infer_schema = kwargs.pop("inferSchema", True)
         return (
@@ -1076,6 +1097,10 @@ class SparkEngine(DataFrameEngine):
         )
 
     def read_parquet(self, path: str, **kwargs: Any) -> Any:
+        """Read a Parquet file via Spark.
+
+        **kwargs: Forwarded to Spark's ``DataFrameReader.parquet()``.
+        """
         return self._session.read.parquet(path, **kwargs)
 
     # -- SQL ----------------------------------------------------------------
@@ -1195,6 +1220,10 @@ class SparkEngine(DataFrameEngine):
         _log.debug("Sedona UDFs registered")
 
     def read_spatial(self, path: str, *, crs: Optional[str] = None, **kwargs: Any) -> Any:
+        """Read a spatial file via GeoPandas and convert to a Spark DataFrame.
+
+        **kwargs: Forwarded to :func:`geopandas.read_file`.
+        """
         # Fallback: read via GeoPandas, convert to Spark DataFrame
         import geopandas as gpd
         from siege_utilities.geo.crs import get_default_crs, reproject_if_needed
@@ -1467,6 +1496,10 @@ class PostGISEngine(DataFrameEngine):
     # -- I/O ----------------------------------------------------------------
 
     def read_csv(self, path: str, **kwargs: Any) -> Any:
+        """Read a CSV file.
+
+        **kwargs: Forwarded to :func:`pandas.read_csv`.
+        """
         import geopandas as gpd
         import pandas as pd
         df = pd.read_csv(path, **kwargs)
@@ -1559,6 +1592,10 @@ class PostGISEngine(DataFrameEngine):
     # -- Spatial -----------------------------------------------------------
 
     def read_spatial(self, path: str, *, crs: Optional[str] = None, **kwargs: Any) -> Any:
+        """Read a spatial file or execute a spatial SQL query.
+
+        **kwargs: Forwarded to :func:`geopandas.read_file`.
+        """
         import geopandas as gpd
         from siege_utilities.geo.crs import get_default_crs, reproject_if_needed
         if path.upper().startswith("SELECT"):

--- a/siege_utilities/files/operations.py
+++ b/siege_utilities/files/operations.py
@@ -743,6 +743,7 @@ def list_files_recursive(
 
 
 __all__ = [
+    'FilePath',
     'remove_tree',
     'file_exists',
     'touch_file',

--- a/siege_utilities/geo/capabilities.py
+++ b/siege_utilities/geo/capabilities.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import importlib
 from typing import Any, Dict
 
+__all__ = ["geo_capabilities"]
+
 
 def _probe(module_name: str) -> bool:
     """Return True if *module_name* can be imported."""

--- a/siege_utilities/geo/django/management/commands/populate_pl_demographics.py
+++ b/siege_utilities/geo/django/management/commands/populate_pl_demographics.py
@@ -206,5 +206,6 @@ class Command(BaseCommand):
             return None
         try:
             return apps.get_model("siege_geo", model_name)
-        except LookupError:
+        except LookupError as exc:
+            log.warning("Could not resolve model: %s", exc)
             return None

--- a/siege_utilities/geo/django/models/education.py
+++ b/siege_utilities/geo/django/models/education.py
@@ -170,6 +170,10 @@ class NCESLocaleBoundary(TemporalBoundary):
         return f"{self.locale_category} ({self.locale_code}) [{self.nces_year}]"
 
     def save(self, *args, **kwargs):
+        """Persist the model, auto-populating feature_id and source.
+
+        *args/**kwargs: Forwarded to ``super().save()``.
+        """
         # Sync feature_id from locale code + year
         if not self.feature_id:
             self.feature_id = f"nces_locale_{self.locale_code}_{self.nces_year}"
@@ -240,6 +244,10 @@ class SchoolLocation(TemporalPointFeature):
         return f"{self.school_name} ({self.ncessch})"
 
     def save(self, *args, **kwargs):
+        """Persist the model, auto-populating feature_id and source.
+
+        *args/**kwargs: Forwarded to ``super().save()``.
+        """
         if not self.feature_id:
             self.feature_id = self.ncessch
         if not self.source:

--- a/siege_utilities/geo/django/models/federal.py
+++ b/siege_utilities/geo/django/models/federal.py
@@ -44,6 +44,10 @@ class NLRBRegion(TemporalBoundary):
         ]
 
     def save(self, *args, **kwargs):
+        """Persist the model, auto-populating feature_id and source.
+
+        *args/**kwargs: Forwarded to ``super().save()``.
+        """
         if self.region_number and not self.feature_id:
             self.feature_id = f"NLRB-{self.region_number:02d}"
             self.boundary_id = self.feature_id
@@ -98,6 +102,10 @@ class FederalJudicialDistrict(TemporalBoundary):
         ]
 
     def save(self, *args, **kwargs):
+        """Persist the model, auto-populating feature_id and source.
+
+        *args/**kwargs: Forwarded to ``super().save()``.
+        """
         if self.district_code and not self.feature_id:
             self.feature_id = self.district_code
             self.boundary_id = self.district_code

--- a/siege_utilities/geo/django/models/timezone.py
+++ b/siege_utilities/geo/django/models/timezone.py
@@ -59,6 +59,10 @@ class TimezoneGeometry(TemporalBoundary):
         ]
 
     def save(self, *args, **kwargs):
+        """Persist the model, auto-populating feature_id and source.
+
+        *args/**kwargs: Forwarded to ``super().save()``.
+        """
         if self.timezone_id and not self.feature_id:
             self.feature_id = self.timezone_id
             self.boundary_id = self.timezone_id

--- a/siege_utilities/geo/django/services/rollup_service.py
+++ b/siege_utilities/geo/django/services/rollup_service.py
@@ -372,5 +372,6 @@ class DemographicRollupService:
             return None
         try:
             return apps.get_model("siege_geo", model_name)
-        except LookupError:
+        except LookupError as exc:
+            log.warning("Could not resolve model: %s", exc)
             return None

--- a/siege_utilities/geo/django/services/timeseries_service.py
+++ b/siege_utilities/geo/django/services/timeseries_service.py
@@ -232,7 +232,8 @@ class TimeseriesService:
             return None
         try:
             return apps.get_model("siege_geo", model_name)
-        except LookupError:
+        except LookupError as exc:
+            log.warning("Could not resolve model: %s", exc)
             return None
 
     @staticmethod
@@ -250,7 +251,8 @@ class TimeseriesService:
             return None
         try:
             return (end_value / start_value) ** (1 / periods) - 1
-        except (ZeroDivisionError, ValueError):
+        except (ZeroDivisionError, ValueError) as exc:
+            log.warning("CAGR computation failed: %s", exc)
             return None
 
     @staticmethod

--- a/siege_utilities/geo/providers/boundary_providers.py
+++ b/siege_utilities/geo/providers/boundary_providers.py
@@ -160,7 +160,8 @@ class CensusTIGERProvider(BoundaryProvider):
 
         try:
             vintages = self.list_available_vintages(timeout=timeout)
-        except requests.RequestException:
+        except requests.RequestException as exc:
+            logger.warning("Failed to fetch latest TIGER vintage: %s", exc)
             return None
         return max(vintages) if vintages else None
 

--- a/siege_utilities/geo/providers/redistricting_data_hub.py
+++ b/siege_utilities/geo/providers/redistricting_data_hub.py
@@ -1070,6 +1070,7 @@ __all__ = [
     "RDHDataFormat",
     "RDHDatasetType",
     # Constants
+    "RDH_MAX_RESULTS",
     "RDH_BASE_URL",
     "RDH_SITE_URL",
     "US_STATES",

--- a/siege_utilities/geo/spatial_runtime.py
+++ b/siege_utilities/geo/spatial_runtime.py
@@ -18,6 +18,16 @@ from typing import Any, Dict, List, Optional, Tuple
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "SpatialRuntimePlan",
+    "resolve_spatial_runtime_plan",
+    "GeometryPayload",
+    "encode_geometry",
+    "decode_geometry",
+    "payload_to_spark_row",
+    "spark_row_to_payload",
+]
+
 try:
     import shapely.geometry.base  # noqa: F401
     import shapely.wkt as _swkt

--- a/siege_utilities/geo/temporal/services.py
+++ b/siege_utilities/geo/temporal/services.py
@@ -206,7 +206,8 @@ class TemporalTimeseriesBuilder:
             return None
         try:
             return (end_value / start_value) ** (1 / periods) - 1
-        except (ZeroDivisionError, ValueError):
+        except (ZeroDivisionError, ValueError) as exc:
+            log.warning("CAGR computation failed: %s", exc)
             return None
 
     @staticmethod

--- a/siege_utilities/survey/render.py
+++ b/siege_utilities/survey/render.py
@@ -16,8 +16,11 @@ Chart type selection by TableType:
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+logger = logging.getLogger(__name__)
 
 import pandas as pd
 
@@ -160,6 +163,7 @@ def _build_map(chain: "Chain", map_generator: Optional[Any] = None) -> Optional[
             from ..reporting.chart_generator import ChartGenerator
             map_generator = ChartGenerator()
         except ImportError:
+            logger.warning("ChartGenerator unavailable — map rendering skipped")
             return None
 
     df = chain.to_dataframe()


### PR DESCRIPTION
## Summary

- **SU-1**: 7 functions silently swallowed exceptions (returning None/False with no log trace). Added `log.warning` so callers get visibility into failures vs. empty results. No return values or control flow changed.
- **SU-2 kwargs**: 16 methods with undocumented `**kwargs` now document their forwarding targets (pandas, geopandas, Spark, Django super().save(), conf overrides).
- **SU-2 __all__**: 3 incomplete `__all__` lists completed (core/logging, files/operations, redistricting_data_hub). 2 modules gained `__all__` (geo/capabilities, geo/spatial_runtime).

## Files changed (16)

| Category | Files |
|----------|-------|
| SU-1 | boundary_providers, survey/render, populate_pl_demographics, rollup_service, timeseries_service, temporal/services |
| SU-2 kwargs | dataframe_engine, education models, federal models, timezone model, conf/__init__ |
| SU-2 __all__ | core/logging, files/operations, redistricting_data_hub, capabilities, spatial_runtime |

## Test plan

- [x] All 16 files pass `py_compile`
- [x] No return values or control flow changed (SU-1 fixes are additive logging only)
- [x] `__all__` additions verified against actual public names in each module