### PR TITLE
fix(SU-1, SU-2): soundness pass — credential logging, docstrings, config exports

### DIFF
--- a/siege_utilities/conf/__init__.py
+++ b/siege_utilities/conf/__init__.py
@@ -146,7 +146,11 @@ class Settings:
 
     @contextmanager
     def override(self, **kwargs):
-        """Temporarily override settings (thread-local, safe for concurrent use)."""
+        """Temporarily override settings (thread-local, safe for concurrent use).
+
+        **kwargs: Setting names and their override values, stored in
+            thread-local context.
+        """
         overrides = getattr(self._local, "overrides", {})
         previous = {k: overrides.get(k, _SENTINEL) for k in kwargs}
         overrides = {**overrides, **kwargs}

--- a/siege_utilities/config/__init__.py
+++ b/siege_utilities/config/__init__.py
@@ -360,7 +360,8 @@ __all__ = [
     'CENSUS_BASE_URL', 'CENSUS_API_BASE_URL', 'CENSUS_FTP_BASE_URL',
     'CANONICAL_GEOGRAPHIC_LEVELS', 'resolve_geographic_level',
     'GEOGRAPHIC_LEVELS', 'GEOGRAPHIC_HIERARCHY',
-    'DATASET_TYPES', 'RELIABILITY_LEVELS', 'SurveyType', 'DataReliability',
+    'DATASET_TYPES', 'RELIABILITY_LEVELS', 'SurveyType', 'DataReliability', 'GeographyLevel',
+    'VARIABLE_GROUPS', 'VARIABLE_DESCRIPTIONS',
     'STATE_FIPS_CODES', 'STATEFIPS_LOOKUP_DICT', 'FIPS_TO_STATE', 'STATE_NAMES',
     'AVAILABLE_CENSUS_YEARS', 'DEFAULT_CENSUS_YEAR', 'DECENNIAL_YEARS', 'ACS_AVAILABLE_YEARS',
     'ACS5_AVAILABLE_YEARS', 'BOUNDARY_CHANGE_YEARS',
@@ -392,6 +393,13 @@ __all__ = [
     'ensure_directory_exists', 'get_project_path', 'get_cache_path', 'get_output_path',
     'get_data_path', 'setup_standard_directories', 'get_file_type', 'get_relative_to_home',
     'initialize_siege_directories',
+
+    # Enhanced config
+    'SiegeConfig',
+    'load_user_profile', 'save_user_profile',
+    'load_client_profile', 'save_client_profile',
+    'list_client_profiles',
+    'export_config_yaml', 'import_config_yaml',
 
     # Existing config classes and functions
     'UserProfile', 'UserConfigManager', 'get_user_config', 'get_download_directory',

--- a/siege_utilities/config/credential_manager.py
+++ b/siege_utilities/config/credential_manager.py
@@ -502,6 +502,7 @@ class CredentialManager:
                 return input(prompt)
                 
         except (EOFError, KeyboardInterrupt):
+            _logger.warning("Interactive credential prompt cancelled by user")
             return None
     
     def store_credential(self, service: str, username: str, value: str,

--- a/siege_utilities/core/logging.py
+++ b/siege_utilities/core/logging.py
@@ -382,6 +382,8 @@ def temporary_logging_config(config: LoggingConfig) -> Generator[None, None, Non
         _logger_manager._shared_config = original_config
 
 __all__ = [
+    'LogLevel',
+    'LoggerName',
     'LoggerManager',
     'LoggingConfig',
     'configure_shared_logging',

--- a/siege_utilities/engines/dataframe_engine.py
+++ b/siege_utilities/engines/dataframe_engine.py
@@ -696,10 +696,18 @@ class PandasEngine(DataFrameEngine):
     # -- I/O ----------------------------------------------------------------
 
     def read_csv(self, path: str, **kwargs: Any) -> Any:
+        """Read a CSV file.
+
+        **kwargs: Forwarded to :func:`pandas.read_csv`.
+        """
         import pandas as pd
         return pd.read_csv(path, **kwargs)
 
     def read_parquet(self, path: str, **kwargs: Any) -> Any:
+        """Read a Parquet file.
+
+        **kwargs: Forwarded to :func:`pandas.read_parquet`.
+        """
         import pandas as pd
         return pd.read_parquet(path, **kwargs)
 
@@ -755,6 +763,10 @@ class PandasEngine(DataFrameEngine):
     # -- Spatial -----------------------------------------------------------
 
     def read_spatial(self, path: str, *, crs: Optional[str] = None, **kwargs: Any) -> Any:
+        """Read a spatial file.
+
+        **kwargs: Forwarded to :func:`geopandas.read_file`.
+        """
         import geopandas as gpd
         from siege_utilities.geo.crs import get_default_crs, reproject_if_needed
         gdf = gpd.read_file(path, **kwargs)
@@ -944,6 +956,11 @@ class DuckDBEngine(DataFrameEngine):
             self._spatial_loaded = True
 
     def read_spatial(self, path: str, *, crs: Optional[str] = None, **kwargs: Any) -> Any:
+        """Read a spatial file via DuckDB's ``ST_Read``.
+
+        **kwargs: Forwarded to :func:`geopandas.read_file` (unused in the
+        current DuckDB path but accepted for interface compatibility).
+        """
         import geopandas as gpd
         from siege_utilities.geo.crs import get_default_crs, reproject_if_needed
         self._ensure_spatial()
@@ -1066,6 +1083,10 @@ class SparkEngine(DataFrameEngine):
     # -- I/O ----------------------------------------------------------------
 
     def read_csv(self, path: str, **kwargs: Any) -> Any:
+        """Read a CSV file via Spark.
+
+        **kwargs: Forwarded to Spark's ``DataFrameReader.csv()``.
+        """
         header = kwargs.pop("header", True)
         infer_schema = kwargs.pop("inferSchema", True)
         return (
@@ -1076,6 +1097,10 @@ class SparkEngine(DataFrameEngine):
         )
 
     def read_parquet(self, path: str, **kwargs: Any) -> Any:
+        """Read a Parquet file via Spark.
+
+        **kwargs: Forwarded to Spark's ``DataFrameReader.parquet()``.
+        """
         return self._session.read.parquet(path, **kwargs)
 
     # -- SQL ----------------------------------------------------------------
@@ -1195,6 +1220,10 @@ class SparkEngine(DataFrameEngine):
         _log.debug("Sedona UDFs registered")
 
     def read_spatial(self, path: str, *, crs: Optional[str] = None, **kwargs: Any) -> Any:
+        """Read a spatial file via GeoPandas and convert to a Spark DataFrame.
+
+        **kwargs: Forwarded to :func:`geopandas.read_file`.
+        """
         # Fallback: read via GeoPandas, convert to Spark DataFrame
         import geopandas as gpd
         from siege_utilities.geo.crs import get_default_crs, reproject_if_needed
@@ -1467,6 +1496,10 @@ class PostGISEngine(DataFrameEngine):
     # -- I/O ----------------------------------------------------------------
 
     def read_csv(self, path: str, **kwargs: Any) -> Any:
+        """Read a CSV file.
+
+        **kwargs: Forwarded to :func:`pandas.read_csv`.
+        """
         import geopandas as gpd
         import pandas as pd
         df = pd.read_csv(path, **kwargs)
@@ -1559,6 +1592,10 @@ class PostGISEngine(DataFrameEngine):
     # -- Spatial -----------------------------------------------------------
 
     def read_spatial(self, path: str, *, crs: Optional[str] = None, **kwargs: Any) -> Any:
+        """Read a spatial file or execute a spatial SQL query.
+
+        **kwargs: Forwarded to :func:`geopandas.read_file`.
+        """
         import geopandas as gpd
         from siege_utilities.geo.crs import get_default_crs, reproject_if_needed
         if path.upper().startswith("SELECT"):

--- a/siege_utilities/files/operations.py
+++ b/siege_utilities/files/operations.py
@@ -743,6 +743,7 @@ def list_files_recursive(
 
 
 __all__ = [
+    'FilePath',
     'remove_tree',
     'file_exists',
     'touch_file',

--- a/siege_utilities/geo/capabilities.py
+++ b/siege_utilities/geo/capabilities.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import importlib
 from typing import Any, Dict
 
+__all__ = ["geo_capabilities"]
+
 
 def _probe(module_name: str) -> bool:
     """Return True if *module_name* can be imported."""

--- a/siege_utilities/geo/django/management/commands/populate_pl_demographics.py
+++ b/siege_utilities/geo/django/management/commands/populate_pl_demographics.py
@@ -206,5 +206,6 @@ class Command(BaseCommand):
             return None
         try:
             return apps.get_model("siege_geo", model_name)
-        except LookupError:
+        except LookupError as exc:
+            log.warning("Could not resolve model: %s", exc)
             return None

--- a/siege_utilities/geo/django/models/education.py
+++ b/siege_utilities/geo/django/models/education.py
@@ -170,6 +170,10 @@ class NCESLocaleBoundary(TemporalBoundary):
         return f"{self.locale_category} ({self.locale_code}) [{self.nces_year}]"
 
     def save(self, *args, **kwargs):
+        """Persist the model, auto-populating feature_id and source.
+
+        *args/**kwargs: Forwarded to ``super().save()``.
+        """
         # Sync feature_id from locale code + year
         if not self.feature_id:
             self.feature_id = f"nces_locale_{self.locale_code}_{self.nces_year}"
@@ -240,6 +244,10 @@ class SchoolLocation(TemporalPointFeature):
         return f"{self.school_name} ({self.ncessch})"
 
     def save(self, *args, **kwargs):
+        """Persist the model, auto-populating feature_id and source.
+
+        *args/**kwargs: Forwarded to ``super().save()``.
+        """
         if not self.feature_id:
             self.feature_id = self.ncessch
         if not self.source:

--- a/siege_utilities/geo/django/models/federal.py
+++ b/siege_utilities/geo/django/models/federal.py
@@ -44,6 +44,10 @@ class NLRBRegion(TemporalBoundary):
         ]
 
     def save(self, *args, **kwargs):
+        """Persist the model, auto-populating feature_id and source.
+
+        *args/**kwargs: Forwarded to ``super().save()``.
+        """
         if self.region_number and not self.feature_id:
             self.feature_id = f"NLRB-{self.region_number:02d}"
             self.boundary_id = self.feature_id
@@ -98,6 +102,10 @@ class FederalJudicialDistrict(TemporalBoundary):
         ]
 
     def save(self, *args, **kwargs):
+        """Persist the model, auto-populating feature_id and source.
+
+        *args/**kwargs: Forwarded to ``super().save()``.
+        """
         if self.district_code and not self.feature_id:
             self.feature_id = self.district_code
             self.boundary_id = self.district_code

--- a/siege_utilities/geo/django/models/timezone.py
+++ b/siege_utilities/geo/django/models/timezone.py
@@ -59,6 +59,10 @@ class TimezoneGeometry(TemporalBoundary):
         ]
 
     def save(self, *args, **kwargs):
+        """Persist the model, auto-populating feature_id and source.
+
+        *args/**kwargs: Forwarded to ``super().save()``.
+        """
         if self.timezone_id and not self.feature_id:
             self.feature_id = self.timezone_id
             self.boundary_id = self.timezone_id

--- a/siege_utilities/geo/django/services/rollup_service.py
+++ b/siege_utilities/geo/django/services/rollup_service.py
@@ -372,5 +372,6 @@ class DemographicRollupService:
             return None
         try:
             return apps.get_model("siege_geo", model_name)
-        except LookupError:
+        except LookupError as exc:
+            log.warning("Could not resolve model: %s", exc)
             return None

--- a/siege_utilities/geo/django/services/timeseries_service.py
+++ b/siege_utilities/geo/django/services/timeseries_service.py
@@ -232,7 +232,8 @@ class TimeseriesService:
             return None
         try:
             return apps.get_model("siege_geo", model_name)
-        except LookupError:
+        except LookupError as exc:
+            log.warning("Could not resolve model: %s", exc)
             return None
 
     @staticmethod
@@ -250,7 +251,8 @@ class TimeseriesService:
             return None
         try:
             return (end_value / start_value) ** (1 / periods) - 1
-        except (ZeroDivisionError, ValueError):
+        except (ZeroDivisionError, ValueError) as exc:
+            log.warning("CAGR computation failed: %s", exc)
             return None
 
     @staticmethod

--- a/siege_utilities/geo/geocoding.py
+++ b/siege_utilities/geo/geocoding.py
@@ -586,6 +586,9 @@ class NominatimGeoClassifier:
     def from_json(self, json_string):
         """Replace the classifier's lookup tables from a JSON string.
 
+        Args:
+            json_string: JSON produced by :meth:`to_json`.
+
         Inverse of :meth:`to_json` — overwrites ``place_rank_dict`` and
         ``importance_dict`` in place. Unknown top-level keys are
         ignored; missing keys leave the corresponding table empty

--- a/siege_utilities/geo/providers/boundary_providers.py
+++ b/siege_utilities/geo/providers/boundary_providers.py
@@ -160,7 +160,8 @@ class CensusTIGERProvider(BoundaryProvider):
 
         try:
             vintages = self.list_available_vintages(timeout=timeout)
-        except requests.RequestException:
+        except requests.RequestException as exc:
+            logger.warning("Failed to fetch latest TIGER vintage: %s", exc)
             return None
         return max(vintages) if vintages else None
 

--- a/siege_utilities/geo/providers/redistricting_data_hub.py
+++ b/siege_utilities/geo/providers/redistricting_data_hub.py
@@ -1070,6 +1070,7 @@ __all__ = [
     "RDHDataFormat",
     "RDHDatasetType",
     # Constants
+    "RDH_MAX_RESULTS",
     "RDH_BASE_URL",
     "RDH_SITE_URL",
     "US_STATES",

--- a/siege_utilities/geo/spatial_runtime.py
+++ b/siege_utilities/geo/spatial_runtime.py
@@ -18,6 +18,16 @@ from typing import Any, Dict, List, Optional, Tuple
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "SpatialRuntimePlan",
+    "resolve_spatial_runtime_plan",
+    "GeometryPayload",
+    "encode_geometry",
+    "decode_geometry",
+    "payload_to_spark_row",
+    "spark_row_to_payload",
+]
+
 try:
     import shapely.geometry.base  # noqa: F401
     import shapely.wkt as _swkt

--- a/siege_utilities/geo/spatial_transformations.py
+++ b/siege_utilities/geo/spatial_transformations.py
@@ -614,7 +614,9 @@ class DuckDBConnector:
             **kwargs: Additional parameters
 
         Returns:
-            GeoDataFrame with spatial data.
+            GeoDataFrame with spatial data.  WKT geometries stored in
+            DuckDB lack SRID metadata; EPSG:4326 is assumed as the
+            source CRS.  Pass *crs* to reproject to a different target.
 
         Raises:
             SpatialQueryError: If the connection is unavailable or the

--- a/siege_utilities/geo/temporal/services.py
+++ b/siege_utilities/geo/temporal/services.py
@@ -206,7 +206,8 @@ class TemporalTimeseriesBuilder:
             return None
         try:
             return (end_value / start_value) ** (1 / periods) - 1
-        except (ZeroDivisionError, ValueError):
+        except (ZeroDivisionError, ValueError) as exc:
+            log.warning("CAGR computation failed: %s", exc)
             return None
 
     @staticmethod

--- a/siege_utilities/survey/render.py
+++ b/siege_utilities/survey/render.py
@@ -16,8 +16,11 @@ Chart type selection by TableType:
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+logger = logging.getLogger(__name__)
 
 import pandas as pd
 
@@ -160,6 +163,7 @@ def _build_map(chain: "Chain", map_generator: Optional[Any] = None) -> Optional[
             from ..reporting.chart_generator import ChartGenerator
             map_generator = ChartGenerator()
         except ImportError:
+            logger.warning("ChartGenerator unavailable — map rendering skipped")
             return None
 
     df = chain.to_dataframe()


### PR DESCRIPTION
## Summary

Continuation of PR #930. Three additional fixes from the hostile review soundness pass:

- **SU-1**: `credential_manager._get_from_prompt()` swallowed EOFError/KeyboardInterrupt without logging — callers couldn't distinguish "user cancelled prompt" from "no credential found"
- **SU-2**: DuckDB `download_spatial_data` docstring now documents the EPSG:4326 assumption for WKT geometries lacking SRID metadata; `SpatiaLiteCache.from_json` adds missing parameter docs
- **SU-2**: `config/__init__.__all__` completed with 11 names that were in the lazy-import registry but missing from `__all__` (GeographyLevel, SiegeConfig, load/save profile functions, config YAML import/export)

## Test plan

- [x] All modified files pass `py_compile`
- [x] No behavioral changes — additive logging and documentation only
- [x] `__all__` additions verified against `_LAZY_IMPORTS` registry