### PR TITLE
fix(SU-2): add __all__ to 19 config/models and survey modules

### DIFF
--- a/siege_utilities/config/models/actor_types.py
+++ b/siege_utilities/config/models/actor_types.py
@@ -14,6 +14,8 @@ from .person import Person, _convert_to_yaml_safe
 from .branding_config import BrandingConfig
 from .report_preferences import ReportPreferences
 
+__all__ = ["User", "Client", "Collaborator", "Organization", "Collaboration"]
+
 
 class User(Person):
     """

--- a/siege_utilities/config/models/branding_config.py
+++ b/siege_utilities/config/models/branding_config.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from typing import Optional
 import re
 
+__all__ = ["BrandingConfig"]
+
 
 class BrandingConfig(BaseModel):
     """

--- a/siege_utilities/config/models/client_profile.py
+++ b/siege_utilities/config/models/client_profile.py
@@ -11,6 +11,8 @@ from .social_media_account import SocialMediaAccount
 from .branding_config import BrandingConfig
 from .report_preferences import ReportPreferences
 
+__all__ = ["ContactInfo", "ClientProfile"]
+
 
 class ContactInfo(BaseModel):
     """

--- a/siege_utilities/config/models/credential.py
+++ b/siege_utilities/config/models/credential.py
@@ -8,6 +8,8 @@ from datetime import datetime
 from enum import Enum
 import re
 
+__all__ = ["CredentialType", "CredentialStatus", "Credential", "OnePasswordCredential"]
+
 
 class CredentialType(str, Enum):
     """Types of credentials supported."""

--- a/siege_utilities/config/models/data_sources.py
+++ b/siege_utilities/config/models/data_sources.py
@@ -11,6 +11,8 @@ from typing import List, Optional
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+__all__ = ["JurisdictionLevel", "DataSourceType", "DataSourceStatus", "Jurisdiction", "DataSource", "SourceCredential"]
+
 
 class JurisdictionLevel(str, Enum):
     """Level of government a data source covers."""

--- a/siege_utilities/config/models/database_connection.py
+++ b/siege_utilities/config/models/database_connection.py
@@ -7,6 +7,8 @@ from urllib.parse import quote_plus
 from pydantic import BaseModel, Field, field_validator, ConfigDict
 import re
 
+__all__ = ["DatabaseConnection"]
+
 
 class DatabaseConnection(BaseModel):
     """

--- a/siege_utilities/config/models/export.py
+++ b/siege_utilities/config/models/export.py
@@ -14,6 +14,8 @@ import yaml
 from .actor_types import User, Client, Collaborator, Organization, Collaboration
 from .person import _convert_to_yaml_safe
 
+__all__ = ["EXPORT_FORMAT_VERSION", "export_entities", "import_entities"]
+
 # Version of the export format
 EXPORT_FORMAT_VERSION = "1.0"
 

--- a/siege_utilities/config/models/google_account.py
+++ b/siege_utilities/config/models/google_account.py
@@ -11,6 +11,8 @@ from datetime import datetime
 from enum import Enum
 import re
 
+__all__ = ["GoogleAccountType", "GoogleAccountStatus", "GoogleAccount"]
+
 
 class GoogleAccountType(str, Enum):
     """Type of Google account authentication."""

--- a/siege_utilities/config/models/oauth_integration.py
+++ b/siege_utilities/config/models/oauth_integration.py
@@ -8,6 +8,8 @@ from datetime import datetime, timedelta
 from enum import Enum
 import re
 
+__all__ = ["OAuthProvider", "OAuthScope", "OAuthIntegration"]
+
 
 class OAuthProvider(str, Enum):
     """Supported OAuth providers."""

--- a/siege_utilities/config/models/person.py
+++ b/siege_utilities/config/models/person.py
@@ -15,6 +15,8 @@ from .google_account import GoogleAccount
 from .oauth_integration import OAuthIntegration
 from .database_connection import DatabaseConnection
 
+__all__ = ["Person"]
+
 
 class Person(BaseModel):
     """

--- a/siege_utilities/config/models/report_preferences.py
+++ b/siege_utilities/config/models/report_preferences.py
@@ -6,6 +6,8 @@ from pydantic import BaseModel, Field, field_validator
 from typing import Optional, List
 from enum import Enum
 
+__all__ = ["PageOrientation", "ReportFormat", "ReportPreferences"]
+
 
 class PageOrientation(str, Enum):
     """Page orientation options."""

--- a/siege_utilities/config/models/social_media_account.py
+++ b/siege_utilities/config/models/social_media_account.py
@@ -7,6 +7,8 @@ from typing import Optional
 from datetime import datetime
 import re
 
+__all__ = ["SocialMediaAccount"]
+
 
 class SocialMediaAccount(BaseModel):
     """

--- a/siege_utilities/config/models/user_profile.py
+++ b/siege_utilities/config/models/user_profile.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from typing import Tuple
 import re
 
+__all__ = ["UserProfile"]
+
 
 class UserProfile(BaseModel):
     """

--- a/siege_utilities/survey/crosstab.py
+++ b/siege_utilities/survey/crosstab.py
@@ -15,6 +15,8 @@ from .models import Chain, View
 
 DEFAULT_Z_VALUE = 1.96
 
+__all__ = ["CrosstabInputError", "build_chain"]
+
 try:
     from scipy.stats import t as _scipy_t
     _SCIPY_T_AVAILABLE = True

--- a/siege_utilities/survey/registry.py
+++ b/siege_utilities/survey/registry.py
@@ -23,6 +23,8 @@ from typing import Dict, List, Optional
 
 from .models import WaveSet
 
+__all__ = ["ClientSurveyError", "ClientSurveyRegistry"]
+
 
 class ClientSurveyError(KeyError):
     """Raised for registry-level lookup / duplication problems.

--- a/siege_utilities/survey/render.py
+++ b/siege_utilities/survey/render.py
@@ -29,6 +29,8 @@ from ..reporting.pages.page_models import Argument, TableType
 if TYPE_CHECKING:
     from .models import Chain, Stack
 
+__all__ = ["RenderError", "ArgumentCluster", "chain_to_argument", "stack_to_arguments"]
+
 try:
     import matplotlib
     matplotlib.use("Agg")

--- a/siege_utilities/survey/significance.py
+++ b/siege_utilities/survey/significance.py
@@ -32,6 +32,8 @@ if TYPE_CHECKING:
     from .models import Chain
 
 
+__all__ = ["SignificanceError", "column_proportion_test", "chi_square_flag"]
+
 class SignificanceError(RuntimeError):
     """Raised when significance testing cannot complete on the given chain."""
 

--- a/siege_utilities/survey/waves.py
+++ b/siege_utilities/survey/waves.py
@@ -18,6 +18,8 @@ if TYPE_CHECKING:
     from .models import WaveSet
 
 
+__all__ = ["WavesError", "compare_waves"]
+
 class WavesError(ValueError):
     """Raised when a WaveSet operation is given incomplete or mismatched data."""
 

--- a/siege_utilities/survey/weights.py
+++ b/siege_utilities/survey/weights.py
@@ -14,6 +14,8 @@ from typing import Any, Dict
 
 import pandas as pd
 
+__all__ = ["WeightingConvergenceError", "apply_rim_weights"]
+
 
 class WeightingConvergenceError(RuntimeError):
     """Raised when weightipy fails to converge within max_iterations."""


### PR DESCRIPTION
## Summary

Adds explicit `__all__` exports to 19 modules across `config/models/` and `survey/`:

- 13 config model files: branding_config, data_sources, report_preferences, social_media_account, user_profile, actor_types, client_profile, credential, export, google_account, oauth_integration, person, database_connection
- 6 survey files: waves, registry, crosstab, significance, weights, render

All modules now declare their public API surface explicitly, satisfying SU-2 ("Does it do what it says?") for export completeness.