### PR TITLE
fix(SU-1, SU-2, SU-3): soundness pass — geo, files, reporting, examples

### DIFF
--- a/siege_utilities/config/user_config.py
+++ b/siege_utilities/config/user_config.py
@@ -159,9 +159,14 @@ class UserConfigManager:
     def update_user_profile(self, **kwargs):
         """
         Update user profile with new values.
-        
+
         Args:
-            **kwargs: Profile fields to update
+            **kwargs: Fields on :class:`UserProfile` to overwrite. Accepted
+                keys include ``username``, ``email``, ``full_name``,
+                ``preferred_download_directory``, ``default_output_format``,
+                ``preferred_map_style``, ``default_color_scheme``, and any
+                other ``UserProfile`` attribute. Unknown keys are logged as
+                warnings and ignored.
         """
         for key, value in kwargs.items():
             if hasattr(self.user_profile, key):

--- a/siege_utilities/examples/enhanced_features_demo.py
+++ b/siege_utilities/examples/enhanced_features_demo.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""
+Enhanced Features Demo for Siege Utilities
+
+This script demonstrates key library features:
+1. User Configuration Management
+2. Page Templates and Chart Types
+3. Spatial Data Sources (Census boundaries and demographics)
+4. Spatial Data Transformation and Format Conversion
+5. Default Download Directory Management
+
+Prerequisites:
+    pip install siege_utilities[geo,reporting]
+"""
+
+import logging
+import sys
+from pathlib import Path
+from typing import Optional
+
+import geopandas as gpd
+import pandas as pd
+
+from siege_utilities import get_user_config, get_download_directory
+from siege_utilities.geo import (
+    get_census_boundaries,
+    get_census_data,
+    download_osm_data,
+    SpatialDataTransformer,
+)
+from siege_utilities.reporting.chart_types import get_chart_registry
+from siege_utilities.reporting.templates.page_templates import get_template_manager
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def demo_user_configuration():
+    """Demonstrate user configuration management."""
+    print("\n" + "=" * 60)
+    print("USER CONFIGURATION DEMO")
+    print("=" * 60)
+
+    user_config = get_user_config()
+    profile = user_config.get_user_profile()
+    print(f"Current user: {profile.full_name} ({profile.username})")
+    print(f"Email: {profile.email}")
+    print(f"Organization: {profile.organization}")
+    print(f"Default download directory: {profile.preferred_download_directory}")
+    print(f"Default output format: {profile.default_output_format}")
+
+    download_dir = get_download_directory()
+    print(f"Using download directory: {download_dir}")
+
+
+def demo_page_templates():
+    """Demonstrate extensible page templates."""
+    print("\n" + "=" * 60)
+    print("PAGE TEMPLATES DEMO")
+    print("=" * 60)
+
+    template_manager = get_template_manager()
+
+    pdf_templates = template_manager.list_templates("pdf")
+    ppt_templates = template_manager.list_templates("powerpoint")
+
+    print(f"Available PDF templates: {pdf_templates}")
+    print(f"Available PowerPoint templates: {ppt_templates}")
+
+    title_template = template_manager.get_template("pdf_title")
+    if title_template:
+        print(f"\nTitle template properties:")
+        print(f"  - Page dimensions: {title_template.page_width}\" x {title_template.page_height}\"")
+        print(f"  - Margins: {title_template.margins}")
+        print(f"  - Custom elements: {title_template.custom_elements}")
+
+
+def demo_chart_types():
+    """Demonstrate extensible chart types."""
+    print("\n" + "=" * 60)
+    print("CHART TYPES DEMO")
+    print("=" * 60)
+
+    chart_registry = get_chart_registry()
+
+    geographic_charts = chart_registry.list_chart_types("geographic")
+    statistical_charts = chart_registry.list_chart_types("statistical")
+
+    print(f"Available geographic charts: {geographic_charts}")
+    print(f"Available statistical charts: {statistical_charts}")
+
+    bivariate_help = chart_registry.get_chart_help("bivariate_choropleth")
+    if bivariate_help:
+        print(f"\nBivariate choropleth chart:")
+        print(f"  - Description: {bivariate_help['description']}")
+        print(f"  - Required parameters: {bivariate_help['required_parameters']}")
+        print(f"  - Supports interactive: {bivariate_help['supports_interactive']}")
+
+
+def demo_spatial_data_sources():
+    """Demonstrate spatial data sources (Census boundaries and demographics)."""
+    print("\n" + "=" * 60)
+    print("SPATIAL DATA SOURCES DEMO")
+    print("=" * 60)
+
+    download_dir = get_download_directory()
+
+    try:
+        print("Downloading Census county boundaries...")
+        counties: Optional[gpd.GeoDataFrame] = get_census_boundaries(
+            year=2020, geographic_level="county"
+        )
+
+        if counties is not None:
+            print(f"Downloaded {len(counties)} counties")
+            print(f"Columns: {list(counties.columns)}")
+            print(f"CRS: {counties.crs}")
+
+            output_path = download_dir / "census_counties_2020.gpkg"
+            counties.to_file(output_path, driver="GPKG")
+            print(f"Saved to: {output_path}")
+        else:
+            logger.warning(
+                "Census boundary download returned None; "
+                "check network connectivity and Census API availability"
+            )
+
+    except Exception as exc:
+        logger.error("Census boundary download failed: %s", exc)
+
+
+def demo_spatial_transformations():
+    """Demonstrate spatial data transformations using GeoPandas and SpatialDataTransformer."""
+    print("\n" + "=" * 60)
+    print("SPATIAL TRANSFORMATIONS DEMO")
+    print("=" * 60)
+
+    download_dir = get_download_directory()
+    counties_path = download_dir / "census_counties_2020.gpkg"
+
+    if not counties_path.exists():
+        logger.info(
+            "Skipping transformation demo: run spatial_data_sources demo first "
+            "to download Census county data"
+        )
+        return
+
+    try:
+        counties = gpd.read_file(counties_path)
+        print(f"Loaded {len(counties)} counties for transformation")
+
+        # CRS reprojection via GeoPandas
+        print("Reprojecting to Web Mercator (EPSG:3857)...")
+        counties_mercator = counties.to_crs(epsg=3857)
+        print(f"Reprojected CRS: {counties_mercator.crs}")
+
+        # Geometry simplification via GeoPandas
+        print("Simplifying geometries (tolerance=1000m in projected CRS)...")
+        counties_mercator["geometry"] = counties_mercator.geometry.simplify(
+            tolerance=1000
+        )
+        print(f"Simplified {len(counties_mercator)} geometries")
+
+        # Format conversion via SpatialDataTransformer
+        print("Converting simplified data to GeoJSON...")
+        geojson_path = download_dir / "counties_simplified.geojson"
+        transformer = SpatialDataTransformer()
+        transformer.convert_format(
+            counties_mercator.to_crs(epsg=4326), "geojson", output_path=str(geojson_path)
+        )
+        print(f"Saved GeoJSON: {geojson_path}")
+
+    except Exception as exc:
+        logger.error("Spatial transformation failed: %s", exc)
+
+
+def main():
+    """Run all demos."""
+    print("SIEGE UTILITIES - ENHANCED FEATURES DEMO")
+    print("=" * 60)
+
+    try:
+        demo_user_configuration()
+        demo_page_templates()
+        demo_chart_types()
+        demo_spatial_data_sources()
+        demo_spatial_transformations()
+
+        print("\n" + "=" * 60)
+        print("ALL DEMOS COMPLETED SUCCESSFULLY")
+        print("=" * 60)
+
+        download_dir = get_download_directory()
+        if download_dir.exists():
+            print(f"\nFiles created in: {download_dir}")
+            for f in sorted(download_dir.glob("*")):
+                if f.is_file():
+                    size_mb = f.stat().st_size / (1024 * 1024)
+                    print(f"  - {f.name} ({size_mb:.2f} MB)")
+
+    except Exception as exc:
+        logger.exception("Demo execution failed: %s", exc)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/siege_utilities/files/remote.py
+++ b/siege_utilities/files/remote.py
@@ -45,6 +45,7 @@ def _safe_content_length(response) -> int:
     try:
         return int(raw)
     except (ValueError, TypeError):
+        log.warning("Malformed Content-Length header: %r", raw)
         return 0
 
 def _get_ssl_verify_path():
@@ -359,13 +360,14 @@ def is_downloadable(url: str, timeout: int = 10) -> bool:
         info = get_file_info(url, timeout)
         if info['size'] > 0:
             return True
-    except (ConnectionError, OSError, ValueError):
-        pass
+    except (ConnectionError, OSError, ValueError) as exc:
+        log.warning("is_downloadable: file info check failed for %s: %s", url, exc)
 
     try:
         response = requests.get(url, stream=True, timeout=timeout)
         return response.ok
-    except (OSError, ValueError):
+    except (OSError, ValueError) as exc:
+        log.warning("is_downloadable: GET request failed for %s: %s", url, exc)
         return False
 
 __all__ = [

--- a/siege_utilities/geo/boundary_result.py
+++ b/siege_utilities/geo/boundary_result.py
@@ -24,12 +24,26 @@ try:
 except ImportError:
     gpd = None
 
+from ..exceptions import SiegeGeoError
+
+__all__ = [
+    "BoundaryConfigurationError",
+    "BoundaryDiscoveryError",
+    "BoundaryDownloadError",
+    "BoundaryFetchResult",
+    "BoundaryInputError",
+    "BoundaryParseError",
+    "BoundaryRetrievalError",
+    "BoundaryUrlValidationError",
+    "fail",
+    "ok",
+    "raise_on_error",
+]
+
 
 # ---------------------------------------------------------------------------
 # Typed Exceptions
 # ---------------------------------------------------------------------------
-
-from ..exceptions import SiegeGeoError
 
 
 class BoundaryRetrievalError(SiegeGeoError):

--- a/siege_utilities/geo/choropleth.py
+++ b/siege_utilities/geo/choropleth.py
@@ -55,6 +55,19 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "BivariateAnalysisResult",
+    "create_bivariate_analysis",
+    "create_bivariate_choropleth",
+    "create_bivariate_companion_maps",
+    "create_bivariate_crosstab",
+    "create_choropleth",
+    "create_choropleth_comparison",
+    "create_classified_comparison",
+    "save_map",
+    "verify_bivariate_classification",
+]
+
 # Check for mapclassify (used by geopandas scheme= parameter)
 try:
     import mapclassify  # noqa: F401

--- a/siege_utilities/geo/codification.py
+++ b/siege_utilities/geo/codification.py
@@ -21,6 +21,12 @@ from typing import Any, Optional, Union
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "BlockProfile",
+    "CodificationResult",
+    "codify_area",
+]
+
 
 # ---------------------------------------------------------------------------
 # Result types

--- a/siege_utilities/geo/data_reception.py
+++ b/siege_utilities/geo/data_reception.py
@@ -36,6 +36,16 @@ from typing import Any, Iterable
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "MISSING_NONE",
+    "MISSING_RAISE",
+    "MISSING_WARN",
+    "detect_format",
+    "extract_attributes_kml",
+    "extract_attributes_ogr",
+    "extract_attributes_swmaps",
+]
+
 # Extension -> format token. Extensions match the dispatcher cases in the
 # salvage source plus the SWMaps `.swmz` archive form.
 _EXTENSION_MAP = {

--- a/siege_utilities/geo/databricks_fallback.py
+++ b/siege_utilities/geo/databricks_fallback.py
@@ -5,6 +5,13 @@ from typing import Iterable, List
 
 from siege_utilities.config.census_constants import resolve_geographic_level
 
+__all__ = [
+    "SpatialLoaderPlan",
+    "build_census_ingest_targets",
+    "build_census_table_name",
+    "select_spatial_loader",
+]
+
 
 @dataclass(frozen=True)
 class SpatialLoaderPlan:

--- a/siege_utilities/geo/h3_utils.py
+++ b/siege_utilities/geo/h3_utils.py
@@ -35,6 +35,16 @@ except ImportError:
     log.info("h3 not available - H3 spatial index functions will raise ImportError")
 
 
+__all__ = [
+    "h3_hex_to_boundary",
+    "h3_index_points",
+    "h3_index_polygon",
+    "h3_resolution_for_admin_level",
+    "h3_resolution_for_area",
+    "h3_spatial_join",
+]
+
+
 def _require_h3():
     """Raise ImportError if h3 is not installed."""
     if not H3_AVAILABLE:

--- a/siege_utilities/geo/isochrones.py
+++ b/siege_utilities/geo/isochrones.py
@@ -23,6 +23,23 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+__all__ = [
+    "DEFAULT_ORS_BASE_URL",
+    "DEFAULT_VALHALLA_BASE_URL",
+    "ISOCHRONE_DEFAULT_RETRIES",
+    "IsochroneError",
+    "IsochroneNetworkError",
+    "IsochroneProvider",
+    "IsochroneProviderError",
+    "IsochroneRequest",
+    "OpenRouteServiceProvider",
+    "ValhallaProvider",
+    "build_isochrone_request",
+    "get_isochrone",
+    "get_provider",
+    "isochrone_to_geodataframe",
+]
+
 DEFAULT_ORS_BASE_URL = "https://api.openrouteservice.org"
 DEFAULT_VALHALLA_BASE_URL = "http://localhost:8002"
 

--- a/siege_utilities/geo/locale.py
+++ b/siege_utilities/geo/locale.py
@@ -29,6 +29,25 @@ from siege_utilities.config.nces_constants import (
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "CITY_LARGE",
+    "CITY_MIDSIZE",
+    "CITY_SMALL",
+    "LocaleCode",
+    "LocaleIndex",
+    "LocaleType",
+    "NCESLocaleClassifier",
+    "RURAL_DISTANT",
+    "RURAL_FRINGE",
+    "RURAL_REMOTE",
+    "SUBURB_LARGE",
+    "SUBURB_MIDSIZE",
+    "SUBURB_SMALL",
+    "TOWN_DISTANT",
+    "TOWN_FRINGE",
+    "TOWN_REMOTE",
+]
+
 # Meters per mile — used for distance conversion after CRS projection
 _METERS_PER_MILE = 1_609.344
 

--- a/siege_utilities/geo/overlay_registry.py
+++ b/siege_utilities/geo/overlay_registry.py
@@ -25,6 +25,12 @@ from typing import Any, Optional
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "OverlayRegistry",
+    "PlaceHistoryOverlay",
+    "overlay_registry",
+]
+
 
 class PlaceHistoryOverlay(abc.ABC):
     """Base class for place history overlays.

--- a/siege_utilities/geo/place_history.py
+++ b/siege_utilities/geo/place_history.py
@@ -22,6 +22,17 @@ from typing import Any, Optional, Protocol, Union
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "CENSUS_DECADE_YEARS",
+    "CrosswalkProvider",
+    "CrosswalkRecord",
+    "DictCrosswalkProvider",
+    "Lineage",
+    "LineageStep",
+    "PlaceHistoryResult",
+    "place_history",
+]
+
 CENSUS_DECADE_YEARS = [1990, 2000, 2010, 2020, 2030]
 
 

--- a/siege_utilities/geo/plan_lifecycle.py
+++ b/siege_utilities/geo/plan_lifecycle.py
@@ -17,6 +17,21 @@ from typing import Any, Optional
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "ACTIVE_STATUSES",
+    "DictPlanLifecycleProvider",
+    "EnactedBy",
+    "PlanLifecycleEvent",
+    "PlanLifecycleProvider",
+    "PlanLifecycleStatus",
+    "PlanLineage",
+    "PlanType",
+    "RedistrictingPlan",
+    "TERMINAL_STATUSES",
+    "build_lineage",
+    "resolve_plan_at",
+]
+
 
 class PlanLifecycleStatus(str, Enum):
     """Status in the lifecycle of a redistricting plan."""

--- a/siege_utilities/geo/precinct_vtd.py
+++ b/siege_utilities/geo/precinct_vtd.py
@@ -16,6 +16,24 @@ from typing import Any, Optional
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "ConfidenceLevel",
+    "DictNameMatchProvider",
+    "DictSpatialOverlapProvider",
+    "MIN_NAME_SIMILARITY",
+    "MIN_OVERLAP_PCT",
+    "NAME_WEIGHT",
+    "NameMatchProvider",
+    "OfficialCrosswalkEntry",
+    "PrecinctVTDMapping",
+    "PrecinctVTDReconciler",
+    "ReconciliationMethod",
+    "ReconciliationResult",
+    "SPATIAL_WEIGHT",
+    "SpatialOverlap",
+    "SpatialOverlapProvider",
+]
+
 
 class ReconciliationMethod(str, Enum):
     """How a precinct-VTD mapping was determined."""

--- a/siege_utilities/geo/providers/boundary_providers.py
+++ b/siege_utilities/geo/providers/boundary_providers.py
@@ -277,7 +277,8 @@ def resolve_boundary_provider(country: str = 'US', **kwargs: Any) -> BoundaryPro
 
     Args:
         country: ISO-2 or ISO-3 country code (default ``'US'``).
-        **kwargs: Forwarded to the provider constructor.
+        **kwargs: Forwarded to :class:`GADMProvider` constructor for non-US
+            countries. Ignored for US (CensusTIGERProvider takes no options).
 
     Returns:
         CensusTIGERProvider for US / US territories, GADMProvider otherwise.

--- a/siege_utilities/geo/rdh_catalog.py
+++ b/siege_utilities/geo/rdh_catalog.py
@@ -17,6 +17,16 @@ from typing import Any, Optional
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "CatalogEntry",
+    "CoverageCell",
+    "DEFAULT_CACHE_TTL",
+    "DictRDHCatalogProvider",
+    "RDHCatalog",
+    "RDHCatalogProvider",
+    "SearchResult",
+]
+
 DEFAULT_CACHE_TTL = 30 * 24 * 3600  # 30 days in seconds
 CACHE_FILENAME = "rdh_catalog.json"
 

--- a/siege_utilities/geo/swmaps_reader.py
+++ b/siege_utilities/geo/swmaps_reader.py
@@ -45,6 +45,12 @@ from typing import Iterator
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "SWMapsArchive",
+    "open_swmaps",
+    "read_features",
+]
+
 # Recognized .swmz container extensions and raw-SQLite extensions.
 _ARCHIVE_EXTS = {".swmz", ".zip"}
 _SQLITE_EXTS = {".sqlite", ".db"}

--- a/siege_utilities/geo/validators.py
+++ b/siege_utilities/geo/validators.py
@@ -21,6 +21,17 @@ import re
 
 from siege_utilities.config.census_constants import FIPS_TO_STATE
 
+__all__ = [
+    "BlockGroupGEOIDValidator",
+    "CountyFIPSValidator",
+    "StateFIPSValidator",
+    "TractGEOIDValidator",
+    "is_valid_block_group_geoid",
+    "is_valid_county_fips",
+    "is_valid_state_fips",
+    "is_valid_tract_geoid",
+]
+
 
 # =============================================================================
 # STANDALONE VALIDATION FUNCTIONS

--- a/siege_utilities/reporting/chart_types.py
+++ b/siege_utilities/reporting/chart_types.py
@@ -411,7 +411,9 @@ class ChartTypeRegistry:
         ----------
         chart_type_name : str
         **kwargs
-            Parameters to validate.
+            Chart parameters to validate against the chart type's
+            ``required_parameters``. If the chart type defines a custom
+            ``validate_function``, all kwargs are forwarded to it.
 
         Returns
         -------

--- a/siege_utilities/reporting/templates/page_templates.py
+++ b/siege_utilities/reporting/templates/page_templates.py
@@ -283,10 +283,14 @@ class PageTemplateManager:
     def modify_template(self, template_name: str, **kwargs):
         """
         Modify an existing template.
-        
+
         Args:
-            template_name: Name of the template to modify
-            **kwargs: Fields to modify
+            template_name: Name of the template to modify.
+            **kwargs: :class:`PageTemplate` attributes to overwrite. Accepted
+                keys include ``page_width``, ``page_height``, ``margins``,
+                ``background_color``, ``default_font``, ``custom_elements``,
+                and any other ``PageTemplate`` field. Unknown keys are logged
+                as warnings and ignored.
         """
         template = self.templates.get(template_name)
         if not template:


### PR DESCRIPTION
## Summary

Multi-rule soundness pass across 21 files:

**SU-1 (Errors are not data):**
- `files/remote.py`: `_safe_content_length()` and `is_downloadable()` now log warnings on failure instead of silently returning 0/False

**SU-2 (Does it do what it says?):**
- Added `__all__` to 15 geo modules (choropleth, h3_utils, isochrones, locale, place_history, plan_lifecycle, precinct_vtd, overlay_registry, codification, data_reception, validators, swmaps_reader, boundary_result, rdh_catalog, databricks_fallback)
- Documented `**kwargs` forwarding targets in 4 functions (user_config, page_templates, chart_types, boundary_providers)

**SU-3 (No demo exemptions):**
- Rewrote `examples/enhanced_features_demo.py` — the original imported nonexistent functions (`transform_spatial_crs`, `simplify_spatial_geometries`, `buffer_spatial_geometries`) and used unavailable top-level imports, crashing on first line. Now uses real, importable APIs.