### PR TITLE
fix(SU-2): add __all__ to 35 modules + document Raises in migration_runner

### DIFF
--- a/siege_utilities/admin/profile_manager.py
+++ b/siege_utilities/admin/profile_manager.py
@@ -16,6 +16,17 @@ from ..config.models import ContactInfo, BrandingConfig, ReportPreferences
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "create_default_profiles",
+    "get_default_profile_location",
+    "get_profile_location",
+    "get_profile_summary",
+    "list_profile_locations",
+    "migrate_profiles",
+    "set_profile_location",
+    "validate_profile_location",
+]
+
 # Global profile location registry
 PROFILE_LOCATIONS: Dict[str, Path] = {}
 

--- a/siege_utilities/analytics/facebook_business.py
+++ b/siege_utilities/analytics/facebook_business.py
@@ -51,6 +51,15 @@ except ImportError:
     def log_error(message): pass
     def log_debug(message): pass
 
+__all__ = [
+    "FacebookBusinessConnector",
+    "batch_retrieve_facebook_data",
+    "create_facebook_account_profile",
+    "list_facebook_accounts_for_client",
+    "load_facebook_account_profile",
+    "save_facebook_account_profile",
+]
+
 
 class FacebookBusinessConnector:
     """Facebook Business connection and data retrieval manager."""

--- a/siege_utilities/analytics/google_analytics.py
+++ b/siege_utilities/analytics/google_analytics.py
@@ -67,6 +67,18 @@ except ImportError:
     def log_error(message): pass
     def log_debug(message): pass
 
+__all__ = [
+    "GoogleAnalyticsConnector",
+    "batch_retrieve_ga_data",
+    "create_ga_account_profile",
+    "create_ga_connector_from_1password",
+    "create_ga_connector_with_oauth2",
+    "create_ga_connector_with_service_account",
+    "list_ga_accounts_for_client",
+    "load_ga_account_profile",
+    "save_ga_account_profile",
+]
+
 
 class GoogleAnalyticsConnector:
     """Google Analytics connection and data retrieval manager."""

--- a/siege_utilities/analytics/google_docs.py
+++ b/siege_utilities/analytics/google_docs.py
@@ -21,6 +21,19 @@ from typing import Any, Dict, List, Optional
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "batch_update",
+    "copy_document",
+    "create_document",
+    "get_document",
+    "insert_image",
+    "insert_paragraph",
+    "insert_table",
+    "insert_text",
+    "read_document_text",
+    "replace_text",
+]
+
 
 def create_document(
     client,

--- a/siege_utilities/analytics/google_sheets.py
+++ b/siege_utilities/analytics/google_sheets.py
@@ -29,6 +29,19 @@ except ImportError:
     pd = None
     _PANDAS_AVAILABLE = False
 
+__all__ = [
+    "add_sheet",
+    "append_rows",
+    "batch_update",
+    "copy_spreadsheet",
+    "create_spreadsheet",
+    "get_spreadsheet_metadata",
+    "read_dataframe",
+    "read_values",
+    "write_dataframe",
+    "write_values",
+]
+
 
 def create_spreadsheet(
     client,

--- a/siege_utilities/analytics/google_slides.py
+++ b/siege_utilities/analytics/google_slides.py
@@ -23,6 +23,20 @@ from typing import Any, Dict, List, Optional
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "add_blank_slide",
+    "batch_update",
+    "copy_presentation",
+    "create_argument_slide",
+    "create_presentation",
+    "create_report_from_arguments",
+    "create_textbox",
+    "get_presentation",
+    "insert_image",
+    "insert_text",
+    "upload_figure_to_drive",
+]
+
 
 def create_presentation(
     client,

--- a/siege_utilities/analytics/google_workspace.py
+++ b/siege_utilities/analytics/google_workspace.py
@@ -50,6 +50,11 @@ try:
 except ImportError:
     _GOOGLE_AVAILABLE = False
 
+__all__ = [
+    "GoogleWorkspaceClient",
+    "WORKSPACE_SCOPES",
+]
+
 # Scopes needed for read/write on Docs, Sheets, Slides
 WORKSPACE_SCOPES = [
     "https://www.googleapis.com/auth/spreadsheets",

--- a/siege_utilities/data/statistics/moe_propagation.py
+++ b/siege_utilities/data/statistics/moe_propagation.py
@@ -22,6 +22,17 @@ from typing import Sequence
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "Estimate",
+    "Z_90",
+    "flag_unreliable",
+    "moe_difference",
+    "moe_product",
+    "moe_proportion",
+    "moe_ratio",
+    "moe_sum",
+]
+
 
 Z_90 = 1.645  # z-score for 90% confidence (ACS default)
 

--- a/siege_utilities/databricks/artifacts.py
+++ b/siege_utilities/databricks/artifacts.py
@@ -1,5 +1,9 @@
 """Databricks artifact helpers."""
 
+__all__ = [
+    "build_databricks_run_url",
+]
+
 
 def build_databricks_run_url(host: str, workspace_id: str, run_id: str) -> str:
     """Build a direct Databricks run URL."""

--- a/siege_utilities/databricks/lakebase.py
+++ b/siege_utilities/databricks/lakebase.py
@@ -6,6 +6,13 @@ from typing import Dict
 
 from siege_utilities.conf import settings
 
+__all__ = [
+    "build_jdbc_url",
+    "build_lakebase_psql_command",
+    "build_pgpass_entry",
+    "parse_conninfo",
+]
+
 
 # Postgres connection-string field allow-lists. These match the typical
 # Postgres identifier rules; values matching anything outside are rejected

--- a/siege_utilities/distributed/hdfs_config.py
+++ b/siege_utilities/distributed/hdfs_config.py
@@ -9,6 +9,16 @@ from typing import Optional, Callable
 
 from siege_utilities.core.logging import get_logger, log_info, log_warning, log_error, log_debug
 
+__all__ = [
+    "HDFSConfig",
+    "create_census_analysis_config",
+    "create_cluster_config",
+    "create_geocoding_config",
+    "create_hdfs_config",
+    "create_local_config",
+    "create_yarn_config",
+]
+
 
 @dataclass
 class HDFSConfig:

--- a/siege_utilities/distributed/hdfs_operations.py
+++ b/siege_utilities/distributed/hdfs_operations.py
@@ -10,6 +10,12 @@ from typing import Optional, Tuple, Dict, List
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "AbstractHDFSOperations",
+    "create_hdfs_operations",
+    "setup_distributed_environment",
+]
+
 
 def _default_hash_function(file_path: str) -> str:
     """Default hash function using built-in hashlib."""

--- a/siege_utilities/economic/bls/qcew.py
+++ b/siege_utilities/economic/bls/qcew.py
@@ -27,6 +27,12 @@ import requests
 
 logger = logging.getLogger(__name__)
 
+__all__ = [
+    "DEFAULT_CACHE_DIR",
+    "QCEW_FILE_URL",
+    "QCEWFiles",
+]
+
 
 # QCEW open-data URL pattern.
 # Example: https://data.bls.gov/cew/data/files/2024/csv/2024_qtrly_singlefile.zip

--- a/siege_utilities/education/nces/files.py
+++ b/siege_utilities/education/nces/files.py
@@ -28,6 +28,17 @@ import requests
 
 logger = logging.getLogger(__name__)
 
+__all__ = [
+    "CCD_DIRECTORY_URL",
+    "CCD_F33_URL",
+    "CCD_NONFISCAL_URL",
+    "CCD_SCHOOL_DIRECTORY_URL",
+    "CCD_SCHOOL_NONFISCAL_URL",
+    "DEFAULT_CACHE_DIR",
+    "EDGE_DISTRICT_DEMOGRAPHICS_URL",
+    "NCESFiles",
+]
+
 # Default cache location.
 DEFAULT_CACHE_DIR = Path.home() / ".siege_utilities" / "cache" / "nces"
 

--- a/siege_utilities/files/hashing.py
+++ b/siege_utilities/files/hashing.py
@@ -31,6 +31,14 @@ except ImportError:  # pragma: no cover - validation should always be present
         "This is almost certainly a packaging bug — investigate."
     )
 
+__all__ = [
+    "calculate_file_hash",
+    "generate_sha256_hash_for_file",
+    "get_file_hash",
+    "get_quick_file_signature",
+    "verify_file_integrity",
+]
+
 # 64 KiB — matches stdlib hashlib's recommended buffered-read size and
 # what the reference filehash recipe uses. Centralised so we don't
 # drift across the four hash helpers below.

--- a/siege_utilities/identifiers/namespaces.py
+++ b/siege_utilities/identifiers/namespaces.py
@@ -10,6 +10,11 @@ shown in the docstrings below).
 
 from uuid import NAMESPACE_URL, UUID, uuid5
 
+__all__ = [
+    "derive_root",
+    "derive_sub_namespace",
+]
+
 
 def derive_root(seed: str) -> UUID:
     """

--- a/siege_utilities/identifiers/normalize.py
+++ b/siege_utilities/identifiers/normalize.py
@@ -27,6 +27,10 @@ NORMALIZER_VERSIONS: dict[str, str] = {
 _PUNCTUATION_RE = re.compile(r"[^\w\s]", flags=re.UNICODE)
 _WHITESPACE_RE = re.compile(r"\s+")
 
+__all__ = [
+    "normalize_name_v1",
+]
+
 
 def normalize_name_v1(name: str) -> str:
     """

--- a/siege_utilities/identifiers/uuid_generation.py
+++ b/siege_utilities/identifiers/uuid_generation.py
@@ -13,6 +13,11 @@ directly, not these helpers.
 
 from uuid import UUID, uuid5
 
+__all__ = [
+    "attestation_uuid",
+    "uuid5_from_seed",
+]
+
 # ASCII Record Separator — never appears in hash strings, version tags, or
 # file paths, so it is an unambiguous component delimiter in attestation seeds.
 _RS = "\x1e"

--- a/siege_utilities/reporting/analytics/polling_analyzer.py
+++ b/siege_utilities/reporting/analytics/polling_analyzer.py
@@ -30,6 +30,11 @@ from siege_utilities.core.logging import log_error
 
 from ..chart_generator import ChartGenerator
 
+__all__ = [
+    "PollingAnalysisError",
+    "PollingAnalyzer",
+]
+
 
 class PollingAnalysisError(RuntimeError):
     """Raised when polling analysis cannot complete due to bad input or config."""

--- a/siege_utilities/reporting/analytics_reports.py
+++ b/siege_utilities/reporting/analytics_reports.py
@@ -14,6 +14,11 @@ from .chart_generator import ChartGenerator
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "AnalyticsReportGenerator",
+]
+
+
 class AnalyticsReportGenerator:
     """
     Generates analytics reports from various data sources.

--- a/siege_utilities/reporting/chart_generator.py
+++ b/siege_utilities/reporting/chart_generator.py
@@ -70,6 +70,24 @@ from .engines import (
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "ChartGenerator",
+    "create_bar_chart",
+    "create_bivariate_choropleth",
+    "create_choropleth_map",
+    "create_convergence_diagram",
+    "create_dashboard",
+    "create_dataframe_summary_charts",
+    "create_flow_map",
+    "create_heatmap",
+    "create_line_chart",
+    "create_marker_map",
+    "create_pie_chart",
+    "create_scatter_plot",
+    "generate_chart_from_dataframe",
+]
+
+
 class ChartGenerator(BaseChartEngine, BarChartMixin, MapChartMixin, StatsChartMixin, CompositeChartMixin):
     """
     Generates charts and visualizations for reports using matplotlib, seaborn, plotly, and folium.

--- a/siege_utilities/reporting/chart_types.py
+++ b/siege_utilities/reporting/chart_types.py
@@ -22,6 +22,17 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "ChartCreationError",
+    "ChartParameterError",
+    "ChartType",
+    "ChartTypeRegistry",
+    "UnknownChartTypeError",
+    "create_chart",
+    "get_chart_registry",
+    "register_chart_type",
+]
+
 
 class UnknownChartTypeError(LookupError):
     """Raised when a chart type name is not in the registry."""

--- a/siege_utilities/reporting/engines/bar_engine.py
+++ b/siege_utilities/reporting/engines/bar_engine.py
@@ -36,6 +36,10 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "BarChartMixin",
+]
+
 
 class BarChartMixin:
     """Bar chart, line chart, pie chart, and proportional text bar chart methods."""

--- a/siege_utilities/reporting/engines/base_engine.py
+++ b/siege_utilities/reporting/engines/base_engine.py
@@ -49,6 +49,10 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "BaseChartEngine",
+]
+
 
 class BaseChartEngine:
     """Core infrastructure: init, colors, styling, scaling, save helpers."""

--- a/siege_utilities/reporting/engines/composite_engine.py
+++ b/siege_utilities/reporting/engines/composite_engine.py
@@ -35,6 +35,10 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "CompositeChartMixin",
+]
+
 
 class CompositeChartMixin:
     """Composite chart methods (convergence diagram, dashboard, summary charts, subplots)."""

--- a/siege_utilities/reporting/engines/map_engine.py
+++ b/siege_utilities/reporting/engines/map_engine.py
@@ -65,6 +65,10 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "MapChartMixin",
+]
+
 
 class MapChartMixin:
     """Geographic map chart methods (choropleth, marker, 3D, heatmap, cluster, flow)."""

--- a/siege_utilities/reporting/engines/stats_engine.py
+++ b/siege_utilities/reporting/engines/stats_engine.py
@@ -36,6 +36,10 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "StatsChartMixin",
+]
+
 
 class StatsChartMixin:
     """Statistical chart methods (heatmap, scatter plot, text heatmap)."""

--- a/siege_utilities/reporting/idml_export.py
+++ b/siege_utilities/reporting/idml_export.py
@@ -36,6 +36,11 @@ except ImportError:
 # ---------------------------------------------------------------------------
 # IDML XML namespace constants
 # ---------------------------------------------------------------------------
+__all__ = [
+    "IDMLExporter",
+    "export_report_idml",
+]
+
 _IDML_NS = "http://ns.adobe.com/AdobeInDesign/idml/1.0/packaging"
 _IDPKG = "http://ns.adobe.com/AdobeInDesign/idpkg/1.0"
 

--- a/siege_utilities/reporting/legend_manager.py
+++ b/siege_utilities/reporting/legend_manager.py
@@ -38,6 +38,15 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "ColorScheme",
+    "LegendManager",
+    "LegendPosition",
+    "create_heatmap_legend_table",
+    "get_optimal_legend_position",
+]
+
+
 class LegendPosition(Enum):
     """Enumeration of legend positions"""
     BEST = "best"

--- a/siege_utilities/reporting/map_3d.py
+++ b/siege_utilities/reporting/map_3d.py
@@ -44,6 +44,13 @@ except ImportError:
 # Map styles
 # ---------------------------------------------------------------------------
 
+__all__ = [
+    "MAP_STYLES",
+    "ThreeDMapRenderer",
+    "create_3d_columns",
+    "create_3d_hexbin",
+]
+
 MAP_STYLES = {
     "dark": "mapbox://styles/mapbox/dark-v11",
     "light": "mapbox://styles/mapbox/light-v11",

--- a/siege_utilities/reporting/powerpoint_generator.py
+++ b/siege_utilities/reporting/powerpoint_generator.py
@@ -21,6 +21,11 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "PowerPointGenerator",
+]
+
+
 class PowerPointGenerator:
     """
     Generates PowerPoint presentations from analytics data and report configurations.

--- a/siege_utilities/reporting/report_generator.py
+++ b/siege_utilities/reporting/report_generator.py
@@ -35,6 +35,10 @@ from .client_branding import ClientBrandingManager, ClientBrandingNotFoundError
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "ReportGenerator",
+]
+
 
 def _escape_paragraph(text: str) -> str:
     """Escape characters ReportLab Paragraph parses as mini-HTML markup.

--- a/siege_utilities/reporting/templates/page_templates.py
+++ b/siege_utilities/reporting/templates/page_templates.py
@@ -13,6 +13,14 @@ from abc import ABC, abstractmethod
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "PageTemplate",
+    "PageTemplateManager",
+    "get_template",
+    "get_template_manager",
+]
+
+
 @dataclass
 class PageTemplate:
     """Base page template configuration."""

--- a/siege_utilities/reporting/wave_charts.py
+++ b/siege_utilities/reporting/wave_charts.py
@@ -15,6 +15,12 @@ from typing import TYPE_CHECKING, Optional
 if TYPE_CHECKING:
     from ..survey.models import Chain
 
+__all__ = [
+    "WaveChartError",
+    "heatmap",
+    "trend_chart",
+]
+
 
 class WaveChartError(ValueError):
     """Raised when a WaveSet chart cannot be rendered from the given Chain."""

--- a/siege_utilities/schema/migration_runner.py
+++ b/siege_utilities/schema/migration_runner.py
@@ -40,6 +40,14 @@ except ImportError:  # pragma: no cover
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "AppliedMigration",
+    "MigrationFile",
+    "MigrationRunner",
+    "MigrationStatus",
+    "PendingMigration",
+]
+
 _IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 _FILENAME_RE = re.compile(r"^V(?P<version>[^_]+)__(?P<description>.+)\.sql$")
 _PG_IDENTIFIER_MAX_LEN = 63  # PostgreSQL silently truncates names longer than this
@@ -64,7 +72,11 @@ class MigrationFile:
 
     @classmethod
     def from_path(cls, path: Path) -> MigrationFile:
-        """Parse ``V<version>__<description>.sql`` and load its SQL body."""
+        """Parse ``V<version>__<description>.sql`` and load its SQL body.
+
+        Raises:
+            ValueError: If the filename does not match the expected pattern.
+        """
         match = _FILENAME_RE.match(path.name)
         if not match:
             raise ValueError(

--- a/siege_utilities/trino/federation.py
+++ b/siege_utilities/trino/federation.py
@@ -23,6 +23,12 @@ from typing import Iterable, List
 
 from siege_utilities.core.sql_safety import validate_sql_identifier
 
+__all__ = [
+    "build_trino_federation_view_sql",
+    "build_trino_schema_and_view_sync_sql",
+    "quote_ident",
+]
+
 
 def quote_ident(value: str) -> str:
     """Quote an identifier in Trino dialect.


### PR DESCRIPTION
## Summary

Continues the SU-2 export-surface completeness pass across remaining packages:

- **reporting/ (16 modules):** core chart, template, engine, and generator modules
- **analytics/ (7):** all Google Workspace + Facebook connectors
- **Other (12):** data/statistics, databricks, distributed, economic, education, files, identifiers, trino, admin

Also documents the ValueError raise in `MigrationFile.from_path()`.

Combined with PRs #929–#934, all frequently-imported modules now declare their public API surface explicitly.