### PR TITLE
fix(SU-2): add __all__ to 4 remaining databricks modules

### DIFF
--- a/siege_utilities/databricks/auth.py
+++ b/siege_utilities/databricks/auth.py
@@ -2,6 +2,11 @@
 
 from typing import Any, Dict, Optional
 
+__all__ = [
+    "get_workspace_client",
+]
+
+
 
 def _validate_azure_sp_inputs(
     azure_client_id: Optional[str],

--- a/siege_utilities/databricks/dataframe_bridge.py
+++ b/siege_utilities/databricks/dataframe_bridge.py
@@ -6,6 +6,14 @@ import pandas as pd
 
 from .session import get_active_spark_session
 
+__all__ = [
+    "geopandas_to_spark",
+    "pandas_to_spark",
+    "spark_to_geopandas",
+    "spark_to_pandas",
+]
+
+
 
 def pandas_to_spark(dataframe: pd.DataFrame, spark: Optional[Any] = None) -> Any:
     """Convert a Pandas DataFrame to a Spark DataFrame."""

--- a/siege_utilities/databricks/lakehouse_federation.py
+++ b/siege_utilities/databricks/lakehouse_federation.py
@@ -24,6 +24,13 @@ from siege_utilities.core.sql_safety import (
     validate_sql_identifier,
 )
 
+__all__ = [
+    "build_foreign_table_sql",
+    "build_schema_and_table_sync_sql",
+    "quote_ident",
+]
+
+
 
 def quote_ident(value: str) -> str:
     """Quote an identifier with backticks for Databricks SQL."""

--- a/siege_utilities/databricks/secrets.py
+++ b/siege_utilities/databricks/secrets.py
@@ -7,6 +7,14 @@ from .session import get_dbutils
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "ensure_secret_scope",
+    "get_runtime_secret",
+    "put_secret",
+    "runtime_secret_exists",
+]
+
+
 
 def get_runtime_secret(scope: str, key: str, dbutils: Optional[Any] = None) -> str:
     """Read a secret from Databricks runtime dbutils."""


### PR DESCRIPTION
## Summary

Adds `__all__` to the remaining databricks modules: auth, dataframe_bridge, secrets, lakehouse_federation.

This completes the export-surface pass — all actively-used library modules now declare their public API explicitly.