### PR TITLE
fix(SU-2): implement 6 ignored parameters

### DIFF
--- a/siege_utilities/config/models/actor_types.py
+++ b/siege_utilities/config/models/actor_types.py
@@ -687,9 +687,12 @@ class Organization(BaseModel):
 
     # YAML Serialization Methods
     def to_dict(self, exclude_sensitive: bool = False) -> dict:
-        """Convert to dictionary."""
+        """Convert to dictionary, optionally stripping sensitive fields."""
         data = self.model_dump()
-        return _convert_to_yaml_safe(data)
+        data = _convert_to_yaml_safe(data)
+        if exclude_sensitive:
+            data = _strip_sensitive_fields(data)
+        return data
 
     def to_yaml(self, path: Optional[Path] = None, exclude_sensitive: bool = False) -> str:
         """Serialize to YAML string, optionally writing to a file."""
@@ -849,9 +852,12 @@ class Collaboration(BaseModel):
 
     # YAML Serialization Methods
     def to_dict(self, exclude_sensitive: bool = False) -> dict:
-        """Convert to dictionary."""
+        """Convert to dictionary, optionally stripping sensitive fields."""
         data = self.model_dump()
-        return _convert_to_yaml_safe(data)
+        data = _convert_to_yaml_safe(data)
+        if exclude_sensitive:
+            data = _strip_sensitive_fields(data)
+        return data
 
     def to_yaml(self, path: Optional[Path] = None, exclude_sensitive: bool = False) -> str:
         """Serialize to YAML string, optionally writing to a file."""

--- a/siege_utilities/engines/dataframe_engine.py
+++ b/siege_utilities/engines/dataframe_engine.py
@@ -605,10 +605,20 @@ class DataFrameEngine(ABC):
     ) -> Any:
         """Find the k nearest targets for each point.
 
-        Default: brute-force via GeoPandas sjoin_nearest.
+        Default: brute-force via GeoPandas sjoin_nearest (supports k=1 only).
         Engines should override for native spatial indexing (Sedona KNN,
-        PostGIS ST_DWithin + ORDER BY distance, DuckDB spatial).
+        PostGIS ST_DWithin + ORDER BY distance, DuckDB spatial) and k>1.
+
+        Raises
+        ------
+        NotImplementedError
+            If k > 1 (base implementation only supports single-nearest).
         """
+        if k > 1:
+            raise NotImplementedError(
+                f"Base GeoPandas engine only supports k=1 (got k={k}). "
+                "Use a spatial-database engine (PostGIS, Sedona, DuckDB) for k-nearest."
+            )
         import geopandas as gpd
 
         pts = self.to_geodataframe(points, point_geom)
@@ -1274,6 +1284,11 @@ class SparkEngine(DataFrameEngine):
 
     def buffer(self, df, distance, geometry_col="geometry", *, crs=None):
         self._ensure_sedona()
+        if crs is not None:
+            raise NotImplementedError(
+                "CRS reprojection before buffer is not yet supported in the "
+                "Sedona engine. Reproject your data beforehand, or omit crs."
+            )
         from siege_utilities.core.sql_safety import validate_sql_identifier_in as validate_identifier_in
         validate_identifier_in(geometry_col, df.columns, label="geometry column")
         # `distance` is interpolated as a float -- coerce so a malicious

--- a/siege_utilities/geo/spatial_runtime.py
+++ b/siege_utilities/geo/spatial_runtime.py
@@ -170,6 +170,9 @@ def _require_shapely(fn_name: str) -> None:
         )
 
 
+_VALID_GEOMETRY_FORMATS = {"wkt", "wkb", "geojson"}
+
+
 def encode_geometry(
     geom: Any,
     fmt: str = "wkt",
@@ -183,17 +186,27 @@ def encode_geometry(
         A ``shapely.geometry.base.BaseGeometry`` instance.
     fmt:
         Primary serialisation format – ``"wkt"``, ``"wkb"``, or ``"geojson"``.
-        All three representations are always populated; *fmt* only controls
-        validation of the primary path.
+        All three representations are always populated; *fmt* validates that
+        the caller's intended primary format is supported.
     crs:
         Coordinate reference system identifier stored on the payload.
 
     Returns
     -------
     GeometryPayload
+
+    Raises
+    ------
+    ValueError
+        If *fmt* is not one of ``"wkt"``, ``"wkb"``, ``"geojson"``.
     """
     _require_shapely("encode_geometry")
     import shapely.geometry  # local import – already guarded
+
+    if fmt not in _VALID_GEOMETRY_FORMATS:
+        raise ValueError(
+            f"fmt must be one of {sorted(_VALID_GEOMETRY_FORMATS)}, got {fmt!r}"
+        )
 
     if not isinstance(geom, shapely.geometry.base.BaseGeometry):
         raise TypeError(

--- a/siege_utilities/reporting/engines/bar_engine.py
+++ b/siege_utilities/reporting/engines/bar_engine.py
@@ -282,7 +282,10 @@ class BarChartMixin:
             fig, ax = plt.subplots(figsize=(width, height), dpi=self.default_dpi)
 
             # Adjust subplot parameters to make room for legend table
-            fig.subplots_adjust(left=0.1, right=0.6, top=0.9, bottom=0.1)
+            if legend_position == "bottom":
+                fig.subplots_adjust(left=0.1, right=0.9, top=0.85, bottom=0.35)
+            else:
+                fig.subplots_adjust(left=0.1, right=0.6, top=0.9, bottom=0.1)
 
             # Create clean pie chart with NO LABELS AT ALL
             ax.pie(values, labels=None, autopct=None,
@@ -309,15 +312,16 @@ class BarChartMixin:
                         f"{pct:.1f}%"
                     ])
 
-                # Create table — bbox is [left, bottom, width, height] in
-                # axes coordinates.  With subplots_adjust(right=0.6) the axes
-                # occupies ~50% of figure width, so 0.6 axes-widths ≈ 1.8in
-                # on a 6-inch figure — enough room for the four columns.
+                # bbox is [left, bottom, width, height] in axes coordinates.
+                if legend_position == "bottom":
+                    table_bbox = [0.0, -0.6, 1.0, 0.5]
+                else:
+                    table_bbox = [1.05, 0.0, 0.6, 0.9]
                 table = ax.table(cellText=legend_data,
                                colLabels=['', 'Label', 'Value', 'Percent'],
                                cellLoc='center',
                                loc='center',
-                               bbox=[1.05, 0.0, 0.6, 0.9])
+                               bbox=table_bbox)
 
                 # Style the table
                 table.auto_set_font_size(False)

--- a/siege_utilities/reporting/engines/base_engine.py
+++ b/siege_utilities/reporting/engines/base_engine.py
@@ -388,7 +388,8 @@ class BaseChartEngine:
             title: Section title
             charts: List of chart images
             description: Section description
-            width: Section width in inches
+            width: Maximum section width in inches. Charts exceeding this
+                width are scaled down proportionally.
 
         Returns:
             List of flowables for the section
@@ -405,8 +406,13 @@ class BaseChartEngine:
             section.append(Paragraph(description, self.styles['BodyText']))
             section.append(Spacer(1, 0.2 * inch))
 
-        # Add charts
+        # Add charts, scaling to fit width constraint
+        max_width = width * inch
         for chart in charts:
+            if hasattr(chart, 'drawWidth') and chart.drawWidth > max_width:
+                scale = max_width / chart.drawWidth
+                chart.drawWidth = max_width
+                chart.drawHeight = chart.drawHeight * scale
             section.append(chart)
             section.append(Spacer(1, 0.2 * inch))
 

--- a/siege_utilities/reporting/engines/map_engine.py
+++ b/siege_utilities/reporting/engines/map_engine.py
@@ -142,7 +142,7 @@ class MapChartMixin:
             folium.LayerControl().add_to(m)
 
             return self._save_folium_map(m, "temp_choropleth_map.html",
-                                        "Choropleth Map", width, height)
+                                        title or "Choropleth Map", width, height)
 
         except (ValueError, TypeError, KeyError, IndexError, AttributeError, OSError) as e:
 
@@ -689,7 +689,7 @@ class MapChartMixin:
             # Add heatmap layer
             plugins.HeatMap(
                 heat_data,
-                radius=20,
+                radius=grid_size,
                 blur=blur_radius,
                 max_zoom=13,
                 gradient={0.2: 'blue', 0.4: 'lime', 0.6: 'orange', 1: 'red'}


### PR DESCRIPTION
## Summary

Fixes 6 functions that accepted parameters they silently discarded — each parameter's documented behavior was a lie.

- **actor_types.py**: `Organization.to_dict(exclude_sensitive)` and `Collaboration.to_dict(exclude_sensitive)` now strip sensitive fields like the `Person` base class
- **dataframe_engine.py**: `nearest(k>1)` raises `NotImplementedError` instead of returning only 1 result; `buffer(crs=...)` raises `NotImplementedError` instead of ignoring CRS
- **spatial_runtime.py**: `encode_geometry(fmt=...)` validates the format parameter
- **map_engine.py**: `create_choropleth_map(title=...)` passes title through; `create_heatmap_map(grid_size=...)` controls HeatMap radius
- **bar_engine.py**: `create_pie_chart(legend_position=...)` positions the legend table correctly
- **base_engine.py**: `create_chart_section(width=...)` scales oversized charts

## Discovery method

AST-scanned all public functions for parameters that never appear as `ast.Name` references in the function body.