### PR TITLE
fix(SU-2): implement 3 more ignored parameters

### DIFF
--- a/siege_utilities/distributed/hdfs_operations.py
+++ b/siege_utilities/distributed/hdfs_operations.py
@@ -224,6 +224,11 @@ class AbstractHDFSOperations:
             RuntimeError: If HDFS sync or Spark session creation fails.
         """
         self.config.log_info('🚀 Setting up distributed environment...')
+        if dependency_paths:
+            self.config.log_info(
+                f'⚠️  dependency_paths ({len(dependency_paths)} items) not yet '
+                'supported — dependencies must be pre-installed on workers'
+            )
         if data_path is None:
             data_path = self.config.data_path
         if data_path is None:

--- a/siege_utilities/economic/bls/qcew.py
+++ b/siege_utilities/economic/bls/qcew.py
@@ -108,6 +108,8 @@ class QCEWFiles:
         year, qtr.
         """
         df = pd.read_csv(csv_path, dtype={"area_fips": str, "industry_code": str})
+        if "year" in df.columns:
+            df = df[df["year"] == year]
         df = df[df["qtr"] == quarter]
         if state_fips:
             df = df[df["area_fips"].str.startswith(state_fips)]

--- a/siege_utilities/reference/sample_data.py
+++ b/siege_utilities/reference/sample_data.py
@@ -422,11 +422,14 @@ def create_sample_dataset(year: int = 2020,
     """
     log_info(f"Creating sample dataset: {geographic_level} level, year {year}, state {state_fips}")
 
-    # Step 1: Get boundaries (raises RuntimeError on failure)
-    boundaries = get_census_boundaries(year, geographic_level, state_fips, county_fips)
-
-    # Step 2: Get data (raises NotImplementedError until Census data API is wired up)
+    # Step 1: Get data (raises NotImplementedError until Census data API is wired up)
     data = get_census_data(year, 'demographics', geographic_level, state_fips, county_fips)
+
+    if not include_geometry:
+        return data
+
+    # Step 2: Get boundaries (raises RuntimeError on failure)
+    boundaries = get_census_boundaries(year, geographic_level, state_fips, county_fips)
 
     # Step 3: Join boundaries and data (raises ValueError/KeyError on failure)
     result = join_boundaries_and_data(boundaries, data)


### PR DESCRIPTION
## Summary

Continues the unused-parameter pass from #939. Three more functions that accepted parameters they silently discarded:

- **qcew.py**: `parse(year=...)` now filters the DataFrame by year column when present
- **hdfs_operations.py**: `setup_distributed_environment(dependency_paths=...)` logs a warning that dependency upload isn't supported yet
- **sample_data.py**: `create_sample_dataset(include_geometry=False)` now skips boundary fetching

## Context

Discovered via AST scan for function parameters that never appear as Name references in the function body.