### PR TITLE
fix(SU-2): wire value_col through to HexagonLayer weights

### DIFF
--- a/siege_utilities/reporting/map_3d.py
+++ b/siege_utilities/reporting/map_3d.py
@@ -169,6 +169,9 @@ class ThreeDMapRenderer:
             auto_highlight=auto_highlight,
             pickable=True,
         )
+        if value_col is not None:
+            hex_layer_kwargs["get_elevation_weight"] = value_col
+            hex_layer_kwargs["get_color_weight"] = value_col
         if color_range is not None:
             hex_layer_kwargs["color_range"] = color_range
 


### PR DESCRIPTION
## Summary

`create_hexagon_layer(value_col=...)` was documented as controlling hex aggregation but the parameter was silently discarded. Now sets `get_elevation_weight` and `get_color_weight` on the pydeck HexagonLayer so hexagons reflect the specified column's values instead of defaulting to point count.