### PR TITLE
fix(SU-2): wire up 6 unused parameters across geo, reference, core, reporting

### DIFF
--- a/siege_utilities/core/logging.py
+++ b/siege_utilities/core/logging.py
@@ -315,12 +315,20 @@ def init_logger(name: LoggerName,
     Returns:
         Configured logger instance
     """
+    if log_to_file and not shared_log_file:
+        import warnings
+        warnings.warn(
+            "init_logger(log_to_file=True) without shared_log_file has no "
+            "effect. Use configure_shared_logging() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     # For backward compatibility, configure shared logging if specified
     if shared_log_file:
         _logger_manager.configure_shared_logging(
             shared_log_file, level, max_bytes, backup_count
         )
-    
+
     return _logger_manager.get_logger(name)
 
 def cleanup_logger(name: LoggerName) -> bool:

--- a/siege_utilities/geo/gazetteers/wikidata_gazetteer.py
+++ b/siege_utilities/geo/gazetteers/wikidata_gazetteer.py
@@ -198,15 +198,23 @@ class WikidataGazetteer:
         if not name or not name.strip():
             raise ValueError("WikidataGazetteer.lookup: empty name")
         rows = self._cached_lookup(name.strip(), (country_hint or "").strip().upper() or None, 10)
+        if admin_hint:
+            admin_lower = admin_hint.strip().lower()
+            rows = tuple(
+                r for r in rows
+                if admin_lower in (r.get("name") or "").lower()
+                or admin_lower in (r.get("country") or "").lower()
+            )
         if not rows:
             raise GazetteerNotFoundError(
                 f"Wikidata: no match for {name!r}"
                 + (f" (country={country_hint!r})" if country_hint else "")
+                + (f" (admin={admin_hint!r})" if admin_hint else "")
             )
         if len(rows) > 1:
             raise GazetteerAmbiguousError(
                 f"Wikidata: {len(rows)} matches for {name!r}; "
-                "pass country_hint or use search() and pick a candidate.",
+                "pass country_hint/admin_hint or use search() and pick a candidate.",
                 candidates=[self._row_to_candidate(r) for r in rows],
             )
         return self._row_to_result(rows[0])

--- a/siege_utilities/geo/providers/redistricting_data_hub.py
+++ b/siege_utilities/geo/providers/redistricting_data_hub.py
@@ -766,14 +766,15 @@ def compare_plans(
         if gdf.empty:
             raise ValueError(f"Cannot compute plan stats: '{label}' has no districts")
         pops = gdf[population_col]
-        ideal = pops.sum() / len(pops)
+        num_districts = int(gdf[district_id_col].nunique()) if district_id_col in gdf.columns else len(gdf)
+        ideal = pops.sum() / num_districts
         if ideal == 0:
             raise ValueError(
                 f"Cannot compute plan stats: '{label}' has zero total population"
             )
         return {
             "label": label,
-            "num_districts": len(gdf),
+            "num_districts": num_districts,
             "total_population": int(pops.sum()),
             "ideal_population": round(ideal, 1),
             "max_deviation": round((pops.max() - ideal) / ideal * 100, 2),

--- a/siege_utilities/geo/timeseries/trend_classifier.py
+++ b/siege_utilities/geo/timeseries/trend_classifier.py
@@ -346,7 +346,7 @@ def get_trend_summary(
     percentages = df[trend_column].value_counts(normalize=True) * 100
 
     summary = {
-        'total_geographies': len(df),
+        'total_geographies': int(df[geoid_column].nunique()) if geoid_column in df.columns else len(df),
         'categories': {},
     }
 

--- a/siege_utilities/reference/sample_data.py
+++ b/siege_utilities/reference/sample_data.py
@@ -441,8 +441,7 @@ def create_sample_dataset(year: int = 2020,
 
 def get_census_county_sample(state_fips: str = "06",
                             county_fips: str = "037",
-                            tract_count: int = 5,
-                            population_per_tract: int = 500) -> Union[pd.DataFrame, gpd.GeoDataFrame]:
+                            tract_count: int = 5) -> Union[pd.DataFrame, gpd.GeoDataFrame]:
     """
     Generate a sample county dataset with multiple tracts and synthetic data.
 
@@ -450,7 +449,6 @@ def get_census_county_sample(state_fips: str = "06",
         state_fips: State FIPS code (default: CA)
         county_fips: County FIPS code (default: Los Angeles)
         tract_count: Number of tracts to include
-        population_per_tract: Population per tract
 
     Returns:
         DataFrame or GeoDataFrame with county data

--- a/siege_utilities/reporting/examples/google_analytics_report_example.py
+++ b/siege_utilities/reporting/examples/google_analytics_report_example.py
@@ -1580,10 +1580,16 @@ def create_footnote_paragraph(terms: List[str], styles_obj=None) -> Optional[Par
     if not definitions:
         return None
 
-    footnote_style = ParagraphStyle(
-        'Footnote', fontSize=7, leading=9, spaceBefore=6, spaceAfter=10,
-        textColor=colors.HexColor('#666666'), leftIndent=10,
-    )
+    if styles_obj and hasattr(styles_obj, 'get'):
+        footnote_style = styles_obj.get('Footnote', ParagraphStyle(
+            'Footnote', fontSize=7, leading=9, spaceBefore=6, spaceAfter=10,
+            textColor=colors.HexColor('#666666'), leftIndent=10,
+        ))
+    else:
+        footnote_style = ParagraphStyle(
+            'Footnote', fontSize=7, leading=9, spaceBefore=6, spaceAfter=10,
+            textColor=colors.HexColor('#666666'), leftIndent=10,
+        )
     text = " | ".join(definitions)
     return Paragraph(text, footnote_style)
 


### PR DESCRIPTION
## Summary

- `get_trend_summary(geoid_column=)`: now uses it for `nunique()` instead of `len(df)`
- `compare_plans(district_id_col=)`: now uses it for district count (handles multi-polygon rows)
- `WikidataGazetteer.lookup(admin_hint=)`: now filters SPARQL results by admin hint
- `get_census_county_sample(population_per_tract=)`: removed — never implemented, aspirational
- `init_logger(log_to_file=)`: emits DeprecationWarning when True without shared_log_file
- `create_footnote_paragraph(styles_obj=)`: now uses it to look up 'Footnote' style

## Test plan

- [x] All 6 modules import cleanly
- [x] `population_per_tract` no longer in `get_census_county_sample` signature
- [x] No new unused params in modified functions