### PR TITLE
fix(SU-2): remove cascading unused population params in sample_data

### DIFF
--- a/siege_utilities/reference/sample_data.py
+++ b/siege_utilities/reference/sample_data.py
@@ -484,15 +484,13 @@ def get_census_county_sample(state_fips: str = "06",
     return county_data
 
 def get_metropolitan_sample(cbsa_code: str = "31080",
-                           county_count: int = 3,
-                           population_per_county: int = 2000) -> Union[pd.DataFrame, gpd.GeoDataFrame]:
+                           county_count: int = 3) -> Union[pd.DataFrame, gpd.GeoDataFrame]:
     """
     Generate a metropolitan area sample with multiple counties.
 
     Args:
         cbsa_code: CBSA code (default: Los Angeles metro)
         county_count: Number of counties to include
-        population_per_county: Population per county
 
     Returns:
         DataFrame or GeoDataFrame with metro data
@@ -509,7 +507,6 @@ def get_metropolitan_sample(cbsa_code: str = "31080",
             state_fips="06",
             county_fips=county_fips,
             tract_count=3,
-            population_per_tract=population_per_county // 3
         )
         county_data['cbsa_code'] = cbsa_code
         all_counties.append(county_data)


### PR DESCRIPTION
## Summary

- PR #945 removed `population_per_tract` from `get_census_county_sample` but `get_metropolitan_sample` still passed it — would cause `TypeError` at runtime
- Also removes `population_per_county` from `get_metropolitan_sample` (was only used to compute the removed param)

## Test plan

- [x] `grep population_per` returns zero hits
- [x] Both functions import and accept their remaining args