### PR TITLE
fix(SU-2): remove 7 phantom __all__ exports from boundary_result and validators

### DIFF
--- a/siege_utilities/geo/boundary_result.py
+++ b/siege_utilities/geo/boundary_result.py
@@ -35,9 +35,6 @@ __all__ = [
     "BoundaryParseError",
     "BoundaryRetrievalError",
     "BoundaryUrlValidationError",
-    "fail",
-    "ok",
-    "raise_on_error",
 ]
 
 

--- a/siege_utilities/geo/validators.py
+++ b/siege_utilities/geo/validators.py
@@ -67,49 +67,56 @@ def is_valid_block_group_geoid(value: str) -> bool:
 # DJANGO VALIDATORS
 # =============================================================================
 
-try:
+
+def _get_validation_error():
+    """Import Django's ValidationError at call time."""
     from django.core.exceptions import ValidationError
+    return ValidationError
 
-    class StateFIPSValidator:
-        """Django validator for 2-digit state FIPS codes."""
 
-        message = "Enter a valid 2-digit state FIPS code."
-        code = "invalid_state_fips"
+class StateFIPSValidator:
+    """Django validator for 2-digit state FIPS codes."""
 
-        def __call__(self, value):
-            if not is_valid_state_fips(value):
-                raise ValidationError(self.message, code=self.code, params={"value": value})
+    message = "Enter a valid 2-digit state FIPS code."
+    code = "invalid_state_fips"
 
-    class CountyFIPSValidator:
-        """Django validator for 5-digit county FIPS codes."""
+    def __call__(self, value):
+        ValidationError = _get_validation_error()
+        if not is_valid_state_fips(value):
+            raise ValidationError(self.message, code=self.code, params={"value": value})
 
-        message = "Enter a valid 5-digit county FIPS code (2-digit state + 3-digit county)."
-        code = "invalid_county_fips"
 
-        def __call__(self, value):
-            if not is_valid_county_fips(value):
-                raise ValidationError(self.message, code=self.code, params={"value": value})
+class CountyFIPSValidator:
+    """Django validator for 5-digit county FIPS codes."""
 
-    class TractGEOIDValidator:
-        """Django validator for 11-digit tract GEOIDs."""
+    message = "Enter a valid 5-digit county FIPS code (2-digit state + 3-digit county)."
+    code = "invalid_county_fips"
 
-        message = "Enter a valid 11-digit Census tract GEOID."
-        code = "invalid_tract_geoid"
+    def __call__(self, value):
+        ValidationError = _get_validation_error()
+        if not is_valid_county_fips(value):
+            raise ValidationError(self.message, code=self.code, params={"value": value})
 
-        def __call__(self, value):
-            if not is_valid_tract_geoid(value):
-                raise ValidationError(self.message, code=self.code, params={"value": value})
 
-    class BlockGroupGEOIDValidator:
-        """Django validator for 12-digit block group GEOIDs."""
+class TractGEOIDValidator:
+    """Django validator for 11-digit tract GEOIDs."""
 
-        message = "Enter a valid 12-digit Census block group GEOID."
-        code = "invalid_block_group_geoid"
+    message = "Enter a valid 11-digit Census tract GEOID."
+    code = "invalid_tract_geoid"
 
-        def __call__(self, value):
-            if not is_valid_block_group_geoid(value):
-                raise ValidationError(self.message, code=self.code, params={"value": value})
+    def __call__(self, value):
+        ValidationError = _get_validation_error()
+        if not is_valid_tract_geoid(value):
+            raise ValidationError(self.message, code=self.code, params={"value": value})
 
-except ImportError:
-    # Django not installed — standalone functions still available
-    pass
+
+class BlockGroupGEOIDValidator:
+    """Django validator for 12-digit block group GEOIDs."""
+
+    message = "Enter a valid 12-digit Census block group GEOID."
+    code = "invalid_block_group_geoid"
+
+    def __call__(self, value):
+        ValidationError = _get_validation_error()
+        if not is_valid_block_group_geoid(value):
+            raise ValidationError(self.message, code=self.code, params={"value": value})


### PR DESCRIPTION
## Summary

- `boundary_result.py`: removed `ok`, `fail`, `raise_on_error` from `__all__` — they are methods on `BoundaryFetchResult`, not module-level names
- `validators.py`: moved 4 Django validator classes out of `try/except ImportError` block so they exist unconditionally; `ValidationError` imported at call time

## Verification

Full AST scan confirms zero broken `__all__` exports remain across the entire package.

## Test plan

- [x] `from siege_utilities.geo.boundary_result import *` succeeds
- [x] `BoundaryFetchResult.ok()` / `.fail()` classmethods still work
- [x] `from siege_utilities.geo.validators import StateFIPSValidator` works without Django
- [x] Standalone validation functions unaffected
- [x] Full phantom-export scan: 0 broken