### PR TITLE
fix(SU-2): complete __all__ exports and privatize test function

### DIFF
--- a/siege_utilities/files/__init__.py
+++ b/siege_utilities/files/__init__.py
@@ -67,7 +67,6 @@ from .hashing import (
     calculate_file_hash,
     get_quick_file_signature,
     verify_file_integrity,
-    test_hash_functions,
 )
 
 # Convenience function for getting download directory
@@ -152,5 +151,4 @@ __all__ = [
     'calculate_file_hash',
     'get_quick_file_signature',
     'verify_file_integrity',
-    'test_hash_functions',
 ]

--- a/siege_utilities/files/hashing.py
+++ b/siege_utilities/files/hashing.py
@@ -237,7 +237,7 @@ def verify_file_integrity(file_path, expected_hash, algorithm='sha256') -> bool:
     return current_hash.lower() == expected_hash.lower()
 
 
-def test_hash_functions():
+def _test_hash_functions():
     """Test the hash functions with a temporary file"""
     import tempfile
     import os
@@ -261,4 +261,4 @@ def test_hash_functions():
 
 
 if __name__ == '__main__':
-    test_hash_functions()
+    _test_hash_functions()

--- a/siege_utilities/geo/locale.py
+++ b/siege_utilities/geo/locale.py
@@ -46,6 +46,7 @@ __all__ = [
     "TOWN_DISTANT",
     "TOWN_FRINGE",
     "TOWN_REMOTE",
+    "locale_from_code",
 ]
 
 # Meters per mile — used for distance conversion after CRS projection

--- a/siege_utilities/geo/precinct_vtd.py
+++ b/siege_utilities/geo/precinct_vtd.py
@@ -32,6 +32,9 @@ __all__ = [
     "SPATIAL_WEIGHT",
     "SpatialOverlap",
     "SpatialOverlapProvider",
+    "reconcile_names",
+    "reconcile_official",
+    "reconcile_spatial",
 ]
 
 

--- a/siege_utilities/geo/timeseries/longitudinal_data.py
+++ b/siege_utilities/geo/timeseries/longitudinal_data.py
@@ -47,6 +47,7 @@ __all__ = [
     "LongitudinalAligner",
     "get_available_years",
     "get_longitudinal_data",
+    "inflation_factor",
     "validate_longitudinal_years",
 ]
 


### PR DESCRIPTION
## Summary

- Privatized `test_hash_functions` (demo function exposed as public API)
- Added 4 public functions to their respective `__all__` lists:
  - `locale_from_code` in geo/locale.py
  - `reconcile_names`, `reconcile_official`, `reconcile_spatial` in geo/precinct_vtd.py
  - `inflation_factor` in geo/timeseries/longitudinal_data.py

## Test plan

- [x] All added names importable via `from module import name`
- [x] `test_hash_functions` no longer importable from public API
- [x] `from siege_utilities.files import *` still works