### PR TITLE
fix(SU-1): restrict file permissions on credential writes to 0o600

### DIFF
--- a/siege_utilities/analytics/google_analytics.py
+++ b/siege_utilities/analytics/google_analytics.py
@@ -173,8 +173,10 @@ class GoogleAnalyticsConnector:
 
     def _save_credentials(self, token_path: pathlib.Path):
         """Save OAuth credentials to file."""
+        import os
         with open(token_path, 'w', encoding='utf-8') as token:
             token.write(self.credentials.to_json())
+        os.chmod(token_path, 0o600)
         log_info(f"Saved credentials to: {token_path}")
 
     def authenticate_service_account(self) -> None:
@@ -465,8 +467,10 @@ def save_ga_account_profile(profile: Dict[str, Any],
     account_id = profile['ga_account_id']
     config_file = config_dir / f"ga_account_{account_id}.json"
 
+    import os
     with open(config_file, 'w', encoding='utf-8') as f:
         json.dump(profile, f, indent=2)
+    os.chmod(config_file, 0o600)
 
     log_info(f"Saved GA account profile to: {config_file}")
     return str(config_file)

--- a/siege_utilities/analytics/google_workspace.py
+++ b/siege_utilities/analytics/google_workspace.py
@@ -125,7 +125,9 @@ class GoogleWorkspaceClient:
             creds = flow.run_local_server(port=0)
 
         if token_file and creds:
+            import os
             Path(token_file).write_text(creds.to_json())
+            os.chmod(token_file, 0o600)
 
         return cls(creds)
 

--- a/siege_utilities/config/connections.py
+++ b/siege_utilities/config/connections.py
@@ -4,6 +4,7 @@ Handles notebook connections, Spark connections, and their persistence.
 """
 
 import json
+import os
 import pathlib
 import logging
 from typing import Dict, Any, Optional, List
@@ -151,6 +152,7 @@ def save_connection_profile(
     
     with open(config_file, 'w', encoding='utf-8') as f:
         json.dump(profile, f, indent=2)
+    os.chmod(config_file, 0o600)
 
     log_info(f"Saved connection profile to: {config_file}")
     return str(config_file)


### PR DESCRIPTION
## Summary

- OAuth tokens and connection profiles were written with default umask permissions
- On permissive systems, credentials could be world-readable
- Added `os.chmod(path, 0o600)` to 4 credential write paths

## Affected files

- `analytics/google_analytics.py` — OAuth token save, GA account profile save
- `analytics/google_workspace.py` — OAuth token save
- `config/connections.py` — connection profile save (contains DB connection strings)

## Test plan

- [x] Files parse without syntax errors
- [x] No behavior change for non-permission logic