### PR TITLE
fix(SU-2): include __all__ names in top-level __dir__()

### DIFF
--- a/siege_utilities/__init__.py
+++ b/siege_utilities/__init__.py
@@ -395,7 +395,7 @@ def __getattr__(name):
 
 
 def __dir__():
-    return sorted(set(list(globals().keys()) + list(_LAZY_IMPORTS.keys())))
+    return sorted(set(list(globals().keys()) + list(_LAZY_IMPORTS.keys()) + __all__))
 
 
 # ── Introspection functions (defined here, always available) ─────────


### PR DESCRIPTION
## Summary

- `PYSPARK_AVAILABLE` and `py_round` were accessible via `__getattr__` (distributed module fallback) but missing from `__dir__()`, breaking tab-completion
- Fixed by adding `__all__` to the set returned by `__dir__()`

## Test plan

- [x] All 39 `__all__` names appear in `dir(siege_utilities)`
- [x] Lazy loading still works for both explicit registry and distributed fallback