### PR TITLE
fix(SU-2): correct stale docstring and missing return annotation

### DIFF
--- a/siege_utilities/files/operations.py
+++ b/siege_utilities/files/operations.py
@@ -525,11 +525,9 @@ def delete_existing_file_and_replace_it_with_an_empty_file(file_path: FilePath, 
         file_path: Path to the file
         create_parents: Whether to create parent directories
 
-    Returns:
-        True if successful, False otherwise
-
     Raises:
         PathSecurityError: If path fails security validation
+        OSError: If file creation fails
     """
     import warnings
     warnings.warn(

--- a/siege_utilities/geo/providers/boundary_providers.py
+++ b/siege_utilities/geo/providers/boundary_providers.py
@@ -50,7 +50,7 @@ class BoundaryProvider(ABC):
         """Human-readable name for this provider."""
 
     @abstractmethod
-    def get_boundary(self, level: str, identifier: Optional[str] = None, **kwargs: Any):
+    def get_boundary(self, level: str, identifier: Optional[str] = None, **kwargs: Any) -> Any:
         """
         Fetch boundary geometry for a given geographic level.
 


### PR DESCRIPTION
## Summary

- Removed stale "Returns: True/False" from deprecated function that returns None
- Added missing `-> Any` annotation to abstract `get_boundary()` method

## Test plan

- [x] Files parse without errors
- [x] No behavioral change