### PR TITLE
docs(#953): codify architectural principles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,110 @@ This overrides any default convention from the agent's built-in system
 prompt. The work belongs to the repo author; the assistant is a tool, not
 a co-author.
 
+## Strategic intent
+
+siege_utilities is a thesaurus of space-time composition tools. Every piece
+exists to serve one question: what happened, where, when, and what does
+proximity imply?
+
+The library ties events to coordinates in space-time, then extrapolates
+significances and meanings from placement. Domain packages (political,
+economic, education, survey, analytics) produce events. Geo locates them.
+Engines scale them. Reporting presents them. The canonical composition chain
+is: address → geocoder → GEOID → boundary provider → demographic overlay →
+choropleth or report.
+
+Domain packages are primitives, not applications. `political/` provides DDL
+and entities. `education/` downloads NCES data. These are building blocks
+consumed by downstream projects (LegiNation, socialwarehouse, electinfo).
+The library encodes domain expertise — what data exists, where it lives, how
+to access it — not domain analysis.
+
+Temporal awareness is first-class. Redistricting plans have effective dates.
+Congressional districts depend on congress number matching vintage year.
+Census data has vintages. Survey data has waves. Not just "where" but
+"where-when."
+
+## Architectural decisions
+
+1. **Geo is the gravitational center.** All domain modules produce events
+   that need space-time location before they become analytically useful.
+   Changes to geo propagate everywhere.
+
+2. **Engine-agnostic DataFrame.** Same analysis at different scales without
+   rewriting: pandas for exploration, DuckDB for medium scale, Spark for
+   distribution, PostGIS for persistence. The abstraction serves the general
+   case; when you must drop to native (Spark SQL, raw pandas), use that
+   engine's idioms. Do not create single-consumer abstractions.
+
+3. **OSGeo preferred, alternatives when constrained.** GDAL/OGR, PROJ, GEOS
+   via Shapely, Fiona, rasterio are the default geospatial stack. When the
+   deployment target cannot run C libraries (Databricks, Lambda, serverless),
+   use Sedona, DuckDB-spatial, or pure-Python paths. The constraint must be
+   explicit, not a silent fallback. A missing non-GDAL path is a gap to fill,
+   not a design choice to accept.
+
+4. **Databricks and Snowflake are first-class targets.** Azure Databricks
+   cannot install GDAL. The `databricks/` bridge pattern (Spark → driver-side
+   GeoPandas → back to Spark) is an architectural choice. Snowflake's
+   geography type and Trino federation are parallel vendor paths.
+
+5. **Pluggable providers with shared contracts.** Boundary providers (Census
+   TIGER, GADM, RDH), geocoders, data sources — all pluggable so callers
+   compose without knowing which provider is active. Provider contracts must
+   be consistent: same failure mode, same return shape, same column names.
+
+6. **Lazy loading by design.** PEP 562 `__getattr__` because the dependency
+   tree is enormous. You must be able to import one piece in a Lambda or
+   notebook without pulling the whole library. Lazy loading defers when errors
+   surface, not whether they surface: `__getattr__` must never catch
+   ImportError and return a stub — let it propagate (SU-1 applies).
+
+7. **Credential management via external tools.** 1Password CLI (`op`),
+   environment variables, Databricks secret scopes. `siege_zsh` sets up the
+   shell environment that siege_utilities expects. `siege_zsh` is a reference
+   architecture — it shows the frameworks and tooling we build for. Code
+   should detect and leverage `siege_zsh` conventions but not hard-fail
+   without them.
+
+8. **Fuzzy matching at seams is expected.** Precinct names from three vendors
+   with different conventions. The library provides the fuzzy-matching
+   mechanism (canonicalization, normalization, scoring); heavy entity
+   resolution belongs in downstream applications.
+
+## Tactical principles
+
+1. **Pythonic patterns.** Scala is a far-off dream; the library is
+   Python-first. Use Python idioms, not Java-in-Python. Protocols over
+   abstract base classes when feasible. Type hints everywhere.
+
+2. **Technology-appropriate implementation.** A PostgreSQL query has different
+   constraints than pandas, even for the same goal. Write SQL that uses SQL
+   strengths (window functions, CTEs, lateral joins). Write pandas that uses
+   pandas strengths (vectorized ops, groupby-apply). Do not transliterate one
+   into the other.
+
+3. **Logging is a primary concern.** Every side-effecting process must produce
+   observable output. Progress indicators for long-running operations. The
+   operator must always be able to see what is happening.
+
+4. **Functional approaches preferred.** Prefer composition and immutability
+   over mutation, not strict purity (logging wraps pure cores). Legibility
+   over elegance within a function (each case obvious to a cold reader);
+   elegance across modules (minimal, orthogonal protocols). The boundary is
+   the module boundary.
+
+5. **Notebooks demonstrate intent; foundations are not negotiable.** Notebooks
+   demonstrate current library capabilities and should be rewritten when
+   functions change. The foundations (user architecture, Spark Connect,
+   credential management, engine abstraction) must be solid because everything
+   composes on top of them.
+
+6. **Reuse siege_zsh when available.** Shell environment setup should leverage
+   `siege_zsh` conventions. Code should detect and use them but not hard-fail
+   without them. The graceful degradation path must actually work and be
+   tested.
+
 ## Package structure
 
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,6 +4,8 @@
 
 **Scope:** ELE-2417 (audit sub-issue 2/6). Consumes [INTENT.md](INTENT.md) and [FAILURE_MODES.md](FAILURE_MODES.md). Ships [ADRs](adr/) for each decision. Snapshot: 2026-04-22 (revised 2026-04-23).
 
+**Cross-references:** strategic intent and principles in [../CLAUDE.md](../CLAUDE.md); hostile-review checks in `claude-configs-public/projects/siege-utilities/skills/hostile-review/`.
+
 ## Layer model
 
 | Layer | Modules | Rule |
@@ -66,6 +68,22 @@ graph TD
 ```
 
 A follow-up PR will add a `pydeps` CI check that fails on upward edges.
+
+## Design tension resolutions
+
+These resolutions were codified in 2026-05-31 and govern how the Adversary (hostile reviewer) judges ambiguous cases.
+
+| Tension | Resolution |
+|---|---|
+| Engine-agnostic vs technology-appropriate | The abstraction serves the general case. When you must drop to native (Spark SQL, raw pandas), use that engine's idioms. Do not create single-consumer abstractions. |
+| OSGeo preferred vs Databricks first-class | OSGeo is the default. Non-GDAL paths are a fallback constraint, not a dual-first-class mandate. A missing non-GDAL path is a gap to fill. |
+| Pythonic patterns vs PySpark's Java-influenced API | Python idioms always. The Scala port is a long dream, not a design constraint. |
+| Functional preferred vs logging as primary concern | "Functional" means composition + immutability, not strict purity. Logging wraps pure cores. |
+| Lazy loading vs SU-1 (errors are not data) | Lazy loading defers *when* errors surface, not *whether*. `__getattr__` must never catch ImportError and return a stub — let it propagate. |
+| Notebooks rewritable vs notebooks as strategic surface | Notebooks demonstrate intent and must reflect current state (SU-4a). Disposable in form, required in substance. |
+| Fuzzy matching scope | Library provides the mechanism (canonicalization, scoring); heavy entity resolution belongs downstream. |
+| siege_zsh dependency | siege_zsh is a reference architecture (shows what we build for), not a runtime dependency. The degraded path must actually work. |
+| Legibility/elegance boundary | Within a function: legibility (each case obvious to a cold reader). Across modules: elegance (minimal, orthogonal protocols). The module boundary is the threshold. |
 
 ## ADR register
 

--- a/docs/TEMPLATES.md
+++ b/docs/TEMPLATES.md
@@ -1,0 +1,263 @@
+# siege_utilities — Canonical Templates
+
+Derived from forensic review of the codebase (2026-06-01). These templates
+describe how functions, modules, and providers **should** be written based
+on the best existing examples. New code must follow these patterns;
+existing code should converge toward them over time.
+
+Source of truth for *why*: [CLAUDE.md](../CLAUDE.md) (principles) and
+[ARCHITECTURE.md](ARCHITECTURE.md) (layer model + tensions).
+
+---
+
+## A. Function template
+
+```python
+def function_name(
+    required_param: ExplicitType,
+    second_param: Union[str, int],
+    *,                                    # keyword-only after this
+    optional_kwarg: Optional[str] = None,
+    on_error: OnErrorStrategy = "raise",  # if failure mode is caller-configurable
+) -> ReturnType:
+    """One-line summary in imperative mood.
+
+    Longer explanation if behavior has non-obvious aspects — edge cases,
+    axis order, temporal semantics, CRS assumptions.
+
+    Args:
+        required_param: What it is and what forms are accepted.
+        second_param: Constraints (e.g. "must be > 0").
+        optional_kwarg: What happens when None (e.g. "uses get_default_crs()").
+
+    Returns:
+        What the shape/type is and what it represents.
+
+    Raises:
+        ValueError: When inputs violate constraints (with actionable message).
+        ImportError: When optional dep is missing (with install instructions).
+        DomainError: When the operation itself fails after validation passes.
+
+    Example:
+        >>> function_name("06037", "county")
+        '06037'
+    """
+    # 1. Input validation — fail fast with actionable messages
+    if not required_param:
+        raise ValueError(
+            f"required_param must be non-empty; got {required_param!r}"
+        )
+
+    # 2. Lazy import of heavy/optional dependencies
+    try:
+        from pyproj import CRS
+    except ImportError as exc:
+        raise ImportError(
+            "pyproj is required for function_name. "
+            "Install with: pip install 'siege-utilities[geo]'"
+        ) from exc
+
+    # 3. Core logic — log for side effects, pure for computation
+    log.info("Starting operation on %s", required_param)
+    result = _do_the_work(required_param, second_param)
+
+    # 4. Return typed result — NEVER return empty on failure (SU-1)
+    return result
+```
+
+### Conventions
+
+| Concern | Rule |
+|---|---|
+| **Type hints** | Every parameter and return. `Union` / `Optional` explicit. No `Any` without justification. |
+| **Keyword-only** | Use `*` separator for optional parameters to prevent positional ambiguity. |
+| **Validation** | First thing in the body. Message names the constraint AND the bad value. |
+| **Lazy imports** | `try/except ImportError as exc: raise ImportError("...install with...") from exc` — always chain with `from exc`. |
+| **Logging** | `log.info` for side effects, `log.debug` for diagnostic detail. Never `print()`. |
+| **Return on failure** | Raise an exception. Never `return []`, `return {}`, `return None` as error signal (SU-1). |
+| **Docstring** | NumPy-style (Args/Returns/Raises/Example). Imperative mood for the one-liner. |
+| **Error strategy** | Use `OnErrorStrategy` parameter when callers legitimately need different failure modes. |
+
+### Positive examples
+
+| File | Function | Why it's good |
+|---|---|---|
+| `geo/crs.py` | `reproject_geom()` | Explicit dep guards with `from exc`, axis-order docs, None only when input is None |
+| `geo/grids.py` | `infer_grid()` | Pure function, exhaustive validation, actionable messages for every contradiction |
+| `geo/geoid_utils.py` | `normalize_geoid()` | Clean signature, ValueError with exact constraint, docstring examples |
+| `cache.py` | `ensure_sample_dataset()` | NumPy-style docstring, domain exception on failure, atomic file ops |
+
+---
+
+## B. Module template
+
+### `__init__.py` — PEP 562 lazy loading
+
+```python
+"""One-sentence module purpose.
+
+Submodules load on first attribute access via PEP 562 __getattr__.
+"""
+
+import importlib
+import sys
+
+_LAZY_IMPORTS: dict[str, str] = {}
+
+
+def _register(names: list[str], module: str) -> None:
+    for name in names:
+        _LAZY_IMPORTS[name] = module
+
+
+# --- submodule_a ---
+_register([
+    "PublicClass",
+    "public_function",
+], ".submodule_a")
+
+# --- submodule_b ---
+_register([
+    "AnotherThing",
+], ".submodule_b")
+
+__all__ = list(_LAZY_IMPORTS.keys())
+
+
+def __getattr__(name: str):
+    if name in _LAZY_IMPORTS:
+        mod = importlib.import_module(_LAZY_IMPORTS[name], __package__)
+        val = getattr(mod, name)
+        setattr(sys.modules[__name__], name, val)
+        return val
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(list(globals().keys()) + list(_LAZY_IMPORTS.keys())))
+```
+
+### Conventions
+
+| Concern | Rule |
+|---|---|
+| **Lazy loading** | Every package uses `_register()` + `__getattr__`. No `from .sub import *` at module level. |
+| **`__all__`** | Derived from the lazy registry. |
+| **`__dir__()`** | Includes lazy names for IDE/tab-completion. |
+| **ImportError** | Never caught in `__getattr__`. Let it propagate (SU-1, principle 6). |
+| **Logging** | Every leaf module: `log = logging.getLogger(__name__)` at module level. |
+| **`__all__` in leaf modules** | Every leaf `.py` file defines `__all__` listing its public API. |
+
+### Positive examples
+
+| File | Why it's good |
+|---|---|
+| `core/__init__.py` | Minimal (49 lines), textbook PEP 562 |
+| `geo/__init__.py` | Scales to ~300 registered names across 30+ submodules, same pattern |
+
+### Anti-pattern
+
+`engines/__init__.py` — uses `from .dataframe_engine import *` (star-import, no lazy
+loading). Works only because it's a single-file module but breaks the convention.
+
+---
+
+## C. Provider template
+
+Providers follow a three-part contract: ABC, concrete implementations, factory/resolver.
+
+### Interface
+
+```python
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class ProviderBase(ABC):
+    """Abstract base class for <domain> providers."""
+
+    @property
+    @abstractmethod
+    def provider_name(self) -> str:
+        """Human-readable name for this provider."""
+
+    @abstractmethod
+    def fetch(self, key: str, **kwargs: Any) -> ResultType:
+        """Primary operation — same signature across all providers.
+
+        Args:
+            key: The canonical lookup key.
+            **kwargs: Provider-specific options.
+
+        Returns:
+            Always the same shape (e.g., GeoDataFrame, GeocodingResult).
+
+        Raises:
+            ProviderError: On failure (never returns empty silently).
+        """
+
+    @abstractmethod
+    def list_capabilities(self) -> list[str]:
+        """Return what this provider can serve."""
+
+    def is_available(self) -> bool:
+        """Return True if deps are installed and service is reachable."""
+        return True
+```
+
+### Factory/resolver
+
+```python
+def resolve_provider(hint: str, **kwargs) -> ProviderBase:
+    """Select the appropriate provider based on hint.
+
+    Args:
+        hint: Selector (e.g., country code, service name).
+
+    Returns:
+        Configured provider instance.
+
+    Raises:
+        ValueError: If no provider matches hint.
+    """
+    ...
+```
+
+### Contract consistency rules
+
+| Rule | What it means |
+|---|---|
+| **Same return shape** | All providers in a family return the same type (e.g., all boundary providers return GeoDataFrame). |
+| **Same failure mode** | Raise a typed exception inheriting from the domain base (`BoundaryFetchError`, `IsochroneError`). Never return None/empty. |
+| **Same column names** | All providers in a family produce the same column names (e.g., geocoders: `lat`, `lon`, `state_geoid`, `tract_geoid`, `match_quality`). |
+| **`is_available()`** | Runtime capability detection — allows composite/fallback patterns. |
+| **Typed results** | Use a dataclass with `.success`/`.matched` properties and typed failure stages when the result carries metadata beyond the primary data. |
+
+### Positive examples
+
+| File | Why it's good |
+|---|---|
+| `geo/providers/batch_geocoder.py` | `BatchGeocoder` ABC + `GeocodingResult` dataclass + `MatchQuality` enum. Clean contract with shared result type. |
+| `geo/isochrones.py` | `IsochroneProvider` ABC with typed exceptions, retry with backoff. Never returns empty on failure. |
+| `geo/providers/boundary_providers.py` | `BoundaryProvider` ABC with `get_boundary()`, `list_levels()`, `is_available()`, factory via `resolve_boundary_provider()`. |
+
+### Anti-pattern
+
+`CensusTIGERProvider.get_boundary()` (boundary_providers.py:118) — returns `None` on
+failure after `log.warning`. Should raise `BoundaryFetchError`. Return type annotation
+missing `Optional[...]` making it SU-1 + SU-2 violation.
+
+---
+
+## Cross-cutting conventions
+
+| Concern | Canonical approach | Reference |
+|---|---|---|
+| **Logging** | `log = logging.getLogger(__name__)` at module top | Every `geo/` module |
+| **Credentials** | Env var first, 1Password CLI fallback, never hardcoded | `config/credential_manager.py` |
+| **Optional deps** | `try/import/except ImportError as exc: raise ImportError("...") from exc` | `geo/crs.py:243-257` |
+| **Exception hierarchy** | All inherit `SiegeError`; domain subtypes (`SiegeGeoError`, `SiegeDataError`) | `exceptions.py` |
+| **Error strategy** | `OnErrorStrategy` type + `handle_error()` for caller-configurable behavior | `exceptions.py:81-119` |
+| **Typed results** | Dataclass with `.success`/`.matched` properties and typed failure stages | `boundary_result.py`, `batch_geocoder.py` |
+| **Validation** | Early, actionable message naming the constraint and the bad value | `grids.py:58-81`, `geoid_utils.py:178-193` |
+| **Temporal awareness** | Enum for vintages, threshold-based selection | `census_geocoder.py:103-130` |


### PR DESCRIPTION
## Summary

- Adds **strategic intent**, **8 architectural decisions**, and **6 tactical principles** to CLAUDE.md (between Attribution and Package structure)
- Adds **9 resolved design tensions** table to docs/ARCHITECTURE.md with cross-references
- Principles sourced from the hostile-review skill ratified in claude-configs-public#272

## Doc audit results

An audit of existing docs found:

| File | Status | Action needed |
|---|---|---|
| `docs/engines/INVARIANTS.md` | Aligned | None |
| `docs/FAILURE_MODES.md` | Aligned | Minor ticket prefix cleanup |
| `docs/INTENT.md` | Needs update | Missing modules in table, stale ticket refs |
| `docs/policies/CODING_STYLE.md` | Needs update | Missing technology-appropriate idioms, logging elevation |
| `docs/DEVELOPER_GUIDE.md` | Stale | Major rewrite needed (outdated structure, SU-1-violating examples) |
| `docs/QUICK_START_GUIDE.md` | Needs update | Geo not centered, error-handling examples violate SU-1 |
| `docs/policies/PR_REVIEW_RUBRIC.md` | Needs update | Missing engine/provider/logging review items |

Follow-up tickets should be filed for docs needing updates (DEVELOPER_GUIDE.md is the most urgent).

## Test plan

- [ ] Docs-only change — no code modified
- [ ] CLAUDE.md principles match hostile-review skill (claude-configs-public#272)
- [ ] ARCHITECTURE.md tension table matches resolved tensions from 2026-05-31 discussion

Closes #953