### PR TITLE
docs(#955): align QUICK_START_GUIDE and INTENT with principles

### DIFF
--- a/docs/INTENT.md
+++ b/docs/INTENT.md
@@ -2,7 +2,9 @@
 
 **Goal:** one-line purpose for every top-level module. The definitive answer to "what is this for?" Divergences between this file and actual behavior should be reconciled by changing one or the other — not left to drift.
 
-**Scope:** ELE-2416 (audit sub-issue 1/6). Snapshot date: 2026-04-22.
+**Guiding principles:** This file is downstream of `CLAUDE.md`, which codifies the architectural decisions and tactical principles for the library. The key axioms: geo is the gravitational center; the engine abstraction serves many scales; domain packages are primitives not applications; temporal awareness is first-class; errors are not data (SU-1 through SU-4). See `CLAUDE.md` for the full set.
+
+**Scope:** Snapshot date: 2026-04-22, updated 2026-05-31.
 
 **Source:** each module's `__init__.py` docstring, cross-referenced with the first substantive commit that introduced the module.
 
@@ -15,45 +17,53 @@ Status column: **Aligned** (behavior matches intent), **Divergent** (discrepancy
 | Module | Purpose | Status | Planned change |
 |---|---|---|---|
 | `admin/` | Manage profile-directory layout + migrations | Aligned | — |
-| `analytics/` | Third-party connectors (GA, Facebook, Snowflake, Data.world, Google Workspace) | Aligned | D1 wrapper rename (ELE-2442) |
+| `analytics/` | Third-party connectors (GA, Facebook, Snowflake, Data.world, Google Workspace) | Aligned | D1 wrapper rename |
 | `conf/` | Foundational settings singleton + hard-coded defaults | Aligned | — |
 | `config/` | Re-exports `conf.settings` + canonical constants (census, FIPS, credentials, pydantic models) | Aligned | — |
 | `configs/` | On-disk config data (palettes, branding templates); not a Python package | Aligned | — |
 | `core/` | Foundational utilities (logging, string, SQL safety); dependency root | Aligned | — |
-| `data/` | Sample datasets + engine-agnostic DataFrame ops + RDH client | **Divergent** | Aggressive split by nature (ELE-2437); RDH moves to `geo/providers/` (ELE-2438) |
-| `databricks/` | Databricks + LakeBase clients, Spark↔pandas bridges | Aligned | Motivation docstring added (ELE-2442) — kept separate from `distributed/` because Azure Databricks lacks Sedona + C-libs |
+| `data/` | Sample datasets + engine-agnostic DataFrame ops + RDH client | **Divergent** | Aggressive split by nature; RDH moves to `geo/providers/` |
+| `databricks/` | Databricks + LakeBase clients, Spark-to-pandas bridges (Azure lacks GDAL — separation is load-bearing) | Aligned | — |
 | `development/` | Meta tooling (architecture diagrams, structure analysis) | Meta | — |
 | `distributed/` | PySpark + HDFS utilities; re-exports `pyspark.sql.functions` names | Aligned | — |
-| `examples/` | Standalone demo `.py` scripts | Meta | Consolidating with `notebooks/` in ELE-2421 |
+| `economic/` | Economic data utilities (BLS, FRED, industry classifications) | Aligned | — |
+| `education/` | Education data access (NCES downloads, school district boundaries) | Aligned | — |
+| `engines/` | Engine-agnostic DataFrame abstraction (pandas, DuckDB, Spark, PostGIS) | Aligned | — |
+| `examples/` | Standalone demo `.py` scripts (held to library standard — SU-3) | Meta | Consolidating with `notebooks/` |
 | `exceptions.py` | Unified exception hierarchy (`SiegeError`); `OnErrorStrategy`; `handle_error()` | Aligned | — |
 | `files/` | Path manipulation, file operations, remote download, hashing | Aligned | — |
-| `geo/` | Geospatial data access, boundary providers, geocoding, CRS, Django models | Aligned | External spatial sources consolidate under `geo/providers/` (ELE-2438); silent-swallow sweep under ELE-2420 |
+| `geo/` | Geospatial data access, boundary providers, geocoding, CRS, Django models | Aligned | External spatial sources consolidate under `geo/providers/` |
 | `git/` | Branch/commit helpers | Aligned | — |
 | `hygiene/` | Maintenance tooling (docstring generation, PyPI release flow) | Meta | — |
-| `reporting/` | PDF/PowerPoint generation, chart types, client branding, page templates | **Divergent** | `reporting/analytics/` subdirectory deleted (ELE-2439); `analytics_reports.py` promoted one level; new `wave_charts.py` lands with ELE-2440 |
+| `identifiers/` | Entity identification, matching, and fuzzy resolution at seams | Aligned | — |
+| `political/` | Political data utilities (DDL, entities, redistricting plans, effective dates) | Aligned | — |
+| `reference/` | Reference data lookups (geographic levels, FIPS, canonical name tables) | Aligned | — |
+| `reporting/` | PDF/PowerPoint generation, chart types, client branding, page templates | **Divergent** | `reporting/analytics/` deleted; `analytics_reports.py` promoted; new `wave_charts.py` |
 | `runtime.py` | Runtime environment detection + guards | Aligned | — |
-| `survey/` | Survey pipeline (Chain, weights, render, significance) | **Divergent** | `Chain.to_argument()` method removed (ELE-2441); new `Wave`/`WaveSet` subsystem (ELE-2440) |
+| `schema/` | Schema definitions and validation (DDL generation, type contracts) | Aligned | — |
+| `survey/` | Survey pipeline (Chain, weights, render, significance) | **Divergent** | `Chain.to_argument()` removed; new `Wave`/`WaveSet` subsystem |
 | `testing/` | Test-only fixtures and helpers | Meta | — |
+| `trino/` | Trino connector for federated queries across data sources | Aligned | — |
 
 ---
 
 ## Divergence catalog
 
-All divergences carry a planned resolution and a target sub-issue.
+All divergences carry a planned resolution.
 
 | ID | Where | Decision | Target |
 |---|---|---|---|
-| D1 | `create_ga_connector_from_1password` wrapper name | Rename — auth-mechanism shouldn't leak into analytics API surface | ELE-2442 |
-| D2 | `data/` bundles multiple natures | Aggressive split: `data/statistics/`, `reference/`, top-level `engines/` | ELE-2437 |
-| D3 | External spatial sources scattered across `geo/` | Consolidate under `geo/providers/` (structural moves only; interface unification is a later epic) | ELE-2438 |
-| D4 | `databricks/` vs `distributed/` | Keep separate. Document in `__init__.py` that Azure Databricks lacks Sedona + C-libs — separation is load-bearing | ELE-2442 |
-| D7 | `reporting/analytics/polling_analyzer` | Deprecate `PollingAnalyzer`; extract longitudinal/change-detection to `data/statistics/`; delete `reporting/analytics/` subdirectory; add survey `Wave`/`WaveSet` | ELE-2439 + ELE-2440 |
-| D8 | `Chain.to_argument()` method vs `chain_to_argument()` function | Delete the method; function is sole entry point. Chain stays pure data | ELE-2441 |
-| D9 | `chart_generator` / `map_generator` kwargs ignored on `chain_to_argument` | Honor them (minimal ceremony — duck type, no Protocol yet). Drop from `ChartTypeRegistry.create_chart` (internal dispatch layer) | ELE-2441 |
+| D1 | `create_ga_connector_from_1password` wrapper name | Rename — auth-mechanism shouldn't leak into analytics API surface | — |
+| D2 | `data/` bundles multiple natures | Aggressive split: `data/statistics/`, `reference/`, top-level `engines/` | — |
+| D3 | External spatial sources scattered across `geo/` | Consolidate under `geo/providers/` (structural moves only; interface unification is a later epic) | — |
+| D4 | `databricks/` vs `distributed/` | Keep separate. Azure Databricks lacks Sedona + C-libs — separation is load-bearing | — |
+| D7 | `reporting/analytics/polling_analyzer` | Deprecate `PollingAnalyzer`; extract longitudinal/change-detection to `data/statistics/`; delete `reporting/analytics/` subdirectory; add survey `Wave`/`WaveSet` | — |
+| D8 | `Chain.to_argument()` method vs `chain_to_argument()` function | Delete the method; function is sole entry point. Chain stays pure data | — |
+| D9 | `chart_generator` / `map_generator` kwargs ignored on `chain_to_argument` | Honor them (minimal ceremony — duck type, no Protocol yet). Drop from `ChartTypeRegistry.create_chart` (internal dispatch layer) | — |
 
 *Closed, no action:*
 - **D5** (`hdfs_legacy/`) — file was already removed; only stale `.pyc` remained.
-- **D6** (`geo/` silent-swallow sites) — not architectural; operational debt tracked under ELE-2420.
+- **D6** (`geo/` silent-swallow sites) — not architectural; operational debt.
 
 ---
 
@@ -63,4 +73,4 @@ All divergences carry a planned resolution and a target sub-issue.
 - **Behavior changed in ways that contradict a row?** Update the row, or open a ticket to restore intent.
 - **Found a new divergence?** Add a `Dn` entry to the catalog and link it to a follow-up issue.
 
-See also: [ARCHITECTURE.md](ARCHITECTURE.md) · [FAILURE_MODES.md](FAILURE_MODES.md) · [ADRs](adr/)
+See also: [ARCHITECTURE.md](ARCHITECTURE.md) · [CLAUDE.md](../CLAUDE.md) · [FAILURE_MODES.md](FAILURE_MODES.md) · [ADRs](adr/)

--- a/docs/QUICK_START_GUIDE.md
+++ b/docs/QUICK_START_GUIDE.md
@@ -1,140 +1,45 @@
 # Quick Start Guide - Siege Utilities
 
-Get up and running with Siege Utilities in minutes! This guide covers the most common use cases.
+Get up and running with Siege Utilities. This guide is ordered by
+architectural priority: geo is the gravitational center, engines scale it,
+credentials unlock it, and domain packages feed it.
 
-## 🚀 Installation
+## Installation
 
 ```bash
-# Basic installation
-pip install siege-utilities
-
-# With geospatial support (recommended)
+# Core with geospatial support (recommended — geo is the center of the library)
 pip install siege-utilities[geo]
 
-# Full installation with all features
+# Full installation (geo + distributed + dev tools)
 pip install siege-utilities[distributed,geo,dev]
 ```
 
-## ⚡ 5-Minute Quick Start
+## The Composition Chain
 
-### 1. Basic Usage
+The canonical workflow in siege_utilities is:
+
+```
+address -> geocoder -> GEOID -> boundary provider -> demographic overlay -> choropleth or report
+```
+
+Everything starts with geo. Domain packages (political, economic, education,
+survey, analytics) produce events; geo locates them in space-time; engines
+scale the computation; reporting presents the results.
+
+## 1. Geospatial (the gravitational center)
 
 ```python
 import siege_utilities as su
 
-# Logging (works immediately)
-su.log_info("Hello from Siege Utilities!")
-
-# File operations
-hash_value = su.get_file_hash("myfile.txt")
-su.ensure_path_exists("data/processed")
-
-# String utilities
-clean_text = su.remove_wrapping_quotes_and_trim('  "hello world"  ')
-print(clean_text)  # "hello world"
-```
-
-### 2. Configuration Setup (NEW!)
-
-```python
-from siege_utilities.config import HydraConfigManager
-
-# Load user profile with validation
-with HydraConfigManager() as manager:
-    user_profile = manager.load_user_profile()
-    print(f"Welcome, {user_profile.full_name}!")
-
-# Load client-specific branding
-branding = manager.load_branding_config("client_a")
-print(f"Brand color: {branding.primary_color}")
-```
-
-### 3. Census Data (with geospatial support)
-
-```python
-# Get Census boundaries
-boundaries = su.get_census_boundaries(
-    year=2020,
-    geographic_level='county',
-    state_fips='06'  # California
-)
-
-print(f"Found {len(boundaries)} counties")
-```
-
-### 4. Distributed Computing (if PySpark available)
-
-```python
-try:
-    # Setup Spark session
-    spark, data_path = su.setup_distributed_environment()
-    print("Spark ready!")
-except ImportError:
-    print("PySpark not available - install with: pip install pyspark")
-```
-
-## 🎯 Common Use Cases
-
-### Data Processing Pipeline
-
-```python
-import siege_utilities as su
-
-# 1. Setup logging
-su.log_info("Starting data pipeline")
-
-# 2. Create directory structure
-su.ensure_path_exists("data/raw")
-su.ensure_path_exists("data/processed")
-
-# 3. Download data
-su.download_file("https://example.com/data.csv", "data/raw/data.csv")
-
-# 4. Verify integrity
-hash_value = su.get_file_hash("data/raw/data.csv")
-su.log_info(f"File hash: {hash_value}")
-
-# 5. Process data (if pandas available)
-try:
-    import pandas as pd
-    df = pd.read_csv("data/raw/data.csv")
-    su.log_info(f"Loaded {len(df)} rows")
-except ImportError:
-    su.log_warning("Pandas not available - install with: pip install pandas")
-```
-
-### Client Report Generation
-
-```python
-from siege_utilities.config import HydraConfigManager, BrandingConfig
-
-# Load client-specific configuration
-with HydraConfigManager() as manager:
-    # Get branding for specific client
-    branding = manager.load_branding_config("client_a")
-    
-    # Use branding in reports
-    print(f"Generating report with:")
-    print(f"  Primary color: {branding.primary_color}")
-    print(f"  Font: {branding.primary_font}")
-    
-    # Load user preferences
-    user_profile = manager.load_user_profile()
-    output_dir = user_profile.preferred_download_directory
-    print(f"  Output directory: {output_dir}")
-```
-
-### Geospatial Analysis
-
-```python
-# Get Census data
+# Get Census boundaries — the starting point for most analyses
 counties = su.get_census_boundaries(
     year=2020,
     geographic_level='county',
     state_fips='06'  # California
 )
+print(f"Found {len(counties)} counties")
 
-# Geocode addresses
+# Geocode addresses into the coordinate system
 addresses = ["San Francisco, CA", "Los Angeles, CA"]
 for address in addresses:
     result = su.use_nominatim_geocoder(address)
@@ -143,84 +48,157 @@ for address in addresses:
         print(f"{address}: {coords['nominatim_lat']}, {coords['nominatim_lng']}")
 ```
 
-## 🔧 Configuration Management
+Geo uses the OSGeo stack (GDAL/OGR, PROJ, Shapely, Fiona, rasterio) by
+default. When the deployment target cannot run C libraries (Databricks,
+Lambda), use Sedona or DuckDB-spatial — the constraint must be explicit.
 
-### Create User Profile
+## 2. Engine-Agnostic DataFrame
+
+The same analysis at different scales without rewriting:
 
 ```python
-from siege_utilities.config import UserProfile
+from siege_utilities.engines import get_engine
 
-# Create a new user profile
+# pandas for exploration
+engine = get_engine("pandas")
+df = engine.read_parquet("boundaries.parquet")
+
+# DuckDB for medium scale
+engine = get_engine("duckdb")
+df = engine.read_parquet("boundaries.parquet")
+
+# Spark for distribution
+engine = get_engine("spark")
+df = engine.read_parquet("boundaries.parquet")
+```
+
+When you must drop to native (Spark SQL, raw pandas), use that engine's
+idioms directly. The abstraction serves the general case.
+
+## 3. Credential Management
+
+Credentials come from external tools — never hardcoded:
+
+```python
+# 1Password CLI (preferred when siege_zsh is available)
+# Environment variables (standard fallback)
+# Databricks secret scopes (in-cluster)
+
+from siege_utilities.config import HydraConfigManager
+
+with HydraConfigManager() as manager:
+    user_profile = manager.load_user_profile()
+    print(f"Welcome, {user_profile.full_name}!")
+```
+
+The `siege_zsh` shell environment sets up credentials that siege_utilities
+expects. Code detects and leverages these conventions but does not hard-fail
+without them.
+
+## 4. Distributed Computing
+
+```python
+# Spark Connect — setup requires PySpark
+spark, data_path = su.setup_distributed_environment()
+```
+
+### Databricks (first-class target)
+
+Azure Databricks cannot install GDAL. The `databricks/` bridge pattern
+(Spark -> driver-side GeoPandas -> back to Spark) is the architectural
+solution:
+
+```python
+from siege_utilities.databricks import get_databricks_client
+
+client = get_databricks_client()
+```
+
+### Snowflake (first-class target)
+
+Snowflake's geography type and Trino federation are parallel vendor paths
+for spatial computation at scale.
+
+## 5. Domain Packages
+
+Domain packages are primitives, not applications. They encode domain
+expertise — what data exists, where it lives, how to access it — not domain
+analysis.
+
+```python
+# Political: DDL and entities for political geography
+from siege_utilities.political import get_redistricting_plan
+
+# Education: NCES data downloads
+from siege_utilities.education import download_nces_data
+
+# Survey: pipeline composition (Chain, weights, significance)
+from siege_utilities.survey import Chain
+
+# Analytics: third-party connectors (GA, data sources)
+from siege_utilities.analytics import create_ga_connector
+```
+
+## 6. Configuration and Profiles
+
+```python
+from siege_utilities.config import UserProfile, ClientProfile, BrandingConfig
+
+# User profile
 user = UserProfile(
-    username="john_doe",
-    email="john@example.com",
-    full_name="John Doe",
+    username="analyst",
+    email="analyst@example.com",
+    full_name="Data Analyst",
     default_output_format="pptx",
-    preferred_download_directory="/Users/john/Downloads/siege_utilities"
+    preferred_download_directory="/Users/analyst/output"
 )
 
-print(f"Created profile for: {user.full_name}")
+# Client branding for reports
+from siege_utilities.config import HydraConfigManager
+
+with HydraConfigManager() as manager:
+    branding = manager.load_branding_config("client_a")
+    print(f"Primary color: {branding.primary_color}")
 ```
 
-### Create Client Profile
+## 7. Core Utilities
 
 ```python
-from siege_utilities.config import ClientProfile, ContactInfo, BrandingConfig
+import siege_utilities as su
 
-# Create client profile with branding
-client = ClientProfile(
-    client_id="acme_corp",
-    client_name="Acme Corporation",
-    client_code="ACME",
-    contact_info=ContactInfo(
-        email="contact@acme.com",
-        website="https://acme.com"
-    ),
-    industry="Technology",
-    branding_config=BrandingConfig(
-        primary_color="#1f77b4",
-        secondary_color="#ff7f0e",
-        primary_font="Arial"
-    )
-)
+# Logging — every side-effecting process must produce observable output
+su.log_info("Starting pipeline")
 
-print(f"Created profile for: {client.client_name}")
+# File operations
+hash_value = su.get_file_hash("myfile.txt")
+su.ensure_path_exists("data/processed")
+
+# String utilities
+clean_text = su.remove_wrapping_quotes_and_trim('  "hello world"  ')
 ```
 
-## 📊 Package Information
-
-```python
-# Get comprehensive package info
-info = su.get_package_info()
-
-print(f"Total functions: {info['total_functions']}")
-print(f"Available categories: {list(info['categories'].keys())}")
-
-# Check specific category
-core_functions = info['categories']['core']
-print(f"Core functions: {len(core_functions)}")
-```
-
-## 🛠️ Troubleshooting
+## Troubleshooting
 
 ### Missing Dependencies
 
 ```python
-# Check what's available
-info = su.get_package_info()
-print(f"Available functions: {info['total_functions']}")
+# ImportError propagates with an actionable message — do not swallow it.
+# The library uses lazy loading (PEP 562 __getattr__), so import errors
+# surface when you first access a name, not at module import time.
 
-# Try a function that might need dependencies
-try:
-    result = su.create_bivariate_choropleth({}, 'location', 'var1', 'var2')
-except ImportError as e:
-    print(f"Install dependencies: {e}")
+# WRONG — violates SU-1 (errors are not data):
+# try:
+#     from siege_utilities.geo import something
+# except ImportError:
+#     print("not available")  # caller cannot distinguish this from success
+
+# RIGHT — let the error propagate with context:
+from siege_utilities.geo import get_census_boundaries  # raises ImportError if GDAL missing
 ```
 
 ### Configuration Issues
 
 ```python
-# Check configuration status
 from siege_utilities.config import get_default_profile_location
 
 profile_dir = get_default_profile_location()
@@ -231,21 +209,20 @@ from siege_utilities.config import create_default_profiles
 create_default_profiles()
 ```
 
-## 🎯 Next Steps
+## Next Steps
 
-1. **Explore Examples**: Start with `docs/EXAMPLES.md` (`notebooks/06_Report_Generation.ipynb` includes the 3D map demo).
-2. **Read Documentation**: Full documentation in `docs/` directory
-3. **Run Tests**: `python -m pytest tests/` to verify everything works
-4. **Check Imports**: Run `python scripts/check_imports.py` for a quick script-level sanity check
+1. **Notebooks**: 32 notebooks in `notebooks/` organized by domain (spatial, engines, reports, foundations)
+2. **Architecture**: `docs/ARCHITECTURE.md` for the full structural picture
+3. **Intent**: `docs/INTENT.md` for one-line module purposes
+4. **Tests**: `python -m pytest tests/` to verify the installation
 
-## 💡 Pro Tips
+## Key Principles
 
-- **Always use the context manager** for HydraConfigManager: `with HydraConfigManager() as manager:`
-- **Check function availability** before using: `info = su.get_package_info()`
-- **Use validation**: The new Pydantic models catch errors early
-- **Client-specific configs**: Override defaults with client-specific YAML files
-- **Migration**: Use the programmatic migration helpers documented in `docs/HYDRA_PYDANTIC_CONFIGURATION.md`
+- **Geo is the gravitational center** — all domain modules produce events that need space-time location
+- **Errors are not data (SU-1)** — never return empty results on failure; raise or log with a warning
+- **Lazy loading by design** — import one piece without pulling the whole library
+- **Temporal awareness is first-class** — not just "where" but "where-when"
 
 ---
 
-**Ready to dive deeper?** Check out the [User Guide](USER_GUIDE.md) for comprehensive documentation!
+**Ready to dive deeper?** See [ARCHITECTURE.md](ARCHITECTURE.md) and [CLAUDE.md](../CLAUDE.md) for the full set of architectural principles.


### PR DESCRIPTION
## Summary

- Restructures QUICK_START_GUIDE to lead with geo as the gravitational center
- Fixes all `try/except ImportError: print(...)` patterns (SU-1 violations)
- Adds engine-agnostic DataFrame, credential management, Databricks/Snowflake sections
- Updates INTENT.md module table with 8 missing modules (engines/, education/, economic/, identifiers/, political/, reference/, schema/, trino/)
- Adds guiding principles preamble to INTENT.md
- Removes stale ELE-ticket references

Part of #955, parent #953