### PR TITLE
fix(#962): convert star imports to PEP 562 lazy loading

### DIFF
--- a/siege_utilities/data/statistics/__init__.py
+++ b/siege_utilities/data/statistics/__init__.py
@@ -1,13 +1,55 @@
-"""
-Statistical primitives for DataFrame analysis.
+"""Statistical primitives for DataFrame analysis.
 
 - :mod:`cross_tabulation` — contingency tables, chi-square, proportion math
 - :mod:`moe_propagation` — ACS margin-of-error propagation through derived estimates
 
-Extracted from top-level ``data/`` during ELE-2437 so tabulation / stats
-primitives live together, distinct from engine infrastructure
-(``siege_utilities.engines``) and reference data (``siege_utilities.reference``).
+Submodules load on first attribute access via PEP 562 __getattr__.
 """
 
-from .cross_tabulation import *  # noqa: F401, F403
-from .moe_propagation import *  # noqa: F401, F403
+import importlib
+import sys
+
+_LAZY_IMPORTS: dict[str, str] = {}
+
+
+def _register(names: list[str], module: str) -> None:
+    for name in names:
+        _LAZY_IMPORTS[name] = module
+
+
+# --- cross_tabulation ---
+_register([
+    "ChiSquareResult",
+    "CrossTabSpec",
+    "chi_square_test",
+    "contingency_table",
+    "moe_cross_tab",
+    "rate_table",
+], ".cross_tabulation")
+
+# --- moe_propagation ---
+_register([
+    "Estimate",
+    "Z_90",
+    "flag_unreliable",
+    "moe_difference",
+    "moe_product",
+    "moe_proportion",
+    "moe_ratio",
+    "moe_sum",
+], ".moe_propagation")
+
+__all__ = list(_LAZY_IMPORTS.keys())
+
+
+def __getattr__(name: str):
+    if name in _LAZY_IMPORTS:
+        mod = importlib.import_module(_LAZY_IMPORTS[name], __package__)
+        val = getattr(mod, name)
+        setattr(sys.modules[__name__], name, val)
+        return val
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(list(globals().keys()) + list(_LAZY_IMPORTS.keys())))

--- a/siege_utilities/engines/__init__.py
+++ b/siege_utilities/engines/__init__.py
@@ -1,17 +1,48 @@
-"""
-Engine abstractions — engine-agnostic DataFrame operations.
+"""Engine abstractions — engine-agnostic DataFrame operations.
 
 Holds the :class:`DataFrameEngine` ABC and its four concrete
 implementations (Pandas, DuckDB, Spark, PostGIS).
 
-Promoted from ``data/`` during ELE-2437 because the engine layer is
-infrastructure ("how we compute"), distinct from ``data/statistics/``
-(stats primitives) and ``reference/`` (reference / sample data).
+Submodules load on first attribute access via PEP 562 __getattr__.
 """
 
-from .dataframe_engine import *  # noqa: F401, F403
+import importlib
+import sys
 
-try:
-    from .dataframe_engine import __all__  # noqa: F401
-except ImportError:
-    pass
+_LAZY_IMPORTS: dict[str, str] = {}
+
+
+def _register(names: list[str], module: str) -> None:
+    for name in names:
+        _LAZY_IMPORTS[name] = module
+
+
+# --- dataframe_engine ---
+_register([
+    "Engine",
+    "PANDAS",
+    "DUCKDB",
+    "SPARK",
+    "POSTGIS",
+    "DataFrameEngine",
+    "PandasEngine",
+    "DuckDBEngine",
+    "SparkEngine",
+    "PostGISEngine",
+    "get_engine",
+], ".dataframe_engine")
+
+__all__ = list(_LAZY_IMPORTS.keys())
+
+
+def __getattr__(name: str):
+    if name in _LAZY_IMPORTS:
+        mod = importlib.import_module(_LAZY_IMPORTS[name], __package__)
+        val = getattr(mod, name)
+        setattr(sys.modules[__name__], name, val)
+        return val
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(list(globals().keys()) + list(_LAZY_IMPORTS.keys())))

--- a/siege_utilities/reference/__init__.py
+++ b/siege_utilities/reference/__init__.py
@@ -1,14 +1,77 @@
-"""
-Reference data and crosswalks that ship with the library.
+"""Reference data and crosswalks that ship with the library.
 
 - :mod:`naics_soc_crosswalk` — NAICS / SOC code mapping and crosswalks
 - :mod:`sample_data` — built-in demo datasets (synthetic + real Census mash-ups)
 
-Extracted from ``data/`` during ELE-2437. Reference data (static tables,
-crosswalks, fixtures) is a distinct nature from DataFrame ops
-(``siege_utilities.data.statistics``) and infrastructure
-(``siege_utilities.engines``).
+Submodules load on first attribute access via PEP 562 __getattr__.
 """
 
-from .naics_soc_crosswalk import *  # noqa: F401, F403
-from .sample_data import *  # noqa: F401, F403
+import importlib
+import sys
+
+_LAZY_IMPORTS: dict[str, str] = {}
+
+
+def _register(names: list[str], module: str) -> None:
+    for name in names:
+        _LAZY_IMPORTS[name] = module
+
+
+# --- naics_soc_crosswalk ---
+_register([
+    "NAICSCode",
+    "NAICS_SECTORS",
+    "parse_naics",
+    "naics_ancestors",
+    "naics_to_sector",
+    "crosswalk_naics",
+    "SOCCode",
+    "SOC_MAJOR_GROUPS",
+    "parse_soc",
+    "soc_to_major_group",
+    "fuzzy_match_naics",
+    "NAICS_SUBSECTORS",
+    "SOC_MINOR_GROUPS",
+    "get_naics_lookup",
+    "get_soc_lookup",
+    "naics_title",
+    "soc_title",
+    "filter_by_naics",
+    "filter_by_naics_sector",
+    "group_by_naics_sector",
+], ".naics_soc_crosswalk")
+
+# --- sample_data ---
+_register([
+    "HOUSING_LOCALE_PRESETS",
+    "SAMPLE_DATASETS",
+    "CENSUS_SAMPLES",
+    "SYNTHETIC_SAMPLES",
+    "list_available_datasets",
+    "get_dataset_info",
+    "load_sample_data",
+    "get_census_boundaries",
+    "get_census_data",
+    "join_boundaries_and_data",
+    "create_sample_dataset",
+    "get_census_county_sample",
+    "get_metropolitan_sample",
+    "generate_synthetic_population",
+    "generate_synthetic_businesses",
+    "generate_synthetic_housing",
+], ".sample_data")
+
+__all__ = list(_LAZY_IMPORTS.keys())
+
+
+def __getattr__(name: str):
+    if name in _LAZY_IMPORTS:
+        mod = importlib.import_module(_LAZY_IMPORTS[name], __package__)
+        val = getattr(mod, name)
+        setattr(sys.modules[__name__], name, val)
+        return val
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(list(globals().keys()) + list(_LAZY_IMPORTS.keys())))


### PR DESCRIPTION
## Summary

- Converts `engines/__init__.py` from `from .dataframe_engine import *` to lazy loading (11 names)
- Converts `reference/__init__.py` from two star imports to lazy loading (37 names)
- Converts `data/statistics/__init__.py` from two star imports to lazy loading (14 names)
- All follow the canonical `_register()` + `__getattr__` pattern from `docs/TEMPLATES.md` section B
- `dir()` and attribute access verified working on all three modules

Closes #962, parent #953