### PR TITLE
fix(#960): eliminate return-empty-on-error in geo providers (SU-1)

### DIFF
--- a/siege_utilities/geo/census/catalog.py
+++ b/siege_utilities/geo/census/catalog.py
@@ -450,9 +450,17 @@ class CensusCatalog:
         ]
 
     def geography_for_table(self, table_id: str) -> list[str]:
+        """Return the geography levels supported by *table_id*.
+
+        Raises:
+            KeyError: If *table_id* is not in the catalog.
+        """
         table = self._tables.get(table_id)
         if table is None:
-            return []
+            raise KeyError(
+                f"Table {table_id!r} not found in catalog; "
+                f"use search() to discover valid table IDs"
+            )
         return list(table.geography_levels)
 
     def families_for_table(self, table_id: str) -> list[CensusFamily]:

--- a/siege_utilities/geo/codification.py
+++ b/siege_utilities/geo/codification.py
@@ -147,11 +147,11 @@ def codify_area(
         return result
 
     if geocoder is None:
-        geocoder = _get_default_geocoder()
-
-    if geocoder is None:
-        result.errors.append("No geocoder available")
-        return result
+        try:
+            geocoder = _get_default_geocoder()
+        except (ImportError, Exception) as exc:
+            result.errors.append(f"No geocoder available: {exc}")
+            return result
 
     result.geocoding_backend = geocoder.backend_name
 
@@ -208,13 +208,25 @@ def _build_block_profiles(geocoded_results) -> list[BlockProfile]:
 
 
 def _get_default_geocoder():
-    """Attempt to create a default CensusBatchGeocoder."""
+    """Attempt to create a default CensusBatchGeocoder.
+
+    Returns:
+        A CensusBatchGeocoder instance.
+
+    Raises:
+        ImportError: When CensusBatchGeocoder is not available.
+        SiegeGeoError: When geocoder initialisation fails.
+    """
     try:
         from siege_utilities.geo.providers.census_batch import CensusBatchGeocoder
         return CensusBatchGeocoder()
     except ImportError:
-        log.debug("CensusBatchGeocoder not available (missing dependency)")
-        return None
+        raise ImportError(
+            "CensusBatchGeocoder not available; install with: "
+            "pip install 'siege-utilities[geo]'"
+        )
     except (RuntimeError, ValueError, TypeError, AttributeError, OSError) as exc:
-        log.warning("Failed to initialise CensusBatchGeocoder: %s", exc)
-        return None
+        from siege_utilities.exceptions import SiegeGeoError
+        raise SiegeGeoError(
+            f"Failed to initialise CensusBatchGeocoder: {exc}"
+        ) from exc

--- a/siege_utilities/geo/django/services/timeseries_service.py
+++ b/siege_utilities/geo/django/services/timeseries_service.py
@@ -91,14 +91,16 @@ class TimeseriesService:
 
         from ..models.demographics import DemographicSnapshot, DemographicTimeSeries
 
-        # Resolve model from geography level
-        model_cls = self._resolve_model(geography_level)
-        if model_cls is None:
+        # Resolve model from geography level — raises ValueError for
+        # unknown levels or missing Django models.
+        try:
+            model_cls = self._resolve_model(geography_level)
+        except ValueError as exc:
             return [
                 TimeseriesResult(
                     variable_code=v,
                     geography_level=geography_level,
-                    errors=[f"Unknown geography level: {geography_level}"],
+                    errors=[str(exc)],
                 )
                 for v in variables
             ]
@@ -151,7 +153,10 @@ class TimeseriesService:
                 # Compute statistics
                 mean_val = sum(series_values) / len(series_values)
                 std_dev = self._std_dev(series_values, mean_val)
-                cagr = self._cagr(series_values[0], series_values[-1], len(series_years) - 1)
+                try:
+                    cagr = self._cagr(series_values[0], series_values[-1], len(series_years) - 1)
+                except ValueError:
+                    cagr = None  # start_value <= 0 — CAGR undefined
                 trend = self._trend_direction(series_values)
 
                 # Check for existing
@@ -234,12 +239,17 @@ class TimeseriesService:
         }
         model_name = LEVEL_TO_MODEL.get(geography_level)
         if model_name is None:
-            return None
+            raise ValueError(
+                f"Unknown geography level {geography_level!r}; "
+                f"expected one of {sorted(LEVEL_TO_MODEL)}"
+            )
         try:
             return apps.get_model("siege_geo", model_name)
         except LookupError as exc:
-            log.warning("Could not resolve model: %s", exc)
-            return None
+            raise ValueError(
+                f"Django model 'siege_geo.{model_name}' for geography "
+                f"level {geography_level!r} is not installed"
+            ) from exc
 
     @staticmethod
     def _std_dev(values: list, mean: float) -> float:
@@ -250,15 +260,35 @@ class TimeseriesService:
         return math.sqrt(variance)
 
     @staticmethod
-    def _cagr(start_value: float, end_value: float, periods: int) -> Optional[float]:
-        """Compound annual growth rate."""
-        if periods <= 0 or start_value <= 0:
-            return None
+    def _cagr(start_value: float, end_value: float, periods: int) -> float:
+        """Compound annual growth rate.
+
+        Args:
+            start_value: Starting value (must be > 0).
+            end_value: Ending value.
+            periods: Number of periods (must be > 0).
+
+        Returns:
+            The compound annual growth rate.
+
+        Raises:
+            ValueError: When inputs violate constraints.
+        """
+        if periods <= 0:
+            raise ValueError(
+                f"CAGR requires periods > 0; got {periods}"
+            )
+        if start_value <= 0:
+            raise ValueError(
+                f"CAGR requires start_value > 0; got {start_value}"
+            )
         try:
             return (end_value / start_value) ** (1 / periods) - 1
         except (ZeroDivisionError, ValueError) as exc:
-            log.warning("CAGR computation failed: %s", exc)
-            return None
+            raise ValueError(
+                f"CAGR computation failed for start={start_value}, "
+                f"end={end_value}, periods={periods}: {exc}"
+            ) from exc
 
     @staticmethod
     def _trend_direction(values: list) -> str:

--- a/siege_utilities/geo/gazetteers/census_gazetteer.py
+++ b/siege_utilities/geo/gazetteers/census_gazetteer.py
@@ -156,7 +156,9 @@ class CensusGazetteer:
         if not name or not name.strip():
             return []
         if country_hint and country_hint.upper() not in ("US", "USA"):
-            return []
+            raise GazetteerNotFoundError(
+                f"CensusGazetteer is US-only; country_hint={country_hint!r}"
+            )
         rows = self._cached_lookup(name.strip(), None)
         return [self._row_to_candidate(r) for r in rows[:limit]]
 

--- a/siege_utilities/geo/providers/boundary_providers.py
+++ b/siege_utilities/geo/providers/boundary_providers.py
@@ -95,7 +95,10 @@ class CensusTIGERProvider(BoundaryProvider):
                       (e.g. ``year``, ``congress_number``).
 
         Returns:
-            GeoDataFrame or None.
+            GeoDataFrame with boundary geometries.
+
+        Raises:
+            BoundaryFetchError: When the boundary retrieval fails.
         """
         from ..spatial_data import CensusDataSource
 
@@ -110,12 +113,10 @@ class CensusTIGERProvider(BoundaryProvider):
         ds = CensusDataSource()
         result = ds.fetch_geographic_boundaries(**call_kwargs)
         if not result.success:
-            logger.warning(
-                'CensusTIGERProvider: boundary retrieval failed [%s] %s',
-                result.error_stage,
-                result.message,
+            raise BoundaryFetchError(
+                f"CensusTIGERProvider: boundary retrieval failed "
+                f"[{result.error_stage}] {result.message}"
             )
-            return None
         return result.geodataframe
 
     def list_levels(self) -> list[str]:


### PR DESCRIPTION
## Summary

Fixes SU-1 violations in the geo composition chain — the spine of the library where silent failures propagate to every downstream operation.

- **boundary_providers.py** — `CensusTIGERProvider.get_boundary()` raises `BoundaryFetchError` instead of returning `None` (SU-1 + SU-2: type annotation now matches)
- **codification.py** — `_get_default_geocoder()` raises `ImportError`/`SiegeGeoError` instead of returning `None`; caller updated to populate error list
- **census_gazetteer.py** — `search()` raises `GazetteerNotFoundError` for non-US hint instead of silent `[]`
- **catalog.py** — `geography_for_table()` raises `KeyError` for unknown table_id instead of `[]`
- **timeseries_service.py** — `_resolve_model()` raises `ValueError` for unknown levels; `_cagr()` raises for invalid inputs

Files NOT modified (legitimate semantics, not SU-1):
- `census/api.py` cache helpers — `None` means "cache miss" (correct)
- `nominatim_gazetteer.py`, `wkls_gazetteer.py` — already raise on service failure; `[]` for empty input is valid

Closes #960, parent #953