### PR TITLE
fix(#961): eliminate return-empty-on-error in config, distributed, files, survey (SU-1)

### DIFF
--- a/siege_utilities/config/credential_manager.py
+++ b/siege_utilities/config/credential_manager.py
@@ -18,6 +18,8 @@ import tempfile  # noqa: F401 -- used by create_temporary_service_account_file; 
 from typing import Dict, Any, Optional, List, Union, Tuple
 from pathlib import Path
 
+from siege_utilities.exceptions import SiegeConfigError
+
 # Import logging functions
 import logging
 import re
@@ -389,9 +391,13 @@ class CredentialManager:
                     content = f.read().strip()
                     return content if content else None
                     
-        except (OSError, json.JSONDecodeError, KeyError) as e:
-            log_warning(f"Error reading credential file {file_path}: {e}")
+        except KeyError:
+            # Field not present in the file's structure -- legitimate "not found".
             return None
+        except (OSError, json.JSONDecodeError) as e:
+            raise SiegeConfigError(
+                f"Failed to read credential file {file_path}: {e}"
+            ) from e
     
     def _find_field_in_dict(self, data: Dict[str, Any], field: str) -> Optional[str]:
         """Recursively search for field in nested dictionary."""
@@ -517,9 +523,15 @@ class CredentialManager:
             else:
                 return input(prompt)
                 
-        except (EOFError, KeyboardInterrupt):
-            _logger.warning("Interactive credential prompt cancelled by user")
-            return None
+        except KeyboardInterrupt:
+            # User deliberately cancelled — propagate so the caller does
+            # not silently fall through to a less-trusted backend.
+            raise
+        except EOFError as e:
+            raise SiegeConfigError(
+                f"Interactive credential prompt for {service}/{field} "
+                f"received EOF — stdin may not be connected"
+            ) from e
     
     def store_credential(self, service: str, username: str, value: str,
                         field: str = "password", backend: str = "1password",

--- a/siege_utilities/distributed/spark_utils.py
+++ b/siege_utilities/distributed/spark_utils.py
@@ -297,36 +297,6 @@ def flatten_json_column_and_join_back_to_df(df: "DataFrame", json_column: str,
                             break
             if '_corrupt_record' in [field.name for field in
                 inferred_schema.fields]:
-                _log_info(
-                    f'All samples contain corrupt JSON. Falling back to string schema for {json_column}'
-                    )
-
-                def validate_json(s):
-                    """Pass-through with parse-check: return *s* if it
-                    decodes as JSON, ``None`` otherwise.
-
-                    Runs as a Spark UDF so each row's value is evaluated
-                    individually (passing this function unwrapped to
-                    .otherwise() would call it once at plan-build time
-                    with a Column object, which always raises and yields
-                    a constant None for every row).
-                    """
-                    if s is None:
-                        return None
-                    try:
-                        json.loads(s)
-                        return s
-                    except (TypeError, json.JSONDecodeError):
-                        return None
-                validate_json_udf = udf(validate_json, StringType())
-                df_with_json = df.withColumn('validated_json', when(col(
-                    json_column).isNull(), lit(None)).otherwise(
-                    validate_json_udf(col(json_column)))).withColumn('parsed_json',
-                    from_json(col('validated_json'), StringType(), {'mode':
-                    'PERMISSIVE'})).drop('validated_json')
-                df_with_json = df_with_json.withColumn('parsed_json', when(
-                    col('parsed_json').isNull(), lit(None).cast(StringType(
-                    ))).otherwise(col('parsed_json')))
                 raise ValueError(
                     f"All JSON samples in column {json_column!r} are corrupt; "
                     f"cannot infer schema for flattening"
@@ -340,15 +310,14 @@ def flatten_json_column_and_join_back_to_df(df: "DataFrame", json_column: str,
         try:
 
             def validate_json(s):
-                """Same JSON pass-through validator as above.
+                """Pass-through with parse-check: return *s* if valid JSON, ``None`` otherwise.
 
-                Defined locally inside the fallback path so it doesn't
-                shadow the outer one when the corrupt-record branch
-                takes a different schema. Both definitions are
-                semantically identical -- they exist as separate
-                closures to match the surrounding try/except scope.
-                Wrapped as a UDF so .otherwise() invokes it per-row,
-                not once at plan-build time.
+                Wrapped as a Spark UDF so .otherwise() invokes it per-row,
+                not once at plan-build time.  Returning ``None`` for
+                unparseable cells is the correct Spark idiom (marks the
+                cell as null) and is NOT an SU-1 violation -- this is a
+                per-row data transform, not a library function returning
+                empty on error.
                 """
                 if s is None:
                     return None

--- a/siege_utilities/files/operations.py
+++ b/siege_utilities/files/operations.py
@@ -352,7 +352,7 @@ def run_command(command: Union[str, List[str]],
                 timeout: Optional[int] = 30,
                 capture_output: bool = True,
                 allow_list: Optional[set] = None,
-                unsafe: bool = False) -> Optional[subprocess.CompletedProcess]:
+                unsafe: bool = False) -> subprocess.CompletedProcess:
     """
     Run a shell command with security validation and proper error handling.
 
@@ -373,11 +373,11 @@ def run_command(command: Union[str, List[str]],
 
     Returns:
         CompletedProcess object on success or non-zero exit.
-        None on timeout or unexpected error (when unsafe=True).
 
     Raises:
         SecurityError: If command fails security validation (when unsafe=False).
-        Exception: Re-raised on unexpected errors when unsafe=False.
+        subprocess.TimeoutExpired: If the command exceeds *timeout*.
+        OSError: If the command binary cannot be found or executed.
 
     Example:
         >>> result = run_command("ls -la")  # doctest: +SKIP
@@ -479,16 +479,12 @@ def run_command(command: Union[str, List[str]],
 
         return result
 
-    except subprocess.TimeoutExpired as e:
+    except subprocess.TimeoutExpired:
         log.error(f"Command timed out: {command}")
-        if not unsafe:
-            raise
-        return None
+        raise
     except (OSError, ValueError) as e:
         log.error(f"Failed to run command {command}: {e}")
-        if not unsafe:
-            raise
-        return None
+        raise
 
 # Backward compatibility aliases
 rmtree = remove_tree

--- a/siege_utilities/survey/render.py
+++ b/siege_utilities/survey/render.py
@@ -144,8 +144,9 @@ def _build_map(chain: "Chain", map_generator: Optional[Any] = None) -> Optional[
     as such would mislabel (e.g. relabeling ``"Democrat"`` / ``"Republican"``
     as states).
 
-    Returns ``None`` when no ``geo_column`` is set or when the geo-rendering
-    library is unavailable. Raises :class:`RenderError` on a configuration
+    Returns ``None`` when no ``geo_column`` is set or when the resulting
+    DataFrame is empty. Raises :class:`ImportError` when the reporting
+    extra is not installed. Raises :class:`RenderError` on a configuration
     mismatch or a rendering failure -- callers should not silently ship
     reports missing maps.
     """
@@ -164,9 +165,11 @@ def _build_map(chain: "Chain", map_generator: Optional[Any] = None) -> Optional[
         try:
             from ..reporting.chart_generator import ChartGenerator
             map_generator = ChartGenerator()
-        except ImportError:
-            logger.warning("ChartGenerator unavailable — map rendering skipped")
-            return None
+        except ImportError as exc:
+            raise ImportError(
+                "ChartGenerator is required for map rendering. "
+                "Install with: pip install 'siege-utilities[reporting]'"
+            ) from exc
 
     df = chain.to_dataframe()
     if df.empty:


### PR DESCRIPTION
## Summary

Fixes SU-1 violations in foundation and infrastructure modules where silent failures mask backend errors.

- **credential_manager.py** — Split except blocks to separate "not found" (None is valid) from "backend error" (now raises `SiegeConfigError`). `KeyboardInterrupt` in prompt path now re-raises instead of silently falling through.
- **spark_utils.py** — Removed dead code in corrupt-record branch. Documented why `return None` in Spark UDF is correct idiom (per-row null marking, not SU-1).
- **files/operations.py** — `run_command` errors now always raise regardless of `unsafe` flag. Return type narrowed from `Optional[CompletedProcess]` to `CompletedProcess`.
- **survey/render.py** — `_build_map` raises `ImportError` with install instructions instead of returning `None`.

Closes #961, parent #953