### PR TITLE
fix(#975): reproject compactness metrics to equal-area CRS

### DIFF
--- a/siege_utilities/geo/django/services/rdh_loader.py
+++ b/siege_utilities/geo/django/services/rdh_loader.py
@@ -476,16 +476,16 @@ class RDHLoaderService:
         )
 
         districts = plan.districts.exclude(geometry__isnull=True)
+        srid = districts.first().geometry.srid if districts.exists() else 4326
         updated = 0
         for district in districts:
-            # Convert GEOS to Shapely for compactness functions
             from shapely import wkt
 
             shapely_geom = wkt.loads(district.geometry.wkt)
-            district.polsby_popper = pp_fn(shapely_geom)
-            district.reock = reock_fn(shapely_geom)
-            district.convex_hull_ratio = chr_fn(shapely_geom)
-            district.schwartzberg = sw_fn(shapely_geom)
+            district.polsby_popper = pp_fn(shapely_geom, source_crs=f"EPSG:{srid}")
+            district.reock = reock_fn(shapely_geom, source_crs=f"EPSG:{srid}")
+            district.convex_hull_ratio = chr_fn(shapely_geom, source_crs=f"EPSG:{srid}")
+            district.schwartzberg = sw_fn(shapely_geom, source_crs=f"EPSG:{srid}")
             district.save(update_fields=[
                 "polsby_popper", "reock", "convex_hull_ratio", "schwartzberg",
             ])

--- a/siege_utilities/geo/providers/redistricting_data_hub.py
+++ b/siege_utilities/geo/providers/redistricting_data_hub.py
@@ -622,41 +622,82 @@ class RDHClient:
 # Compactness scoring
 # ---------------------------------------------------------------------------
 
-def polsby_popper(geometry) -> float:
+_EQUAL_AREA_CRS = "ESRI:54009"
+
+
+def _reproject_geometry(geom, source_crs, target_crs=_EQUAL_AREA_CRS):
+    """Reproject a single Shapely geometry between CRS."""
+    from pyproj import Transformer
+    from shapely.ops import transform
+
+    transformer = Transformer.from_crs(source_crs, target_crs, always_xy=True)
+    return transform(transformer.transform, geom)
+
+
+def _is_geographic_crs(crs) -> bool:
+    """Return True if crs is a geographic (lat/lon) coordinate system."""
+    from pyproj import CRS
+
+    parsed = CRS.from_user_input(crs)
+    return parsed.is_geographic
+
+
+def polsby_popper(geometry, source_crs=None) -> float:
     """Compute Polsby-Popper compactness score for a geometry.
 
     Score = (4 * pi * area) / perimeter^2
     Range: 0 (least compact) to 1 (circle).
+
+    Parameters
+    ----------
+    geometry : shapely geometry
+        Must be in a projected (equal-area) CRS for meaningful results.
+    source_crs : optional
+        If provided and geographic, geometry is reprojected to equal-area
+        before calculation. Pass the CRS (e.g., "EPSG:4326") when calling
+        with unprojected data.
     """
     import math
+
     if geometry is None or geometry.is_empty:
-        return 0.0
+        return float("nan")
+    if source_crs is not None and _is_geographic_crs(source_crs):
+        geometry = _reproject_geometry(geometry, source_crs)
     area = geometry.area
     perimeter = geometry.length
     if perimeter == 0:
-        return 0.0
+        return float("nan")
     return (4.0 * math.pi * area) / (perimeter ** 2)
 
 
-def reock(geometry) -> float:
+def reock(geometry, source_crs=None) -> float:
     """Compute Reock compactness score for a geometry.
 
     Score = area / area_of_minimum_bounding_circle
     Range: 0 (least compact) to 1 (circle).
+
+    Parameters
+    ----------
+    geometry : shapely geometry
+        Must be in a projected (equal-area) CRS for meaningful results.
+    source_crs : optional
+        If provided and geographic, geometry is reprojected to equal-area.
     """
     import math
+
     if geometry is None or geometry.is_empty:
-        return 0.0
+        return float("nan")
+    if source_crs is not None and _is_geographic_crs(source_crs):
+        geometry = _reproject_geometry(geometry, source_crs)
     area = geometry.area
-    # Approximate MBC using minimum rotated rectangle's diagonal
     mrr = geometry.minimum_rotated_rectangle
     if mrr is None or mrr.is_empty:
-        return 0.0
+        return float("nan")
     coords = list(mrr.exterior.coords)
     if len(coords) < 4:
-        return 0.0
-    # Diagonal of the minimum rotated rectangle as diameter estimate
+        return float("nan")
     from shapely.geometry import Point
+
     p0, p1, p2 = Point(coords[0]), Point(coords[1]), Point(coords[2])
     side1 = p0.distance(p1)
     side2 = p1.distance(p2)
@@ -664,37 +705,56 @@ def reock(geometry) -> float:
     radius = diameter / 2.0
     circle_area = math.pi * radius**2
     if circle_area == 0:
-        return 0.0
+        return float("nan")
     return area / circle_area
 
 
-def convex_hull_ratio(geometry) -> float:
+def convex_hull_ratio(geometry, source_crs=None) -> float:
     """Compute convex hull ratio for a geometry.
 
     Score = area / convex_hull_area
     Range: 0 to 1.
+
+    Parameters
+    ----------
+    geometry : shapely geometry
+        Must be in a projected (equal-area) CRS for meaningful results.
+    source_crs : optional
+        If provided and geographic, geometry is reprojected to equal-area.
     """
     if geometry is None or geometry.is_empty:
-        return 0.0
+        return float("nan")
+    if source_crs is not None and _is_geographic_crs(source_crs):
+        geometry = _reproject_geometry(geometry, source_crs)
     hull = geometry.convex_hull
     if hull.is_empty or hull.area == 0:
-        return 0.0
+        return float("nan")
     return geometry.area / hull.area
 
 
-def schwartzberg(geometry) -> float:
+def schwartzberg(geometry, source_crs=None) -> float:
     """Compute Schwartzberg compactness score.
 
     Score = 1 / (perimeter / circumference_of_equal_area_circle)
     Range: 0 to 1.
+
+    Parameters
+    ----------
+    geometry : shapely geometry
+        Must be in a projected (equal-area) CRS for meaningful results.
+    source_crs : optional
+        If provided and geographic, geometry is reprojected to equal-area.
     """
     import math
+
     if geometry is None or geometry.is_empty:
-        return 0.0
+        return float("nan")
+    if source_crs is not None and _is_geographic_crs(source_crs):
+        geometry = _reproject_geometry(geometry, source_crs)
     area = geometry.area
     perimeter = geometry.length
     if perimeter == 0 or area == 0:
-        return 0.0
+        return float("nan")
     circle_circumference = 2.0 * math.pi * math.sqrt(area / math.pi)
     return circle_circumference / perimeter
 
@@ -705,6 +765,9 @@ def compute_compactness(
     geometry_col: str = "geometry",
 ) -> "pd.DataFrame":
     """Compute all compactness metrics for a GeoDataFrame of districts.
+
+    Automatically reprojects to an equal-area CRS (Mollweide) before
+    calculating area-dependent metrics.
 
     Parameters
     ----------
@@ -723,8 +786,12 @@ def compute_compactness(
     if not HAS_PANDAS:
         raise ImportError("pandas is required")
 
+    projected = gdf
+    if gdf.crs is not None and _is_geographic_crs(gdf.crs):
+        projected = gdf.to_crs(_EQUAL_AREA_CRS)
+
     records = []
-    for _, row in gdf.iterrows():
+    for _, row in projected.iterrows():
         geom = row[geometry_col]
         records.append({
             "district_id": row[district_id_col],

--- a/tests/test_redistricting_data_hub.py
+++ b/tests/test_redistricting_data_hub.py
@@ -533,10 +533,18 @@ class TestPolsbyPopper:
     def test_empty_geometry(self):
         from shapely.geometry import Point
         empty = Point().buffer(0)
-        assert polsby_popper(empty) == 0.0
+        assert math.isnan(polsby_popper(empty))
 
     def test_none(self):
-        assert polsby_popper(None) == 0.0
+        assert math.isnan(polsby_popper(None))
+
+    def test_with_source_crs_reprojects(self):
+        from shapely.geometry import box
+        geom_4326 = box(-90.0, 30.0, -89.9, 30.1)
+        score_raw = polsby_popper(geom_4326)
+        score_projected = polsby_popper(geom_4326, source_crs="EPSG:4326")
+        assert score_projected != score_raw
+        assert 0 < score_projected <= 1.0
 
 
 class TestReock:
@@ -557,11 +565,11 @@ class TestReock:
         assert abs(score - 2 / math.pi) < 0.02
 
     def test_none(self):
-        assert reock(None) == 0.0
+        assert math.isnan(reock(None))
 
     def test_empty(self):
         from shapely.geometry import Point
-        assert reock(Point().buffer(0)) == 0.0
+        assert math.isnan(reock(Point().buffer(0)))
 
 
 class TestConvexHullRatio:
@@ -583,7 +591,7 @@ class TestConvexHullRatio:
         assert score > 0.5
 
     def test_none(self):
-        assert convex_hull_ratio(None) == 0.0
+        assert math.isnan(convex_hull_ratio(None))
 
 
 class TestSchwartzberg:
@@ -601,7 +609,7 @@ class TestSchwartzberg:
         assert score < 0.5
 
     def test_none(self):
-        assert schwartzberg(None) == 0.0
+        assert math.isnan(schwartzberg(None))
 
 
 class TestComputeCompactness:
@@ -630,6 +638,26 @@ class TestComputeCompactness:
 
         # Circle should have highest PP score
         assert result.iloc[0]["polsby_popper"] > result.iloc[2]["polsby_popper"]
+
+    def test_compute_reprojects_geographic_crs(self):
+        import pandas as pd
+        import geopandas as gpd
+        from shapely.geometry import box
+
+        gdf_4326 = gpd.GeoDataFrame(
+            {"GEOID": ["D1", "D2"]},
+            geometry=[
+                box(-90.0, 30.0, -89.5, 30.5),
+                box(-90.0, 30.0, -89.9, 30.9),
+            ],
+            crs="EPSG:4326",
+        )
+
+        result = compute_compactness(gdf_4326)
+        assert len(result) == 2
+        for col in ["polsby_popper", "reock", "convex_hull_ratio", "schwartzberg"]:
+            for val in result[col]:
+                assert 0 < val <= 1.0, f"{col} out of range: {val}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Compactness metrics (Polsby-Popper, Reock, Schwartzberg, Convex Hull Ratio) computed `.area`/`.length` on raw geometry without CRS awareness. On WGS84 input, scores were in degrees-squared — dimensionally meaningless and latitude-dependent.

## Changes

- `compute_compactness()` reprojects to ESRI:54009 (Mollweide equal-area) when input CRS is geographic
- Individual functions accept optional `source_crs` parameter for bare Shapely geometry callers
- Return `float('nan')` for null/empty geometry (was `0.0` — conflated "no data" with "least compact")
- `rdh_loader` passes source SRID when calling compactness functions on Django geometries
- Tests updated: NaN semantics + geographic CRS reprojection verification

## Test plan

- [x] 21 compactness tests pass (unit square, circle, elongated, None, empty, CRS-aware)
- [x] New test verifies `compute_compactness` with EPSG:4326 GDF produces valid [0,1] scores
- [x] New test verifies `polsby_popper(geom, source_crs="EPSG:4326")` differs from raw calculation

Ref: #975, hostile review round 9 (#974)