### PR TITLE
fix(#978): atomic file writes via tmp+rename pattern

### DIFF
--- a/siege_utilities/analytics/facebook_business.py
+++ b/siege_utilities/analytics/facebook_business.py
@@ -296,12 +296,17 @@ class FacebookBusinessConnector:
         output_path = pathlib.Path(output_path)
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
+        from siege_utilities.files.operations import atomic_write_path
+
         if format.lower() == 'parquet':
-            df.to_parquet(output_path, index=False)
+            with atomic_write_path(output_path) as tmp:
+                df.to_parquet(tmp, index=False)
         elif format.lower() == 'csv':
-            df.to_csv(output_path, index=False)
+            with atomic_write_path(output_path) as tmp:
+                df.to_csv(tmp, index=False)
         elif format.lower() == 'excel':
-            df.to_excel(output_path, index=False)
+            with atomic_write_path(output_path) as tmp:
+                df.to_excel(tmp, index=False)
         else:
             raise ValueError(f"Unsupported format: {format}")
 

--- a/siege_utilities/analytics/google_analytics.py
+++ b/siege_utilities/analytics/google_analytics.py
@@ -375,12 +375,17 @@ class GoogleAnalyticsConnector:
         output_path = pathlib.Path(output_path)
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
+        from siege_utilities.files.operations import atomic_write_path
+
         if format.lower() == 'parquet':
-            df.to_parquet(output_path, index=False)
+            with atomic_write_path(output_path) as tmp:
+                df.to_parquet(tmp, index=False)
         elif format.lower() == 'csv':
-            df.to_csv(output_path, index=False)
+            with atomic_write_path(output_path) as tmp:
+                df.to_csv(tmp, index=False)
         elif format.lower() == 'excel':
-            df.to_excel(output_path, index=False)
+            with atomic_write_path(output_path) as tmp:
+                df.to_excel(tmp, index=False)
         else:
             raise ValueError(f"Unsupported format: {format}")
 

--- a/siege_utilities/files/formats.py
+++ b/siege_utilities/files/formats.py
@@ -82,21 +82,26 @@ def save_spatial(
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
 
+    from siege_utilities.files.operations import atomic_write_path
+
     if fmt is SpatialFormat.GEOPARQUET:
-        gdf.to_parquet(str(path), **kwargs)
+        with atomic_write_path(path) as tmp:
+            gdf.to_parquet(str(tmp), **kwargs)
 
     elif fmt is SpatialFormat.PARQUET:
-        # Drop geometry, write plain parquet via pandas
         import pandas as pd
 
         df = pd.DataFrame(gdf.drop(columns="geometry"))
-        df.to_parquet(str(path), **kwargs)
+        with atomic_write_path(path) as tmp:
+            df.to_parquet(str(tmp), **kwargs)
 
     elif fmt is SpatialFormat.GPKG:
-        gdf.to_file(str(path), driver="GPKG", **kwargs)
+        with atomic_write_path(path) as tmp:
+            gdf.to_file(str(tmp), driver="GPKG", **kwargs)
 
     elif fmt is SpatialFormat.GEOJSON:
-        gdf.to_file(str(path), driver="GeoJSON", **kwargs)
+        with atomic_write_path(path) as tmp:
+            gdf.to_file(str(tmp), driver="GeoJSON", **kwargs)
 
     elif fmt is SpatialFormat.TOPOJSON:
         try:
@@ -107,17 +112,20 @@ def save_spatial(
                 "Install with: pip install topojson"
             ) from exc
         topo = tp.Topology(gdf, **kwargs)
-        path.write_text(topo.to_json())
+        with atomic_write_path(path) as tmp:
+            tmp.write_text(topo.to_json())
 
     elif fmt is SpatialFormat.CSV:
         import pandas as pd
 
         df = gdf.copy()
         df["geometry"] = df.geometry.astype(str)
-        pd.DataFrame(df).to_csv(str(path), index=False, **kwargs)
+        with atomic_write_path(path) as tmp:
+            pd.DataFrame(df).to_csv(str(tmp), index=False, **kwargs)
 
     elif fmt is SpatialFormat.SHAPEFILE:
-        gdf.to_file(str(path), driver="ESRI Shapefile", **kwargs)
+        from siege_utilities.files.operations import atomic_write_shapefile
+        atomic_write_shapefile(gdf, path, **kwargs)
 
     else:
         raise ValueError(f"Unsupported spatial format: {fmt}")
@@ -156,17 +164,23 @@ def save_tabular(
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
 
+    from siege_utilities.files.operations import atomic_write_path
+
     if fmt is TabularFormat.PARQUET:
-        df.to_parquet(str(path), **kwargs)
+        with atomic_write_path(path) as tmp:
+            df.to_parquet(str(tmp), **kwargs)
 
     elif fmt is TabularFormat.CSV:
-        df.to_csv(str(path), index=False, **kwargs)
+        with atomic_write_path(path) as tmp:
+            df.to_csv(str(tmp), index=False, **kwargs)
 
     elif fmt is TabularFormat.EXCEL:
-        df.to_excel(str(path), index=False, **kwargs)
+        with atomic_write_path(path) as tmp:
+            df.to_excel(str(tmp), index=False, **kwargs)
 
     elif fmt is TabularFormat.JSON:
-        df.to_json(str(path), orient="records", **kwargs)
+        with atomic_write_path(path) as tmp:
+            df.to_json(str(tmp), orient="records", **kwargs)
 
     else:
         raise ValueError(f"Unsupported tabular format: {fmt}")

--- a/siege_utilities/files/operations.py
+++ b/siege_utilities/files/operations.py
@@ -3,11 +3,14 @@ Modern file operations for siege_utilities.
 Provides clean, type-safe file manipulation utilities.
 """
 
+import contextlib
 import json
+import os
 import subprocess
 import shutil
 import logging
-from typing import Union, Optional, List, Any
+import tempfile
+from typing import Generator, Union, Optional, List, Any
 from pathlib import Path
 
 # Get logger for this module
@@ -15,6 +18,60 @@ log = logging.getLogger(__name__)
 
 # Type aliases
 FilePath = Union[str, Path]
+
+
+@contextlib.contextmanager
+def atomic_write_path(target: FilePath) -> Generator[Path, None, None]:
+    """Context manager that yields a temporary path for writing, then
+    atomically replaces the target on successful exit.
+
+    Usage::
+
+        with atomic_write_path("/data/output.csv") as tmp:
+            df.to_csv(tmp, index=False)
+        # target is now atomically updated
+
+    If the block raises, the temp file is cleaned up and the target
+    is left unchanged.
+    """
+    target = Path(target)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        dir=target.parent,
+        prefix="atomic_",
+        suffix=target.suffix or ".tmp",
+    )
+    os.close(fd)
+    tmp = Path(tmp_path)
+    try:
+        yield tmp
+        os.replace(tmp, target)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def atomic_write_shapefile(gdf, target: FilePath, **kwargs) -> None:
+    """Write a GeoDataFrame as a Shapefile atomically.
+
+    Shapefiles produce sidecar files (.shx, .dbf, .prj, .cpg). This writes
+    to a temp stem then renames all produced files to the final stem.
+    """
+    target = Path(target)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp_dir = Path(tempfile.mkdtemp(dir=target.parent, prefix="atomic_shp_"))
+    tmp_shp = tmp_dir / target.name
+    try:
+        gdf.to_file(str(tmp_shp), driver="ESRI Shapefile", **kwargs)
+        for f in tmp_dir.iterdir():
+            dest = target.parent / (target.stem + f.suffix)
+            os.replace(f, dest)
+        tmp_dir.rmdir()
+    except BaseException:
+        import shutil
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise
+
 
 def remove_tree(path: FilePath) -> None:
     """
@@ -783,6 +840,8 @@ def list_files_recursive(
 
 __all__ = [
     'FilePath',
+    'atomic_write_path',
+    'atomic_write_shapefile',
     'remove_tree',
     'file_exists',
     'touch_file',

--- a/siege_utilities/geo/spatial_transformations.py
+++ b/siege_utilities/geo/spatial_transformations.py
@@ -117,47 +117,60 @@ class SpatialDataTransformer:
     def _convert_to_shapefile(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to ESRI Shapefile format."""
         output_path = kwargs.get('output_path', 'output.shp')
-        gdf.to_file(output_path, driver='ESRI Shapefile')
+        from siege_utilities.files.operations import atomic_write_shapefile
+        atomic_write_shapefile(gdf, output_path)
         log.info(f"Successfully converted to Shapefile: {output_path}")
 
     def _convert_to_geojson(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to GeoJSON format."""
         output_path = kwargs.get('output_path', 'output.geojson')
-        gdf.to_file(output_path, driver='GeoJSON')
+        from siege_utilities.files.operations import atomic_write_path
+        with atomic_write_path(output_path) as tmp:
+            gdf.to_file(str(tmp), driver='GeoJSON')
         log.info(f"Successfully converted to GeoJSON: {output_path}")
 
     def _convert_to_geopackage(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to GeoPackage format."""
         output_path = kwargs.get('output_path', 'output.gpkg')
-        gdf.to_file(output_path, driver='GPKG')
+        from siege_utilities.files.operations import atomic_write_path
+        with atomic_write_path(output_path) as tmp:
+            gdf.to_file(str(tmp), driver='GPKG')
         log.info(f"Successfully converted to GeoPackage: {output_path}")
 
     def _convert_to_kml(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to KML format."""
         output_path = kwargs.get('output_path', 'output.kml')
-        gdf.to_file(output_path, driver='KML')
+        from siege_utilities.files.operations import atomic_write_path
+        with atomic_write_path(output_path) as tmp:
+            gdf.to_file(str(tmp), driver='KML')
         log.info(f"Successfully converted to KML: {output_path}")
 
     def _convert_to_gml(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to GML format."""
         output_path = kwargs.get('output_path', 'output.gml')
-        gdf.to_file(output_path, driver='GML')
+        from siege_utilities.files.operations import atomic_write_path
+        with atomic_write_path(output_path) as tmp:
+            gdf.to_file(str(tmp), driver='GML')
         log.info(f"Successfully converted to GML: {output_path}")
 
     def _convert_to_wkt(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to WKT (Well-Known Text) format."""
         output_path = kwargs.get('output_path', 'output.wkt')
+        from siege_utilities.files.operations import atomic_write_path
         wkt_data = gdf.copy()
         wkt_data['geometry'] = wkt_data.geometry.astype(str)
-        wkt_data.to_csv(output_path, index=False)
+        with atomic_write_path(output_path) as tmp:
+            wkt_data.to_csv(str(tmp), index=False)
         log.info(f"Successfully converted to WKT: {output_path}")
 
     def _convert_to_wkb(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to WKB (Well-Known Binary) format."""
         output_path = kwargs.get('output_path', 'output.wkb')
+        from siege_utilities.files.operations import atomic_write_path
         wkb_data = gdf.copy()
         wkb_data['geometry'] = wkb_data.geometry.apply(lambda geom: geom.wkb)
-        wkb_data.to_pickle(output_path)
+        with atomic_write_path(output_path) as tmp:
+            wkb_data.to_pickle(str(tmp))
         log.info(f"Successfully converted to WKB: {output_path}")
     
     def _convert_to_postgis(self, gdf: GeoDataFrame, **kwargs) -> None:
@@ -172,8 +185,9 @@ class SpatialDataTransformer:
             + "'));"
         )
 
-        with open(output_path, 'w', encoding='utf-8') as f:
-            f.write('\n'.join(sql_lines))
+        from siege_utilities.files.operations import atomic_write_path
+        with atomic_write_path(output_path) as tmp:
+            tmp.write_text('\n'.join(sql_lines), encoding='utf-8')
 
         log.info(f"Successfully generated PostGIS SQL: {output_path}")
 

--- a/tests/test_file_operations.py
+++ b/tests/test_file_operations.py
@@ -3,6 +3,7 @@
 import pytest
 
 from siege_utilities.files.operations import (
+    atomic_write_path,
     remove_tree,
     file_exists,
     touch_file,
@@ -212,3 +213,43 @@ class TestDeleteAndReplace:
         delete_existing_file_and_replace_it_with_an_empty_file(str(f))
         assert f.exists()
         assert f.read_text() == ""
+
+
+class TestAtomicWritePath:
+    def test_successful_write_replaces_target(self, tmp_path):
+        target = tmp_path / "output.csv"
+        target.write_text("old data")
+        with atomic_write_path(target) as tmp:
+            tmp.write_text("new data")
+        assert target.read_text() == "new data"
+
+    def test_failed_write_leaves_target_unchanged(self, tmp_path):
+        target = tmp_path / "output.csv"
+        target.write_text("original")
+        with pytest.raises(ValueError):
+            with atomic_write_path(target) as tmp:
+                tmp.write_text("partial")
+                raise ValueError("simulated failure")
+        assert target.read_text() == "original"
+
+    def test_failed_write_cleans_up_temp(self, tmp_path):
+        target = tmp_path / "output.csv"
+        captured_tmp = None
+        with pytest.raises(RuntimeError):
+            with atomic_write_path(target) as tmp:
+                captured_tmp = tmp
+                tmp.write_text("data")
+                raise RuntimeError("boom")
+        assert not captured_tmp.exists()
+
+    def test_creates_parent_directories(self, tmp_path):
+        target = tmp_path / "a" / "b" / "c" / "file.txt"
+        with atomic_write_path(target) as tmp:
+            tmp.write_text("nested")
+        assert target.read_text() == "nested"
+
+    def test_preserves_extension(self, tmp_path):
+        target = tmp_path / "data.parquet"
+        with atomic_write_path(target) as tmp:
+            assert tmp.suffix == ".parquet"
+            tmp.write_text("fake parquet")


### PR DESCRIPTION
Closes #978

All file-writing paths now use atomic writes (write to temp, rename on success) to prevent corrupt partial files when processes crash or are interrupted mid-write.

**Changes:**
- `files/operations.py`: Added `atomic_write_path` context manager and `atomic_write_shapefile` (handles multi-file sidecar atomicity)
- `files/formats.py`: All spatial and tabular format writers use `atomic_write_path`
- `analytics/facebook_business.py`: DataFrame export uses atomic writes
- `analytics/google_analytics.py`: DataFrame export uses atomic writes
- `geo/spatial_transformations.py`: All format converters (shapefile, geojson, gpkg, kml, gml, wkt, wkb, postgis SQL) use atomic writes
- `tests/test_file_operations.py`: 5 new tests verifying atomic contract (success replaces, failure preserves original, temp cleanup, parent creation, extension preservation)

**Design decisions:**
- OGR drivers require correct file extension on temp files — uses `target.suffix` not `.tmp`
- OGR rejects leading dots in filenames (layer name derivation) — prefix is `atomic_` not `.atomic_`
- Shapefiles produce sidecar files (.shx/.dbf/.prj/.cpg) — isolated via temp directory + per-file rename