### PR TITLE
fix(#977): enforce Seat and VTD political geography invariants

### DIFF
--- a/siege_utilities/geo/django/migrations/0010_seat_state_constraint.py
+++ b/siege_utilities/geo/django/migrations/0010_seat_state_constraint.py
@@ -1,0 +1,27 @@
+"""#977: Enforce that Seat.state is non-null unless office is PRESIDENT.
+
+DB-level check constraint prevents House/Senate/Governor seats from
+having a null state FK — only PRESIDENT is stateless.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("siege_geo", "0009_redistrictingplan_plan_status"),
+    ]
+
+    operations = [
+        migrations.AddConstraint(
+            model_name="seat",
+            constraint=models.CheckConstraint(
+                condition=(
+                    models.Q(state__isnull=False)
+                    | models.Q(office="PRESIDENT")
+                ),
+                name="seat_state_required_unless_president",
+            ),
+        ),
+    ]

--- a/siege_utilities/geo/django/models/political.py
+++ b/siege_utilities/geo/django/models/political.py
@@ -5,6 +5,7 @@ State legislative districts (upper/lower chambers), voting tabulation
 districts (VTDs), and precincts.  All inherit from CensusTIGERBoundary.
 """
 
+from django.core.exceptions import ValidationError
 from django.db import models
 
 from .base import CensusTIGERBoundary
@@ -217,6 +218,20 @@ class VTD(CensusTIGERBoundary):
             "county_fips": geoid[2:5],
             "vtd_code": geoid[5:],
         }
+
+    def clean(self):
+        super().clean()
+        if self.congressional_district_id and self.state_fips:
+            cd = self.congressional_district
+            if cd is not None and cd.state_fips != self.state_fips:
+                raise ValidationError(
+                    {
+                        "congressional_district": (
+                            f"VTD state_fips '{self.state_fips}' does not match "
+                            f"congressional district state_fips '{cd.state_fips}'."
+                        )
+                    }
+                )
 
     def populate_parent_relationships(self):
         """

--- a/siege_utilities/geo/django/models/temporal_political.py
+++ b/siege_utilities/geo/django/models/temporal_political.py
@@ -167,6 +167,15 @@ class Seat(models.Model):
             models.Index(fields=["office", "state"]),
             models.Index(fields=["office"]),
         ]
+        constraints = [
+            models.CheckConstraint(
+                condition=(
+                    models.Q(state__isnull=False)
+                    | models.Q(office="PRESIDENT")
+                ),
+                name="seat_state_required_unless_president",
+            ),
+        ]
 
     def __str__(self):
         parts = [self.get_office_display()]

--- a/tests/test_seat_vtd_constraints.py
+++ b/tests/test_seat_vtd_constraints.py
@@ -1,0 +1,78 @@
+"""Tests for #977: Seat and VTD model constraint enforcement.
+
+Seat constraint (DB-level CheckConstraint) is verified structurally.
+VTD clean() validation is tested via direct model method invocation.
+"""
+
+import pytest
+
+try:
+    from django.core.exceptions import ValidationError
+
+    from siege_utilities.geo.django.models.temporal_political import Seat
+    from siege_utilities.geo.django.models.political import VTD
+
+    HAS_DJANGO_GIS = True
+except (ImportError, RuntimeError, Exception):
+    HAS_DJANGO_GIS = False
+    Seat = None
+    VTD = None
+
+pytestmark = pytest.mark.skipif(
+    not HAS_DJANGO_GIS, reason="Django GIS (GDAL) not available"
+)
+
+
+class TestSeatConstraintStructure:
+    """Verify the CheckConstraint exists on the Seat model Meta."""
+
+    def test_constraint_exists(self):
+        constraint_names = [c.name for c in Seat._meta.constraints]
+        assert "seat_state_required_unless_president" in constraint_names
+
+    def test_constraint_condition_covers_president(self):
+        constraint = next(
+            c for c in Seat._meta.constraints
+            if c.name == "seat_state_required_unless_president"
+        )
+        assert constraint is not None
+
+
+class TestVTDCrossStateValidation:
+    """VTD.clean() must reject cross-state congressional_district links."""
+
+    def _make_vtd(self, state_fips, cd_state_fips=None):
+        """Create a VTD instance with a mock congressional district."""
+        vtd = VTD(
+            geoid=f"{state_fips}037001",
+            state_fips=state_fips,
+            county_fips="037",
+            vtd_code="001",
+            vintage_year=2020,
+        )
+        if cd_state_fips is not None:
+
+            class FakeCD:
+                def __init__(self, sf):
+                    self.state_fips = sf
+
+            vtd.congressional_district_id = 999
+            vtd._congressional_district_cache = FakeCD(cd_state_fips)
+            # Django caches FK objects on the descriptor; simulate by
+            # patching the attribute the clean() method reads.
+            vtd.congressional_district = FakeCD(cd_state_fips)
+        return vtd
+
+    def test_same_state_passes(self):
+        vtd = self._make_vtd("06", "06")
+        vtd.clean()
+
+    def test_cross_state_raises(self):
+        vtd = self._make_vtd("06", "48")
+        with pytest.raises(ValidationError) as exc_info:
+            vtd.clean()
+        assert "congressional_district" in exc_info.value.message_dict
+
+    def test_no_cd_assigned_passes(self):
+        vtd = self._make_vtd("06", cd_state_fips=None)
+        vtd.clean()


### PR DESCRIPTION
Closes #977

Adds two model-level constraints that prevent impossible political geography states:

**Changes:**
- `temporal_political.py` (Seat): DB-level `CheckConstraint` — state FK must be non-null unless `office == 'PRESIDENT'`. Prevents House/Senate/Governor seats from having null state.
- `political.py` (VTD): `clean()` validation — when a congressional district FK is set, its `state_fips` must match the VTD's `state_fips`. Prevents cross-state VTD-to-district links (e.g., Texas VTD linked to California CD).
- Migration `0010_seat_state_constraint.py` for the DB-level constraint.
- `test_seat_vtd_constraints.py`: structural + logic tests (skip without GDAL).

**Design decisions:**
- Seat uses CheckConstraint (DB-level) because it's a simple field comparison enforceable in SQL.
- VTD uses clean() (model-level) because `db_constraint=False` is intentional for cross-database FK scenarios — validation should not be at the DB level for soft FKs.