### PR TITLE
fix(#979): RDHClient and WikidataGazetteer session lifecycle

### DIFF
--- a/siege_utilities/geo/gazetteers/wikidata_gazetteer.py
+++ b/siege_utilities/geo/gazetteers/wikidata_gazetteer.py
@@ -177,9 +177,26 @@ class WikidataGazetteer:
             "Accept": "application/sparql-results+json",
             "User-Agent": _USER_AGENT,
         })
+        self._closed = False
         self._cached_lookup = functools.lru_cache(maxsize=cache_size)(
             self._uncached_lookup
         )
+
+    def close(self) -> None:
+        """Close the underlying HTTP session."""
+        if not self._closed:
+            self._session.close()
+            self._closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
+    def __del__(self):
+        self.close()
 
     def is_available(self) -> bool:
         return REQUESTS_AVAILABLE and SHAPELY_AVAILABLE

--- a/siege_utilities/geo/providers/redistricting_data_hub.py
+++ b/siege_utilities/geo/providers/redistricting_data_hub.py
@@ -189,6 +189,23 @@ class RDHClient:
             self.cache_dir = Path(cache_dir)
 
         self._session = requests.Session()
+        self._closed = False
+
+    def close(self) -> None:
+        """Close the underlying HTTP session."""
+        if not self._closed:
+            self._session.close()
+            self._closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
+    def __del__(self):
+        self.close()
 
     # -- Authentication check -------------------------------------------------
 

--- a/tests/test_redistricting_data_hub.py
+++ b/tests/test_redistricting_data_hub.py
@@ -987,3 +987,29 @@ class TestRDHClientErrorPaths:
                     states=["VA"], format=None, year=None,
                     dataset_type=None, geography=None, official=None,
                 )
+
+
+class TestRDHClientSessionLifecycle:
+    """#979: RDHClient implements context manager and close()."""
+
+    def test_close_closes_session(self):
+        client = RDHClient(username="u", password="p")
+        client.close()
+        assert client._closed is True
+
+    def test_close_idempotent(self):
+        client = RDHClient(username="u", password="p")
+        client.close()
+        client.close()
+        assert client._closed is True
+
+    def test_context_manager_closes_on_exit(self):
+        with RDHClient(username="u", password="p") as client:
+            assert client._closed is False
+        assert client._closed is True
+
+    def test_context_manager_closes_on_exception(self):
+        with pytest.raises(RuntimeError):
+            with RDHClient(username="u", password="p") as client:
+                raise RuntimeError("boom")
+        assert client._closed is True

--- a/tests/test_wikidata_gazetteer.py
+++ b/tests/test_wikidata_gazetteer.py
@@ -370,3 +370,32 @@ def test_overpass_empty_elements_raises_backend_error(wd_gaz):
          patch.object(wd_gaz._session, "post", return_value=overpass_empty):
         with pytest.raises(GazetteerBackendError, match="no elements"):
             wd_gaz.lookup("X")
+
+
+# ---------------------------------------------------------------------------
+# #979: Session lifecycle tests
+# ---------------------------------------------------------------------------
+
+class TestWikidataGazetteerSessionLifecycle:
+
+    def test_close_closes_session(self, wd_gaz):
+        wd_gaz.close()
+        assert wd_gaz._closed is True
+
+    def test_close_idempotent(self, wd_gaz):
+        wd_gaz.close()
+        wd_gaz.close()
+        assert wd_gaz._closed is True
+
+    def test_context_manager_closes_on_exit(self):
+        from siege_utilities.geo.gazetteers.wikidata_gazetteer import WikidataGazetteer
+        with WikidataGazetteer() as gaz:
+            assert gaz._closed is False
+        assert gaz._closed is True
+
+    def test_context_manager_closes_on_exception(self):
+        from siege_utilities.geo.gazetteers.wikidata_gazetteer import WikidataGazetteer
+        with pytest.raises(RuntimeError):
+            with WikidataGazetteer() as gaz:
+                raise RuntimeError("boom")
+        assert gaz._closed is True


### PR DESCRIPTION
Closes #979

Adds proper HTTP session lifecycle management to both classes that create `requests.Session()` in `__init__`.

**Changes:**
- `RDHClient`: Added `close()`, `__enter__`/`__exit__`, `__del__` with `_closed` idempotency flag
- `WikidataGazetteer`: Same pattern
- 4 tests per class: close works, close is idempotent, context manager closes on exit, context manager closes on exception

**Backward compatible:** existing code without `with` continues to work. Context manager is additive. `__del__` is a safety net for cases where `close()` is never called.