### PR TITLE
promote: develop to main (hostile review fixes #975-#979)

### DIFF
--- a/siege_utilities/analytics/facebook_business.py
+++ b/siege_utilities/analytics/facebook_business.py
@@ -296,12 +296,17 @@ class FacebookBusinessConnector:
         output_path = pathlib.Path(output_path)
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
+        from siege_utilities.files.operations import atomic_write_path
+
         if format.lower() == 'parquet':
-            df.to_parquet(output_path, index=False)
+            with atomic_write_path(output_path) as tmp:
+                df.to_parquet(tmp, index=False)
         elif format.lower() == 'csv':
-            df.to_csv(output_path, index=False)
+            with atomic_write_path(output_path) as tmp:
+                df.to_csv(tmp, index=False)
         elif format.lower() == 'excel':
-            df.to_excel(output_path, index=False)
+            with atomic_write_path(output_path) as tmp:
+                df.to_excel(tmp, index=False)
         else:
             raise ValueError(f"Unsupported format: {format}")
 

--- a/siege_utilities/analytics/google_analytics.py
+++ b/siege_utilities/analytics/google_analytics.py
@@ -375,12 +375,17 @@ class GoogleAnalyticsConnector:
         output_path = pathlib.Path(output_path)
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
+        from siege_utilities.files.operations import atomic_write_path
+
         if format.lower() == 'parquet':
-            df.to_parquet(output_path, index=False)
+            with atomic_write_path(output_path) as tmp:
+                df.to_parquet(tmp, index=False)
         elif format.lower() == 'csv':
-            df.to_csv(output_path, index=False)
+            with atomic_write_path(output_path) as tmp:
+                df.to_csv(tmp, index=False)
         elif format.lower() == 'excel':
-            df.to_excel(output_path, index=False)
+            with atomic_write_path(output_path) as tmp:
+                df.to_excel(tmp, index=False)
         else:
             raise ValueError(f"Unsupported format: {format}")
 

--- a/siege_utilities/engines/dataframe_engine.py
+++ b/siege_utilities/engines/dataframe_engine.py
@@ -789,6 +789,11 @@ class PandasEngine(DataFrameEngine):
             left = left.set_geometry(left_geom)
         if right.geometry.name != right_geom:
             right = right.set_geometry(right_geom)
+        if left.crs is not None and right.crs is not None and left.crs != right.crs:
+            raise ValueError(
+                f"CRS mismatch in spatial_join: left has {left.crs}, "
+                f"right has {right.crs}. Reproject one input to match the other."
+            )
         return gpd.sjoin(left, right, how=how, predicate=predicate)
 
     def buffer(self, df, distance, geometry_col="geometry", *, crs=None):

--- a/siege_utilities/files/formats.py
+++ b/siege_utilities/files/formats.py
@@ -82,21 +82,26 @@ def save_spatial(
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
 
+    from siege_utilities.files.operations import atomic_write_path
+
     if fmt is SpatialFormat.GEOPARQUET:
-        gdf.to_parquet(str(path), **kwargs)
+        with atomic_write_path(path) as tmp:
+            gdf.to_parquet(str(tmp), **kwargs)
 
     elif fmt is SpatialFormat.PARQUET:
-        # Drop geometry, write plain parquet via pandas
         import pandas as pd
 
         df = pd.DataFrame(gdf.drop(columns="geometry"))
-        df.to_parquet(str(path), **kwargs)
+        with atomic_write_path(path) as tmp:
+            df.to_parquet(str(tmp), **kwargs)
 
     elif fmt is SpatialFormat.GPKG:
-        gdf.to_file(str(path), driver="GPKG", **kwargs)
+        with atomic_write_path(path) as tmp:
+            gdf.to_file(str(tmp), driver="GPKG", **kwargs)
 
     elif fmt is SpatialFormat.GEOJSON:
-        gdf.to_file(str(path), driver="GeoJSON", **kwargs)
+        with atomic_write_path(path) as tmp:
+            gdf.to_file(str(tmp), driver="GeoJSON", **kwargs)
 
     elif fmt is SpatialFormat.TOPOJSON:
         try:
@@ -107,17 +112,20 @@ def save_spatial(
                 "Install with: pip install topojson"
             ) from exc
         topo = tp.Topology(gdf, **kwargs)
-        path.write_text(topo.to_json())
+        with atomic_write_path(path) as tmp:
+            tmp.write_text(topo.to_json())
 
     elif fmt is SpatialFormat.CSV:
         import pandas as pd
 
         df = gdf.copy()
         df["geometry"] = df.geometry.astype(str)
-        pd.DataFrame(df).to_csv(str(path), index=False, **kwargs)
+        with atomic_write_path(path) as tmp:
+            pd.DataFrame(df).to_csv(str(tmp), index=False, **kwargs)
 
     elif fmt is SpatialFormat.SHAPEFILE:
-        gdf.to_file(str(path), driver="ESRI Shapefile", **kwargs)
+        from siege_utilities.files.operations import atomic_write_shapefile
+        atomic_write_shapefile(gdf, path, **kwargs)
 
     else:
         raise ValueError(f"Unsupported spatial format: {fmt}")
@@ -156,17 +164,23 @@ def save_tabular(
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
 
+    from siege_utilities.files.operations import atomic_write_path
+
     if fmt is TabularFormat.PARQUET:
-        df.to_parquet(str(path), **kwargs)
+        with atomic_write_path(path) as tmp:
+            df.to_parquet(str(tmp), **kwargs)
 
     elif fmt is TabularFormat.CSV:
-        df.to_csv(str(path), index=False, **kwargs)
+        with atomic_write_path(path) as tmp:
+            df.to_csv(str(tmp), index=False, **kwargs)
 
     elif fmt is TabularFormat.EXCEL:
-        df.to_excel(str(path), index=False, **kwargs)
+        with atomic_write_path(path) as tmp:
+            df.to_excel(str(tmp), index=False, **kwargs)
 
     elif fmt is TabularFormat.JSON:
-        df.to_json(str(path), orient="records", **kwargs)
+        with atomic_write_path(path) as tmp:
+            df.to_json(str(tmp), orient="records", **kwargs)
 
     else:
         raise ValueError(f"Unsupported tabular format: {fmt}")

--- a/siege_utilities/files/operations.py
+++ b/siege_utilities/files/operations.py
@@ -3,11 +3,14 @@ Modern file operations for siege_utilities.
 Provides clean, type-safe file manipulation utilities.
 """
 
+import contextlib
 import json
+import os
 import subprocess
 import shutil
 import logging
-from typing import Union, Optional, List, Any
+import tempfile
+from typing import Generator, Union, Optional, List, Any
 from pathlib import Path
 
 # Get logger for this module
@@ -15,6 +18,60 @@ log = logging.getLogger(__name__)
 
 # Type aliases
 FilePath = Union[str, Path]
+
+
+@contextlib.contextmanager
+def atomic_write_path(target: FilePath) -> Generator[Path, None, None]:
+    """Context manager that yields a temporary path for writing, then
+    atomically replaces the target on successful exit.
+
+    Usage::
+
+        with atomic_write_path("/data/output.csv") as tmp:
+            df.to_csv(tmp, index=False)
+        # target is now atomically updated
+
+    If the block raises, the temp file is cleaned up and the target
+    is left unchanged.
+    """
+    target = Path(target)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        dir=target.parent,
+        prefix="atomic_",
+        suffix=target.suffix or ".tmp",
+    )
+    os.close(fd)
+    tmp = Path(tmp_path)
+    try:
+        yield tmp
+        os.replace(tmp, target)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def atomic_write_shapefile(gdf, target: FilePath, **kwargs) -> None:
+    """Write a GeoDataFrame as a Shapefile atomically.
+
+    Shapefiles produce sidecar files (.shx, .dbf, .prj, .cpg). This writes
+    to a temp stem then renames all produced files to the final stem.
+    """
+    target = Path(target)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp_dir = Path(tempfile.mkdtemp(dir=target.parent, prefix="atomic_shp_"))
+    tmp_shp = tmp_dir / target.name
+    try:
+        gdf.to_file(str(tmp_shp), driver="ESRI Shapefile", **kwargs)
+        for f in tmp_dir.iterdir():
+            dest = target.parent / (target.stem + f.suffix)
+            os.replace(f, dest)
+        tmp_dir.rmdir()
+    except BaseException:
+        import shutil
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise
+
 
 def remove_tree(path: FilePath) -> None:
     """
@@ -783,6 +840,8 @@ def list_files_recursive(
 
 __all__ = [
     'FilePath',
+    'atomic_write_path',
+    'atomic_write_shapefile',
     'remove_tree',
     'file_exists',
     'touch_file',

--- a/siege_utilities/geo/django/migrations/0010_seat_state_constraint.py
+++ b/siege_utilities/geo/django/migrations/0010_seat_state_constraint.py
@@ -1,0 +1,27 @@
+"""#977: Enforce that Seat.state is non-null unless office is PRESIDENT.
+
+DB-level check constraint prevents House/Senate/Governor seats from
+having a null state FK — only PRESIDENT is stateless.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("siege_geo", "0009_redistrictingplan_plan_status"),
+    ]
+
+    operations = [
+        migrations.AddConstraint(
+            model_name="seat",
+            constraint=models.CheckConstraint(
+                condition=(
+                    models.Q(state__isnull=False)
+                    | models.Q(office="PRESIDENT")
+                ),
+                name="seat_state_required_unless_president",
+            ),
+        ),
+    ]

--- a/siege_utilities/geo/django/models/political.py
+++ b/siege_utilities/geo/django/models/political.py
@@ -5,6 +5,7 @@ State legislative districts (upper/lower chambers), voting tabulation
 districts (VTDs), and precincts.  All inherit from CensusTIGERBoundary.
 """
 
+from django.core.exceptions import ValidationError
 from django.db import models
 
 from .base import CensusTIGERBoundary
@@ -217,6 +218,20 @@ class VTD(CensusTIGERBoundary):
             "county_fips": geoid[2:5],
             "vtd_code": geoid[5:],
         }
+
+    def clean(self):
+        super().clean()
+        if self.congressional_district_id and self.state_fips:
+            cd = self.congressional_district
+            if cd is not None and cd.state_fips != self.state_fips:
+                raise ValidationError(
+                    {
+                        "congressional_district": (
+                            f"VTD state_fips '{self.state_fips}' does not match "
+                            f"congressional district state_fips '{cd.state_fips}'."
+                        )
+                    }
+                )
 
     def populate_parent_relationships(self):
         """

--- a/siege_utilities/geo/django/models/temporal_political.py
+++ b/siege_utilities/geo/django/models/temporal_political.py
@@ -167,6 +167,15 @@ class Seat(models.Model):
             models.Index(fields=["office", "state"]),
             models.Index(fields=["office"]),
         ]
+        constraints = [
+            models.CheckConstraint(
+                condition=(
+                    models.Q(state__isnull=False)
+                    | models.Q(office="PRESIDENT")
+                ),
+                name="seat_state_required_unless_president",
+            ),
+        ]
 
     def __str__(self):
         parts = [self.get_office_display()]

--- a/siege_utilities/geo/django/services/rdh_loader.py
+++ b/siege_utilities/geo/django/services/rdh_loader.py
@@ -476,16 +476,16 @@ class RDHLoaderService:
         )
 
         districts = plan.districts.exclude(geometry__isnull=True)
+        srid = districts.first().geometry.srid if districts.exists() else 4326
         updated = 0
         for district in districts:
-            # Convert GEOS to Shapely for compactness functions
             from shapely import wkt
 
             shapely_geom = wkt.loads(district.geometry.wkt)
-            district.polsby_popper = pp_fn(shapely_geom)
-            district.reock = reock_fn(shapely_geom)
-            district.convex_hull_ratio = chr_fn(shapely_geom)
-            district.schwartzberg = sw_fn(shapely_geom)
+            district.polsby_popper = pp_fn(shapely_geom, source_crs=f"EPSG:{srid}")
+            district.reock = reock_fn(shapely_geom, source_crs=f"EPSG:{srid}")
+            district.convex_hull_ratio = chr_fn(shapely_geom, source_crs=f"EPSG:{srid}")
+            district.schwartzberg = sw_fn(shapely_geom, source_crs=f"EPSG:{srid}")
             district.save(update_fields=[
                 "polsby_popper", "reock", "convex_hull_ratio", "schwartzberg",
             ])

--- a/siege_utilities/geo/gazetteers/wikidata_gazetteer.py
+++ b/siege_utilities/geo/gazetteers/wikidata_gazetteer.py
@@ -177,9 +177,26 @@ class WikidataGazetteer:
             "Accept": "application/sparql-results+json",
             "User-Agent": _USER_AGENT,
         })
+        self._closed = False
         self._cached_lookup = functools.lru_cache(maxsize=cache_size)(
             self._uncached_lookup
         )
+
+    def close(self) -> None:
+        """Close the underlying HTTP session."""
+        if not self._closed:
+            self._session.close()
+            self._closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
+    def __del__(self):
+        self.close()
 
     def is_available(self) -> bool:
         return REQUESTS_AVAILABLE and SHAPELY_AVAILABLE

--- a/siege_utilities/geo/locale.py
+++ b/siege_utilities/geo/locale.py
@@ -273,12 +273,26 @@ class NCESLocaleClassifier:
         self._place_populations = place_populations
         self._ua_populations = ua_populations or {}
         self._projection_crs = projection_crs or settings.PROJECTION_CRS
+        self._input_crs = f"EPSG:{settings.INPUT_CRS}"
+        self._align_input_crs()
 
         self._locale_index: Optional[LocaleIndex] = None
 
         # Lazily projected copies (created on first classify call)
         self._ua_proj = None
         self._uc_proj = None
+
+    def _align_input_crs(self) -> None:
+        """Reproject boundary layers to input CRS if mismatched."""
+        if self._ua is not None and self._ua.crs is not None:
+            if str(self._ua.crs) != self._input_crs:
+                self._ua = self._ua.to_crs(self._input_crs)
+        if self._uc is not None and self._uc.crs is not None:
+            if str(self._uc.crs) != self._input_crs:
+                self._uc = self._uc.to_crs(self._input_crs)
+        if self._principal_cities is not None and self._principal_cities.crs is not None:
+            if str(self._principal_cities.crs) != self._input_crs:
+                self._principal_cities = self._principal_cities.to_crs(self._input_crs)
 
     def _ensure_projected(self) -> None:
         """Project UA/UC layers to the configured CRS for distance ops."""

--- a/siege_utilities/geo/providers/redistricting_data_hub.py
+++ b/siege_utilities/geo/providers/redistricting_data_hub.py
@@ -622,41 +622,82 @@ class RDHClient:
 # Compactness scoring
 # ---------------------------------------------------------------------------
 
-def polsby_popper(geometry) -> float:
+_EQUAL_AREA_CRS = "ESRI:54009"
+
+
+def _reproject_geometry(geom, source_crs, target_crs=_EQUAL_AREA_CRS):
+    """Reproject a single Shapely geometry between CRS."""
+    from pyproj import Transformer
+    from shapely.ops import transform
+
+    transformer = Transformer.from_crs(source_crs, target_crs, always_xy=True)
+    return transform(transformer.transform, geom)
+
+
+def _is_geographic_crs(crs) -> bool:
+    """Return True if crs is a geographic (lat/lon) coordinate system."""
+    from pyproj import CRS
+
+    parsed = CRS.from_user_input(crs)
+    return parsed.is_geographic
+
+
+def polsby_popper(geometry, source_crs=None) -> float:
     """Compute Polsby-Popper compactness score for a geometry.
 
     Score = (4 * pi * area) / perimeter^2
     Range: 0 (least compact) to 1 (circle).
+
+    Parameters
+    ----------
+    geometry : shapely geometry
+        Must be in a projected (equal-area) CRS for meaningful results.
+    source_crs : optional
+        If provided and geographic, geometry is reprojected to equal-area
+        before calculation. Pass the CRS (e.g., "EPSG:4326") when calling
+        with unprojected data.
     """
     import math
+
     if geometry is None or geometry.is_empty:
-        return 0.0
+        return float("nan")
+    if source_crs is not None and _is_geographic_crs(source_crs):
+        geometry = _reproject_geometry(geometry, source_crs)
     area = geometry.area
     perimeter = geometry.length
     if perimeter == 0:
-        return 0.0
+        return float("nan")
     return (4.0 * math.pi * area) / (perimeter ** 2)
 
 
-def reock(geometry) -> float:
+def reock(geometry, source_crs=None) -> float:
     """Compute Reock compactness score for a geometry.
 
     Score = area / area_of_minimum_bounding_circle
     Range: 0 (least compact) to 1 (circle).
+
+    Parameters
+    ----------
+    geometry : shapely geometry
+        Must be in a projected (equal-area) CRS for meaningful results.
+    source_crs : optional
+        If provided and geographic, geometry is reprojected to equal-area.
     """
     import math
+
     if geometry is None or geometry.is_empty:
-        return 0.0
+        return float("nan")
+    if source_crs is not None and _is_geographic_crs(source_crs):
+        geometry = _reproject_geometry(geometry, source_crs)
     area = geometry.area
-    # Approximate MBC using minimum rotated rectangle's diagonal
     mrr = geometry.minimum_rotated_rectangle
     if mrr is None or mrr.is_empty:
-        return 0.0
+        return float("nan")
     coords = list(mrr.exterior.coords)
     if len(coords) < 4:
-        return 0.0
-    # Diagonal of the minimum rotated rectangle as diameter estimate
+        return float("nan")
     from shapely.geometry import Point
+
     p0, p1, p2 = Point(coords[0]), Point(coords[1]), Point(coords[2])
     side1 = p0.distance(p1)
     side2 = p1.distance(p2)
@@ -664,37 +705,56 @@ def reock(geometry) -> float:
     radius = diameter / 2.0
     circle_area = math.pi * radius**2
     if circle_area == 0:
-        return 0.0
+        return float("nan")
     return area / circle_area
 
 
-def convex_hull_ratio(geometry) -> float:
+def convex_hull_ratio(geometry, source_crs=None) -> float:
     """Compute convex hull ratio for a geometry.
 
     Score = area / convex_hull_area
     Range: 0 to 1.
+
+    Parameters
+    ----------
+    geometry : shapely geometry
+        Must be in a projected (equal-area) CRS for meaningful results.
+    source_crs : optional
+        If provided and geographic, geometry is reprojected to equal-area.
     """
     if geometry is None or geometry.is_empty:
-        return 0.0
+        return float("nan")
+    if source_crs is not None and _is_geographic_crs(source_crs):
+        geometry = _reproject_geometry(geometry, source_crs)
     hull = geometry.convex_hull
     if hull.is_empty or hull.area == 0:
-        return 0.0
+        return float("nan")
     return geometry.area / hull.area
 
 
-def schwartzberg(geometry) -> float:
+def schwartzberg(geometry, source_crs=None) -> float:
     """Compute Schwartzberg compactness score.
 
     Score = 1 / (perimeter / circumference_of_equal_area_circle)
     Range: 0 to 1.
+
+    Parameters
+    ----------
+    geometry : shapely geometry
+        Must be in a projected (equal-area) CRS for meaningful results.
+    source_crs : optional
+        If provided and geographic, geometry is reprojected to equal-area.
     """
     import math
+
     if geometry is None or geometry.is_empty:
-        return 0.0
+        return float("nan")
+    if source_crs is not None and _is_geographic_crs(source_crs):
+        geometry = _reproject_geometry(geometry, source_crs)
     area = geometry.area
     perimeter = geometry.length
     if perimeter == 0 or area == 0:
-        return 0.0
+        return float("nan")
     circle_circumference = 2.0 * math.pi * math.sqrt(area / math.pi)
     return circle_circumference / perimeter
 
@@ -705,6 +765,9 @@ def compute_compactness(
     geometry_col: str = "geometry",
 ) -> "pd.DataFrame":
     """Compute all compactness metrics for a GeoDataFrame of districts.
+
+    Automatically reprojects to an equal-area CRS (Mollweide) before
+    calculating area-dependent metrics.
 
     Parameters
     ----------
@@ -723,8 +786,12 @@ def compute_compactness(
     if not HAS_PANDAS:
         raise ImportError("pandas is required")
 
+    projected = gdf
+    if gdf.crs is not None and _is_geographic_crs(gdf.crs):
+        projected = gdf.to_crs(_EQUAL_AREA_CRS)
+
     records = []
-    for _, row in gdf.iterrows():
+    for _, row in projected.iterrows():
         geom = row[geometry_col]
         records.append({
             "district_id": row[district_id_col],

--- a/siege_utilities/geo/providers/redistricting_data_hub.py
+++ b/siege_utilities/geo/providers/redistricting_data_hub.py
@@ -189,6 +189,23 @@ class RDHClient:
             self.cache_dir = Path(cache_dir)
 
         self._session = requests.Session()
+        self._closed = False
+
+    def close(self) -> None:
+        """Close the underlying HTTP session."""
+        if not self._closed:
+            self._session.close()
+            self._closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
+    def __del__(self):
+        self.close()
 
     # -- Authentication check -------------------------------------------------
 

--- a/siege_utilities/geo/spatial_transformations.py
+++ b/siege_utilities/geo/spatial_transformations.py
@@ -117,47 +117,60 @@ class SpatialDataTransformer:
     def _convert_to_shapefile(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to ESRI Shapefile format."""
         output_path = kwargs.get('output_path', 'output.shp')
-        gdf.to_file(output_path, driver='ESRI Shapefile')
+        from siege_utilities.files.operations import atomic_write_shapefile
+        atomic_write_shapefile(gdf, output_path)
         log.info(f"Successfully converted to Shapefile: {output_path}")
 
     def _convert_to_geojson(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to GeoJSON format."""
         output_path = kwargs.get('output_path', 'output.geojson')
-        gdf.to_file(output_path, driver='GeoJSON')
+        from siege_utilities.files.operations import atomic_write_path
+        with atomic_write_path(output_path) as tmp:
+            gdf.to_file(str(tmp), driver='GeoJSON')
         log.info(f"Successfully converted to GeoJSON: {output_path}")
 
     def _convert_to_geopackage(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to GeoPackage format."""
         output_path = kwargs.get('output_path', 'output.gpkg')
-        gdf.to_file(output_path, driver='GPKG')
+        from siege_utilities.files.operations import atomic_write_path
+        with atomic_write_path(output_path) as tmp:
+            gdf.to_file(str(tmp), driver='GPKG')
         log.info(f"Successfully converted to GeoPackage: {output_path}")
 
     def _convert_to_kml(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to KML format."""
         output_path = kwargs.get('output_path', 'output.kml')
-        gdf.to_file(output_path, driver='KML')
+        from siege_utilities.files.operations import atomic_write_path
+        with atomic_write_path(output_path) as tmp:
+            gdf.to_file(str(tmp), driver='KML')
         log.info(f"Successfully converted to KML: {output_path}")
 
     def _convert_to_gml(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to GML format."""
         output_path = kwargs.get('output_path', 'output.gml')
-        gdf.to_file(output_path, driver='GML')
+        from siege_utilities.files.operations import atomic_write_path
+        with atomic_write_path(output_path) as tmp:
+            gdf.to_file(str(tmp), driver='GML')
         log.info(f"Successfully converted to GML: {output_path}")
 
     def _convert_to_wkt(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to WKT (Well-Known Text) format."""
         output_path = kwargs.get('output_path', 'output.wkt')
+        from siege_utilities.files.operations import atomic_write_path
         wkt_data = gdf.copy()
         wkt_data['geometry'] = wkt_data.geometry.astype(str)
-        wkt_data.to_csv(output_path, index=False)
+        with atomic_write_path(output_path) as tmp:
+            wkt_data.to_csv(str(tmp), index=False)
         log.info(f"Successfully converted to WKT: {output_path}")
 
     def _convert_to_wkb(self, gdf: GeoDataFrame, **kwargs) -> None:
         """Convert to WKB (Well-Known Binary) format."""
         output_path = kwargs.get('output_path', 'output.wkb')
+        from siege_utilities.files.operations import atomic_write_path
         wkb_data = gdf.copy()
         wkb_data['geometry'] = wkb_data.geometry.apply(lambda geom: geom.wkb)
-        wkb_data.to_pickle(output_path)
+        with atomic_write_path(output_path) as tmp:
+            wkb_data.to_pickle(str(tmp))
         log.info(f"Successfully converted to WKB: {output_path}")
     
     def _convert_to_postgis(self, gdf: GeoDataFrame, **kwargs) -> None:
@@ -172,8 +185,9 @@ class SpatialDataTransformer:
             + "'));"
         )
 
-        with open(output_path, 'w', encoding='utf-8') as f:
-            f.write('\n'.join(sql_lines))
+        from siege_utilities.files.operations import atomic_write_path
+        with atomic_write_path(output_path) as tmp:
+            tmp.write_text('\n'.join(sql_lines), encoding='utf-8')
 
         log.info(f"Successfully generated PostGIS SQL: {output_path}")
 

--- a/tests/test_file_operations.py
+++ b/tests/test_file_operations.py
@@ -3,6 +3,7 @@
 import pytest
 
 from siege_utilities.files.operations import (
+    atomic_write_path,
     remove_tree,
     file_exists,
     touch_file,
@@ -212,3 +213,43 @@ class TestDeleteAndReplace:
         delete_existing_file_and_replace_it_with_an_empty_file(str(f))
         assert f.exists()
         assert f.read_text() == ""
+
+
+class TestAtomicWritePath:
+    def test_successful_write_replaces_target(self, tmp_path):
+        target = tmp_path / "output.csv"
+        target.write_text("old data")
+        with atomic_write_path(target) as tmp:
+            tmp.write_text("new data")
+        assert target.read_text() == "new data"
+
+    def test_failed_write_leaves_target_unchanged(self, tmp_path):
+        target = tmp_path / "output.csv"
+        target.write_text("original")
+        with pytest.raises(ValueError):
+            with atomic_write_path(target) as tmp:
+                tmp.write_text("partial")
+                raise ValueError("simulated failure")
+        assert target.read_text() == "original"
+
+    def test_failed_write_cleans_up_temp(self, tmp_path):
+        target = tmp_path / "output.csv"
+        captured_tmp = None
+        with pytest.raises(RuntimeError):
+            with atomic_write_path(target) as tmp:
+                captured_tmp = tmp
+                tmp.write_text("data")
+                raise RuntimeError("boom")
+        assert not captured_tmp.exists()
+
+    def test_creates_parent_directories(self, tmp_path):
+        target = tmp_path / "a" / "b" / "c" / "file.txt"
+        with atomic_write_path(target) as tmp:
+            tmp.write_text("nested")
+        assert target.read_text() == "nested"
+
+    def test_preserves_extension(self, tmp_path):
+        target = tmp_path / "data.parquet"
+        with atomic_write_path(target) as tmp:
+            assert tmp.suffix == ".parquet"
+            tmp.write_text("fake parquet")

--- a/tests/test_redistricting_data_hub.py
+++ b/tests/test_redistricting_data_hub.py
@@ -533,10 +533,18 @@ class TestPolsbyPopper:
     def test_empty_geometry(self):
         from shapely.geometry import Point
         empty = Point().buffer(0)
-        assert polsby_popper(empty) == 0.0
+        assert math.isnan(polsby_popper(empty))
 
     def test_none(self):
-        assert polsby_popper(None) == 0.0
+        assert math.isnan(polsby_popper(None))
+
+    def test_with_source_crs_reprojects(self):
+        from shapely.geometry import box
+        geom_4326 = box(-90.0, 30.0, -89.9, 30.1)
+        score_raw = polsby_popper(geom_4326)
+        score_projected = polsby_popper(geom_4326, source_crs="EPSG:4326")
+        assert score_projected != score_raw
+        assert 0 < score_projected <= 1.0
 
 
 class TestReock:
@@ -557,11 +565,11 @@ class TestReock:
         assert abs(score - 2 / math.pi) < 0.02
 
     def test_none(self):
-        assert reock(None) == 0.0
+        assert math.isnan(reock(None))
 
     def test_empty(self):
         from shapely.geometry import Point
-        assert reock(Point().buffer(0)) == 0.0
+        assert math.isnan(reock(Point().buffer(0)))
 
 
 class TestConvexHullRatio:
@@ -583,7 +591,7 @@ class TestConvexHullRatio:
         assert score > 0.5
 
     def test_none(self):
-        assert convex_hull_ratio(None) == 0.0
+        assert math.isnan(convex_hull_ratio(None))
 
 
 class TestSchwartzberg:
@@ -601,7 +609,7 @@ class TestSchwartzberg:
         assert score < 0.5
 
     def test_none(self):
-        assert schwartzberg(None) == 0.0
+        assert math.isnan(schwartzberg(None))
 
 
 class TestComputeCompactness:
@@ -630,6 +638,26 @@ class TestComputeCompactness:
 
         # Circle should have highest PP score
         assert result.iloc[0]["polsby_popper"] > result.iloc[2]["polsby_popper"]
+
+    def test_compute_reprojects_geographic_crs(self):
+        import pandas as pd
+        import geopandas as gpd
+        from shapely.geometry import box
+
+        gdf_4326 = gpd.GeoDataFrame(
+            {"GEOID": ["D1", "D2"]},
+            geometry=[
+                box(-90.0, 30.0, -89.5, 30.5),
+                box(-90.0, 30.0, -89.9, 30.9),
+            ],
+            crs="EPSG:4326",
+        )
+
+        result = compute_compactness(gdf_4326)
+        assert len(result) == 2
+        for col in ["polsby_popper", "reock", "convex_hull_ratio", "schwartzberg"]:
+            for val in result[col]:
+                assert 0 < val <= 1.0, f"{col} out of range: {val}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_redistricting_data_hub.py
+++ b/tests/test_redistricting_data_hub.py
@@ -987,3 +987,29 @@ class TestRDHClientErrorPaths:
                     states=["VA"], format=None, year=None,
                     dataset_type=None, geography=None, official=None,
                 )
+
+
+class TestRDHClientSessionLifecycle:
+    """#979: RDHClient implements context manager and close()."""
+
+    def test_close_closes_session(self):
+        client = RDHClient(username="u", password="p")
+        client.close()
+        assert client._closed is True
+
+    def test_close_idempotent(self):
+        client = RDHClient(username="u", password="p")
+        client.close()
+        client.close()
+        assert client._closed is True
+
+    def test_context_manager_closes_on_exit(self):
+        with RDHClient(username="u", password="p") as client:
+            assert client._closed is False
+        assert client._closed is True
+
+    def test_context_manager_closes_on_exception(self):
+        with pytest.raises(RuntimeError):
+            with RDHClient(username="u", password="p") as client:
+                raise RuntimeError("boom")
+        assert client._closed is True

--- a/tests/test_seat_vtd_constraints.py
+++ b/tests/test_seat_vtd_constraints.py
@@ -1,0 +1,78 @@
+"""Tests for #977: Seat and VTD model constraint enforcement.
+
+Seat constraint (DB-level CheckConstraint) is verified structurally.
+VTD clean() validation is tested via direct model method invocation.
+"""
+
+import pytest
+
+try:
+    from django.core.exceptions import ValidationError
+
+    from siege_utilities.geo.django.models.temporal_political import Seat
+    from siege_utilities.geo.django.models.political import VTD
+
+    HAS_DJANGO_GIS = True
+except (ImportError, RuntimeError, Exception):
+    HAS_DJANGO_GIS = False
+    Seat = None
+    VTD = None
+
+pytestmark = pytest.mark.skipif(
+    not HAS_DJANGO_GIS, reason="Django GIS (GDAL) not available"
+)
+
+
+class TestSeatConstraintStructure:
+    """Verify the CheckConstraint exists on the Seat model Meta."""
+
+    def test_constraint_exists(self):
+        constraint_names = [c.name for c in Seat._meta.constraints]
+        assert "seat_state_required_unless_president" in constraint_names
+
+    def test_constraint_condition_covers_president(self):
+        constraint = next(
+            c for c in Seat._meta.constraints
+            if c.name == "seat_state_required_unless_president"
+        )
+        assert constraint is not None
+
+
+class TestVTDCrossStateValidation:
+    """VTD.clean() must reject cross-state congressional_district links."""
+
+    def _make_vtd(self, state_fips, cd_state_fips=None):
+        """Create a VTD instance with a mock congressional district."""
+        vtd = VTD(
+            geoid=f"{state_fips}037001",
+            state_fips=state_fips,
+            county_fips="037",
+            vtd_code="001",
+            vintage_year=2020,
+        )
+        if cd_state_fips is not None:
+
+            class FakeCD:
+                def __init__(self, sf):
+                    self.state_fips = sf
+
+            vtd.congressional_district_id = 999
+            vtd._congressional_district_cache = FakeCD(cd_state_fips)
+            # Django caches FK objects on the descriptor; simulate by
+            # patching the attribute the clean() method reads.
+            vtd.congressional_district = FakeCD(cd_state_fips)
+        return vtd
+
+    def test_same_state_passes(self):
+        vtd = self._make_vtd("06", "06")
+        vtd.clean()
+
+    def test_cross_state_raises(self):
+        vtd = self._make_vtd("06", "48")
+        with pytest.raises(ValidationError) as exc_info:
+            vtd.clean()
+        assert "congressional_district" in exc_info.value.message_dict
+
+    def test_no_cd_assigned_passes(self):
+        vtd = self._make_vtd("06", cd_state_fips=None)
+        vtd.clean()

--- a/tests/test_wikidata_gazetteer.py
+++ b/tests/test_wikidata_gazetteer.py
@@ -370,3 +370,32 @@ def test_overpass_empty_elements_raises_backend_error(wd_gaz):
          patch.object(wd_gaz._session, "post", return_value=overpass_empty):
         with pytest.raises(GazetteerBackendError, match="no elements"):
             wd_gaz.lookup("X")
+
+
+# ---------------------------------------------------------------------------
+# #979: Session lifecycle tests
+# ---------------------------------------------------------------------------
+
+class TestWikidataGazetteerSessionLifecycle:
+
+    def test_close_closes_session(self, wd_gaz):
+        wd_gaz.close()
+        assert wd_gaz._closed is True
+
+    def test_close_idempotent(self, wd_gaz):
+        wd_gaz.close()
+        wd_gaz.close()
+        assert wd_gaz._closed is True
+
+    def test_context_manager_closes_on_exit(self):
+        from siege_utilities.geo.gazetteers.wikidata_gazetteer import WikidataGazetteer
+        with WikidataGazetteer() as gaz:
+            assert gaz._closed is False
+        assert gaz._closed is True
+
+    def test_context_manager_closes_on_exception(self):
+        from siege_utilities.geo.gazetteers.wikidata_gazetteer import WikidataGazetteer
+        with pytest.raises(RuntimeError):
+            with WikidataGazetteer() as gaz:
+                raise RuntimeError("boom")
+        assert gaz._closed is True


### PR DESCRIPTION
Promotes 5 hostile review remediation fixes from develop to main:

- **#975** (PR #980): CRS-aware compactness metrics — reprojects to ESRI:54009 for area-dependent calculations
- **#976** (PR #981): CRS-blind spatial join guard — ValueError on mismatched CRS, locale auto-alignment
- **#978** (PR #982): Atomic file writes — tmp+rename pattern prevents corrupt partial files
- **#977** (PR #983): Seat/VTD model constraints — CheckConstraint for seat state, clean() for VTD cross-state
- **#979** (PR #984): HTTP session lifecycle — close()/context manager for RDHClient and WikidataGazetteer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Atomic file writes for all data exports prevent corruption from incomplete writes
  * Automatic coordinate system validation and reprojection for improved geospatial data handling
  * Session lifecycle management with automatic resource cleanup for API clients

* **Bug Fixes**
  * Invalid geometries now properly return NaN in spatial metric calculations instead of zero
  * Enhanced validation for geographic state constraints

* **Tests**
  * Added comprehensive test coverage for atomic file operations, CRS handling, and resource lifecycle management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->