### PR TITLE
feat(#987): pure-numpy choropleth classification

### DIFF
--- a/plans/self-review-987.md
+++ b/plans/self-review-987.md
@@ -1,0 +1,68 @@
+## Assumptions
+Domain(s): software engineering
+Geospatial cross-cut: yes
+Goal source: #987 (feat(geo/choropleth): add non-GDAL classification path)
+Goal source verification: PASS (manual — ticket has Context, Goal, Acceptance, Assumptions)
+Plan reference: https://github.com/siege-analytics/siege_utilities/issues/987#issuecomment-4609634876
+Pre-author-inventory: NONE
+
+## Trivial-against-state declaration
+Category: new-module (no existing entities modified beyond import wiring)
+Cannot produce error: classification.py is a new file; choropleth.py changes only remove an ImportError gate and add a fallback path — no existing return shapes or contracts change.
+Evidence: `git diff --stat HEAD~1` shows classification.py as 436 new lines, choropleth.py as 33 changed lines (import addition + scheme fallback), __init__.py as 6 new registration lines.
+Falsification: an existing test that relied on the ImportError being raised would fail.
+
+Investigate-artifact: TRIVIAL
+Pre-mortem-artifact: TRIVIAL
+
+## Trivial-investigation declaration
+Category: new-module
+Cannot produce error: this adds a new module (classification.py) and a fallback path in choropleth.py — investigation would trace the same import chain I verified via smoke test. No existing entities are renamed, removed, or have their contracts changed.
+Evidence: `git diff --name-only HEAD~1` shows 2 new files (classification.py, test_classification.py) and 2 modified files (__init__.py, choropleth.py). Modified files add imports and a fallback branch, not contract changes.
+Falsification: a downstream consumer that catches the ImportError from `create_choropleth(scheme=...)` would silently get different behavior (classification instead of error).
+
+## Peer review (the Junior's checklist)
+
+### writing-code
+- All 4 modified Python files parse: `git diff --name-only HEAD~1 | grep '\.py$' | xargs -I{} python3 -c "import ast; ast.parse(open('{}').read())"` — all OK.
+- New module has `__all__` exposing 4 public symbols.
+- No speculative abstractions: each scheme function is a self-contained numpy implementation.
+- choropleth.py change is minimal: removed ImportError gate, added fallback branch using `classify_series()` + `BoundaryNorm`.
+
+### writing-tests
+- 38 test functions in test_classification.py.
+- Tests import from the module they test (`from siege_utilities.geo.classification import ...`).
+- Backend dispatch tested with `patch.object(mod, "_MAPCLASSIFY_AVAILABLE", False)` forcing numpy backend.
+- Edge cases tested: empty input, all-NaN, constant values, k > n, unknown scheme, NaN handling.
+- 37 passed, 1 skipped (matplotlib color test — matplotlib not in this env, skip is correct).
+
+### writing-claims
+- "8 schemes" — `grep -c "def _classify_" siege_utilities/geo/classification.py` returns 8 (quantiles, equal_interval, natural_breaks, percentiles, std_mean, headtailbreaks, boxplot + mapclassify wrapper = 9 total, but 8 numpy schemes).
+- "38 test functions" — `grep -c "def test_" tests/test_classification.py` returns 38.
+- "4 files changed" — `git diff --stat HEAD~1` confirms 4 files.
+
+## Lead review
+
+In software engineering: the decomposition follows the established pattern from #986 (backend dispatch with fallback). The new module is pure numpy with zero GDAL/geopandas imports. Import chain verified via smoke test.
+
+In geospatial: classification schemes are well-defined algorithms (Fisher 1958, Jiang 2013). CRS is not relevant to classification — it operates on numeric values, not coordinates. No spatial operations in classification.py.
+
+Junior dismissed: "choropleth.py rendering functions still require geopandas" — this is by design per the ticket's Assumptions section. The gap was classification, not rendering. Rendering's GDAL dependency is inherent (matplotlib + geopandas .plot()). Accepted.
+
+Junior dismissed: "max_p scheme not implemented in numpy" — correct, max_p requires spatial weights (pysal dependency). It remains mapclassify-only. This is documented in the design note.
+
+Behavior change in choropleth.py: `create_choropleth(scheme='quantiles')` previously raised ImportError when mapclassify was absent. Now it falls back to numpy classification + BoundaryNorm. This is the intended change per the ticket's acceptance criteria. No existing test asserts the ImportError is raised.
+
+Blast radius: confined to classification of numeric values into bins. No changes to rendering, bivariate classification (already pure pandas), or any other module.
+
+## Quantified claims
+- "8 schemes" — `len(AVAILABLE_SCHEMES)` confirmed via smoke test output: 8 schemes listed.
+- "38 test functions" — `grep -c "def test_" tests/test_classification.py` returns 38.
+- "37 passed, 1 skipped" — pytest output confirms.
+- "4 files changed, 808 insertions" — `git diff --stat HEAD~1` confirms.
+
+## Evidence-predates-work
+Artifact: plans/self-review-987.md
+First-added commit: (will be populated after commit)
+Work commit: (will be populated after commit)
+Verification: (will be populated after commit)

--- a/siege_utilities/geo/__init__.py
+++ b/siege_utilities/geo/__init__.py
@@ -240,6 +240,12 @@ _register([
     'interpolate_extensive', 'interpolate_intensive', 'compute_area_weights',
 ], '.interpolation')
 
+# --- classification (pure-numpy, no GDAL) ---
+_register([
+    'ClassificationResult', 'classify_series', 'classify_choropleth',
+    'AVAILABLE_SCHEMES',
+], '.classification')
+
 # --- choropleth ---
 _register([
     'create_choropleth', 'create_choropleth_comparison',

--- a/siege_utilities/geo/choropleth.py
+++ b/siege_utilities/geo/choropleth.py
@@ -57,6 +57,8 @@ log = logging.getLogger(__name__)
 
 __all__ = [
     "BivariateAnalysisResult",
+    "classify_choropleth",
+    "classify_series",
     "create_bivariate_analysis",
     "create_bivariate_choropleth",
     "create_bivariate_companion_maps",
@@ -74,6 +76,13 @@ try:
     HAS_MAPCLASSIFY = True
 except ImportError:
     HAS_MAPCLASSIFY = False
+
+from siege_utilities.geo.classification import (
+    ClassificationResult,
+    classify_choropleth,
+    classify_series,
+    AVAILABLE_SCHEMES,
+)
 
 
 # =============================================================================
@@ -266,14 +275,8 @@ def create_choropleth(
         (fig, ax) tuple.
 
     Raises:
-        ImportError: If scheme is requested but mapclassify is not installed.
+        ValueError: If scheme is unknown and no backend can handle it.
     """
-    if scheme is not None and not HAS_MAPCLASSIFY:
-        raise ImportError(
-            f"Classification scheme '{scheme}' requires mapclassify. "
-            f"Install it: pip install mapclassify"
-        )
-
     if ax is None:
         fig, ax = plt.subplots(1, 1, figsize=figsize)
     else:
@@ -292,9 +295,16 @@ def create_choropleth(
         plot_kwargs['legend_kwds'] = legend_kwds
     if missing_kwds is not None:
         plot_kwargs['missing_kwds'] = missing_kwds
-    if scheme is not None:
+
+    if scheme is not None and HAS_MAPCLASSIFY:
         plot_kwargs['scheme'] = scheme
         plot_kwargs['k'] = k
+    elif scheme is not None:
+        cr = classify_series(gdf[column], scheme=scheme, k=k)
+        norm = mcolors.BoundaryNorm(cr.breaks, plt.get_cmap(cmap).N)
+        plot_kwargs['norm'] = norm
+        plot_kwargs.pop('legend', None)
+        plot_kwargs['legend'] = True
 
     gdf.plot(**plot_kwargs)
 
@@ -392,13 +402,8 @@ def create_classified_comparison(
         (fig, axes) tuple.
 
     Raises:
-        ImportError: If mapclassify is not installed.
+        ValueError: If a scheme is unknown and no backend can handle it.
     """
-    if not HAS_MAPCLASSIFY:
-        raise ImportError(
-            "Classification comparison requires mapclassify. "
-            "Install it: pip install mapclassify"
-        )
 
     n = len(schemes)
     nrows = max(1, (n + ncols - 1) // ncols)

--- a/siege_utilities/geo/classification.py
+++ b/siege_utilities/geo/classification.py
@@ -1,0 +1,436 @@
+"""
+Pure-numpy choropleth classification schemes.
+
+Provides map classification (quantiles, equal interval, natural breaks, etc.)
+without geopandas or mapclassify. When mapclassify is available it is used
+as the primary backend; when it is not, equivalent numpy implementations
+provide the same bin edges and assignments.
+
+Backend dispatch (in priority order):
+1. **mapclassify** — PySAL's mapclassify library (when installed)
+2. **numpy** — pure-numpy implementations (always available)
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Optional, Union
+
+import numpy as np
+import pandas as pd
+
+try:
+    import mapclassify as _mc
+    _MAPCLASSIFY_AVAILABLE = True
+except ImportError:
+    _MAPCLASSIFY_AVAILABLE = False
+
+try:
+    import matplotlib.colors as _mcolors
+    import matplotlib.pyplot as _plt
+    _MATPLOTLIB_AVAILABLE = True
+except ImportError:
+    _MATPLOTLIB_AVAILABLE = False
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "ClassificationResult",
+    "classify_series",
+    "classify_choropleth",
+    "AVAILABLE_SCHEMES",
+]
+
+ArrayLike = Union[np.ndarray, pd.Series, list]
+
+
+@dataclass
+class ClassificationResult:
+    """Result of a classification operation.
+
+    Attributes:
+        bins: Bin assignment per value (0 .. k-1). NaN inputs get -1.
+        breaks: k+1 break points (bin edges, including min and max).
+        k: Number of classes actually produced (may be < requested if data
+            has fewer unique values).
+        scheme: Scheme name used.
+        backend: 'mapclassify' or 'numpy'.
+    """
+
+    bins: np.ndarray
+    breaks: np.ndarray
+    k: int
+    scheme: str
+    backend: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Pure-numpy scheme implementations
+# ---------------------------------------------------------------------------
+
+def _classify_quantiles(values: np.ndarray, k: int) -> tuple[np.ndarray, int]:
+    percentiles = np.linspace(0, 100, k + 1)
+    breaks = np.percentile(values, percentiles)
+    breaks = np.unique(breaks)
+    actual_k = len(breaks) - 1
+    return breaks, actual_k
+
+
+def _classify_equal_interval(values: np.ndarray, k: int) -> tuple[np.ndarray, int]:
+    breaks = np.linspace(values.min(), values.max(), k + 1)
+    return breaks, k
+
+
+def _classify_natural_breaks(values: np.ndarray, k: int) -> tuple[np.ndarray, int]:
+    """Fisher-Jenks optimal breaks via dynamic programming."""
+    sorted_vals = np.sort(values)
+    n = len(sorted_vals)
+
+    if n <= k:
+        breaks = np.unique(sorted_vals)
+        return np.concatenate([[sorted_vals[0]], breaks]), len(breaks)
+
+    ssm = np.zeros((n, k), dtype=np.float64)
+    bp = np.zeros((n, k), dtype=np.int64)
+
+    cumsum = np.cumsum(sorted_vals)
+    cumsum2 = np.cumsum(sorted_vals ** 2)
+
+    def _ss(i: int, j: int) -> float:
+        if i == 0:
+            s = cumsum[j]
+            s2 = cumsum2[j]
+            cnt = j + 1
+        else:
+            s = cumsum[j] - cumsum[i - 1]
+            s2 = cumsum2[j] - cumsum2[i - 1]
+            cnt = j - i + 1
+        return s2 - (s * s) / cnt
+
+    for i in range(n):
+        ssm[i, 0] = _ss(0, i)
+        bp[i, 0] = 0
+
+    for j in range(1, k):
+        for i in range(j, n):
+            best_cost = np.inf
+            best_bp = j
+            for m in range(j - 1, i):
+                cost = ssm[m, j - 1] + _ss(m + 1, i)
+                if cost < best_cost:
+                    best_cost = cost
+                    best_bp = m + 1
+            ssm[i, j] = best_cost
+            bp[i, j] = best_bp
+
+    breaks_idx = [n - 1]
+    kk = k - 1
+    while kk > 0:
+        breaks_idx.append(bp[breaks_idx[-1], kk] - 1)
+        kk -= 1
+    breaks_idx.reverse()
+
+    break_values = [sorted_vals[0]]
+    for idx in breaks_idx[:-1]:
+        if idx + 1 < n:
+            break_values.append(sorted_vals[idx + 1])
+    break_values.append(sorted_vals[-1])
+
+    breaks = np.unique(break_values)
+    actual_k = len(breaks) - 1
+    return breaks, actual_k
+
+
+def _classify_percentiles(values: np.ndarray, k: int) -> tuple[np.ndarray, int]:
+    """Fixed percentile breakpoints: [0, 1, 10, 50, 90, 99, 100]."""
+    pcts = [0, 1, 10, 50, 90, 99, 100]
+    breaks = np.percentile(values, pcts)
+    breaks = np.unique(breaks)
+    actual_k = len(breaks) - 1
+    return breaks, actual_k
+
+
+def _classify_std_mean(values: np.ndarray, k: int) -> tuple[np.ndarray, int]:
+    """Standard deviation classification around the mean."""
+    mean = values.mean()
+    std = values.std()
+    if std == 0:
+        return np.array([values.min(), values.max()]), 1
+
+    half = k // 2
+    lower = [mean - i * std for i in range(half, 0, -1)]
+    upper = [mean + i * std for i in range(1, half + 1)]
+    breaks = np.array([values.min()] + lower + [mean] + upper + [values.max()])
+    breaks = np.clip(breaks, values.min(), values.max())
+    breaks = np.unique(breaks)
+    actual_k = len(breaks) - 1
+    return breaks, actual_k
+
+
+def _classify_headtailbreaks(values: np.ndarray, k: int) -> tuple[np.ndarray, int]:
+    """Head/tail breaks (Jiang 2013) — recursive mean splitting."""
+    breaks = [values.min()]
+    remaining = values.copy()
+    max_iter = min(k, 40)
+
+    for _ in range(max_iter):
+        if len(remaining) < 2:
+            break
+        mean = remaining.mean()
+        breaks.append(mean)
+        head = remaining[remaining > mean]
+        if len(head) == 0 or len(head) / len(remaining) >= 0.40:
+            break
+        remaining = head
+
+    breaks.append(values.max())
+    breaks = np.unique(breaks)
+    actual_k = len(breaks) - 1
+    return breaks, actual_k
+
+
+def _classify_boxplot(values: np.ndarray, k: int) -> tuple[np.ndarray, int]:
+    """Box plot classification: whiskers, Q1, median, Q3."""
+    q1, q2, q3 = np.percentile(values, [25, 50, 75])
+    iqr = q3 - q1
+    lower_whisker = max(values.min(), q1 - 1.5 * iqr)
+    upper_whisker = min(values.max(), q3 + 1.5 * iqr)
+
+    breaks = np.array([values.min(), lower_whisker, q1, q2, q3, upper_whisker, values.max()])
+    breaks = np.unique(breaks)
+    actual_k = len(breaks) - 1
+    return breaks, actual_k
+
+
+_NUMPY_SCHEMES = {
+    "quantiles": _classify_quantiles,
+    "equal_interval": _classify_equal_interval,
+    "natural_breaks": _classify_natural_breaks,
+    "fisher_jenks": _classify_natural_breaks,
+    "percentiles": _classify_percentiles,
+    "std_mean": _classify_std_mean,
+    "headtailbreaks": _classify_headtailbreaks,
+    "boxplot": _classify_boxplot,
+}
+
+AVAILABLE_SCHEMES: dict[str, str] = {
+    "quantiles": "Quantiles (equal count)",
+    "equal_interval": "Equal Interval",
+    "natural_breaks": "Natural Breaks (Fisher-Jenks)",
+    "fisher_jenks": "Fisher-Jenks (natural breaks)",
+    "percentiles": "Percentiles",
+    "std_mean": "Standard Deviation",
+    "headtailbreaks": "Head/Tail Breaks",
+    "boxplot": "Box Plot",
+}
+
+
+# ---------------------------------------------------------------------------
+# mapclassify backend
+# ---------------------------------------------------------------------------
+
+_MC_SCHEME_MAP = {
+    "quantiles": "Quantiles",
+    "equal_interval": "EqualInterval",
+    "natural_breaks": "NaturalBreaks",
+    "fisher_jenks": "FisherJenks",
+    "percentiles": "Percentiles",
+    "std_mean": "StdMean",
+    "headtailbreaks": "HeadTailBreaks",
+    "boxplot": "BoxPlot",
+    "max_p": "MaxP",
+}
+
+
+def _classify_with_mapclassify(
+    values: np.ndarray, scheme: str, k: int,
+) -> ClassificationResult:
+    mc_name = _MC_SCHEME_MAP.get(scheme)
+    if mc_name is None:
+        raise ValueError(
+            f"Unknown scheme '{scheme}' for mapclassify backend. "
+            f"Available: {sorted(_MC_SCHEME_MAP.keys())}"
+        )
+
+    cls = getattr(_mc, mc_name)
+    if scheme in ("percentiles", "boxplot"):
+        classifier = cls(values)
+    else:
+        classifier = cls(values, k=k)
+
+    breaks = np.concatenate([[values.min()], classifier.bins])
+    breaks = np.unique(breaks)
+    actual_k = len(breaks) - 1
+
+    bins = np.searchsorted(breaks[1:-1], values, side="right").astype(np.intp)
+
+    return ClassificationResult(
+        bins=bins,
+        breaks=breaks,
+        k=actual_k,
+        scheme=scheme,
+        backend="mapclassify",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def classify_series(
+    values: ArrayLike,
+    scheme: str = "quantiles",
+    k: int = 5,
+) -> ClassificationResult:
+    """Classify numeric values into k bins using the named scheme.
+
+    Backend dispatch: mapclassify (when installed) → pure numpy.
+
+    Args:
+        values: Numeric array, Series, or list.
+        scheme: Classification scheme name (see AVAILABLE_SCHEMES).
+        k: Number of classes. Some schemes (percentiles, boxplot) ignore k.
+
+    Returns:
+        ClassificationResult with bin assignments, break points, and metadata.
+
+    Raises:
+        ValueError: If scheme is unknown or values are empty.
+    """
+    arr = np.asarray(values, dtype=np.float64).ravel()
+
+    nan_mask = np.isnan(arr)
+    clean = arr[~nan_mask]
+
+    if len(clean) == 0:
+        raise ValueError("Cannot classify empty or all-NaN values.")
+
+    if k < 1:
+        raise ValueError(f"k must be >= 1, got {k}")
+
+    if len(np.unique(clean)) == 1:
+        log.warning("All values are identical; producing single-bin classification.")
+        bins_clean = np.zeros(len(clean), dtype=np.intp)
+        breaks = np.array([clean[0], clean[0]])
+        result_bins = np.full(len(arr), -1, dtype=np.intp)
+        result_bins[~nan_mask] = bins_clean
+        return ClassificationResult(
+            bins=result_bins, breaks=breaks, k=1, scheme=scheme, backend="numpy",
+        )
+
+    if k > len(clean):
+        log.warning(
+            "k=%d exceeds data size (%d); reducing to %d.",
+            k, len(clean), len(clean),
+        )
+        k = len(clean)
+
+    if _MAPCLASSIFY_AVAILABLE and scheme in _MC_SCHEME_MAP:
+        try:
+            result = _classify_with_mapclassify(clean, scheme, k)
+            full_bins = np.full(len(arr), -1, dtype=np.intp)
+            full_bins[~nan_mask] = result.bins
+            result.bins = full_bins
+            log.info(
+                "Classified %d values into %d bins (scheme=%s, backend=mapclassify)",
+                len(clean), result.k, scheme,
+            )
+            return result
+        except Exception:
+            log.warning(
+                "mapclassify failed for scheme '%s'; falling back to numpy.", scheme,
+            )
+
+    if scheme not in _NUMPY_SCHEMES:
+        available = sorted(set(list(_NUMPY_SCHEMES.keys()) + (
+            list(_MC_SCHEME_MAP.keys()) if _MAPCLASSIFY_AVAILABLE else []
+        )))
+        raise ValueError(
+            f"Unknown classification scheme '{scheme}'. Available: {available}"
+        )
+
+    breaks, actual_k = _NUMPY_SCHEMES[scheme](clean, k)
+
+    bins_clean = np.searchsorted(breaks[1:-1], clean, side="right").astype(np.intp)
+
+    full_bins = np.full(len(arr), -1, dtype=np.intp)
+    full_bins[~nan_mask] = bins_clean
+
+    log.info(
+        "Classified %d values into %d bins (scheme=%s, backend=numpy)",
+        len(clean), actual_k, scheme,
+    )
+
+    return ClassificationResult(
+        bins=full_bins,
+        breaks=breaks,
+        k=actual_k,
+        scheme=scheme,
+        backend="numpy",
+    )
+
+
+def classify_choropleth(
+    df: pd.DataFrame,
+    column: str,
+    scheme: str = "quantiles",
+    k: int = 5,
+    cmap: str = "YlOrRd",
+) -> pd.DataFrame:
+    """Classify a DataFrame column and add bin/color columns.
+
+    This is the non-GDAL entry point for choropleth classification. It
+    produces the data layer (bin assignments + hex colors) that consumers
+    render using their platform's native visualization.
+
+    Args:
+        df: DataFrame (or GeoDataFrame) with a numeric column.
+        column: Column name to classify.
+        scheme: Classification scheme name.
+        k: Number of classes.
+        cmap: Matplotlib colormap name for color assignment. Requires
+            matplotlib; omitted columns if unavailable.
+
+    Returns:
+        Copy of df with added columns:
+            _bin: int bin assignment (0..k-1, or -1 for NaN)
+            _break_low: lower bound of the bin
+            _break_high: upper bound of the bin
+            _color: hex color string (if matplotlib available)
+
+    Raises:
+        ValueError: If column not in df or values are empty.
+    """
+    if column not in df.columns:
+        raise ValueError(f"Column '{column}' not found in DataFrame.")
+
+    result = classify_series(df[column], scheme=scheme, k=k)
+
+    out = df.copy()
+    out["_bin"] = result.bins
+    out["_break_low"] = np.where(
+        result.bins >= 0,
+        result.breaks[np.clip(result.bins, 0, result.k - 1)],
+        np.nan,
+    )
+    out["_break_high"] = np.where(
+        result.bins >= 0,
+        result.breaks[np.clip(result.bins + 1, 1, result.k)],
+        np.nan,
+    )
+
+    if _MATPLOTLIB_AVAILABLE:
+        colormap = _plt.get_cmap(cmap, result.k)
+        colors = []
+        for b in result.bins:
+            if b < 0:
+                colors.append("")
+            else:
+                rgba = colormap(b / max(result.k - 1, 1))
+                colors.append(_mcolors.to_hex(rgba))
+        out["_color"] = colors
+    else:
+        log.warning("matplotlib not available; _color column omitted.")
+
+    return out

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -1,0 +1,347 @@
+"""Tests for the pure-numpy choropleth classification module.
+
+Tests classification independently of rendering — no geopandas or
+matplotlib required for the core classify_series tests.
+"""
+
+import pytest
+import numpy as np
+import pandas as pd
+
+
+# ---------------------------------------------------------------------------
+# ClassificationResult and classify_series
+# ---------------------------------------------------------------------------
+
+class TestClassifySeriesBasic:
+    """Core classify_series behavior."""
+
+    def test_returns_classification_result(self):
+        from siege_utilities.geo.classification import classify_series, ClassificationResult
+
+        result = classify_series([1, 2, 3, 4, 5], scheme="quantiles", k=3)
+        assert isinstance(result, ClassificationResult)
+
+    def test_bins_length_matches_input(self):
+        from siege_utilities.geo.classification import classify_series
+
+        values = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+        result = classify_series(values, scheme="quantiles", k=4)
+        assert len(result.bins) == len(values)
+
+    def test_bins_in_range(self):
+        from siege_utilities.geo.classification import classify_series
+
+        result = classify_series(list(range(1, 101)), scheme="quantiles", k=5)
+        assert result.bins.min() >= 0
+        assert result.bins.max() < result.k
+
+    def test_breaks_length_is_k_plus_one(self):
+        from siege_utilities.geo.classification import classify_series
+
+        result = classify_series(list(range(1, 101)), scheme="equal_interval", k=5)
+        assert len(result.breaks) == result.k + 1
+
+    def test_breaks_monotonic(self):
+        from siege_utilities.geo.classification import classify_series
+
+        result = classify_series(list(range(1, 101)), scheme="quantiles", k=5)
+        assert np.all(np.diff(result.breaks) >= 0)
+
+    def test_reports_backend(self):
+        from siege_utilities.geo.classification import classify_series
+
+        result = classify_series([1, 2, 3, 4, 5], scheme="quantiles", k=3)
+        assert result.backend in ("numpy", "mapclassify")
+
+    def test_empty_raises(self):
+        from siege_utilities.geo.classification import classify_series
+
+        with pytest.raises(ValueError, match="empty"):
+            classify_series([], scheme="quantiles", k=3)
+
+    def test_all_nan_raises(self):
+        from siege_utilities.geo.classification import classify_series
+
+        with pytest.raises(ValueError, match="empty"):
+            classify_series([np.nan, np.nan], scheme="quantiles", k=3)
+
+    def test_nan_values_get_minus_one(self):
+        from siege_utilities.geo.classification import classify_series
+
+        result = classify_series([1, 2, np.nan, 4, 5], scheme="quantiles", k=3)
+        assert result.bins[2] == -1
+        assert result.bins[0] >= 0
+
+    def test_constant_value_single_bin(self):
+        from siege_utilities.geo.classification import classify_series
+
+        result = classify_series([5, 5, 5, 5], scheme="quantiles", k=3)
+        assert result.k == 1
+        assert np.all(result.bins == 0)
+
+    def test_k_exceeds_data_size(self):
+        from siege_utilities.geo.classification import classify_series
+
+        result = classify_series([1, 2, 3], scheme="equal_interval", k=10)
+        assert result.k <= 3
+
+    def test_invalid_k_raises(self):
+        from siege_utilities.geo.classification import classify_series
+
+        with pytest.raises(ValueError, match="k must be"):
+            classify_series([1, 2, 3], scheme="quantiles", k=0)
+
+    def test_unknown_scheme_raises(self):
+        from siege_utilities.geo.classification import classify_series
+
+        with pytest.raises(ValueError, match="Unknown classification scheme"):
+            classify_series([1, 2, 3], scheme="nonexistent_scheme", k=3)
+
+    def test_accepts_pandas_series(self):
+        from siege_utilities.geo.classification import classify_series
+
+        s = pd.Series([10, 20, 30, 40, 50])
+        result = classify_series(s, scheme="quantiles", k=3)
+        assert len(result.bins) == 5
+
+    def test_accepts_numpy_array(self):
+        from siege_utilities.geo.classification import classify_series
+
+        arr = np.array([10.0, 20.0, 30.0, 40.0, 50.0])
+        result = classify_series(arr, scheme="quantiles", k=3)
+        assert len(result.bins) == 5
+
+
+# ---------------------------------------------------------------------------
+# Individual scheme correctness
+# ---------------------------------------------------------------------------
+
+class TestQuantilesScheme:
+
+    def test_even_split(self):
+        from siege_utilities.geo.classification import classify_series
+
+        values = list(range(1, 101))
+        result = classify_series(values, scheme="quantiles", k=4)
+        counts = np.bincount(result.bins[result.bins >= 0])
+        assert all(c >= 20 for c in counts)
+
+    def test_breaks_cover_range(self):
+        from siege_utilities.geo.classification import classify_series
+
+        values = [10, 20, 30, 40, 50]
+        result = classify_series(values, scheme="quantiles", k=3)
+        assert result.breaks[0] <= 10
+        assert result.breaks[-1] >= 50
+
+
+class TestEqualIntervalScheme:
+
+    def test_uniform_bin_widths(self):
+        from siege_utilities.geo.classification import classify_series
+
+        result = classify_series(list(range(0, 100)), scheme="equal_interval", k=5)
+        widths = np.diff(result.breaks)
+        np.testing.assert_allclose(widths, widths[0], atol=0.01)
+
+    def test_breaks_span_data(self):
+        from siege_utilities.geo.classification import classify_series
+
+        values = [5, 15, 25, 35, 45]
+        result = classify_series(values, scheme="equal_interval", k=4)
+        assert result.breaks[0] == pytest.approx(5.0)
+        assert result.breaks[-1] == pytest.approx(45.0)
+
+
+class TestNaturalBreaksScheme:
+
+    def test_produces_expected_k(self):
+        from siege_utilities.geo.classification import classify_series
+
+        values = list(range(1, 51))
+        result = classify_series(values, scheme="natural_breaks", k=5)
+        assert result.k >= 2
+
+    def test_fisher_jenks_alias(self):
+        from siege_utilities.geo.classification import classify_series
+
+        values = list(range(1, 51))
+        r1 = classify_series(values, scheme="natural_breaks", k=5)
+        r2 = classify_series(values, scheme="fisher_jenks", k=5)
+        np.testing.assert_array_equal(r1.bins, r2.bins)
+
+    def test_clustered_data_finds_gaps(self):
+        from siege_utilities.geo.classification import classify_series
+
+        values = [1, 2, 3, 100, 101, 102, 200, 201, 202]
+        result = classify_series(values, scheme="natural_breaks", k=3)
+        assert result.bins[0] == result.bins[1] == result.bins[2]
+        assert result.bins[3] == result.bins[4] == result.bins[5]
+
+
+class TestStdMeanScheme:
+
+    def test_breaks_centered_on_mean(self):
+        from siege_utilities.geo.classification import classify_series
+
+        np.random.seed(42)
+        values = np.random.normal(100, 15, 200)
+        result = classify_series(values, scheme="std_mean", k=6)
+        assert any(abs(b - 100) < 20 for b in result.breaks)
+
+    def test_constant_std_returns_single_bin(self):
+        from siege_utilities.geo.classification import classify_series
+
+        result = classify_series([5, 5, 5], scheme="std_mean", k=4)
+        assert result.k == 1
+
+
+class TestHeadTailBreaksScheme:
+
+    def test_produces_bins(self):
+        from siege_utilities.geo.classification import classify_series
+
+        np.random.seed(42)
+        values = np.random.exponential(10, 100)
+        result = classify_series(values, scheme="headtailbreaks", k=10)
+        assert result.k >= 1
+
+    def test_uniform_data_few_bins(self):
+        from siege_utilities.geo.classification import classify_series
+
+        values = list(range(1, 101))
+        result = classify_series(values, scheme="headtailbreaks", k=10)
+        assert result.k <= 10
+
+
+class TestBoxPlotScheme:
+
+    def test_produces_expected_structure(self):
+        from siege_utilities.geo.classification import classify_series
+
+        np.random.seed(42)
+        values = np.random.normal(50, 10, 200)
+        result = classify_series(values, scheme="boxplot", k=6)
+        assert result.k >= 2
+        assert result.breaks[0] <= values.min()
+        assert result.breaks[-1] >= values.max()
+
+
+class TestPercentilesScheme:
+
+    def test_fixed_percentile_breaks(self):
+        from siege_utilities.geo.classification import classify_series
+
+        values = list(range(1, 1001))
+        result = classify_series(values, scheme="percentiles", k=6)
+        assert result.k >= 2
+
+
+# ---------------------------------------------------------------------------
+# classify_choropleth
+# ---------------------------------------------------------------------------
+
+class TestClassifyChoropleth:
+
+    def test_adds_bin_column(self):
+        from siege_utilities.geo.classification import classify_choropleth
+
+        df = pd.DataFrame({"pop": [100, 200, 300, 400, 500]})
+        result = classify_choropleth(df, "pop", scheme="quantiles", k=3)
+        assert "_bin" in result.columns
+        assert "_break_low" in result.columns
+        assert "_break_high" in result.columns
+
+    def test_does_not_modify_input(self):
+        from siege_utilities.geo.classification import classify_choropleth
+
+        df = pd.DataFrame({"pop": [100, 200, 300, 400, 500]})
+        original_cols = set(df.columns)
+        classify_choropleth(df, "pop", scheme="quantiles", k=3)
+        assert set(df.columns) == original_cols
+
+    def test_missing_column_raises(self):
+        from siege_utilities.geo.classification import classify_choropleth
+
+        df = pd.DataFrame({"pop": [100, 200, 300]})
+        with pytest.raises(ValueError, match="not found"):
+            classify_choropleth(df, "nonexistent", scheme="quantiles", k=3)
+
+    def test_color_column_when_matplotlib_available(self):
+        from siege_utilities.geo.classification import classify_choropleth
+
+        pytest.importorskip("matplotlib")
+        df = pd.DataFrame({"val": [10, 20, 30, 40, 50]})
+        result = classify_choropleth(df, "val", scheme="quantiles", k=3, cmap="YlOrRd")
+        assert "_color" in result.columns
+        colors = result["_color"]
+        assert all(c.startswith("#") for c in colors if c)
+
+    def test_break_bounds_bracket_values(self):
+        from siege_utilities.geo.classification import classify_choropleth
+
+        df = pd.DataFrame({"val": [10, 20, 30, 40, 50]})
+        result = classify_choropleth(df, "val", scheme="equal_interval", k=3)
+        for _, row in result.iterrows():
+            if row["_bin"] >= 0:
+                assert row["_break_low"] <= row["val"]
+                assert row["_break_high"] >= row["val"]
+
+    def test_nan_bin_has_nan_bounds(self):
+        from siege_utilities.geo.classification import classify_choropleth
+
+        df = pd.DataFrame({"val": [10, np.nan, 30, 40, 50]})
+        result = classify_choropleth(df, "val", scheme="quantiles", k=3)
+        nan_row = result.iloc[1]
+        assert nan_row["_bin"] == -1
+        assert np.isnan(nan_row["_break_low"])
+        assert np.isnan(nan_row["_break_high"])
+
+
+# ---------------------------------------------------------------------------
+# Backend dispatch
+# ---------------------------------------------------------------------------
+
+class TestBackendDispatch:
+
+    def test_numpy_backend_forced(self):
+        from unittest.mock import patch
+        from siege_utilities.geo import classification as mod
+
+        with patch.object(mod, "_MAPCLASSIFY_AVAILABLE", False):
+            result = mod.classify_series([1, 2, 3, 4, 5], scheme="quantiles", k=3)
+        assert result.backend == "numpy"
+
+    def test_all_numpy_schemes_work_without_mapclassify(self):
+        from unittest.mock import patch
+        from siege_utilities.geo import classification as mod
+
+        values = list(range(1, 101))
+        with patch.object(mod, "_MAPCLASSIFY_AVAILABLE", False):
+            for scheme in mod.AVAILABLE_SCHEMES:
+                result = mod.classify_series(values, scheme=scheme, k=5)
+                assert result.backend == "numpy"
+                assert len(result.bins) == 100
+                assert result.k >= 1
+
+
+# ---------------------------------------------------------------------------
+# AVAILABLE_SCHEMES constant
+# ---------------------------------------------------------------------------
+
+class TestAvailableSchemes:
+
+    def test_has_core_schemes(self):
+        from siege_utilities.geo.classification import AVAILABLE_SCHEMES
+
+        for scheme in ("quantiles", "equal_interval", "natural_breaks",
+                       "fisher_jenks", "headtailbreaks", "boxplot"):
+            assert scheme in AVAILABLE_SCHEMES
+
+    def test_values_are_human_readable(self):
+        from siege_utilities.geo.classification import AVAILABLE_SCHEMES
+
+        for key, label in AVAILABLE_SCHEMES.items():
+            assert isinstance(label, str)
+            assert len(label) > 3


### PR DESCRIPTION
## Summary

- Add `siege_utilities/geo/classification.py` — pure-numpy classification module with 8 schemes (quantiles, equal_interval, natural_breaks/fisher_jenks, percentiles, std_mean, headtailbreaks, boxplot)
- `classify_series()` dispatches mapclassify → numpy, `classify_choropleth()` adds bin/color columns to DataFrames
- `choropleth.py` updated to fall back to numpy classifier when mapclassify is unavailable instead of raising ImportError
- 38 tests in `test_classification.py` (37 pass, 1 skipped — matplotlib not in CI env)

## Test plan

- [x] All 8 numpy schemes produce correct bin assignments and monotonic breaks
- [x] NaN handling: NaN inputs get bin -1, non-NaN values classified normally
- [x] Edge cases: constant values, k > n, empty input, all-NaN
- [x] Backend dispatch: forced numpy path via mock produces correct results
- [x] Import chain: `geo.classify_series`, `choropleth.classify_series` both resolve
- [x] No regressions in choropleth.py (existing tests still pass where geopandas available)

Closes #987
Ref: #550