### PR TITLE
feat(#988): boundary provider engine abstraction

### DIFF
--- a/siege_utilities/engines/dataframe_engine.py
+++ b/siege_utilities/engines/dataframe_engine.py
@@ -225,6 +225,23 @@ class DataFrameEngine(ABC):
         Always returns a ``geopandas.GeoDataFrame`` regardless of engine.
         """
 
+    def from_geodataframe(
+        self,
+        gdf: Any,
+        geometry_col: str = "geometry",
+    ) -> Any:
+        """Convert a GeoPandas ``GeoDataFrame`` to this engine's native format.
+
+        The inverse of :meth:`to_geodataframe`.  Geometry is serialized
+        as WKB-hex (DuckDB) or WKT (Spark/PostGIS) for engine-native
+        spatial operations.
+
+        Subclasses should override this for engine-specific conversion.
+        The default implementation returns the GeoDataFrame unchanged
+        (suitable for PandasEngine).
+        """
+        return gdf
+
     # -- Grid indexing (concrete defaults; engines may override) -----------
 
     def index_points(
@@ -1050,13 +1067,44 @@ class DuckDBEngine(DataFrameEngine):
             non_null = df[geometry_col].dropna()
             sample = non_null.iloc[0] if not non_null.empty else None
             if sample is not None and not isinstance(sample, BaseGeometry):
-                if isinstance(sample, bytes):
-                    geoms = df[geometry_col].apply(lambda g: shapely_wkb.loads(g) if g is not None else None)
+                if isinstance(sample, (bytes, bytearray)):
+                    geoms = df[geometry_col].apply(lambda g: shapely_wkb.loads(bytes(g) if isinstance(g, bytearray) else g) if g is not None else None)
                 else:
                     geoms = df[geometry_col].apply(lambda g: shapely_wkt.loads(g) if isinstance(g, str) else g)
                 return gpd.GeoDataFrame(df, geometry=geoms, crs=crs or get_default_crs())
             return gpd.GeoDataFrame(df, geometry=geometry_col, crs=crs or get_default_crs())
         raise ValueError(f"Cannot construct GeoDataFrame: column '{geometry_col}' not found")
+
+    def from_geodataframe(self, gdf, geometry_col="geometry"):
+        """Convert GeoDataFrame to a DuckDB pandas DataFrame with WKB-hex geometry."""
+        import pandas as pd
+
+        self._ensure_spatial()
+
+        attr_cols = [c for c in gdf.columns if c != geometry_col]
+        df = pd.DataFrame({c: gdf[c].values for c in attr_cols})
+        df["_geom_wkb"] = [
+            g.wkb_hex if g is not None else None
+            for g in gdf[geometry_col]
+        ]
+
+        if df.empty:
+            result = pd.DataFrame(columns=attr_cols + [geometry_col])
+            return result
+
+        tbl_name = f"_boundary_{id(gdf) % 100000}"
+        self._connection.register(tbl_name, df)
+
+        col_list = ", ".join(f'"{c}"' for c in attr_cols)
+        sql = (
+            f"SELECT {col_list}, "
+            f"ST_GeomFromWKB(UNHEX(_geom_wkb)) AS {geometry_col} "
+            f"FROM {tbl_name}"
+        )
+        result = self._connection.execute(sql).fetchdf()
+        self._connection.unregister(tbl_name)
+
+        return result
 
 
 # ---------------------------------------------------------------------------

--- a/siege_utilities/geo/providers/boundary_providers.py
+++ b/siege_utilities/geo/providers/boundary_providers.py
@@ -57,10 +57,14 @@ class BoundaryProvider(ABC):
         Args:
             level: Geographic level (e.g. 'county', 'tract', 'admin1').
             identifier: Optional identifier to narrow the query (e.g. state FIPS).
-            **kwargs: Provider-specific options.
+            **kwargs: Provider-specific options. Recognized cross-provider kwargs:
+                engine: Optional DataFrameEngine instance. When provided,
+                    the result is converted to the engine's native format
+                    via ``engine.from_geodataframe()``. Default (None)
+                    returns a GeoDataFrame.
 
         Returns:
-            GeoDataFrame with boundary geometries.
+            GeoDataFrame when engine is None; engine-native DataFrame otherwise.
         """
 
     @abstractmethod
@@ -70,6 +74,16 @@ class BoundaryProvider(ABC):
     @abstractmethod
     def is_available(self) -> bool:
         """Return True if this provider's dependencies are installed and reachable."""
+
+    def _maybe_convert(self, gdf: Any, engine: Any = None) -> Any:
+        """Convert GeoDataFrame to engine-native format if engine is provided."""
+        if engine is None:
+            return gdf
+        logger.info(
+            "%s: converting result to %s engine format",
+            self.provider_name, getattr(engine, 'name', type(engine).__name__),
+        )
+        return engine.from_geodataframe(gdf)
 
 
 class CensusTIGERProvider(BoundaryProvider):
@@ -93,16 +107,18 @@ class CensusTIGERProvider(BoundaryProvider):
             identifier: State FIPS code when the level requires it.
             **kwargs: Forwarded to ``CensusDataSource.fetch_geographic_boundaries``
                       (e.g. ``year``, ``congress_number``).
+                      ``engine``: Optional DataFrameEngine for result conversion.
 
         Returns:
-            GeoDataFrame with boundary geometries.
+            GeoDataFrame (default) or engine-native DataFrame when engine is provided.
 
         Raises:
             BoundaryFetchError: When the boundary retrieval fails.
         """
         from ..spatial_data import CensusDataSource
 
-        kwargs.pop('geographic_level', None)  # level arg is authoritative
+        engine = kwargs.pop('engine', None)
+        kwargs.pop('geographic_level', None)
         call_kwargs: dict[str, Any] = {
             'geographic_level': level,
             **kwargs,
@@ -117,7 +133,7 @@ class CensusTIGERProvider(BoundaryProvider):
                 f"CensusTIGERProvider: boundary retrieval failed "
                 f"[{result.error_stage}] {result.message}"
             )
-        return result.geodataframe
+        return self._maybe_convert(result.geodataframe, engine)
 
     def list_levels(self) -> list[str]:
         """Return canonical Census geographic level names."""
@@ -210,14 +226,16 @@ class GADMProvider(BoundaryProvider):
             identifier: ISO-3 country code (e.g. 'DEU', 'FRA').
                         Can also be passed as ``country_code`` kwarg.
             **kwargs: ``country_code`` accepted as an alias for *identifier*.
+                      ``engine``: Optional DataFrameEngine for result conversion.
 
         Returns:
-            GeoDataFrame with boundary geometries.
+            GeoDataFrame (default) or engine-native DataFrame when engine is provided.
 
         Raises:
             ValueError: If *level* is unknown or *country_code* is missing.
             ImportError: If geopandas is not installed.
         """
+        engine = kwargs.pop('engine', None)
         country_code = kwargs.pop('country_code', None) or identifier
         if country_code is None:
             raise ValueError('GADMProvider.get_boundary() requires a country_code or identifier.')
@@ -242,7 +260,8 @@ class GADMProvider(BoundaryProvider):
             ) from e
 
         logger.info('Downloading GADM boundaries: %s', url)
-        return gpd.read_file(url)
+        gdf = gpd.read_file(url)
+        return self._maybe_convert(gdf, engine)
 
     def list_levels(self) -> list[str]:
         """Return GADM administrative levels."""
@@ -380,14 +399,17 @@ class RDHProvider(BoundaryProvider):
                 ``state`` — alias for *identifier*.
                 ``year`` — filter datasets by year string (e.g. ``'2022'``).
                 ``format`` — ``'shp'`` (default) or ``'csv'``.
+                ``engine`` — Optional DataFrameEngine for result conversion.
 
         Returns:
-            GeoDataFrame with boundary geometries (shapefiles) or None.
+            GeoDataFrame (default) or engine-native DataFrame when engine is provided.
+            None if no matching datasets found.
 
         Raises:
             ValueError: If *level* is not recognised or *state* is missing.
             ImportError: If geopandas is not installed.
         """
+        engine = kwargs.pop('engine', None)
         if level not in self._LEVELS:
             raise ValueError(
                 f"Unknown RDH level {level!r}. Choose from {self._LEVELS}."
@@ -436,10 +458,9 @@ class RDHProvider(BoundaryProvider):
             )
             return None
 
-        # Load the first matching dataset as a GeoDataFrame. Only shapefile
-        # formats are loadable; other formats would need a different reader.
         try:
-            return client.load_shapefile(datasets[0], **kwargs)
+            gdf = client.load_shapefile(datasets[0], **kwargs)
+            return self._maybe_convert(gdf, engine)
         except (OSError, ValueError) as exc:
             raise BoundaryFetchError(
                 f"RDHProvider: failed to load {level} shapefile for state={state}, "

--- a/tests/test_boundary_engine.py
+++ b/tests/test_boundary_engine.py
@@ -1,0 +1,228 @@
+"""Tests for boundary provider engine abstraction (#988).
+
+Tests the from_geodataframe() engine method and the engine= parameter
+on boundary providers. Uses synthetic GeoDataFrames to avoid network calls.
+"""
+
+import pytest
+import numpy as np
+import pandas as pd
+
+
+@pytest.fixture
+def sample_gdf():
+    """Create a minimal GeoDataFrame for testing engine conversion."""
+    gpd = pytest.importorskip("geopandas")
+    from shapely.geometry import box
+
+    return gpd.GeoDataFrame(
+        {"name": ["A", "B", "C"], "pop": [100, 200, 300]},
+        geometry=[box(0, 0, 1, 1), box(1, 0, 2, 1), box(2, 0, 3, 1)],
+        crs="EPSG:4326",
+    )
+
+
+# ---------------------------------------------------------------------------
+# DataFrameEngine.from_geodataframe — base class (default = passthrough)
+# ---------------------------------------------------------------------------
+
+class TestFromGeoDataFrameBase:
+
+    def test_base_returns_gdf_unchanged(self, sample_gdf):
+        gpd = pytest.importorskip("geopandas")
+        from siege_utilities.engines.dataframe_engine import PandasEngine
+
+        engine = PandasEngine()
+        result = engine.from_geodataframe(sample_gdf)
+        assert isinstance(result, gpd.GeoDataFrame)
+        assert len(result) == 3
+        assert list(result.columns) == list(sample_gdf.columns)
+
+
+# ---------------------------------------------------------------------------
+# DuckDBEngine.from_geodataframe
+# ---------------------------------------------------------------------------
+
+class TestDuckDBFromGeoDataFrame:
+
+    @pytest.fixture(autouse=True)
+    def _skip_without_duckdb(self):
+        pytest.importorskip("duckdb")
+
+    def test_returns_pandas_dataframe(self, sample_gdf):
+        from siege_utilities.engines.dataframe_engine import DuckDBEngine
+
+        engine = DuckDBEngine()
+        result = engine.from_geodataframe(sample_gdf)
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 3
+
+    def test_preserves_attribute_columns(self, sample_gdf):
+        from siege_utilities.engines.dataframe_engine import DuckDBEngine
+
+        engine = DuckDBEngine()
+        result = engine.from_geodataframe(sample_gdf)
+        assert "name" in result.columns
+        assert "pop" in result.columns
+
+    def test_has_geometry_column(self, sample_gdf):
+        from siege_utilities.engines.dataframe_engine import DuckDBEngine
+
+        engine = DuckDBEngine()
+        result = engine.from_geodataframe(sample_gdf)
+        assert "geometry" in result.columns
+
+    def test_no_wkb_helper_column(self, sample_gdf):
+        from siege_utilities.engines.dataframe_engine import DuckDBEngine
+
+        engine = DuckDBEngine()
+        result = engine.from_geodataframe(sample_gdf)
+        assert "_geom_wkb" not in result.columns
+
+    def test_empty_gdf(self):
+        gpd = pytest.importorskip("geopandas")
+        from siege_utilities.engines.dataframe_engine import DuckDBEngine
+
+        empty_gdf = gpd.GeoDataFrame(
+            {"name": pd.Series(dtype=str)},
+            geometry=gpd.GeoSeries([], crs="EPSG:4326"),
+        )
+        engine = DuckDBEngine()
+        result = engine.from_geodataframe(empty_gdf)
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 0
+
+
+# ---------------------------------------------------------------------------
+# BoundaryProvider._maybe_convert
+# ---------------------------------------------------------------------------
+
+class TestMaybeConvert:
+
+    def test_none_engine_returns_gdf(self, sample_gdf):
+        gpd = pytest.importorskip("geopandas")
+        from siege_utilities.geo.providers.boundary_providers import CensusTIGERProvider
+
+        provider = CensusTIGERProvider()
+        result = provider._maybe_convert(sample_gdf, engine=None)
+        assert isinstance(result, gpd.GeoDataFrame)
+        assert result is sample_gdf
+
+    def test_with_engine_converts(self, sample_gdf):
+        pytest.importorskip("duckdb")
+        from siege_utilities.engines.dataframe_engine import DuckDBEngine
+        from siege_utilities.geo.providers.boundary_providers import CensusTIGERProvider
+
+        engine = DuckDBEngine()
+        provider = CensusTIGERProvider()
+        result = provider._maybe_convert(sample_gdf, engine=engine)
+        assert isinstance(result, pd.DataFrame)
+        assert "name" in result.columns
+
+
+# ---------------------------------------------------------------------------
+# CensusTIGERProvider with engine (mocked fetch)
+# ---------------------------------------------------------------------------
+
+class TestCensusTIGERWithEngine:
+
+    @pytest.fixture(autouse=True)
+    def _mock_spatial_data_module(self):
+        """Inject a mock spatial_data module so CensusTIGERProvider's local
+        import resolves without bs4/requests/etc."""
+        import sys
+        from unittest.mock import MagicMock
+        key = "siege_utilities.geo.spatial_data"
+        already = key in sys.modules
+        if not already:
+            sys.modules[key] = MagicMock()
+        yield
+        if not already:
+            del sys.modules[key]
+
+    def test_engine_param_passes_through(self, sample_gdf):
+        pytest.importorskip("duckdb")
+        from unittest.mock import patch, MagicMock
+        from siege_utilities.engines.dataframe_engine import DuckDBEngine
+        from siege_utilities.geo.providers.boundary_providers import CensusTIGERProvider
+
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.geodataframe = sample_gdf
+
+        engine = DuckDBEngine()
+        provider = CensusTIGERProvider()
+
+        with patch(
+            "siege_utilities.geo.spatial_data.CensusDataSource"
+        ) as MockDS:
+            MockDS.return_value.fetch_geographic_boundaries.return_value = mock_result
+            result = provider.get_boundary("county", "06", engine=engine)
+
+        assert isinstance(result, pd.DataFrame)
+        assert "name" in result.columns
+        assert len(result) == 3
+
+    def test_no_engine_returns_gdf(self, sample_gdf):
+        gpd = pytest.importorskip("geopandas")
+        from unittest.mock import patch, MagicMock
+        from siege_utilities.geo.providers.boundary_providers import CensusTIGERProvider
+
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.geodataframe = sample_gdf
+
+        provider = CensusTIGERProvider()
+
+        with patch(
+            "siege_utilities.geo.spatial_data.CensusDataSource"
+        ) as MockDS:
+            MockDS.return_value.fetch_geographic_boundaries.return_value = mock_result
+            result = provider.get_boundary("county", "06")
+
+        assert isinstance(result, gpd.GeoDataFrame)
+
+    def test_fetch_failure_still_raises(self, sample_gdf):
+        pytest.importorskip("duckdb")
+        from unittest.mock import patch, MagicMock
+        from siege_utilities.engines.dataframe_engine import DuckDBEngine
+        from siege_utilities.geo.providers.boundary_providers import (
+            CensusTIGERProvider,
+            BoundaryFetchError,
+        )
+
+        mock_result = MagicMock()
+        mock_result.success = False
+        mock_result.error_stage = "download"
+        mock_result.message = "HTTP 404"
+
+        engine = DuckDBEngine()
+        provider = CensusTIGERProvider()
+
+        with patch(
+            "siege_utilities.geo.spatial_data.CensusDataSource"
+        ) as MockDS:
+            MockDS.return_value.fetch_geographic_boundaries.return_value = mock_result
+            with pytest.raises(BoundaryFetchError, match="HTTP 404"):
+                provider.get_boundary("county", "06", engine=engine)
+
+
+# ---------------------------------------------------------------------------
+# Roundtrip: from_geodataframe → to_geodataframe
+# ---------------------------------------------------------------------------
+
+class TestRoundtrip:
+
+    def test_duckdb_roundtrip_preserves_data(self, sample_gdf):
+        pytest.importorskip("duckdb")
+        gpd = pytest.importorskip("geopandas")
+        from siege_utilities.engines.dataframe_engine import DuckDBEngine
+
+        engine = DuckDBEngine()
+        duckdb_df = engine.from_geodataframe(sample_gdf)
+        roundtrip = engine.to_geodataframe(duckdb_df, geometry_col="geometry")
+
+        assert isinstance(roundtrip, gpd.GeoDataFrame)
+        assert len(roundtrip) == 3
+        assert list(roundtrip["name"]) == ["A", "B", "C"]
+        assert list(roundtrip["pop"]) == [100, 200, 300]


### PR DESCRIPTION
## Summary

Closes #988.

- Add `DataFrameEngine.from_geodataframe()` — inverse of `to_geodataframe()`. Base class returns GeoDataFrame unchanged (PandasEngine behavior). DuckDB override serializes geometry via WKB-hex → `ST_GeomFromWKB(UNHEX(...))` and returns a plain pandas DataFrame with DuckDB GEOMETRY column.
- Add `BoundaryProvider._maybe_convert()` helper — passthrough when `engine=None`, calls `engine.from_geodataframe()` otherwise.
- Wire `engine=` kwarg through `CensusTIGERProvider`, `GADMProvider`, and `RDHProvider`.
- Fix `DuckDBEngine.to_geodataframe()` bytearray handling — DuckDB `fetchdf()` returns `bytearray` for GEOMETRY columns, but shapely `wkb.loads()` only accepts `bytes`. Added coercion.

## Test plan

- [x] 12 new tests in `tests/test_boundary_engine.py` — all pass
- [x] `TestFromGeoDataFrameBase`: PandasEngine passthrough
- [x] `TestDuckDBFromGeoDataFrame` (5): type, columns, geometry column, no WKB leak, empty GDF
- [x] `TestMaybeConvert` (2): None engine passthrough, engine conversion
- [x] `TestCensusTIGERWithEngine` (3): engine param passthrough, no-engine returns GDF, fetch error still raises
- [x] `TestRoundtrip`: `from_geodataframe` → `to_geodataframe` preserves data
- [x] No regressions in `test_classification.py` (37 pass)