### PR TITLE
fix(#992): geo-expansion test-implementation mismatches

### DIFF
--- a/siege_utilities/geo/overlay_registry.py
+++ b/siege_utilities/geo/overlay_registry.py
@@ -137,7 +137,11 @@ class OverlayRegistry:
             return self._overlays[name]
 
         if name in self._classes:
-            instance = self._classes[name]()
+            try:
+                instance = self._classes[name]()
+            except Exception as exc:
+                log.warning("Failed to instantiate overlay %r: %s", name, exc)
+                return None
             self._overlays[name] = instance
             return instance
 

--- a/siege_utilities/geo/place_history.py
+++ b/siege_utilities/geo/place_history.py
@@ -396,7 +396,7 @@ def place_history(
                 result.overlays[name] = overlay_impl.fetch(
                     geoid, from_year, to_year, state_fips
                 )
-            except (ValueError, TypeError, KeyError, AttributeError, OSError) as exc:
+            except Exception as exc:
                 result.errors.append(f"Overlay '{name}' failed: {exc}")
                 log.warning("Overlay %s failed for %s: %s", name, geoid, exc)
 

--- a/siege_utilities/geo/precinct_vtd.py
+++ b/siege_utilities/geo/precinct_vtd.py
@@ -441,7 +441,7 @@ class PrecinctVTDReconciler:
             try:
                 overlaps = self._spatial.compute_overlaps(precinct_ids)
                 spatial_mappings = reconcile_spatial(overlaps)
-            except (ValueError, TypeError, KeyError, AttributeError, OSError) as exc:
+            except Exception as exc:
                 errors.append(f"Spatial reconciliation error: {exc}")
 
         if self._names is not None:

--- a/siege_utilities/geo/rdh_catalog.py
+++ b/siege_utilities/geo/rdh_catalog.py
@@ -260,7 +260,8 @@ class RDHCatalog:
             return len(self._entries)
 
         if self._provider is None:
-            raise RuntimeError("No provider configured; cannot load catalog")
+            log.warning("No provider configured; catalog is empty")
+            return 0
 
         entries = self._provider.fetch_all_datasets()
         self._entries = entries

--- a/tests/test_census_catalog.py
+++ b/tests/test_census_catalog.py
@@ -223,7 +223,8 @@ class TestCensusCatalog:
         cat.add_tables(mixed_tables)
         geo = cat.geography_for_table("B01003")
         assert "block_group" in geo
-        assert cat.geography_for_table("NONEXISTENT") == []
+        with pytest.raises(KeyError, match="NONEXISTENT"):
+            cat.geography_for_table("NONEXISTENT")
 
     def test_build_families(self, mixed_tables):
         cat = CensusCatalog()


### PR DESCRIPTION
## Summary

Closes #992.

- Widen exception catch to `Exception` in 3 pluggable-provider catch clauses (overlay fetch, overlay instantiation, spatial reconciliation) — narrow tuple `(ValueError, TypeError, ...)` missed `RuntimeError` from test fixtures and any other exception type pluggable code might throw.
- Return 0 from `RDHCatalog.load()` when no provider configured instead of raising.
- Fix `test_geography_for_table` to expect `KeyError` (matching implementation docstring).

## Test plan

- [x] 469 geo-expansion tests pass (was 5 failures)
- [x] 49 boundary/classification tests pass (no regressions)
- [x] 35 skipped (expected — optional dependencies)