### PR TITLE
fix(#867): validate method param in classify_polygon

### DIFF
--- a/plans/self-review-867.md
+++ b/plans/self-review-867.md
@@ -1,0 +1,58 @@
+# Self-Review: fix(#867) validate method parameter in classify_polygon/classify_polygons
+
+## Assumptions
+Domain(s): software engineering
+Geospatial cross-cut: yes
+Goal source: ticket #867
+Goal source verification: PASS — ticket #867 states classify_polygon accepts invalid method strings without error
+Plan reference: https://github.com/siege-analytics/siege_utilities/issues/867#issuecomment-4609896803
+Pre-author-inventory: NONE
+Investigate-artifact: TRIVIAL
+Pre-mortem-artifact: TRIVIAL
+
+Trivial-against-state: the change adds a validation guard at method entry; it does not modify data-shape, config-state, topology, plan-shape, or version-resolution.
+
+## Trivial-investigation declaration
+
+Category: single-line-fix
+Cannot produce error: the change adds a frozenset check before any computation runs; no existing data flow is altered, only invalid inputs are rejected earlier.
+Evidence: `git diff --stat HEAD~1` → 2 files changed: locale.py (+16), test_locale.py (+37). All additions are validation guards and tests.
+Falsification: a valid method string that should be accepted is rejected by the frozenset check.
+
+## Peer review (Junior's checklist)
+
+### Correctness
+- `_VALID_METHODS = frozenset({"area_weighted", "majority", "distribution"})` matches the three methods documented in the docstrings and used downstream.
+- Validation placed at top of both `classify_polygon()` (line 550) and `classify_polygons()` (line 633), before any computation.
+- `ValueError` with descriptive message including the bad value and valid options.
+
+### Tests
+- 3 tests in `TestClassifyPolygonMethodValidation`: rejects "invalid", rejects typo "majoriy", rejects "mean" on bulk method.
+- All 3 pass: `python -m pytest tests/test_locale.py::TestClassifyPolygonMethodValidation -v` → 3 passed.
+
+### Syntax check
+- `git diff --name-only HEAD~1 | grep '\.py$' | xargs -I{} python3 -c "import ast; ast.parse(open('{}').read()"` → All files parse OK.
+
+### Existing tests
+- No existing tests broken — the valid methods ("majority", "distribution", "area_weighted") are unaffected by the guard.
+
+## Lead review
+
+Domain: software engineering + geospatial cross-cut.
+
+The Junior's implementation is correct. The frozenset is defined once at module level, checked at method entry, raises before any GeoDataFrame work starts. The three valid methods match the docstring and the if/elif branches downstream.
+
+Approach-fit: correct — fail-fast validation at entry point, not deep in computation. No blast radius: existing valid calls pass through unchanged.
+
+Sequencing assumption: none — this is a pure input validation addition.
+
+Affirmative standard (geospatial): the validation sits above CRS operations, so no geospatial concern. The test fixture correctly uses EPSG:4269 (NAD83) for the UA layer, matching Census convention.
+
+## Quantified claims
+
+- "3 tests pass" — `python -m pytest tests/test_locale.py::TestClassifyPolygonMethodValidation -v --tb=short --override-ini="addopts="` → 3 passed in 0.42s
+- "2 files changed" — `git diff --stat HEAD~1` → siege_utilities/geo/locale.py | 16 +++, tests/test_locale.py | 37 +++
+
+## Evidence-predates-work
+Artifact: plans/self-review-867.md
+Work commit: 07fb087c0e3c422d1312ac46dcfa519fceb490be

--- a/siege_utilities/geo/locale.py
+++ b/siege_utilities/geo/locale.py
@@ -29,6 +29,8 @@ from siege_utilities.config.nces_constants import (
 
 log = logging.getLogger(__name__)
 
+_VALID_METHODS = frozenset({"area_weighted", "majority", "distribution"})
+
 __all__ = [
     "CITY_LARGE",
     "CITY_MIDSIZE",
@@ -541,7 +543,14 @@ class NCESLocaleClassifier:
             If ``method="majority"``: ``{"locale_code": 21, "locale_label": "..."}``
             If ``method="distribution"`` or ``"area_weighted"``: dict of
             ``{code: fraction}`` pairs summing to ~1.0.
+
+        Raises:
+            ValueError: If *method* is not one of the valid options.
         """
+        if method not in _VALID_METHODS:
+            raise ValueError(
+                f"Invalid method {method!r}; must be one of {sorted(_VALID_METHODS)}"
+            )
         import geopandas as gpd
 
         self._ensure_projected()
@@ -617,7 +626,14 @@ class NCESLocaleClassifier:
 
         Returns:
             The input GeoDataFrame with locale columns added.
+
+        Raises:
+            ValueError: If *method* is not one of the valid options.
         """
+        if method not in _VALID_METHODS:
+            raise ValueError(
+                f"Invalid method {method!r}; must be one of {sorted(_VALID_METHODS)}"
+            )
         gdf = gdf.copy()
 
         if method == "majority":

--- a/tests/test_locale.py
+++ b/tests/test_locale.py
@@ -694,3 +694,40 @@ class TestFromCensusYearHelpers:
         """_UA_POP_THRESHOLD should be 50,000."""
         from siege_utilities.geo.locale import _UA_POP_THRESHOLD
         assert _UA_POP_THRESHOLD == 50_000
+
+
+class TestClassifyPolygonMethodValidation:
+    """classify_polygon and classify_polygons reject invalid method strings (#867)."""
+
+    @pytest.fixture()
+    def classifier(self):
+        ua = gpd.GeoDataFrame(
+            {"UACE20": ["00001"]},
+            geometry=[box(-98.5, 29.5, -97.5, 30.5)],
+            crs="EPSG:4269",
+        )
+        empty = gpd.GeoDataFrame(columns=["geometry"], geometry="geometry", crs="EPSG:4269")
+        return NCESLocaleClassifier(
+            urbanized_areas=ua,
+            urban_clusters=empty,
+            principal_cities=empty,
+            place_populations={},
+            ua_populations={"00001": 500_000},
+        )
+
+    def test_classify_polygon_rejects_invalid(self, classifier):
+        poly = box(-98.0, 30.0, -97.9, 30.1)
+        with pytest.raises(ValueError, match="Invalid method"):
+            classifier.classify_polygon(poly, method="invalid")
+
+    def test_classify_polygon_rejects_typo(self, classifier):
+        poly = box(-98.0, 30.0, -97.9, 30.1)
+        with pytest.raises(ValueError, match="Invalid method"):
+            classifier.classify_polygon(poly, method="majoriy")
+
+    def test_classify_polygons_rejects_invalid(self, classifier):
+        gdf = gpd.GeoDataFrame(
+            {"id": [1]}, geometry=[box(-98.0, 30.0, -97.9, 30.1)], crs="EPSG:4326"
+        )
+        with pytest.raises(ValueError, match="Invalid method"):
+            classifier.classify_polygons(gdf, method="mean")


### PR DESCRIPTION
## Summary

- Adds `_VALID_METHODS` frozenset (`area_weighted`, `majority`, `distribution`) at module level in `locale.py`
- Guards both `classify_polygon()` and `classify_polygons()` with `ValueError` on invalid method strings
- 3 new tests covering invalid value, typo, and bulk-method rejection

Closes #867

## Test plan

- [x] `TestClassifyPolygonMethodValidation::test_classify_polygon_rejects_invalid` — passes
- [x] `TestClassifyPolygonMethodValidation::test_classify_polygon_rejects_typo` — passes
- [x] `TestClassifyPolygonMethodValidation::test_classify_polygons_rejects_invalid` — passes
- [x] Existing locale tests unaffected (valid methods unchanged)

Self-Review: plans/self-review-867.md