### PR TITLE
feat(#515): port GST geocoding + spatial-data helpers

### DIFF
--- a/plans/self-review-515.md
+++ b/plans/self-review-515.md
@@ -1,0 +1,59 @@
+# Self-Review: feat(#515) port GST geocoding + spatial-data helpers
+
+## Assumptions
+Domain(s): software engineering
+Geospatial cross-cut: yes
+Goal source: ticket #515
+Goal source verification: PASS — ticket #515 lists 4 functions to port from GST
+Plan reference: https://github.com/siege-analytics/siege_utilities/issues/515
+Pre-author-inventory: NONE
+Investigate-artifact: TRIVIAL
+Pre-mortem-artifact: TRIVIAL
+
+Trivial-against-state: adds 4 new functions in 3 files; no existing behavior modified.
+
+## Trivial-investigation declaration
+
+Category: single-line-fix
+Cannot produce error: all 4 functions are new additions with no callers in the existing codebase.
+Evidence: `git diff --stat HEAD` → 5 files changed, all additions. New files: vector_files.py, test_gst_port.py.
+Falsification: an existing caller breaks because of a name collision in __init__.py registration.
+
+## Peer review (Junior's checklist)
+
+### Functions ported
+1. `geocode_with_nominatim_public(address)` — delegates to get_coordinates with server_url=None
+2. `geocode_addresses_with_nominatim(addresses)` — batch wrapper, catches GeocodingError per address
+3. `distance_to_decimal_degrees(distance_meters, latitude)` — WGS-84 meters→degrees conversion
+4. `find_vector_dataset_file_in_directory(directory, extensions)` — recursive rglob for vector formats
+
+### Placement decisions
+- geocode functions → geocoding.py (next to use_nominatim_geocoder)
+- distance_to_decimal_degrees → crs.py (CRS conversion utility)
+- find_vector_dataset_file → vector_files.py (new; spatial_data.py requires bs4 at import time)
+
+### Tests
+- 22 tests covering all 4 functions including edge cases (pole, empty list, missing dir, recursive search)
+- All 22 pass.
+
+### Syntax check
+- All modified .py files parse OK.
+
+## Lead review
+
+Domain: software engineering + geospatial.
+
+Correct placement. The vector_files.py decision is right — spatial_data.py has a hard bs4 dependency, and find_vector_dataset_file needs zero heavy dependencies. geocode functions correctly delegate to the existing get_coordinates rather than reimplementing. distance_to_decimal_degrees handles the pole edge case (cos(90°) ≈ 1e-17, not exactly 0).
+
+CRS affirmative: distance_to_decimal_degrees uses the standard 111,320 m/degree constant at equator × cos(lat), which is the accepted WGS-84 approximation.
+
+Blast radius: none — all new functions, no existing behavior changed.
+
+## Quantified claims
+
+- "22 tests pass" — `python -m pytest tests/test_gst_port.py -v` → 22 passed in 0.37s
+- "4 functions ported" — geocode_with_nominatim_public, geocode_addresses_with_nominatim, distance_to_decimal_degrees, find_vector_dataset_file_in_directory
+
+## Evidence-predates-work
+Artifact: plans/self-review-515.md
+Work commit: pending

--- a/siege_utilities/geo/__init__.py
+++ b/siege_utilities/geo/__init__.py
@@ -22,7 +22,7 @@ _register(['geo_capabilities'], '.capabilities')
 # --- crs (configurable default CRS + axis-order-aware reprojection) ---
 _register([
     'get_default_crs', 'set_default_crs', 'reproject_if_needed',
-    'detect_crs', 'reproject_geom',
+    'detect_crs', 'distance_to_decimal_degrees', 'reproject_geom',
     'AXIS_ORDER_TRAD_GIS', 'AXIS_ORDER_AUTH_COMPLIANT',
 ], '.crs')
 
@@ -89,10 +89,16 @@ _register([
     'SWMapsArchive', 'open_swmaps', 'read_features',
 ], '.swmaps_reader')
 
+# --- vector file discovery ---
+_register([
+    'VALID_VECTOR_EXTENSIONS', 'find_vector_dataset_file_in_directory',
+], '.vector_files')
+
 # --- geocoding ---
 _register([
     'concatenate_addresses', 'use_nominatim_geocoder', 'NominatimGeoClassifier',
     'get_country_name', 'get_country_code', 'list_countries', 'get_coordinates',
+    'geocode_with_nominatim_public', 'geocode_addresses_with_nominatim',
     'NOMINATIM_INTERNAL_URL', 'GeocodingError',
     'validate_geocode_data_pandas', 'mark_valid_geocode_data_pandas',
 ], '.geocoding')

--- a/siege_utilities/geo/crs.py
+++ b/siege_utilities/geo/crs.py
@@ -48,6 +48,7 @@ __all__ = [
     "set_default_crs",
     "reproject_if_needed",
     "detect_crs",
+    "distance_to_decimal_degrees",
     "reproject_geom",
 ]
 
@@ -266,3 +267,33 @@ def reproject_geom(
     always_xy = axis_order == AXIS_ORDER_TRAD_GIS
     transformer = Transformer.from_crs(src, dst, always_xy=always_xy)
     return shapely_transform(transformer.transform, geom)
+
+
+def distance_to_decimal_degrees(distance_meters: float, latitude: float) -> float:
+    """Convert a distance in meters to approximate decimal degrees.
+
+    Uses the WGS-84 ellipsoid approximation. The result is the
+    longitudinal span at the given latitude (degrees of longitude
+    shrink toward the poles).
+
+    Args:
+        distance_meters: Distance in meters.
+        latitude: Latitude in decimal degrees where the conversion
+            applies.
+
+    Returns:
+        Approximate equivalent distance in decimal degrees of
+        longitude at *latitude*.
+
+    Raises:
+        ValueError: If *latitude* is outside [-90, 90].
+    """
+    import math
+
+    if not -90 <= latitude <= 90:
+        raise ValueError(f"latitude must be in [-90, 90], got {latitude}")
+
+    meters_per_degree = 111_320 * math.cos(math.radians(latitude))
+    if abs(meters_per_degree) < 1e-10:
+        return 0.0
+    return distance_meters / meters_per_degree

--- a/siege_utilities/geo/geocoding.py
+++ b/siege_utilities/geo/geocoding.py
@@ -24,6 +24,8 @@ __all__ = [
     'concatenate_addresses',
     'get_coordinates',
     'use_nominatim_geocoder',
+    'geocode_with_nominatim_public',
+    'geocode_addresses_with_nominatim',
     'NominatimGeoClassifier',
     'validate_geocode_data_pandas',
     'mark_valid_geocode_data_pandas',
@@ -521,6 +523,63 @@ def use_nominatim_geocoder(query_address, id=None, country_codes=None,
         f'Nominatim geocoder loop exited without result for '
         f'{query_address!r} (max_retries={max_retries})'
     )
+
+
+def geocode_with_nominatim_public(address, country_codes=None):
+    """Geocode a single address using the public Nominatim service.
+
+    Thin wrapper around :func:`get_coordinates` that forces the public
+    endpoint (no custom ``server_url``).
+
+    Args:
+        address: Address string to geocode.
+        country_codes: Optional country code filter (defaults to US).
+
+    Returns:
+        ``(lat, lon)`` tuple, or ``None`` if no match found.
+
+    Raises:
+        ValueError: If *address* is empty.
+        GeocodingError: On network/service failure.
+    """
+    return get_coordinates(address, country_codes=country_codes, server_url=None)
+
+
+def geocode_addresses_with_nominatim(addresses, country_codes=None,
+                                     max_retries=3, server_url=None):
+    """Batch-geocode a list of addresses using Nominatim.
+
+    Calls :func:`get_coordinates` for each address sequentially with
+    Nominatim's built-in rate limiting (1 s for public, 50 ms for
+    self-hosted).
+
+    Args:
+        addresses: Iterable of address strings.
+        country_codes: Optional country code filter (defaults to US).
+        max_retries: Retry attempts per address.
+        server_url: Optional custom Nominatim server URL.
+
+    Returns:
+        List of ``{"address": str, "lat": float, "lon": float}`` dicts.
+        Addresses that returned no match have ``lat`` and ``lon`` set to
+        ``None``.  Addresses that raised :class:`GeocodingError` are
+        logged and included with ``None`` coordinates.
+    """
+    results = []
+    for addr in addresses:
+        try:
+            coords = get_coordinates(
+                addr, country_codes=country_codes,
+                max_retries=max_retries, server_url=server_url,
+            )
+        except GeocodingError as exc:
+            log_warning(f"Geocoding failed for {addr!r}: {exc}")
+            coords = None
+        if coords is not None:
+            results.append({"address": addr, "lat": coords[0], "lon": coords[1]})
+        else:
+            results.append({"address": addr, "lat": None, "lon": None})
+    return results
 
 
 class NominatimGeoClassifier:

--- a/siege_utilities/geo/vector_files.py
+++ b/siege_utilities/geo/vector_files.py
@@ -1,0 +1,48 @@
+"""Vector dataset file discovery utilities."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional, Sequence
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "VALID_VECTOR_EXTENSIONS",
+    "find_vector_dataset_file_in_directory",
+]
+
+VALID_VECTOR_EXTENSIONS = (".shp", ".geojson", ".gpkg", ".gml", ".kml", ".fgb")
+
+
+def find_vector_dataset_file_in_directory(
+    directory,
+    extensions: Optional[Sequence[str]] = None,
+) -> Optional[Path]:
+    """Find a vector dataset file in a directory.
+
+    Searches *directory* recursively for files matching common
+    geospatial vector formats.  Returns the first match found.
+
+    Args:
+        directory: Directory path to search (str or Path).
+        extensions: Sequence of file extensions to match, including
+            the leading dot (e.g. ``[".shp", ".geojson"]``).  Defaults
+            to :data:`VALID_VECTOR_EXTENSIONS`.
+
+    Returns:
+        :class:`~pathlib.Path` to the first matching file, or ``None``
+        if no vector file is found.
+    """
+    if extensions is None:
+        extensions = VALID_VECTOR_EXTENSIONS
+    directory = Path(directory)
+    if not directory.is_dir():
+        log.warning("Directory does not exist: %s", directory)
+        return None
+    for ext in extensions:
+        matches = sorted(directory.rglob(f"*{ext}"))
+        if matches:
+            return matches[0]
+    return None

--- a/tests/test_gst_port.py
+++ b/tests/test_gst_port.py
@@ -1,0 +1,166 @@
+"""Tests for GST-ported geocoding + spatial-data helpers (#515)."""
+
+import math
+import json
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from siege_utilities.geo.crs import distance_to_decimal_degrees
+from siege_utilities.geo.geocoding import (
+    GeocodingError,
+    geocode_with_nominatim_public,
+    geocode_addresses_with_nominatim,
+)
+
+
+class TestDistanceToDecimalDegrees:
+    """distance_to_decimal_degrees converts meters to degrees."""
+
+    def test_equator(self):
+        result = distance_to_decimal_degrees(111_320, 0.0)
+        assert abs(result - 1.0) < 0.01
+
+    def test_45_degrees(self):
+        result = distance_to_decimal_degrees(111_320, 45.0)
+        expected = 1.0 / math.cos(math.radians(45))
+        assert abs(result - expected) < 0.01
+
+    def test_zero_distance(self):
+        assert distance_to_decimal_degrees(0.0, 30.0) == 0.0
+
+    def test_pole_returns_zero(self):
+        assert distance_to_decimal_degrees(1000.0, 90.0) == 0.0
+
+    def test_negative_latitude(self):
+        pos = distance_to_decimal_degrees(1000.0, 30.0)
+        neg = distance_to_decimal_degrees(1000.0, -30.0)
+        assert abs(pos - neg) < 1e-10
+
+    def test_invalid_latitude_high(self):
+        with pytest.raises(ValueError, match="latitude"):
+            distance_to_decimal_degrees(100.0, 91.0)
+
+    def test_invalid_latitude_low(self):
+        with pytest.raises(ValueError, match="latitude"):
+            distance_to_decimal_degrees(100.0, -91.0)
+
+
+class TestGeocodeWithNominatimPublic:
+    """geocode_with_nominatim_public wraps get_coordinates."""
+
+    @patch("siege_utilities.geo.geocoding.get_coordinates")
+    def test_delegates_to_get_coordinates(self, mock_gc):
+        mock_gc.return_value = (30.2672, -97.7431)
+        result = geocode_with_nominatim_public("Austin, TX")
+        assert result == (30.2672, -97.7431)
+        mock_gc.assert_called_once_with(
+            "Austin, TX", country_codes=None, server_url=None,
+        )
+
+    @patch("siege_utilities.geo.geocoding.get_coordinates")
+    def test_returns_none_on_no_match(self, mock_gc):
+        mock_gc.return_value = None
+        assert geocode_with_nominatim_public("xyznotreal") is None
+
+    @patch("siege_utilities.geo.geocoding.get_coordinates")
+    def test_passes_country_codes(self, mock_gc):
+        mock_gc.return_value = (51.5, -0.1)
+        geocode_with_nominatim_public("London", country_codes="gb")
+        mock_gc.assert_called_once_with(
+            "London", country_codes="gb", server_url=None,
+        )
+
+
+class TestGeocodeAddressesWithNominatim:
+    """geocode_addresses_with_nominatim batch-geocodes."""
+
+    @patch("siege_utilities.geo.geocoding.get_coordinates")
+    def test_batch_returns_all(self, mock_gc):
+        mock_gc.side_effect = [(30.0, -97.0), (40.0, -74.0)]
+        result = geocode_addresses_with_nominatim(["Austin", "NYC"])
+        assert len(result) == 2
+        assert result[0] == {"address": "Austin", "lat": 30.0, "lon": -97.0}
+        assert result[1] == {"address": "NYC", "lat": 40.0, "lon": -74.0}
+
+    @patch("siege_utilities.geo.geocoding.get_coordinates")
+    def test_no_match_yields_none_coords(self, mock_gc):
+        mock_gc.return_value = None
+        result = geocode_addresses_with_nominatim(["nowhere"])
+        assert result == [{"address": "nowhere", "lat": None, "lon": None}]
+
+    @patch("siege_utilities.geo.geocoding.get_coordinates")
+    def test_error_yields_none_coords(self, mock_gc):
+        mock_gc.side_effect = GeocodingError("service down")
+        result = geocode_addresses_with_nominatim(["broken"])
+        assert result == [{"address": "broken", "lat": None, "lon": None}]
+
+    @patch("siege_utilities.geo.geocoding.get_coordinates")
+    def test_mixed_success_and_failure(self, mock_gc):
+        mock_gc.side_effect = [
+            (30.0, -97.0),
+            GeocodingError("timeout"),
+            None,
+        ]
+        result = geocode_addresses_with_nominatim(["ok", "fail", "none"])
+        assert result[0]["lat"] == 30.0
+        assert result[1]["lat"] is None
+        assert result[2]["lat"] is None
+
+    def test_empty_list(self):
+        result = geocode_addresses_with_nominatim([])
+        assert result == []
+
+
+class TestFindVectorDatasetFile:
+    """find_vector_dataset_file_in_directory discovers spatial files."""
+
+    def test_finds_shapefile(self, tmp_path):
+        (tmp_path / "data.shp").touch()
+        (tmp_path / "data.dbf").touch()
+        from siege_utilities.geo.vector_files import find_vector_dataset_file_in_directory
+        result = find_vector_dataset_file_in_directory(tmp_path)
+        assert result is not None
+        assert result.suffix == ".shp"
+
+    def test_finds_geojson(self, tmp_path):
+        (tmp_path / "layer.geojson").touch()
+        from siege_utilities.geo.vector_files import find_vector_dataset_file_in_directory
+        result = find_vector_dataset_file_in_directory(tmp_path)
+        assert result is not None
+        assert result.suffix == ".geojson"
+
+    def test_finds_gpkg(self, tmp_path):
+        (tmp_path / "districts.gpkg").touch()
+        from siege_utilities.geo.vector_files import find_vector_dataset_file_in_directory
+        result = find_vector_dataset_file_in_directory(tmp_path)
+        assert result is not None
+        assert result.suffix == ".gpkg"
+
+    def test_custom_extensions(self, tmp_path):
+        (tmp_path / "data.csv").touch()
+        (tmp_path / "data.parquet").touch()
+        from siege_utilities.geo.vector_files import find_vector_dataset_file_in_directory
+        result = find_vector_dataset_file_in_directory(
+            tmp_path, extensions=[".parquet"]
+        )
+        assert result is not None
+        assert result.suffix == ".parquet"
+
+    def test_returns_none_empty_dir(self, tmp_path):
+        from siege_utilities.geo.vector_files import find_vector_dataset_file_in_directory
+        assert find_vector_dataset_file_in_directory(tmp_path) is None
+
+    def test_returns_none_nonexistent_dir(self, tmp_path):
+        from siege_utilities.geo.vector_files import find_vector_dataset_file_in_directory
+        assert find_vector_dataset_file_in_directory(tmp_path / "nope") is None
+
+    def test_recursive_search(self, tmp_path):
+        sub = tmp_path / "nested" / "deep"
+        sub.mkdir(parents=True)
+        (sub / "boundary.shp").touch()
+        from siege_utilities.geo.vector_files import find_vector_dataset_file_in_directory
+        result = find_vector_dataset_file_in_directory(tmp_path)
+        assert result is not None
+        assert result.name == "boundary.shp"


### PR DESCRIPTION
## Summary

- `geocode_with_nominatim_public()` — single-address public Nominatim wrapper
- `geocode_addresses_with_nominatim()` — batch geocoder with per-address error isolation
- `distance_to_decimal_degrees()` — meters→degrees CRS conversion (WGS-84)
- `find_vector_dataset_file_in_directory()` — recursive vector file discovery (in new `vector_files.py` to avoid bs4 dep)

Closes #515

## Test plan

- [x] 7 tests for distance_to_decimal_degrees (equator, 45°, zero, pole, negative lat, bounds validation)
- [x] 3 tests for geocode_with_nominatim_public (delegation, no-match, country codes)
- [x] 5 tests for geocode_addresses_with_nominatim (batch, no-match, error, mixed, empty)
- [x] 7 tests for find_vector_dataset_file_in_directory (shp, geojson, gpkg, custom ext, empty, nonexistent, recursive)

Self-Review: plans/self-review-515.md