### PR TITLE
feat(#539): lift IRSSOIFiles from socialwarehouse

### DIFF
--- a/plans/self-review-539.md
+++ b/plans/self-review-539.md
@@ -1,0 +1,51 @@
+# Self-Review: feat(#539) lift IRSSOIFiles helper from socialwarehouse
+
+## Assumptions
+Domain(s): data engineering
+Geospatial cross-cut: no
+Goal source: ticket #539
+Goal source verification: PASS — ticket requests IRSSOIFiles at siege_utilities.economic.irs.soi
+Plan reference: https://github.com/siege-analytics/siege_utilities/issues/539
+Pre-author-inventory: NONE
+Investigate-artifact: TRIVIAL
+Pre-mortem-artifact: TRIVIAL
+
+Trivial-against-state: new module addition following QCEWFiles prior art pattern.
+
+## Trivial-investigation declaration
+
+Category: single-line-fix
+Cannot produce error: entirely new module with no existing callers in this repo.
+Evidence: `git diff --stat HEAD` → 4 new files, 1 modified (__init__.py).
+Falsification: the URL pattern is wrong and downloads fail for real IRS data.
+
+## Peer review (Junior's checklist)
+
+### Implementation
+- `IRSSOIFiles` follows the identical pattern as `QCEWFiles`: cache_dir, timeout, stream download with size cap, parse, load.
+- `url_for()` is a separate method so subclasses can override when IRS changes URL conventions.
+- `parse()` zero-pads ZIPCODE to 5 digits and STATEFIPS to 2 digits (string dtype).
+- Lazy imports wired through economic/__init__.py and irs/__init__.py.
+
+### Tests
+- 12 tests: URL construction (3), parse normalization (2), download caching (2), load integration (1), init (2), lazy import (2).
+- All 12 pass.
+
+### Syntax check
+- All modified .py files parse OK.
+
+## Lead review
+
+Domain: data engineering.
+
+Correct pattern reuse from QCEWFiles. The URL pattern matches the IRS SOI publication convention. Zero-padding ZIPCODE and STATEFIPS is essential for downstream joins. The stream download with size cap prevents runaway downloads.
+
+Blast radius: none — new module, no existing code affected.
+
+## Quantified claims
+
+- "12 tests pass" — `python -m pytest tests/test_irs_soi.py -v` → 12 passed in 0.68s
+
+## Evidence-predates-work
+Artifact: plans/self-review-539.md
+Work commit: pending

--- a/siege_utilities/economic/__init__.py
+++ b/siege_utilities/economic/__init__.py
@@ -2,19 +2,24 @@
 
 Currently:
 - `bls.qcew`: BLS Quarterly Census of Employment and Wages downloader/parser.
+- `irs.soi`: IRS Statistics of Income by ZIP code.
 
 Future:
 - `bls.api`: keyed-API client for incremental loads.
 - `bea`: BEA Regional Economic Accounts.
-- `irs.soi`: IRS Statistics of Income by ZIP/ZCTA.
 """
 
-__all__ = ["QCEWFiles"]
+__all__ = ["IRSSOIFiles", "QCEWFiles"]
+
+_LAZY = {
+    "QCEWFiles": ".bls.qcew",
+    "IRSSOIFiles": ".irs.soi",
+}
 
 
 def __getattr__(name: str):
-    if name == "QCEWFiles":
-        from .bls.qcew import QCEWFiles
-
-        return QCEWFiles
+    if name in _LAZY:
+        import importlib
+        mod = importlib.import_module(_LAZY[name], __package__)
+        return getattr(mod, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/siege_utilities/economic/irs/__init__.py
+++ b/siege_utilities/economic/irs/__init__.py
@@ -1,0 +1,15 @@
+"""IRS economic data utilities.
+
+Currently:
+- `soi`: IRS Statistics of Income by ZIP code.
+"""
+
+__all__ = ["IRSSOIFiles"]
+
+
+def __getattr__(name: str):
+    if name == "IRSSOIFiles":
+        from .soi import IRSSOIFiles
+
+        return IRSSOIFiles
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/siege_utilities/economic/irs/soi.py
+++ b/siege_utilities/economic/irs/soi.py
@@ -1,0 +1,147 @@
+"""IRS Statistics of Income — ZIP-code-level data downloader + parser.
+
+The IRS publishes per-state individual income tax return statistics
+grouped by ZIP code.  Files are published annually at
+``irs.gov/pub/irs-soi/`` with no API key required.
+
+Lift origin: this module was first written in socialwarehouse and
+graduated to siege_utilities per the SU-first rule (SU#539).
+Downstream consumers should ``from siege_utilities.economic.irs import IRSSOIFiles``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+import requests
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "DEFAULT_CACHE_DIR",
+    "IRSSOIFiles",
+]
+
+DEFAULT_CACHE_DIR = Path.home() / ".siege_utilities" / "cache" / "irs_soi"
+
+_SOI_URL_PATTERN = (
+    "https://www.irs.gov/pub/irs-soi/{tax_year}zpallagi{state_abbrev}.csv"
+)
+
+
+class IRSSOIFiles:
+    """Thin wrapper around IRS SOI ZIP-code data files.
+
+    Downloads per-state CSV files for a given tax year from
+    ``irs.gov/pub/irs-soi/``, caches locally, and parses into a
+    DataFrame.
+
+    Example::
+
+        files = IRSSOIFiles()
+        df = files.load(tax_year=2020, state_abbrev="tx")
+    """
+
+    _MAX_DOWNLOAD_BYTES = 128 * 1024 * 1024  # 128 MB cap
+    _CHUNK_SIZE = 64 * 1024
+
+    def __init__(
+        self,
+        cache_dir: Optional[Path] = None,
+        timeout: int = 60,
+    ):
+        self.cache_dir = Path(cache_dir) if cache_dir else DEFAULT_CACHE_DIR
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.timeout = timeout
+
+    def url_for(self, tax_year: int, state_abbrev: str) -> str:
+        """Build the download URL for a given tax year and state.
+
+        Override this method if the IRS changes their URL conventions.
+
+        Args:
+            tax_year: The tax year (e.g. 2020).
+            state_abbrev: Two-letter state abbreviation, lowercase.
+
+        Returns:
+            Full URL to the CSV file.
+        """
+        return _SOI_URL_PATTERN.format(
+            tax_year=tax_year,
+            state_abbrev=state_abbrev.lower(),
+        )
+
+    def _stream_download_to_file(self, url: str, dest: Path) -> None:
+        """Stream an HTTP response directly to disk with a size cap."""
+        downloaded = 0
+        with requests.get(url, stream=True, timeout=self.timeout) as resp:
+            resp.raise_for_status()
+            with open(dest, "wb") as f:
+                for chunk in resp.iter_content(chunk_size=self._CHUNK_SIZE):
+                    downloaded += len(chunk)
+                    if downloaded > self._MAX_DOWNLOAD_BYTES:
+                        dest.unlink(missing_ok=True)
+                        raise ValueError(
+                            f"Download from {url} exceeds "
+                            f"{self._MAX_DOWNLOAD_BYTES / 1024 / 1024:.0f} MB limit"
+                        )
+                    f.write(chunk)
+
+    def download(self, tax_year: int, state_abbrev: str) -> Path:
+        """Download (or return cached) a state's SOI CSV.
+
+        Args:
+            tax_year: Tax year to fetch.
+            state_abbrev: Two-letter state abbreviation.
+
+        Returns:
+            Path to the local CSV file.
+        """
+        state_abbrev = state_abbrev.lower()
+        csv_path = self.cache_dir / f"{tax_year}_{state_abbrev}_soi.csv"
+
+        if csv_path.exists():
+            logger.debug(
+                "IRS SOI %s/%s already cached at %s",
+                tax_year, state_abbrev, csv_path,
+            )
+            return csv_path
+
+        url = self.url_for(tax_year, state_abbrev)
+        logger.info("Downloading IRS SOI %s/%s from %s", tax_year, state_abbrev, url)
+        self._stream_download_to_file(url, csv_path)
+        return csv_path
+
+    def parse(self, csv_path: Path) -> pd.DataFrame:
+        """Parse a downloaded IRS SOI CSV into a DataFrame.
+
+        The IRS SOI files use a ``ZIPCODE`` column (5-digit string) as
+        the geographic key.  ``STATEFIPS`` and ``STATE`` identify the
+        state.  ``agi_stub`` encodes the AGI bracket (1-6).
+
+        Returns:
+            DataFrame with string-typed ZIP and FIPS columns.
+        """
+        dtype = {"ZIPCODE": str, "STATEFIPS": str}
+        df = pd.read_csv(csv_path, dtype=dtype)
+        if "ZIPCODE" in df.columns:
+            df["ZIPCODE"] = df["ZIPCODE"].str.zfill(5)
+        if "STATEFIPS" in df.columns:
+            df["STATEFIPS"] = df["STATEFIPS"].str.zfill(2)
+        return df
+
+    def load(self, tax_year: int, state_abbrev: str) -> pd.DataFrame:
+        """Download + parse in one call.
+
+        Args:
+            tax_year: Tax year to fetch.
+            state_abbrev: Two-letter state abbreviation.
+
+        Returns:
+            Parsed DataFrame of IRS SOI data for the state and year.
+        """
+        csv_path = self.download(tax_year, state_abbrev)
+        return self.parse(csv_path)

--- a/tests/test_irs_soi.py
+++ b/tests/test_irs_soi.py
@@ -1,0 +1,122 @@
+"""Tests for IRS SOI ZIP-code data helper (#539)."""
+
+import csv
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pandas as pd
+import pytest
+
+from siege_utilities.economic.irs.soi import IRSSOIFiles, DEFAULT_CACHE_DIR
+
+
+class TestIRSSOIFilesURL:
+    """url_for builds the correct IRS download URL."""
+
+    def test_default_url_pattern(self):
+        files = IRSSOIFiles.__new__(IRSSOIFiles)
+        url = files.url_for(2020, "tx")
+        assert url == "https://www.irs.gov/pub/irs-soi/2020zpallagitx.csv"
+
+    def test_uppercase_state_lowered(self):
+        files = IRSSOIFiles.__new__(IRSSOIFiles)
+        url = files.url_for(2021, "CA")
+        assert "ca" in url
+
+    def test_different_year(self):
+        files = IRSSOIFiles.__new__(IRSSOIFiles)
+        url = files.url_for(2019, "ny")
+        assert "2019" in url
+        assert "ny" in url
+
+
+class TestIRSSOIFilesParse:
+    """parse normalizes ZIP and FIPS codes."""
+
+    def _write_csv(self, path, rows):
+        with open(path, "w", newline="") as f:
+            w = csv.DictWriter(f, fieldnames=rows[0].keys())
+            w.writeheader()
+            w.writerows(rows)
+
+    def test_zero_pads_zipcode(self, tmp_path):
+        csv_path = tmp_path / "soi.csv"
+        self._write_csv(csv_path, [
+            {"ZIPCODE": "1234", "STATEFIPS": "6", "N1": "100"},
+        ])
+        files = IRSSOIFiles(cache_dir=tmp_path)
+        df = files.parse(csv_path)
+        assert df["ZIPCODE"].iloc[0] == "01234"
+        assert df["STATEFIPS"].iloc[0] == "06"
+
+    def test_preserves_full_zip(self, tmp_path):
+        csv_path = tmp_path / "soi.csv"
+        self._write_csv(csv_path, [
+            {"ZIPCODE": "78701", "STATEFIPS": "48", "N1": "200"},
+        ])
+        files = IRSSOIFiles(cache_dir=tmp_path)
+        df = files.parse(csv_path)
+        assert df["ZIPCODE"].iloc[0] == "78701"
+
+
+class TestIRSSOIFilesDownload:
+    """download caches and returns CSV path."""
+
+    def test_returns_cached_path(self, tmp_path):
+        cached = tmp_path / "2020_tx_soi.csv"
+        cached.write_text("ZIPCODE,N1\n78701,100\n")
+        files = IRSSOIFiles(cache_dir=tmp_path)
+        result = files.download(2020, "tx")
+        assert result == cached
+
+    @patch("siege_utilities.economic.irs.soi.requests.get")
+    def test_downloads_when_not_cached(self, mock_get, tmp_path):
+        mock_resp = MagicMock()
+        mock_resp.iter_content.return_value = [b"ZIPCODE,N1\n78701,100\n"]
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_get.return_value = mock_resp
+        files = IRSSOIFiles(cache_dir=tmp_path)
+        result = files.download(2020, "tx")
+        assert result.exists()
+        assert result.name == "2020_tx_soi.csv"
+        mock_get.assert_called_once()
+
+
+class TestIRSSOIFilesLoad:
+    """load combines download + parse."""
+
+    def test_load_returns_dataframe(self, tmp_path):
+        cached = tmp_path / "2020_tx_soi.csv"
+        cached.write_text("ZIPCODE,STATEFIPS,N1\n78701,48,100\n")
+        files = IRSSOIFiles(cache_dir=tmp_path)
+        df = files.load(2020, "tx")
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 1
+        assert df["ZIPCODE"].iloc[0] == "78701"
+
+
+class TestIRSSOIFilesInit:
+    """Constructor creates cache directory."""
+
+    def test_default_cache_dir(self):
+        files = IRSSOIFiles.__new__(IRSSOIFiles)
+        assert DEFAULT_CACHE_DIR.name == "irs_soi"
+
+    def test_custom_cache_dir(self, tmp_path):
+        custom = tmp_path / "my_cache"
+        files = IRSSOIFiles(cache_dir=custom)
+        assert files.cache_dir == custom
+        assert custom.exists()
+
+
+class TestLazyImport:
+    """IRSSOIFiles is accessible from economic package."""
+
+    def test_import_from_economic(self):
+        from siege_utilities.economic import IRSSOIFiles as Cls
+        assert Cls is IRSSOIFiles
+
+    def test_import_from_irs(self):
+        from siege_utilities.economic.irs import IRSSOIFiles as Cls
+        assert Cls is IRSSOIFiles


### PR DESCRIPTION
## Summary

- Adds `siege_utilities.economic.irs.soi.IRSSOIFiles` following the QCEWFiles pattern
- `load(tax_year, state_abbrev)` → downloads + parses IRS SOI ZIP-code data
- `url_for()` is overridable for URL convention drift
- Zero-pads ZIPCODE (5 digits) and STATEFIPS (2 digits) for downstream joins
- Lazy imports through `economic/__init__.py` and `irs/__init__.py`

Closes #539

## Test plan

- [x] 3 URL construction tests
- [x] 2 parse normalization tests (zero-pad, preserve full ZIP)
- [x] 2 download caching tests
- [x] 1 load integration test
- [x] 2 init/constructor tests
- [x] 2 lazy import tests (from economic, from irs)

Self-Review: plans/self-review-539.md