### PR TITLE
feat(#970): complete Sphinx docs cleanup, add missing package RSTs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -47,6 +47,8 @@ The canonical composition chain::
    packages/databricks
    packages/trino
    packages/config
+   packages/conf
+   packages/oss_unity_catalog
 
 .. toctree::
    :maxdepth: 2
@@ -75,6 +77,7 @@ The canonical composition chain::
    packages/admin
    packages/cache
    packages/testing
+   packages/development
    exception_hierarchy
 
 .. toctree::
@@ -109,7 +112,7 @@ The canonical composition chain::
      Nominatim, TAMU geocoders
    - **PEP 562 lazy loading** — import one piece without pulling the whole library
    - **Tiered geo extras** — ``[geo-lite]`` / ``[geo]`` / ``[geodjango]``
-   - **32 Jupyter notebooks** organized by domain
+   - **24 Jupyter notebooks** organized by domain
    - **Report generation** — PDF, PowerPoint, branded multi-client reports, hex cartograms
 
    Install: ``pip install siege-utilities``

--- a/docs/source/notebooks.rst
+++ b/docs/source/notebooks.rst
@@ -1,93 +1,61 @@
 Jupyter Notebooks
 =================
 
-The ``notebooks/`` directory contains 27 runnable Jupyter notebooks
-demonstrating all major library capabilities. Run them headlessly
-via the test runner::
+The ``notebooks/`` directory contains 24 active Jupyter notebooks organized
+by domain, plus 12 archived notebooks from prior reorganizations.
 
-    pytest tests/test_notebooks.py -k pure_python -v
+Foundations
+-----------
 
-Configuration & Profiles
-------------------------
+- **01_configuration** — Hydra + Pydantic configuration system with client overlays
+- **02_profiles_branding** — Client profile registration and branded chart rendering
+- **entity_identification** — Deduplicating donors across vendor lists (normalize, UUID5, namespace)
+- **file_operations_and_security** — Atomic writes, path security, safe I/O, command restriction
 
-- **NB01** — Configuration System Demo (Hydra + Pydantic)
-- **NB02** — Create User & Client Profiles
-- **NB03** — Person/Actor Architecture (full model reference)
+Engines
+-------
 
-Geospatial & Census
---------------------
+- **01_multi_engine_dataframes** — Same ranking query against pandas and DuckDB backends
+- **02_distributed_spark** — Spark + Sedona call shapes for scaled operations (conceptual)
+- **03_databricks_geo** — Asset Bundles, LakeBase, Unity Catalog DDL, Spark-GeoPandas bridge
+- **04_statistics_primitives** — MOE propagation, NAICS/SOC hierarchies, contingency tables
 
-- **NB04** — Spatial Data & Census Boundaries (comprehensive reference)
-- **NB05** — Choropleth Maps & Classification
-- **NB07** — Geocoding & Address Processing
-- **NB15** — Census Demographics Quick Start
-- **NB25** — SpatiaLite Cache & Advanced Geocoding
-- **NB26** — International Boundaries (GADM)
-- **NB27** — Advanced Census (MOE Propagation, NAICS/SOC)
+Spatial
+-------
 
-Political & Redistricting
---------------------------
+- **01_boundaries** — Census TIGER geographies (state, county, tract) with ACS join
+- **02_geocoding** — Batch geocoding with Census geocoder, cache, quality flags
+- **03_choropleth_maps** — Bivariate choropleths (Dem share x turnout), tertile binning
+- **04_redistricting** — Congressional district boundary comparison across cycles
+- **05_multi_source_joins** — Unifying three polling vendors via exact + fuzzy joins
+- **06_geodjango** — GeoDjango model + PostGIS + FeatureCollection endpoint (conceptual)
+- **07_natural_language_to_geometry** — NL query to Shapely polygon via WKLS/Etter
 
-- **NB22** — Temporal Political Models (CongressionalTerm, Seat, Race)
-- **NB23** — Redistricting Analysis (Plans, Compactness, Demographics)
-
-Data Engines
-------------
-
-- **NB24** — DuckDB & Engine Abstraction (engine switching, spatial ops)
-- **NB16** — Spark & Sedona Distributed Operations
-
-Reporting
+Analytics
 ---------
 
-- **NB06** — Report Generation (chart gallery)
-- **NB11** — ReportLab PDF Features
-- **NB12** — PowerPoint Generation
-- **NB21** — Enterprise Onboarding Presentation
+- **01_connectors** — GA, Snowflake, data.world connector patterns
+- **02_ga_end_to_end** — Weekly GA digest pipeline: fetch, chart, PDF
 
-Analytics & Integrations
--------------------------
+Reports
+-------
 
-- **NB09** — Analytics Connectors (Facebook, GA4, Snowflake)
-- **NB14** — GA Analytics Report
-- **NB18** — Google Workspace Write APIs
+- **01_charts_and_pdf** — Branded Q1 deliverable assembly (chart + table + PDF)
+- **02_slides_pptx_and_google** — 5-slide deck generation (PPTX + Google Slides)
+- **03_polling_survey_analysis** — Three-wave party-ID tracker with crosstabs and trends
+- **04_survey_full_showcase** — All seven TableTypes with branded multi-section PDF
 
-Data & Development
-------------------
+Economic
+--------
 
-- **NB08** — Sample Data Generation
-- **NB10** — Profile & Branding Testing
-- **NB13** — GeoDjango Integration
-- **NB17** — Developer Tooling
-- **NB19** — NLRB Data Integration
-- **NB20** — Multi-Source Spatial Tabulation
+- **economic_data_irs_bls** — IRS SOI ZIP-code income data and BLS QCEW employment context
 
-Dependency Groups
------------------
+Git
+---
 
-Notebooks are grouped by dependency for selective execution:
+- **repo_analysis** — Repository status, commit history, branch analysis (read-only)
 
-.. list-table::
-   :header-rows: 1
+Config
+------
 
-   * - Group
-     - Marker
-     - Count
-   * - Pure Python
-     - (none)
-     - 13
-   * - Geo (GDAL)
-     - ``requires_gdal``
-     - 5
-   * - Django (PostGIS)
-     - ``requires_gdal`` + ``django_db``
-     - 2
-   * - Analytics (credentials)
-     - ``integration``
-     - 3
-   * - Spark
-     - ``integration``
-     - 1
-   * - External downloads
-     - ``integration``
-     - 3
+- **credential_management** — Credential backend discovery and management patterns

--- a/docs/source/packages/conf.rst
+++ b/docs/source/packages/conf.rst
@@ -1,0 +1,14 @@
+conf — Project Settings
+=======================
+
+Django-style project settings with multi-source resolution.
+
+.. automodule:: siege_utilities.conf
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: siege_utilities.conf.defaults
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/packages/development.rst
+++ b/docs/source/packages/development.rst
@@ -1,0 +1,10 @@
+development — Internal Development Tooling
+==========================================
+
+Utilities for package development, testing infrastructure, and
+code quality automation.
+
+.. automodule:: siege_utilities.development
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/packages/oss_unity_catalog.rst
+++ b/docs/source/packages/oss_unity_catalog.rst
@@ -1,0 +1,11 @@
+oss_unity_catalog — Unity Catalog Registration
+===============================================
+
+Helpers for the open-source Unity Catalog implementation
+(unitycatalog.io). Register tables, schemas, and catalogs
+against a self-hosted Unity Catalog REST API.
+
+.. automodule:: siege_utilities.oss_unity_catalog
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/plans/self-review-970.md
+++ b/plans/self-review-970.md
@@ -1,0 +1,73 @@
+# Self-Review: feat(#970) Sphinx docs cleanup and completion
+
+## Assumptions
+Domain(s): software engineering
+Geospatial cross-cut: no
+Goal source: ticket #970
+Goal source verification: PASS — ticket requests Sphinx rewrite and Wiki population
+Plan reference: https://github.com/siege-analytics/siege_utilities/issues/970#issuecomment-4614538591
+Pre-author-inventory: NONE
+Investigate-artifact: TRIVIAL
+Pre-mortem-artifact: TRIVIAL
+
+Trivial-against-state: doc-only changes; no runtime code modified.
+
+## Trivial-investigation declaration
+
+Category: doc-only
+Cannot produce error: no runtime code modified; only .rst files under docs/source/.
+Evidence: `git diff --stat HEAD` → only .rst files and plans/ changed.
+Falsification: a toctree entry references a nonexistent file, breaking the Sphinx build.
+
+## Peer review (Junior's checklist)
+
+### Implementation
+
+**Phase 1 — Sphinx cleanup:**
+- Deleted 36 duplicate RST files ("admin 2.rst", "analytics 3.rst", etc.) from docs/source/packages/
+- Created 3 missing package RST files: conf.rst, development.rst, oss_unity_catalog.rst
+- Updated index.rst: added conf, oss_unity_catalog to Engines & Infrastructure toctree; added development to Utilities toctree; fixed notebook count 32 → 24
+- Rewrote notebooks.rst: replaced stale NB01-NB27 numbering with current directory-based organization (24 active notebooks across 7 directories)
+
+**Phase 2 — GitHub Wiki:**
+- Wiki already enabled and populated with 10 well-structured pages (Home, Getting Started, Geocoding, Census, Engine, Credentials, Databricks, Reports, Survey, Political)
+- Sidebar navigation in place
+- Content is current (references space-time composition identity, 29 packages, lazy loading)
+- No changes needed
+
+**Assessment vs ticket description:**
+The ticket described deeply stale docs. Several fixes had already landed:
+- index.rst: already geo-centered (not "auto-discovery")
+- getting_started.rst: already leads with geo
+- architecture_diagram.rst: correctly shows geo as gravitational center
+- All 25 existing package RST files have proper automodule directives
+- Version already 3.21.0
+
+Remaining work was cleanup (duplicates, missing packages, stale notebooks page).
+
+### Syntax check
+- All new .rst files are valid RST (structural markup only, no executable code).
+
+## Lead review
+
+Domain: software engineering.
+
+The actual state of the docs was better than the ticket described. The Junior correctly assessed what had already been fixed vs what remained, avoiding unnecessary rewrites of content that was already current.
+
+The 36 duplicate files were filesystem artifacts (not git-tracked), so their removal doesn't appear in the diff. The 3 new RST files and the index/notebooks updates are the meaningful changes.
+
+The Wiki phase turned out to be a no-op — already populated. The Junior correctly documented this rather than fabricating work.
+
+Blast radius: none. Doc-only changes.
+
+## Quantified claims
+
+- "36 duplicate files" — `find docs/source/packages -name '* 2.rst' -o -name '* 3.rst' | wc -l` → 36 (pre-deletion)
+- "3 missing packages" — conf, development, oss_unity_catalog: verified via set difference between Python packages with __init__.py and existing RST files
+- "24 active notebooks" — `find notebooks/ -name '*.ipynb' -not -path '*/archive/*' -not -path '*/.ipynb_checkpoints/*' | wc -l` → 24
+- "10 wiki pages" — `ls /tmp/siege_utilities_wiki/*.md | wc -l` → 11 (including _Sidebar.md)
+- "25 existing RST files" — `ls docs/source/packages/*.rst | wc -l` → 25 (pre-addition)
+
+## Evidence-predates-work
+Artifact: plans/self-review-970.md
+Work commit: pending


### PR DESCRIPTION
## Summary

- Added RST files for 3 missing packages (conf, development, oss_unity_catalog)
- Updated index.rst toctree to include all packages; fixed notebook count 32 → 24
- Rewrote notebooks.rst from stale NB01-NB27 numbering to current directory-based organization
- Wiki (Phase 2): verified already populated with 10 comprehensive pages, no changes needed
- Deleted 36 local duplicate RST files (not git-tracked)

Closes #970

Self-Review: 3 new RST files, index/notebooks updated, wiki verified current
Self-Review-Source: plans/self-review-970.md