### PR TITLE
fix(#1006): correct credential_management notebook API calls

### DIFF
--- a/notebooks/config/credential_management.ipynb
+++ b/notebooks/config/credential_management.ipynb
@@ -91,20 +91,11 @@
    "cell_type": "markdown",
    "id": "5dd71dab",
    "metadata": {},
-   "source": [
-    "## 2. The CredentialManager Class\n",
-    "\n",
-    "The manager initializes with all available backends and provides a\n",
-    "unified `get()` method. It searches backends in priority order:\n",
-    "1Password -> Keychain -> environment -> files -> interactive prompt.\n",
-    "\n",
-    "When a credential isn't found, it raises `CredentialNotFoundError` —\n",
-    "never returns None or empty string (SU-1: errors are not data)."
-   ]
+   "source": "## 2. The CredentialManager Class\n\nThe manager initializes with all available backends and provides a\nunified `get_credential()` method. It searches backends in priority order:\n1Password -> Keychain -> environment -> files -> interactive prompt.\n\nWhen a credential isn't found, it raises `CredentialNotFoundError` —\nnever returns None or empty string (SU-1: errors are not data)."
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "7ab009dc",
    "metadata": {
     "execution": {
@@ -114,57 +105,8 @@
      "shell.execute_reply": "2026-06-03T16:20:21.382303Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[siege_utilities] 2026-06-03 11:20:21,380 INFO: Available credential backends: ['files', 'env', 'prompt', '1password', 'keychain']\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[siege_utilities] 2026-06-03 11:20:21,380 INFO: Credential manager initialized with backends: {'files': True, 'env': True, 'prompt': True, '1password': True, 'keychain': True}\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[siege_utilities] 2026-06-03 11:20:21,380 INFO: Credential search paths: [PosixPath('/Users/dheerajchand/Documents/Professional/Siege_Analytics/Code/siege_utilities/notebooks/config/credentials'), PosixPath('/Users/dheerajchand/.siege_utilities/credentials')]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Manager initialized\n",
-      "Backends: configured\n",
-      "\n",
-      "Missing credential raises: AttributeError\n",
-      "  (SU-1: errors are not data)\n"
-     ]
-    }
-   ],
-   "source": [
-    "from siege_utilities.config.credential_manager import (\n",
-    "    CredentialManager, CredentialNotFoundError\n",
-    ")\n",
-    "\n",
-    "manager = CredentialManager()\n",
-    "\n",
-    "print(f\"Manager initialized\")\n",
-    "print(f\"Backends: {list(manager.backends.keys()) if hasattr(manager, 'backends') else 'configured'}\")\n",
-    "\n",
-    "# Missing credentials raise, not return empty\n",
-    "try:\n",
-    "    manager.get(\"nonexistent-service\", \"fake-user\")\n",
-    "except (CredentialNotFoundError, Exception) as e:\n",
-    "    print(f\"\\nMissing credential raises: {type(e).__name__}\")\n",
-    "    print(f\"  (SU-1: errors are not data)\")"
-   ]
+   "outputs": [],
+   "source": "from siege_utilities.config.credential_manager import (\n    CredentialManager, CredentialNotFoundError\n)\n\nmanager = CredentialManager()\n\nprint(f\"Manager initialized\")\nprint(f\"Backends: {list(manager.backends.keys()) if hasattr(manager, 'backends') else 'configured'}\")\n\n# Missing credentials raise, not return empty\ntry:\n    manager.get_credential(\"nonexistent-service\", \"fake-user\")\nexcept (CredentialNotFoundError, Exception) as e:\n    print(f\"\\nMissing credential raises: {type(e).__name__}\")\n    print(f\"  (SU-1: errors are not data)\")"
   },
   {
    "cell_type": "markdown",
@@ -180,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "c5c79084",
    "metadata": {
     "execution": {
@@ -190,38 +132,8 @@
      "shell.execute_reply": "2026-06-03T16:20:21.386210Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DB Host: localhost\n",
-      "DB Port: 5432\n",
-      "\n",
-      "Pattern: os.environ.get() for CI, CredentialManager.get() for local dev\n"
-     ]
-    }
-   ],
-   "source": [
-    "import os\n",
-    "\n",
-    "# Demonstrate the env-var credential pattern\n",
-    "# In production, these would be set by CI or the shell profile\n",
-    "os.environ[\"SIEGE_TEST_DB_HOST\"] = \"localhost\"\n",
-    "os.environ[\"SIEGE_TEST_DB_PORT\"] = \"5432\"\n",
-    "\n",
-    "# The pattern: check env first, fall back to credential manager\n",
-    "db_host = os.environ.get(\"SIEGE_TEST_DB_HOST\", \"not-set\")\n",
-    "db_port = os.environ.get(\"SIEGE_TEST_DB_PORT\", \"not-set\")\n",
-    "\n",
-    "print(f\"DB Host: {db_host}\")\n",
-    "print(f\"DB Port: {db_port}\")\n",
-    "print(f\"\\nPattern: os.environ.get() for CI, CredentialManager.get() for local dev\")\n",
-    "\n",
-    "# Clean up\n",
-    "del os.environ[\"SIEGE_TEST_DB_HOST\"]\n",
-    "del os.environ[\"SIEGE_TEST_DB_PORT\"]"
-   ]
+   "outputs": [],
+   "source": "import os\n\n# Demonstrate the env-var credential pattern\n# In production, these would be set by CI or the shell profile\nos.environ[\"SIEGE_TEST_DB_HOST\"] = \"localhost\"\nos.environ[\"SIEGE_TEST_DB_PORT\"] = \"5432\"\n\n# The pattern: check env first, fall back to credential manager\ndb_host = os.environ.get(\"SIEGE_TEST_DB_HOST\", \"not-set\")\ndb_port = os.environ.get(\"SIEGE_TEST_DB_PORT\", \"not-set\")\n\nprint(f\"DB Host: {db_host}\")\nprint(f\"DB Port: {db_port}\")\nprint(f\"\\nPattern: os.environ.get() for CI, CredentialManager.get_credential() for local dev\")\n\n# Clean up\ndel os.environ[\"SIEGE_TEST_DB_HOST\"]\ndel os.environ[\"SIEGE_TEST_DB_PORT\"]"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

- Fixes `credential_management.ipynb` calling `manager.get()` which doesn't exist — corrected to `get_credential()` across 3 cells (1 markdown, 2 code)
- All 4 library symbols verified against source: `CredentialManager` (line 125), `get_credential` (line 258/896), `CredentialNotFoundError` (line 82), `credential_status` (module-level)

## Test plan

- [x] `grep "manager\.get(" notebooks/config/credential_management.ipynb` → 0 matches (bare form eliminated)
- [x] `grep "get_credential" notebooks/config/credential_management.ipynb` → 3 matches (all corrected)
- [x] `ast.parse` on all 3 code cells → clean
- [x] 50 unit tests pass, 0 regressions

Closes #1006

Self-Review: https://github.com/siege-analytics/siege_utilities/issues/1006#issuecomment-4615939904