### PR TITLE
fix(#1007): correct entity_identification notebook false narrative

### DIFF
--- a/notebooks/foundations/entity_identification.ipynb
+++ b/notebooks/foundations/entity_identification.ipynb
@@ -4,18 +4,7 @@
    "cell_type": "markdown",
    "id": "32893b50",
    "metadata": {},
-   "source": [
-    "# Deduplicating Donors Across Vendor Lists\n",
-    "\n",
-    "**Scenario:** A political campaign receives donor lists from three vendors.\n",
-    "Each vendor formats names differently — ALL CAPS, mixed case, abbreviations.\n",
-    "We need to match donors across lists without manual review.\n",
-    "\n",
-    "siege_utilities solves this with three primitives:\n",
-    "1. **Name normalization** — canonicalize names so \"SMITH, JOHN A\" and \"smith, john\" match\n",
-    "2. **Deterministic namespaces** — derive org-specific UUID namespaces\n",
-    "3. **Deterministic UUIDs** — same normalized input always produces the same UUID"
-   ]
+   "source": "# Deduplicating Donors Across Vendor Lists\n\n**Scenario:** A political campaign receives donor lists from three vendors.\nEach vendor formats names differently — ALL CAPS, mixed case, abbreviations.\nWe need to match donors across lists without manual review.\n\nsiege_utilities solves this with three primitives:\n1. **Name normalization** — canonicalize case, punctuation, and whitespace so \"John Smith\" and \"john smith\" produce the same seed\n2. **Deterministic namespaces** — derive org-specific UUID namespaces\n3. **Deterministic UUIDs** — same normalized input always produces the same UUID\n\n**Limitation:** `normalize_name_v1` handles case, punctuation, and whitespace\nbut does NOT reorder names. \"SMITH, JOHN A\" (Last, First) normalizes to\n\"smith john a\", not \"john smith\". Matching across name-order conventions\nrequires preprocessing before normalization — a v2 concern."
   },
   {
    "cell_type": "markdown",
@@ -163,12 +152,7 @@
    "cell_type": "markdown",
    "id": "5dd34e4c",
    "metadata": {},
-   "source": [
-    "## Verifying Determinism\n",
-    "\n",
-    "The key property: running this tomorrow, on a different machine, with the\n",
-    "same inputs, produces the same UUIDs. No database sequence, no random seed."
-   ]
+   "source": "## Verifying Determinism\n\nThe key property: running this tomorrow, on a different machine, with the\nsame inputs, produces the same UUIDs. No database sequence, no random seed.\n\nNote that \"SMITH, JOHN A\" and \"John Smith\" produce *different* UUIDs below\nbecause `normalize_name_v1` preserves word order — \"smith john a\" ≠ \"john smith\".\nNames in the same format (like \"John Smith\" and \"john smith\") DO match."
   },
   {
    "cell_type": "code",
@@ -223,14 +207,7 @@
    "cell_type": "markdown",
    "id": "a8d409a9",
    "metadata": {},
-   "source": [
-    "## Key Takeaways\n",
-    "\n",
-    "- **normalize_name_v1** strips punctuation, lowercases, reorders \"Last, First\" → \"first last\"\n",
-    "- **derive_root / derive_sub_namespace** create organization-scoped UUID namespaces\n",
-    "- **uuid5_from_seed** generates deterministic UUIDs: same namespace + same input = same UUID\n",
-    "- Combine all three to match entities across messy vendor lists without manual review"
-   ]
+   "source": "## Key Takeaways\n\n- **normalize_name_v1** strips punctuation, lowercases, and collapses whitespace (preserves word order — does NOT reorder \"Last, First\" to \"first last\")\n- **derive_root / derive_sub_namespace** create organization-scoped UUID namespaces\n- **uuid5_from_seed** generates deterministic UUIDs: same namespace + same input = same UUID\n- Combine all three to match entities across vendor lists where formatting differs but word order is consistent\n- Matching across name-order conventions (e.g., \"SMITH, JOHN\" vs \"John Smith\") requires preprocessing before normalization"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

- Fixes `entity_identification.ipynb` falsely claiming `normalize_name_v1` reorders "Last, First" → "first last" — it preserves word order
- Corrected 3 markdown cells: intro (added Limitation paragraph), Verifying Determinism (explains why "All match: False" is expected), Key Takeaways (removed false reordering claim)
- Zero code cell changes — the code was correct, only the narrative was wrong

## Test plan

- [x] `grep "reorders" notebooks/foundations/entity_identification.ipynb` → 0 matches (false claim eliminated)
- [x] `grep "does NOT reorder" notebooks/foundations/entity_identification.ipynb` → 2 matches (accurate description)
- [x] `ast.parse` on all 3 code cells → clean
- [x] 50 unit tests pass, 0 regressions

Closes #1007

Self-Review: https://github.com/siege-analytics/siege_utilities/issues/1007#issuecomment-4616096394