### PR TITLE
feat(#1014): add HUBSPOT, ZOHO, DYNAMICS to OAuthProvider enum

### DIFF
--- a/siege_utilities/config/models/oauth_integration.py
+++ b/siege_utilities/config/models/oauth_integration.py
@@ -22,6 +22,9 @@ class OAuthProvider(str, Enum):
     SALESFORCE = "salesforce"
     SLACK = "slack"
     ZOOM = "zoom"
+    HUBSPOT = "hubspot"
+    ZOHO = "zoho"
+    DYNAMICS = "dynamics"
     CUSTOM = "custom"
 
 
@@ -229,7 +232,10 @@ class OAuthIntegration(BaseModel):
             OAuthProvider.TWITTER: "https://twitter.com/i/oauth2/authorize",
             OAuthProvider.SALESFORCE: "https://login.salesforce.com/services/oauth2/authorize",
             OAuthProvider.SLACK: "https://slack.com/oauth/v2/authorize",
-            OAuthProvider.ZOOM: "https://zoom.us/oauth/authorize"
+            OAuthProvider.ZOOM: "https://zoom.us/oauth/authorize",
+            OAuthProvider.HUBSPOT: "https://app.hubspot.com/oauth/authorize",
+            OAuthProvider.ZOHO: "https://accounts.zoho.com/oauth/v2/auth",
+            OAuthProvider.DYNAMICS: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
         }
         
         if self.provider not in base_urls:


### PR DESCRIPTION
## Summary

- Adds 3 new CRM providers to `OAuthProvider` enum: HUBSPOT, ZOHO, DYNAMICS
- Adds corresponding OAuth authorization URLs to `get_authorization_url()`
- Foundation ticket for CRM Integrations epic (#1010)

## Test plan

- [x] `ast.parse` on modified file → clean
- [x] 106 config model validation tests pass, 0 regressions
- [x] Import verification: all 13 enum values present
- [x] DYNAMICS correctly shares Microsoft Azure AD auth URL

Closes #1014

Self-Review: https://github.com/siege-analytics/siege_utilities/issues/1014#issuecomment-4618415519