### PR TITLE
chore: bump version to 3.22.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siege-utilities"
-version = "3.21.0"
+version = "3.22.0"
 description = "A comprehensive Python utilities package with enhanced auto-discovery"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Pre-CRM-integration release. Bumps version from 3.21.0 to 3.22.0 to capture 69 commits since v3.21.0.

### Highlights since v3.21.0

**New packages / features:**
- `connectors/` package with `ConnectorProtocol` and shared CRM types (#1011)
- OAuthProvider enum extensions for HubSpot, Zoho, Dynamics (#1014)
- GST geocoding + spatial-data helpers ported to siege_utilities (#515)
- IRS SOI Files lifted from socialwarehouse (#539)
- DuckDB and Shapely backends for areal interpolation (#986)
- Pure-numpy choropleth classification module (#987)
- `from_geodataframe()` and `engine=` param on boundary providers (#988)
- Reporting `sort_by`/`sort_order` parameters (#973)

**Quality infrastructure:**
- mypy config, strict on public API surface (#779)
- Integration tests for Narratives 3 and 5 (#780)
- Interrogate docstring enforcement (#784)
- 63 new tests, coverage threshold bumped to 48% (#578)
- Complete Sphinx docs cleanup (#970)
- Notebook audit: 3 demos rewritten, 2 new (#580)
- Notebook coverage for economic, files, identifiers (#816)

**Fixes:**
- HTTP session lifecycle for RDHClient and WikidataGazetteer (#979)
- CRS agreement checks before spatial joins (#976)
- Compactness metrics reprojected to equal-area CRS (#975)
- Atomic file writes via tmp+rename pattern (#978)
- Seat null-state and VTD cross-state invariants (#977)
- Locale method parameter validation (#867)
- Geo-expansion test alignment (#992)
- Notebook API call corrections (#1006, #1007)

One-line change: `pyproject.toml` version bump.