### PR TITLE
docs: update to v3.22.0, add connectors RST

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.abspath('../../'))
 project = 'Siege Utilities'
 copyright = '2025-2026, Dheeraj Chand'
 author = 'Dheeraj Chand'
-release = '3.21.0'
+release = '3.22.0'
 
 extensions = [
     'sphinx.ext.autodoc',

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -46,6 +46,7 @@ The canonical composition chain::
    packages/distributed
    packages/databricks
    packages/trino
+   packages/connectors
    packages/config
    packages/conf
    packages/oss_unity_catalog
@@ -100,19 +101,20 @@ The canonical composition chain::
 
 .. note::
 
-   **v3.21.0** (June 2026) — `PyPI <https://pypi.org/project/siege-utilities/>`_
+   **v3.22.0** (June 2026) — `PyPI <https://pypi.org/project/siege-utilities/3.22.0/>`_
 
    Key capabilities:
 
    - **Geo is the gravitational center** — boundaries, geocoding, spatial transforms,
      isochrones, Census data intelligence, redistricting analysis
    - **Engine-agnostic DataFrame** — pandas, DuckDB, Spark+Sedona, PostGIS
+   - **CRM connectors** — ``ConnectorProtocol`` for Salesforce, HubSpot, Zoho, Dynamics
    - **Temporal political models** — CongressionalTerm, Seat, Race, RedistrictingPlan
    - **Pluggable providers** — Census TIGER, GADM, RDH boundary providers; Census,
      Nominatim, TAMU geocoders
    - **PEP 562 lazy loading** — import one piece without pulling the whole library
    - **Tiered geo extras** — ``[geo-lite]`` / ``[geo]`` / ``[geodjango]``
-   - **24 Jupyter notebooks** organized by domain
+   - **32 Jupyter notebooks** organized by domain
    - **Report generation** — PDF, PowerPoint, branded multi-client reports, hex cartograms
 
    Install: ``pip install siege-utilities``

--- a/docs/source/packages/connectors.rst
+++ b/docs/source/packages/connectors.rst
@@ -1,0 +1,17 @@
+Connectors
+==========
+
+CRM connector primitives. Pull/push records from commercial CRMs
+(Salesforce, HubSpot, Zoho, Microsoft Dynamics 365) through a unified
+:class:`~siege_utilities.connectors.ConnectorProtocol`.
+
+.. automodule:: siege_utilities.connectors
+   :members:
+   :show-inheritance:
+
+Protocol
+--------
+
+.. automodule:: siege_utilities.connectors._protocol
+   :members:
+   :show-inheritance:


### PR DESCRIPTION
## Summary

- Bump docs version from 3.21.0 to 3.22.0 in `conf.py`
- Add `packages/connectors.rst` for the new `connectors/` package (ConnectorProtocol autodoc)
- Update `index.rst` version note and notebook count (24 -> 32)
- Add connectors to Engines & Infrastructure toctree

Sphinx build succeeds locally.