### PR TITLE
fix(#1011): repair __dir__ NameError and register connectors in lazy imports

### DIFF
--- a/siege_utilities/__init__.py
+++ b/siege_utilities/__init__.py
@@ -282,6 +282,14 @@ _register_lazy([
     'list_facebook_accounts_for_client', 'batch_retrieve_facebook_data',
 ], '.analytics.facebook_business', deps=['facebook-business'])
 
+# ── CRM Connectors (protocol + error types, core-only deps) ───────────
+
+_register_lazy([
+    'ConnectorProtocol', 'UpsertResult', 'UpsertError',
+    'ConnectorError', 'ConnectorAuthError',
+    'ConnectorRateLimitError', 'ConnectorNotFoundError',
+], '.connectors._protocol', deps=['pandas'])
+
 # ── Reporting (requires matplotlib, reportlab, etc.) ─────────────────
 
 _register_lazy([
@@ -395,7 +403,7 @@ def __getattr__(name):
 
 
 def __dir__():
-    return sorted(set(list(globals().keys()) + list(_LAZY_IMPORTS.keys()) + __all__))
+    return sorted(set(list(globals().keys()) + list(_LAZY_IMPORTS.keys())))
 
 
 # ── Introspection functions (defined here, always available) ─────────


### PR DESCRIPTION
## Summary

- **`__dir__()` crashed with `NameError`** — referenced undefined `__all__` at module scope (line 398). Broke `dir(siege_utilities)` and the `lazy-import-integrity` CI job. Dropped the redundant reference; `_LAZY_IMPORTS.keys()` already covers discoverable names.
- **Connectors package missing from `_LAZY_IMPORTS`** — `ConnectorProtocol`, `UpsertResult`, and the error hierarchy from #1011 were never registered for lazy import. Added `_register_lazy` block with all 7 public symbols.

## Test plan

- [x] `python3 -c "import siege_utilities; dir(siege_utilities)"` succeeds (was `NameError`)
- [x] `'ConnectorProtocol' in dir(siege_utilities)` → `True`
- [x] `python3 scripts/check_lazy_imports.py` — 0 new failures (1 pre-existing `user_config` issue unchanged)
- [x] `ast.parse` on changed file — clean
- [x] Smoke tests pass (16/16)

Refs: #1011