### PR TITLE
chore: bump version to 3.22.1

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.abspath('../../'))
 project = 'Siege Utilities'
 copyright = '2025-2026, Dheeraj Chand'
 author = 'Dheeraj Chand'
-release = '3.22.0'
+release = '3.22.1'
 
 extensions = [
     'sphinx.ext.autodoc',

--- a/docs/source/conf_fast.py
+++ b/docs/source/conf_fast.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.abspath('../../'))
 project = 'Siege Utilities'
 copyright = '2025-2026, Dheeraj Chand'
 author = 'Dheeraj Chand'
-release = '3.21.0'
+release = '3.22.1'
 
 extensions = [
     'sphinx.ext.autodoc',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siege-utilities"
-version = "3.22.0"
+version = "3.22.1"
 description = "A comprehensive Python utilities package with enhanced auto-discovery"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- Bump version to 3.22.1 across pyproject.toml, docs/source/conf.py, docs/source/conf_fast.py
- Patch release for __dir__ NameError fix (#1038) and docs update (#1037)

## Test plan

- [x] Version strings consistent across all 3 files