### PR TITLE
fix(#1043): GA connector auth failure + batch success flag (SU-1)

### DIFF
--- a/plans/self-review-1043.md
+++ b/plans/self-review-1043.md
@@ -1,0 +1,56 @@
+## Assumptions
+Domain(s): analytics, Google Analytics connector
+Geospatial cross-cut: no
+Goal source: ticket #1043
+Goal source verification: Codex hostile review session 260619-apt-sequoia, findings S1-4 and S1-5
+Plan reference: design note on #1043
+Pre-author-inventory: siege_utilities/analytics/google_analytics.py (existing file)
+Investigate-artifact: TRIVIAL (see declaration below)
+Pre-mortem-artifact: TRIVIAL (see declaration below)
+
+## Trivial-investigation declaration
+Two functions in a single module. `batch_retrieve_ga_data` has no callers within siege_utilities (top-level convenience API). `GoogleAnalyticsConnector.__init__` is called by `create_ga_connector_with_service_account()` and `batch_retrieve_ga_data()` — both in the same file. No cross-module impact.
+
+## Trivial-pre-mortem declaration
+Risk surface: constructor now raises RuntimeError instead of silently continuing with None credentials. Any caller that caught and retried was already using a broken connector. The success flag fix is additive — existing callers that checked `results['success']` were getting a lie; now they get truth.
+
+## Peer review
+
+### Syntax check
+Python: `ast.parse()` passes on `google_analytics.py`.
+
+### Test suite
+No test files for google_analytics.py found. Verified via grep.
+
+### Build validation
+No build changes.
+
+### Shelf: conventions
+SU-1 restored: constructor raises on auth failure instead of silently producing unusable object. Batch retrieval's success flag now reflects actual outcome.
+
+## Lead review
+
+### Phase A: Structural coherence
+Two changes:
+1. Constructor (lines 115-129): `except ImportError` and `except CalledProcessError` now raise `RuntimeError` with actionable messages instead of logging warnings and continuing.
+2. `batch_retrieve_ga_data` (line 646): `results['success'] = not results['errors']` set before return, overriding the initial `True`.
+
+### Phase B: Did this close the gap?
+- [x] Constructor raises on 1Password ImportError (was: log warning, continue)
+- [x] Constructor raises on 1Password CalledProcessError (was: log warning, continue)
+- [x] Success message at line 130 only reached when auth actually succeeded
+- [x] batch_retrieve_ga_data success flag reflects actual error state
+- [x] AST parse clean
+
+### Phase C: Findings triage
+
+## Findings
+
+No findings.
+
+## Quantified claims
+- "Constructor raises instead of silently continuing" — verified: both except blocks now raise RuntimeError. Correct.
+- "Success flag set before return" — verified: `results['success'] = not results['errors']` at line 646. Correct.
+
+## Evidence-predates-work
+Artifact: plans/self-review-1043.md

--- a/siege_utilities/analytics/google_analytics.py
+++ b/siege_utilities/analytics/google_analytics.py
@@ -119,9 +119,16 @@ class GoogleAnalyticsConnector:
                 self.service_account_data = get_google_service_account_from_1password()
                 self.authenticate_service_account()
             except ImportError:
-                log_warning("Could not import 1Password service account function")
-            except subprocess.CalledProcessError:
-                log_warning("No service account data provided and could not retrieve from 1Password")
+                raise RuntimeError(
+                    "service_account auth requested but no service_account_data "
+                    "provided and the 1Password config module is not available. "
+                    "Either pass service_account_data or install the config extras."
+                )
+            except subprocess.CalledProcessError as exc:
+                raise RuntimeError(
+                    "service_account auth requested but 1Password credential "
+                    f"lookup failed: {exc}"
+                ) from exc
 
         log_info(f"Initialized Google Analytics connector with {auth_method} authentication")
 
@@ -642,6 +649,7 @@ def batch_retrieve_ga_data(client_id: str, start_date: str, end_date: str,
                 results['errors'].append(error_msg)
                 logger.error("Error processing account %s", account['ga_account_id'], exc_info=True)
 
+        results['success'] = not results['errors']
         log_info(f"Batch GA data retrieval completed: {results['accounts_processed']} accounts, {results['total_rows']} rows")
         return results
 


### PR DESCRIPTION
Closes #1043

## Summary

- **Constructor:** Raises `RuntimeError` when `service_account` auth is requested but 1Password lookup fails (was: log warning, continue with None credentials)
- **batch_retrieve_ga_data:** Sets `success = not errors` before returning (was: always True regardless of errors)

Both are SU-1 violations: returning valid-shaped results on failure.

## Source

Codex hostile review session 260619-apt-sequoia, findings S1-4 and S1-5.

## Self-review

`plans/self-review-1043.md`