### PR TITLE
fix(#1047): correct quote_ident() docstring — does not self-validate

### DIFF
--- a/plans/self-review-1047.md
+++ b/plans/self-review-1047.md
@@ -1,0 +1,42 @@
+## Assumptions
+Domain(s): trino, SQL safety
+Geospatial cross-cut: no
+Goal source: ticket #1047
+Goal source verification: Codex hostile review session 260619-apt-sequoia, finding S2-7
+Plan reference: design note on #1047 (inline — docstring-only fix)
+Pre-author-inventory: siege_utilities/trino/federation.py (existing file)
+Investigate-artifact: TRIVIAL (see declaration below)
+Pre-mortem-artifact: TRIVIAL (see declaration below)
+
+## Trivial-investigation declaration
+Docstring-only fix. `quote_ident()` docstring claimed it runs validation; it does not. The higher-level `build_trino_federation_view_sql()` calls `validate_sql_identifier()` before `quote_ident()`. The fix narrows the docstring to match reality.
+
+## Trivial-pre-mortem declaration
+Docstring text change only. No behavioral change. No API change.
+
+## Peer review
+
+### Syntax check
+Python: `ast.parse()` passes.
+
+### Test suite
+No behavioral change to test.
+
+### Build validation
+No build changes.
+
+## Lead review
+
+### Phase A: Structural coherence
+Docstring now says "Callers must validate identifiers before passing them here" instead of claiming self-validation.
+
+### Phase B: Did this close the gap?
+- [x] False validation claim removed from docstring
+- [x] Caller responsibility documented
+- [x] AST parse clean
+
+## Findings
+No findings.
+
+## Evidence-predates-work
+Artifact: plans/self-review-1047.md

--- a/siege_utilities/trino/federation.py
+++ b/siege_utilities/trino/federation.py
@@ -35,9 +35,9 @@ def quote_ident(value: str) -> str:
 
     Trino uses ANSI double quotes for identifiers (not backticks like
     Databricks). Internal double-quote characters are escaped by
-    doubling. The identifier itself is also run through the SU
-    identifier allow-list before quoting, so the double-quote
-    doubling is defense-in-depth.
+    doubling. Callers must validate identifiers before passing them
+    here (the higher-level federation builders call
+    ``validate_sql_identifier`` before ``quote_ident``).
     """
     return '"' + value.replace('"', '""') + '"'
 


### PR DESCRIPTION
Closes #1047

## Summary

The `quote_ident()` docstring falsely claimed the identifier was validated against the SU allow-list. It isn't — validation happens in the higher-level `build_trino_federation_view_sql()`. Narrowed the docstring to match reality.

## Source

Codex hostile review session 260619-apt-sequoia, finding S2-7.

## Self-review

`plans/self-review-1047.md`