### PR TITLE
fix(#1048): warn on settings coercion fallback to default

### DIFF
--- a/plans/self-review-1048.md
+++ b/plans/self-review-1048.md
@@ -1,0 +1,44 @@
+## Assumptions
+Domain(s): configuration
+Geospatial cross-cut: no
+Goal source: ticket #1048
+Goal source verification: Codex hostile review session 260619-apt-sequoia, finding S2-8
+Plan reference: inline design (add warning log on coercion fallback)
+Pre-author-inventory: siege_utilities/conf/__init__.py (existing file)
+Investigate-artifact: TRIVIAL (see declaration below)
+Pre-mortem-artifact: TRIVIAL (see declaration below)
+
+## Trivial-investigation declaration
+Single function `_coerce()` in `conf/__init__.py`. Called only by `__getattr__` in the same class. The fix adds `logger.warning()` calls on the fallback paths — no behavioral change, just observability.
+
+## Trivial-pre-mortem declaration
+Adding warning logs to exception handlers. The default value is still returned (existing behavior preserved). No API change. The only new behavior is a log line.
+
+## Peer review
+
+### Syntax check
+Python: `ast.parse()` passes.
+
+### Test suite
+No behavioral change to test — only new log output.
+
+### Build validation
+No build changes.
+
+## Lead review
+
+### Phase A: Structural coherence
+Added `import logging` and `_logger = logging.getLogger(__name__)`. Two `_logger.warning()` calls in the `except (ValueError, TypeError)` handlers for int and float coercion, logging the setting name, bad value, and default.
+
+### Phase B: Did this close the gap?
+- [x] Invalid int env vars now produce a warning
+- [x] Invalid float env vars now produce a warning
+- [x] Warning includes setting name, bad value, and default
+- [x] Default still returned (no behavioral change)
+- [x] AST parse clean
+
+## Findings
+No findings.
+
+## Evidence-predates-work
+Artifact: plans/self-review-1048.md

--- a/siege_utilities/conf/__init__.py
+++ b/siege_utilities/conf/__init__.py
@@ -18,10 +18,13 @@ Override in tests:
         assert settings.STORAGE_CRS == 4326
 """
 
+import logging
 import os
 import threading
 from contextlib import contextmanager
 from pathlib import Path
+
+_logger = logging.getLogger(__name__)
 
 from .defaults import DEFAULTS
 
@@ -89,11 +92,19 @@ class Settings:
             try:
                 return int(val)
             except (ValueError, TypeError):
+                _logger.warning(
+                    "Invalid int for setting %s=%r; falling back to default %r",
+                    name, val, default,
+                )
                 return default
         if isinstance(default, float):
             try:
                 return float(val)
             except (ValueError, TypeError):
+                _logger.warning(
+                    "Invalid float for setting %s=%r; falling back to default %r",
+                    name, val, default,
+                )
                 return default
         return val
 


### PR DESCRIPTION
Closes #1048

## Summary

`_coerce()` silently discarded invalid int/float env vars and returned the library default. Now logs a warning with the setting name, bad value, and default being used.

## Source

Codex hostile review session 260619-apt-sequoia, finding S2-8.

## Self-review

`plans/self-review-1048.md`