### PR TITLE
fix(#1045): overlay registry propagates constructor exceptions (SU-1)

### DIFF
--- a/plans/self-review-1045.md
+++ b/plans/self-review-1045.md
@@ -1,0 +1,40 @@
+## Assumptions
+Domain(s): geo, overlay registry
+Geospatial cross-cut: yes
+Goal source: ticket #1045
+Goal source verification: Codex hostile review session 260619-apt-sequoia, finding S2-4
+Plan reference: inline design (let constructor exceptions propagate)
+Pre-author-inventory: siege_utilities/geo/overlay_registry.py (existing file)
+Investigate-artifact: TRIVIAL (see declaration below)
+Pre-mortem-artifact: TRIVIAL (see declaration below)
+
+## Trivial-investigation declaration
+Single method `OverlayRegistry.get()`. The broad `except Exception` swallowed constructor failures and returned None — making a broken registered overlay indistinguishable from an unregistered one. Fix: remove the try/except and let constructor exceptions propagate.
+
+## Trivial-pre-mortem declaration
+Risk: callers that relied on `get()` returning None for broken overlays will now see exceptions. But that's the correct behavior — a registered overlay that can't be instantiated is an error, not an absence. Callers should handle it explicitly.
+
+## Peer review
+
+### Syntax check
+Python: `ast.parse()` passes.
+
+### Build validation
+No build changes.
+
+## Lead review
+
+### Phase A: Structural coherence
+Removed `try/except Exception` wrapper around `self._classes[name]()`. Updated docstring to document the Raises section.
+
+### Phase B: Did this close the gap?
+- [x] Constructor exceptions now propagate
+- [x] Docstring updated with Raises section
+- [x] None still returned for genuinely unregistered overlays
+- [x] AST parse clean
+
+## Findings
+No findings.
+
+## Evidence-predates-work
+Artifact: plans/self-review-1045.md

--- a/siege_utilities/geo/overlay_registry.py
+++ b/siege_utilities/geo/overlay_registry.py
@@ -131,17 +131,16 @@ class OverlayRegistry:
             name: Overlay identifier.
 
         Returns:
-            PlaceHistoryOverlay instance or None if not registered.
+            PlaceHistoryOverlay instance, or None if not registered.
+
+        Raises:
+            Exception: If the registered overlay class fails to instantiate.
         """
         if name in self._overlays:
             return self._overlays[name]
 
         if name in self._classes:
-            try:
-                instance = self._classes[name]()
-            except Exception as exc:
-                log.warning("Failed to instantiate overlay %r: %s", name, exc)
-                return None
+            instance = self._classes[name]()
             self._overlays[name] = instance
             return instance
 


### PR DESCRIPTION
Closes #1045

## Summary

`OverlayRegistry.get()` caught broad `Exception` from overlay constructors and returned `None`. A broken registered overlay was indistinguishable from an unregistered one. Constructor failures now propagate.

## Source

Codex hostile review session 260619-apt-sequoia, finding S2-4.

## Self-review

`plans/self-review-1045.md`