### PR TITLE
fix(#1044): RDHProvider raises BoundaryFetchError instead of returning None

### DIFF
--- a/plans/self-review-1044.md
+++ b/plans/self-review-1044.md
@@ -1,0 +1,45 @@
+## Assumptions
+Domain(s): geo, boundary providers
+Geospatial cross-cut: yes
+Goal source: ticket #1044
+Goal source verification: Codex hostile review session 260619-apt-sequoia, findings S2-1/2/3
+Plan reference: design note on #1044
+Pre-author-inventory: siege_utilities/geo/providers/boundary_providers.py (existing file)
+Investigate-artifact: TRIVIAL (see declaration below)
+Pre-mortem-artifact: TRIVIAL (see declaration below)
+
+## Trivial-investigation declaration
+Three findings in the ticket, but two are already handled:
+- `get_geographic_boundaries()` — already deprecated with DeprecationWarning, replacement exists (fetch_geographic_boundaries)
+- `get_census_boundaries()` — already deprecated since v3.16.0
+
+The only actionable finding is RDHProvider.get_boundary() returning None when no datasets found, while CensusTIGERProvider raises BoundaryFetchError. The ABC contract says GeoDataFrame return, not Optional[GeoDataFrame].
+
+## Trivial-pre-mortem declaration
+Single line change in RDHProvider.get_boundary(). No external callers check for None from this provider — grep confirms all references are re-exports or the definition itself.
+
+## Peer review
+
+### Syntax check
+Python: `ast.parse()` passes.
+
+### Build validation
+No build changes.
+
+## Lead review
+
+### Phase A: Structural coherence
+Changed `return None` to `raise BoundaryFetchError(...)` at boundary_providers.py:454-459. Now consistent with CensusTIGERProvider (line 132) and the ABC contract.
+
+### Phase B: Did this close the gap?
+- [x] RDH raises BoundaryFetchError on no datasets (was: return None)
+- [x] Error message includes level, state, year, format for diagnostics
+- [x] Consistent with CensusTIGERProvider behavior
+- [x] No external callers checked for None from this path
+- [x] AST parse clean
+
+## Findings
+No findings.
+
+## Evidence-predates-work
+Artifact: plans/self-review-1044.md

--- a/siege_utilities/geo/providers/boundary_providers.py
+++ b/siege_utilities/geo/providers/boundary_providers.py
@@ -452,11 +452,10 @@ class RDHProvider(BoundaryProvider):
             )
 
         if not datasets:
-            logger.warning(
-                'RDHProvider: no %s datasets found for state=%s year=%s format=%s',
-                level, state, year, fmt,
+            raise BoundaryFetchError(
+                f"RDHProvider: no {level} datasets found for state={state}, "
+                f"year={year}, format={fmt}"
             )
-            return None
 
         try:
             gdf = client.load_shapefile(datasets[0], **kwargs)


### PR DESCRIPTION
Closes #1044

## Summary

RDHProvider.get_boundary() returned None when no datasets were found, while CensusTIGERProvider raised BoundaryFetchError for the same case. The ABC contract specifies GeoDataFrame return, not Optional. Now consistent.

Note: The other two findings in #1044 (get_geographic_boundaries, get_census_boundaries returning None) are already deprecated with DeprecationWarnings pointing to fetch_geographic_boundaries(). No action needed on those.

## Source

Codex hostile review session 260619-apt-sequoia, findings S2-1/2/3.

## Self-review

`plans/self-review-1044.md`