### PR TITLE
chore(release): bump to 3.23.0

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.abspath('../../'))
 project = 'Siege Utilities'
 copyright = '2025-2026, Dheeraj Chand'
 author = 'Dheeraj Chand'
-release = '3.22.1'
+release = '3.23.0'
 
 extensions = [
     'sphinx.ext.autodoc',

--- a/docs/source/conf_fast.py
+++ b/docs/source/conf_fast.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.abspath('../../'))
 project = 'Siege Utilities'
 copyright = '2025-2026, Dheeraj Chand'
 author = 'Dheeraj Chand'
-release = '3.22.1'
+release = '3.23.0'
 
 extensions = [
     'sphinx.ext.autodoc',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "siege-utilities"
-version = "3.22.1"
+version = "3.23.0"
 description = "A comprehensive Python utilities package with enhanced auto-discovery"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -345,7 +345,7 @@ markers = [
 ]
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.23.0"
 ignore_missing_imports = true
 warn_unused_configs = true
 warn_return_any = true

--- a/scripts/release_manager.py
+++ b/scripts/release_manager.py
@@ -76,6 +76,9 @@ def read_versions() -> Dict[str, str]:
     """Read current version from each location."""
     versions = {}
     for name, spec in VERSION_FILES.items():
+        if not spec['path'].exists():
+            versions[name] = 'FILE MISSING'
+            continue
         content = spec['path'].read_text()
         match = re.search(spec['pattern'], content)
         if match:
@@ -150,7 +153,7 @@ def check_ci_status() -> bool:
 def check_consistency() -> Dict:
     """Check version consistency across all files."""
     versions = read_versions()
-    unique = set(versions.values()) - {'NOT FOUND'}
+    unique = set(versions.values()) - {'NOT FOUND', 'FILE MISSING'}
     return {
         'versions': versions,
         'consistent': len(unique) <= 1,
@@ -162,6 +165,9 @@ def set_version(new_version: str):
     """Set version across all files."""
     for name, spec in VERSION_FILES.items():
         path = spec['path']
+        if not path.exists():
+            logger.warning(f"Skipping {name} (file not found: {path})")
+            continue
         content = path.read_text()
         new_content = re.sub(spec['pattern'], rf'\g<1>{new_version}\2', content)
         if new_content == content:

--- a/siege_utilities/__init__.py
+++ b/siege_utilities/__init__.py
@@ -30,7 +30,7 @@ try:
     from importlib.metadata import version as _meta_version
     __version__ = _meta_version("siege-utilities")
 except (ImportError, ValueError, ModuleNotFoundError):
-    __version__ = "3.18.1-dev"  # fallback for editable installs without metadata
+    __version__ = "3.23.0"  # fallback for editable installs without metadata
 __author__ = "Siege Analytics"
 __description__ = "Comprehensive utilities for data engineering, analytics, and distributed computing"
 


### PR DESCRIPTION
Version bump to 3.23.0 for the Codex hostile review session (260619-apt-sequoia) — all 10 tickets resolved (#1041–#1050).

Also fixes release_manager.py to handle missing version files gracefully (docs/conf.py listed in VERSION_FILES but file doesn't exist).