### PR TITLE
ci: add manual publish-tag workflow for PyPI backfills

### DIFF
--- a/.github/workflows/publish-tag.yml
+++ b/.github/workflows/publish-tag.yml
@@ -1,0 +1,50 @@
+name: Publish Tag to PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag to build and publish (e.g. v3.22.1)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.tag }}
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build twine
+
+    - name: Verify tag matches package version
+      run: |
+        TAG_VERSION="${{ inputs.tag }}"
+        TAG_VERSION="${TAG_VERSION#v}"
+        PKG_VERSION=$(python -c "import re; print(re.search(r'version\s*=\s*\"([^\"]+)\"', open('pyproject.toml').read()).group(1))")
+        if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+          echo "ERROR: Tag ${TAG_VERSION} does not match package version ${PKG_VERSION}"
+          exit 1
+        fi
+        echo "Tag v${TAG_VERSION} matches package version ${PKG_VERSION}"
+
+    - name: Build package
+      run: python -m build
+
+    - name: Check package
+      run: twine check dist/*
+
+    - name: Publish to PyPI
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      run: twine upload dist/*


### PR DESCRIPTION
Adds a workflow_dispatch workflow that builds and publishes any existing git tag to PyPI. Needed to backfill 7 releases (v3.12.1, v3.13.0, v3.13.1, v3.18.0, v3.19.0, v3.20.0, v3.22.1) that were never published because the release event uses the workflow from the tag commit (which had test dependencies blocking build/release).