### PR TITLE
ci: fix release-gating self-trap and gdal build failure (#1064)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        uv sync --extra all --extra dev
+        echo "gdal==$(gdal-config --version)" > /tmp/uv-constraints.txt
+        UV_CONSTRAINT=/tmp/uv-constraints.txt uv sync --extra all --extra dev
 
     - name: Lint with flake8
       run: |
@@ -287,9 +288,6 @@ jobs:
     runs-on: ubuntu-latest
     name: "api contract regression"
 
-    env:
-      BASELINE_VERSION: "3.18.0"
-
     steps:
     - uses: actions/checkout@v4
 
@@ -297,6 +295,12 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.11"
+
+    - name: Resolve baseline version (latest published on PyPI)
+      run: |
+        BV=$(curl -s https://pypi.org/pypi/siege-utilities/json | python3 -c "import sys,json,re; d=json.load(sys.stdin); vs=[k for k,f in d['releases'].items() if f]; print(max(vs, key=lambda s:[int(x) for x in re.findall(r'\d+', s)]))")
+        echo "BASELINE_VERSION=${BV}" >> $GITHUB_ENV
+        echo "Resolved baseline (latest published on PyPI): ${BV}"
 
     - name: Infer release impact from version delta
       id: impact
@@ -447,7 +451,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        uv sync --extra all --extra dev
+        echo "gdal==$(gdal-config --version)" > /tmp/uv-constraints.txt
+        UV_CONSTRAINT=/tmp/uv-constraints.txt uv sync --extra all --extra dev
 
     - name: Run Battle Testing Suite
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,8 +193,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        echo "gdal==$(gdal-config --version)" > /tmp/uv-constraints.txt
-        UV_CONSTRAINT=/tmp/uv-constraints.txt uv sync --extra all --extra dev
+        sed -i "s/\"gdal>=3.6,<4\"/\"gdal==$(gdal-config --version)\"/g" pyproject.toml
+        uv sync --extra all --extra dev
 
     - name: Lint with flake8
       run: |
@@ -451,8 +451,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        echo "gdal==$(gdal-config --version)" > /tmp/uv-constraints.txt
-        UV_CONSTRAINT=/tmp/uv-constraints.txt uv sync --extra all --extra dev
+        sed -i "s/\"gdal>=3.6,<4\"/\"gdal==$(gdal-config --version)\"/g" pyproject.toml
+        uv sync --extra all --extra dev
 
     - name: Run Battle Testing Suite
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,7 @@ jobs:
     - name: Install dependencies
       run: |
         sed -i "s/\"gdal>=3.6,<4\"/\"gdal==$(gdal-config --version)\"/g" pyproject.toml
+        grep -qE '"gdal==[0-9]' pyproject.toml || { echo "gdal pin rewrite failed (gdal-config missing or pin literal changed)"; exit 1; }
         uv sync --extra all --extra dev
 
     - name: Lint with flake8
@@ -298,7 +299,7 @@ jobs:
 
     - name: Resolve baseline version (latest published on PyPI)
       run: |
-        BV=$(curl -s https://pypi.org/pypi/siege-utilities/json | python3 -c "import sys,json,re; d=json.load(sys.stdin); vs=[k for k,f in d['releases'].items() if f]; print(max(vs, key=lambda s:[int(x) for x in re.findall(r'\d+', s)]))")
+        BV=$(curl -sf --retry 3 --max-time 20 https://pypi.org/pypi/siege-utilities/json | python3 -c "import sys,json; print(json.load(sys.stdin)['info']['version'])")
         echo "BASELINE_VERSION=${BV}" >> $GITHUB_ENV
         echo "Resolved baseline (latest published on PyPI): ${BV}"
 
@@ -433,6 +434,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Install system geospatial libraries
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          gdal-bin libgdal-dev libgeos-dev libproj-dev
+
     - name: Set up Java 17
       uses: actions/setup-java@v4
       with:
@@ -452,6 +459,7 @@ jobs:
     - name: Install dependencies
       run: |
         sed -i "s/\"gdal>=3.6,<4\"/\"gdal==$(gdal-config --version)\"/g" pyproject.toml
+        grep -qE '"gdal==[0-9]' pyproject.toml || { echo "gdal pin rewrite failed (gdal-config missing or pin literal changed)"; exit 1; }
         uv sync --extra all --extra dev
 
     - name: Run Battle Testing Suite

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,13 @@ geo = [
     "tobler>=0.11.0",
     "osmnx>=1.9.4",
     "pysal>=24.1",
+    # pysal pulls segregation -> numba -> llvmlite transitively. Floor numba to
+    # a release with cp312/cp313 wheels: the CI gdal pin edits pyproject (to
+    # match the runner's libgdal), which invalidates uv.lock and forces a fresh
+    # resolve; without this floor that resolve backtracks to segregation 2.5.4
+    # -> numba 0.53.1 -> llvmlite 0.36.0, which has no 3.12/3.13 wheel and fails
+    # to build. numba>=0.61 forces segregation 2.5.5 + llvmlite 0.44+ (wheels).
+    "numba>=0.61",
     "censusgeocode>=0.5.2",
     "topojson>=1.8",
     # Required by PostGISConnector.upload_spatial_data for full-column
@@ -240,6 +247,9 @@ all = [
     "tobler>=0.11.0",
     "osmnx>=1.9.4",
     "pysal>=24.1",
+    # See the geo extra: floor numba so the CI-gdal-pin's fresh resolve does
+    # not pull the unbuildable llvmlite 0.36.0 on Python 3.12/3.13.
+    "numba>=0.61",
     "censusgeocode>=0.5.2",
     # h3
     "h3>=4.0.0",

--- a/pytest.ini
+++ b/pytest.ini
@@ -50,6 +50,7 @@ markers =
     databricks: Tests requiring Databricks runtime or SDK
     requires_gdal: Tests requiring GDAL libraries
     requires_spark: Tests requiring PySpark
+    requires_api_key: Tests requiring a live external API key (skipped without credentials)
 
 # Test filtering
 filterwarnings =

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,8 @@
 # ================================================================
 [pytest]
 DJANGO_SETTINGS_MODULE = tests.django_project.settings
+# Ensure the repo root is importable so tests.django_project.settings resolves
+pythonpath = .
 # Test discovery and execution
 testpaths =
     tests

--- a/scripts/contracts/contract_allowlist.json
+++ b/scripts/contracts/contract_allowlist.json
@@ -6,7 +6,9 @@
     "get_isochrone",
     "isochrone_to_geodataframe"
   ],
-  "removed_symbols": [],
+  "removed_symbols": [
+    "user_config"
+  ],
   "signature_changes": [
     "compare_census_datasets",
     "compare_datasets",

--- a/siege_utilities/__init__.py
+++ b/siege_utilities/__init__.py
@@ -153,7 +153,7 @@ _register_lazy([
 # ── Pydantic config system (requires pydantic>=2.0) ──────────────────
 
 _register_lazy([
-    'UserConfigManager', 'UserProfile', 'user_config',
+    'UserConfigManager', 'UserProfile',
     'get_user_config', 'get_download_directory',
 ], '.config.user_config', deps=['pydantic>=2.0'])
 

--- a/siege_utilities/analytics/instagram.py
+++ b/siege_utilities/analytics/instagram.py
@@ -34,7 +34,6 @@ from siege_utilities.analytics._social_protocol import (
     SocialMediaAuthError,
     SocialMediaError,
     SocialMediaRateLimitError,
-    SocialPost,
 )
 
 log = logging.getLogger(__name__)

--- a/siege_utilities/config/census_registry.py
+++ b/siege_utilities/config/census_registry.py
@@ -118,8 +118,8 @@ CANONICAL_GEOGRAPHIC_LEVELS: Dict[str, dict] = {
     "zcta":        {"aliases": ["zip_code", "zcta5", "zipcode", "zip code"],      "geoid_length": 5},
     "cbsa":        {"aliases": [],                                               "geoid_length": 5},
     "puma":        {"aliases": [],                                               "geoid_length": 7},
-    "vtd":         {"aliases": ["voting_district", "voting district"],            "geoid_length": 6},
-    "vtd20":       {"aliases": [],                                               "geoid_length": 6},
+    "vtd":         {"aliases": ["voting_district", "voting district"],            "geoid_length": 11},
+    "vtd20":       {"aliases": [],                                               "geoid_length": 11},
 }
 
 # Build reverse lookup: alias → canonical (computed once at import time)

--- a/siege_utilities/config/databases.py
+++ b/siege_utilities/config/databases.py
@@ -8,7 +8,7 @@ import os
 import pathlib
 import logging
 import re
-from typing import Dict, Any, Optional
+from typing import Dict, Any
 from urllib.parse import quote_plus
 
 __all__ = [

--- a/siege_utilities/config/hydra_manager.py
+++ b/siege_utilities/config/hydra_manager.py
@@ -11,7 +11,6 @@ from omegaconf import OmegaConf
 from pathlib import Path
 from typing import Dict, Any, Optional, List
 import logging
-import yaml
 
 from .models import (
     UserProfile,

--- a/siege_utilities/config/models/actor_types.py
+++ b/siege_utilities/config/models/actor_types.py
@@ -10,7 +10,7 @@ import re
 
 import yaml
 
-from .person import Person, _convert_to_yaml_safe
+from .person import Person, _convert_to_yaml_safe, _strip_sensitive_fields
 from .branding_config import BrandingConfig
 from .report_preferences import ReportPreferences
 

--- a/siege_utilities/data/dataframe_engine.py
+++ b/siege_utilities/data/dataframe_engine.py
@@ -1,0 +1,21 @@
+"""Deprecation shim — re-exports from :mod:`siege_utilities.engines.dataframe_engine`.
+
+The multi-engine DataFrame abstraction moved to ``siege_utilities.engines``
+(engines are an execution concern, not a data-domain one). Update your imports;
+this shim will be removed in v4.0.0.
+"""
+import warnings as _warnings
+
+_warnings.warn(
+    "siege_utilities.data.dataframe_engine has moved to "
+    "siege_utilities.engines.dataframe_engine. Update your imports; "
+    "this shim will be removed in v4.0.0.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+from ..engines.dataframe_engine import *  # noqa: F401, F403, E402
+
+# Re-export everything from the canonical module location
+from ..engines.dataframe_engine import __all__ as _upstream_all  # noqa: F401, E402
+__all__ = _upstream_all if _upstream_all else []  # noqa: E402

--- a/siege_utilities/examples/enhanced_features_demo.py
+++ b/siege_utilities/examples/enhanced_features_demo.py
@@ -15,17 +15,13 @@ Prerequisites:
 
 import logging
 import sys
-from pathlib import Path
 from typing import Optional
 
 import geopandas as gpd
-import pandas as pd
 
 from siege_utilities import get_user_config, get_download_directory
 from siege_utilities.geo import (
     get_census_boundaries,
-    get_census_data,
-    download_osm_data,
     SpatialDataTransformer,
 )
 from siege_utilities.reporting.chart_types import get_chart_registry

--- a/siege_utilities/examples/enhanced_features_demo.py
+++ b/siege_utilities/examples/enhanced_features_demo.py
@@ -74,7 +74,7 @@ def demo_page_templates():
 
     title_template = template_manager.get_template("pdf_title")
     if title_template:
-        print(f"\nTitle template properties:")
+        print("\nTitle template properties:")
         print(f"  - Page dimensions: {title_template.page_width}\" x {title_template.page_height}\"")
         print(f"  - Margins: {title_template.margins}")
         print(f"  - Custom elements: {title_template.custom_elements}")
@@ -96,7 +96,7 @@ def demo_chart_types():
 
     bivariate_help = chart_registry.get_chart_help("bivariate_choropleth")
     if bivariate_help:
-        print(f"\nBivariate choropleth chart:")
+        print("\nBivariate choropleth chart:")
         print(f"  - Description: {bivariate_help['description']}")
         print(f"  - Required parameters: {bivariate_help['required_parameters']}")
         print(f"  - Supports interactive: {bivariate_help['supports_interactive']}")

--- a/siege_utilities/files/operations.py
+++ b/siege_utilities/files/operations.py
@@ -130,7 +130,7 @@ def remove_tree(path: FilePath) -> None:
         >>> remove_tree(Path("old_files"))  # doctest: +SKIP
     """
     try:
-        from siege_utilities.files.validation import validate_safe_path, PathSecurityError
+        from siege_utilities.files.validation import validate_safe_path
         path_obj = validate_safe_path(path, allow_absolute=True)
     except ImportError:
         path_obj = Path(path)
@@ -215,7 +215,7 @@ def touch_file(path: FilePath, create_parents: bool = True) -> None:
         >>> touch_file(Path("data/output.txt"))  # doctest: +SKIP
     """
     try:
-        from siege_utilities.files.validation import validate_safe_path, PathSecurityError
+        from siege_utilities.files.validation import validate_safe_path
         path_obj = validate_safe_path(path, allow_absolute=True)
     except ImportError:
         path_obj = Path(path)
@@ -251,7 +251,7 @@ def count_lines(file_path: FilePath, encoding: str = 'utf-8') -> int:
         >>> print(f"File has {line_count} lines")  # doctest: +SKIP
     """
     try:
-        from siege_utilities.files.validation import validate_file_path, PathSecurityError
+        from siege_utilities.files.validation import validate_file_path
         path_obj = validate_file_path(file_path, must_exist=True)
     except ImportError:
         path_obj = Path(file_path)
@@ -290,7 +290,7 @@ def copy_file(source: FilePath, destination: FilePath, overwrite: bool = False) 
         >>> copy_file(Path("config.yaml"), Path("config.yaml.bak"))  # doctest: +SKIP
     """
     try:
-        from siege_utilities.files.validation import validate_file_path, validate_safe_path, PathSecurityError
+        from siege_utilities.files.validation import validate_file_path, validate_safe_path
         source_obj = validate_file_path(source, must_exist=True)
         dest_obj = validate_safe_path(destination, allow_absolute=True)
     except ImportError:
@@ -333,7 +333,7 @@ def move_file(source: FilePath, destination: FilePath, overwrite: bool = False) 
         >>> move_file(Path("old.log"), Path("logs/old.log"))  # doctest: +SKIP
     """
     try:
-        from siege_utilities.files.validation import validate_file_path, validate_safe_path, PathSecurityError
+        from siege_utilities.files.validation import validate_file_path, validate_safe_path
         source_obj = validate_file_path(source, must_exist=True)
         dest_obj = validate_safe_path(destination, allow_absolute=True)
     except ImportError:
@@ -377,7 +377,7 @@ def get_file_size(file_path: FilePath) -> int:
         >>> print(f"File size: {size} bytes")  # doctest: +SKIP
     """
     try:
-        from siege_utilities.files.validation import validate_file_path, PathSecurityError
+        from siege_utilities.files.validation import validate_file_path
         path_obj = validate_file_path(file_path, must_exist=True)
     except ImportError:
         path_obj = Path(file_path)
@@ -420,7 +420,7 @@ def list_directory(path: FilePath,
         >>> dirs = list_directory("logs", include_files=False)  # doctest: +SKIP
     """
     try:
-        from siege_utilities.files.validation import validate_directory_path, PathSecurityError
+        from siege_utilities.files.validation import validate_directory_path
         path_obj = validate_directory_path(path, must_exist=True)
     except ImportError:
         path_obj = Path(path)

--- a/siege_utilities/files/operations.py
+++ b/siege_utilities/files/operations.py
@@ -6,6 +6,7 @@ Provides clean, type-safe file manipulation utilities.
 import contextlib
 import json
 import os
+import re
 import subprocess
 import shutil
 import logging
@@ -18,6 +19,43 @@ log = logging.getLogger(__name__)
 
 # Type aliases
 FilePath = Union[str, Path]
+
+# Characters that are unsafe in a filename across the common filesystems.
+# Anything that is not a word char, dot, or hyphen is replaced.
+_UNSAFE_FILENAME_CHARS = re.compile(r"[^\w.\-]+")
+
+
+def sanitize_filename(name: str) -> str:
+    """Convert an arbitrary string into a safe filename component.
+
+    Unsafe characters (path separators, control characters, punctuation other
+    than ``.`` and ``-``) are replaced with underscores, runs of underscores
+    are collapsed, and leading/trailing dots and underscores are trimmed. The
+    result is always a non-empty string and the operation is idempotent
+    (``sanitize_filename(sanitize_filename(x)) == sanitize_filename(x)``).
+
+    Parameters
+    ----------
+    name : str
+        Arbitrary input string.
+
+    Returns
+    -------
+    str
+        A filesystem-safe filename component.
+
+    Raises
+    ------
+    TypeError
+        If ``name`` is not a string.
+    """
+    if not isinstance(name, str):
+        raise TypeError(f"name must be str, got {type(name).__name__}")
+
+    cleaned = _UNSAFE_FILENAME_CHARS.sub("_", name)
+    cleaned = re.sub(r"_+", "_", cleaned)
+    cleaned = cleaned.strip("._")
+    return cleaned or "_"
 
 
 @contextlib.contextmanager
@@ -840,6 +878,7 @@ def list_files_recursive(
 
 __all__ = [
     'FilePath',
+    'sanitize_filename',
     'atomic_write_path',
     'atomic_write_shapefile',
     'remove_tree',

--- a/siege_utilities/files/remote.py
+++ b/siege_utilities/files/remote.py
@@ -131,7 +131,7 @@ def download_file(url: str, local_filename: FilePath,
     log.info(f'Downloading {url} to {local_filename}')
 
     try:
-        from siege_utilities.files.validation import validate_safe_path, PathSecurityError
+        from siege_utilities.files.validation import validate_safe_path
         local_path = validate_safe_path(local_filename, allow_absolute=True)
     except ImportError:
         local_path = Path(local_filename)
@@ -238,7 +238,7 @@ def generate_local_path_from_url(url: str, directory_path: FilePath,
         raise ValueError(f"Could not extract filename from URL: {url}")
 
     try:
-        from siege_utilities.files.validation import validate_directory_path, PathSecurityError
+        from siege_utilities.files.validation import validate_directory_path
         dir_path = validate_directory_path(directory_path, must_exist=False)
     except ImportError:
         dir_path = Path(directory_path)

--- a/siege_utilities/geo/boundary_providers.py
+++ b/siege_utilities/geo/boundary_providers.py
@@ -4,8 +4,6 @@ Moved during ELE-2438 (spatial providers consolidated under
 ``geo/providers/``). Will be removed in v4.0.0.
 """
 
-# __all__ is inherited from the wildcard re-export below.
-
 import warnings as _warnings
 
 _warnings.warn(
@@ -16,7 +14,14 @@ _warnings.warn(
     stacklevel=2,
 )
 
-from .providers.boundary_providers import *  # noqa: F401, F403, E402
+from .providers.boundary_providers import (  # noqa: E402
+    BoundaryFetchError,
+    BoundaryProvider,
+    CensusTIGERProvider,
+    GADMProvider,
+    RDHProvider,
+    resolve_boundary_provider,
+)
 
 __all__ = [
     "BoundaryFetchError",

--- a/siege_utilities/geo/census/catalog_docs.py
+++ b/siege_utilities/geo/census/catalog_docs.py
@@ -10,13 +10,11 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Optional
 
 from .catalog import (
     CensusCatalog,
     CensusCatalogDataset,
     CensusFamily,
-    CensusSubject,
     CensusTable,
     FamilyType,
 )
@@ -187,7 +185,7 @@ def _render_table_page(
             lines.append(f"- {ds.dataset_id} ({ds.survey_type}, {ds.year})")
         lines.append("")
 
-    lines.append(f"[← Back to index](../index.md)")
+    lines.append("[← Back to index](../index.md)")
     lines.append("")
 
     return "\n".join(lines)

--- a/siege_utilities/geo/census/catalog_populator.py
+++ b/siege_utilities/geo/census/catalog_populator.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Optional
 
 import requests
 

--- a/siege_utilities/geo/census_api_client.py
+++ b/siege_utilities/geo/census_api_client.py
@@ -200,7 +200,7 @@ class CensusAPIClient:
         df = self._make_request_with_retry(url)
 
         # Process response
-        df = self._process_response(df, geography, state_fips, county_fips)
+        df = self._process_response(df, geography)
 
         # Cache result
         self._save_to_cache(cache_key, df)
@@ -300,10 +300,8 @@ class CensusAPIClient:
     def _make_request_with_retry(self, url: str) -> pd.DataFrame:
         return self._api._make_request_with_retry(url)
 
-    def _process_response(self, df: pd.DataFrame, geography: str,
-                          state_fips: Optional[str],
-                          county_fips: Optional[str]) -> pd.DataFrame:
-        return self._api._process_response(df, geography, state_fips, county_fips)
+    def _process_response(self, df: pd.DataFrame, geography: str) -> pd.DataFrame:
+        return self._api._process_response(df, geography)
 
     def _resolve_api_key(self, explicit_key: Optional[str]) -> Optional[str]:
         return CensusAPI._resolve_api_key(explicit_key)

--- a/siege_utilities/geo/choropleth.py
+++ b/siege_utilities/geo/choropleth.py
@@ -78,10 +78,8 @@ except ImportError:
     HAS_MAPCLASSIFY = False
 
 from siege_utilities.geo.classification import (
-    ClassificationResult,
     classify_choropleth,
     classify_series,
-    AVAILABLE_SCHEMES,
 )
 
 

--- a/siege_utilities/geo/classification.py
+++ b/siege_utilities/geo/classification.py
@@ -233,7 +233,11 @@ AVAILABLE_SCHEMES: dict[str, str] = {
 _MC_SCHEME_MAP = {
     "quantiles": "Quantiles",
     "equal_interval": "EqualInterval",
-    "natural_breaks": "NaturalBreaks",
+    # "natural_breaks" is documented as Fisher-Jenks (see AVAILABLE_SCHEMES) and
+    # the numpy fallback aliases the two. Use the exact FisherJenks classifier
+    # for both -- mapclassify's "NaturalBreaks" is a k-means approximation that
+    # produces suboptimal, non-aliased breaks.
+    "natural_breaks": "FisherJenks",
     "fisher_jenks": "FisherJenks",
     "percentiles": "Percentiles",
     "std_mean": "StdMean",
@@ -263,7 +267,9 @@ def _classify_with_mapclassify(
     breaks = np.unique(breaks)
     actual_k = len(breaks) - 1
 
-    bins = np.searchsorted(breaks[1:-1], values, side="right").astype(np.intp)
+    # mapclassify bins are upper-inclusive (a value <= an edge belongs to that
+    # bin), so a value exactly on an interior break maps to the lower bin.
+    bins = np.searchsorted(breaks[1:-1], values, side="left").astype(np.intp)
 
     return ClassificationResult(
         bins=bins,

--- a/siege_utilities/geo/classification.py
+++ b/siege_utilities/geo/classification.py
@@ -14,8 +14,8 @@ Backend dispatch (in priority order):
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
-from typing import Optional, Union
+from dataclasses import dataclass
+from typing import Union
 
 import numpy as np
 import pandas as pd

--- a/siege_utilities/geo/codification_blocks.py
+++ b/siege_utilities/geo/codification_blocks.py
@@ -6,10 +6,9 @@ geographic spread metrics (block count, spatial extent, concentration).
 
 from __future__ import annotations
 
-import math
 import logging
 from collections import Counter
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional
 
 __all__ = [

--- a/siege_utilities/geo/codification_demographics.py
+++ b/siege_utilities/geo/codification_demographics.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 
 import abc
 import logging
-from dataclasses import dataclass, field
-from typing import Any, Optional
+from dataclasses import dataclass
+from typing import Optional
 
 __all__ = [
     'BlockDemographics',

--- a/siege_utilities/geo/interpolation/areal.py
+++ b/siege_utilities/geo/interpolation/areal.py
@@ -32,7 +32,6 @@ except ImportError:
     _GEOPANDAS_AVAILABLE = False
 
 try:
-    import shapely
     from shapely import STRtree
     _SHAPELY_AVAILABLE = True
 except ImportError:
@@ -151,7 +150,6 @@ def _interpolate_duckdb(
 ) -> gpd.GeoDataFrame:
     """Area-weighted interpolation via DuckDB spatial SQL."""
     import pandas as pd
-    from shapely import wkb as shapely_wkb
 
     con = _duckdb.connect()
     con.execute("INSTALL spatial; LOAD spatial;")

--- a/siege_utilities/geo/nces_download.py
+++ b/siege_utilities/geo/nces_download.py
@@ -3,8 +3,6 @@
 Moved during ELE-2438. Will be removed in v4.0.0.
 """
 
-# __all__ is inherited from the wildcard re-export below.
-
 import warnings as _warnings
 
 _warnings.warn(
@@ -15,7 +13,13 @@ _warnings.warn(
     stacklevel=2,
 )
 
-from .providers.nces_download import *  # noqa: F401, F403, E402
+from .providers.nces_download import (  # noqa: E402
+    DISTRICT_DATA_COLUMNS,
+    LOCALE_BOUNDARY_COLUMNS,
+    NCESDownloadError,
+    NCESDownloader,
+    SCHOOL_LOCATION_COLUMNS,
+)
 
 __all__ = [
     "LOCALE_BOUNDARY_COLUMNS",

--- a/siege_utilities/geo/overlays/election_results.py
+++ b/siege_utilities/geo/overlays/election_results.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import abc
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Optional
 
 from siege_utilities.geo.overlay_registry import PlaceHistoryOverlay
 

--- a/siege_utilities/geo/overlays/redistricting.py
+++ b/siege_utilities/geo/overlays/redistricting.py
@@ -10,13 +10,9 @@ import abc
 import logging
 from dataclasses import dataclass, field
 from datetime import date
-from typing import Any, Optional
+from typing import Optional
 
 from siege_utilities.geo.overlay_registry import PlaceHistoryOverlay
-from siege_utilities.geo.plan_lifecycle import (
-    PlanType,
-    RedistrictingPlan,
-)
 
 log = logging.getLogger(__name__)
 

--- a/siege_utilities/geo/overlays/seats.py
+++ b/siege_utilities/geo/overlays/seats.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import abc
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Optional
 
 from siege_utilities.geo.overlay_registry import PlaceHistoryOverlay
 

--- a/siege_utilities/geo/place_history.py
+++ b/siege_utilities/geo/place_history.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import abc
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Optional, Protocol, Union
+from typing import Any, Optional
 
 log = logging.getLogger(__name__)
 

--- a/siege_utilities/geo/providers/census_batch.py
+++ b/siege_utilities/geo/providers/census_batch.py
@@ -8,7 +8,7 @@ converting :class:`CensusGeocodeResult` to the unified
 from __future__ import annotations
 
 import logging
-from typing import Optional, Union
+from typing import Union
 
 from .batch_geocoder import (
     AddressInput,

--- a/siege_utilities/geo/providers/census_geocoder.py
+++ b/siege_utilities/geo/providers/census_geocoder.py
@@ -28,7 +28,10 @@ import os
 import tempfile
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 logger = logging.getLogger(__name__)
 

--- a/siege_utilities/geo/providers/composite_geocoder.py
+++ b/siege_utilities/geo/providers/composite_geocoder.py
@@ -11,7 +11,7 @@ Nominatim or TAMU for failures.
 from __future__ import annotations
 
 import logging
-from typing import Optional, Union
+from typing import Union
 
 from .batch_geocoder import (
     AddressInput,

--- a/siege_utilities/geo/providers/etter_filter.py
+++ b/siege_utilities/geo/providers/etter_filter.py
@@ -276,10 +276,11 @@ class EtterParser:
             raise EtterParseError("Empty query string")
         try:
             geo_query = self._parser.parse(query)
-        except (ValueError, TypeError, KeyError, AttributeError) as exc:
-            # If the upstream raised its own low-confidence error
-            # (matching by class name to avoid a hard import dependency
-            # on a moving target), surface it as our typed exception.
+        except Exception as exc:
+            # Any upstream parse failure is surfaced as our typed exception
+            # (cause chained). If the upstream raised its own low-confidence
+            # error (matched by class name to avoid a hard import dependency on
+            # a moving target), translate it specifically.
             if type(exc).__name__ == "LowConfidenceError":
                 raise EtterLowConfidenceError(
                     f"Upstream rejected {query!r} as low-confidence: {exc}"

--- a/siege_utilities/geo/providers/nominatim_batch.py
+++ b/siege_utilities/geo/providers/nominatim_batch.py
@@ -130,7 +130,9 @@ class NominatimBatchGeocoder(BatchGeocoder):
                     match_quality=MatchQuality.APPROXIMATE.value,
                     backend=self.backend_name,
                 )
-        except (OSError, ValueError, TypeError, KeyError, AttributeError) as exc:
+        except Exception as exc:
+            # Batch robustness: any failure on one address is logged and
+            # recorded as an unmatched result so the rest of the batch proceeds.
             log.warning("Nominatim geocode failed for %s: %s", addr.input_id, exc)
 
         return GeocodingResult(
@@ -166,7 +168,9 @@ class NominatimBatchGeocoder(BatchGeocoder):
                         lon = float(data[0]["lon"])
                         return (lat, lon)
                     return None
-            except (OSError, ValueError, TypeError):
+            except Exception:
+                # Retry on any request/parse failure up to max_retries, then
+                # re-raise so the caller sees the underlying error.
                 if attempt == self._max_retries:
                     raise
                 time.sleep(self._rate_limit)

--- a/siege_utilities/geo/providers/tamu_batch.py
+++ b/siege_utilities/geo/providers/tamu_batch.py
@@ -132,7 +132,9 @@ class TAMUBatchGeocoder(BatchGeocoder):
             resp = self._tamu_request(addr)
             if resp is not None:
                 return resp
-        except (OSError, ValueError, TypeError, KeyError, AttributeError) as exc:
+        except Exception as exc:
+            # Batch robustness: any failure on one address is logged and
+            # recorded as an unmatched result so the rest of the batch proceeds.
             log.warning("TAMU geocode failed for %s: %s", addr.input_id, exc)
 
         return GeocodingResult(
@@ -169,7 +171,9 @@ class TAMUBatchGeocoder(BatchGeocoder):
                 with urllib.request.urlopen(req, timeout=15) as resp:
                     data = json.loads(resp.read().decode("utf-8"))
                     return self._parse_response(data, addr)
-            except (OSError, ValueError, TypeError):
+            except Exception:
+                # Retry on any request/parse failure up to max_retries, then
+                # re-raise so the caller sees the underlying error.
                 if attempt == self._max_retries:
                     raise
                 time.sleep(self._rate_limit)

--- a/siege_utilities/geo/spatial_data.py
+++ b/siege_utilities/geo/spatial_data.py
@@ -1082,7 +1082,11 @@ class CensusDirectoryDiscovery:
                 f"URL validation timed out after {self.timeout}s: {url}",
                 context=ctx,
             ) from e
-        except (requests.exceptions.RequestException, OSError) as e:
+        except BoundaryUrlValidationError:
+            raise
+        except Exception as e:
+            # Any failure reaching the validation endpoint means the URL could
+            # not be validated; surface it as the documented typed error.
             ctx["error_type"] = type(e).__name__
             raise BoundaryUrlValidationError(
                 f"URL validation failed for {url}: {e}",
@@ -1405,7 +1409,7 @@ class CensusDataSource(SpatialDataSource):
                 message=str(e),
                 context={**base_ctx, **e.context},
             )
-        except (OSError, ValueError, TypeError, KeyError, AttributeError, requests.exceptions.RequestException, ImportError) as e:
+        except Exception as e:
             return BoundaryFetchResult.fail(
                 error_code="UNEXPECTED_ERROR",
                 error_stage="unknown",

--- a/siege_utilities/geo/spatial_data.py
+++ b/siege_utilities/geo/spatial_data.py
@@ -2349,7 +2349,7 @@ def __getattr__(name: str):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-__all__ = [
+__all__ = [  # noqa: F822  -- census_source/government_source/osm_source are PEP 562 lazy attrs via __getattr__
     # Errors
     'SpatialDataError',
     # Classes

--- a/siege_utilities/geo/spatial_transformations.py
+++ b/siege_utilities/geo/spatial_transformations.py
@@ -59,7 +59,10 @@ class SpatialDataTransformer:
         """Initialize the spatial data transformer."""
         try:
             self.user_config = get_user_config()
-        except (ImportError, OSError, ValueError, KeyError, AttributeError) as e:
+        except Exception as e:
+            # user_config is optional; ANY failure to load it (missing pydantic,
+            # bad config file, validation error, etc.) degrades to None rather
+            # than breaking construction. The error is logged, not swallowed.
             log.warning(f"Failed to load user config: {e}")
             # Use None (not {}) so callers branching on `is None` work
             # uniformly across SpatialDataTransformer / PostGISConnector
@@ -242,7 +245,10 @@ class PostGISConnector:
         """
         try:
             self.user_config = get_user_config()
-        except (ImportError, OSError, ValueError, KeyError, AttributeError) as e:
+        except Exception as e:
+            # user_config is optional; ANY failure to load it (missing pydantic,
+            # bad config file, validation error, etc.) degrades to None rather
+            # than breaking construction. The error is logged, not swallowed.
             log.warning(f"Failed to load user config: {e}")
             self.user_config = None
 
@@ -347,7 +353,11 @@ class PostGISConnector:
                 f"({len(gdf)} rows, {len(gdf.columns)} columns)"
             )
 
-        except (_Psycopg2Error, OSError, ValueError, TypeError, AttributeError, ImportError) as e:
+        except Exception as e:
+            # to_postgis surfaces failures as SQLAlchemy / psycopg2 / value
+            # errors depending on the cause; wrap them all in the documented
+            # SpatialQueryError (preserving the cause). The engine is already
+            # disposed in the finally above.
             raise SpatialQueryError(f"Failed to upload to PostGIS: {e}") from e
     
     def download_spatial_data(self, table_name: str, *, crs: str | None = None, **kwargs) -> GeoDataFrame:
@@ -531,7 +541,10 @@ class DuckDBConnector:
         
         try:
             self.user_config = get_user_config()
-        except (ImportError, OSError, ValueError, KeyError, AttributeError) as e:
+        except Exception as e:
+            # user_config is optional; ANY failure to load it (missing pydantic,
+            # bad config file, validation error, etc.) degrades to None rather
+            # than breaking construction. The error is logged, not swallowed.
             log.warning(f"Failed to load user config: {e}")
             self.user_config = None
 
@@ -553,7 +566,9 @@ class DuckDBConnector:
         try:
             self.connection = duckdb.connect(self.db_path)
             log.info("Successfully connected to DuckDB")
-        except (_DuckDBError, OSError) as e:
+        except Exception as e:
+            # Any failure opening the connection is a connection failure; wrap
+            # it (preserving the cause) so callers see one typed error.
             raise RuntimeError(f"Failed to connect to DuckDB: {e}") from e
 
     def close(self):

--- a/siege_utilities/geo/timeseries/longitudinal_data.py
+++ b/siege_utilities/geo/timeseries/longitudinal_data.py
@@ -184,7 +184,9 @@ def get_longitudinal_data(
             else:
                 log.warning(f"  No data returned for {year}")
 
-        except (OSError, ValueError, TypeError, KeyError, AttributeError, RuntimeError) as e:
+        except Exception as e:
+            # Any per-year fetch failure is surfaced: strict_years re-raises it
+            # as ValueError (documented), otherwise it is logged and skipped.
             if strict_years:
                 raise ValueError(
                     f"Failed to fetch data for year {year}: {e}. "

--- a/siege_utilities/geo/timeseries/longitudinal_data.py
+++ b/siege_utilities/geo/timeseries/longitudinal_data.py
@@ -722,7 +722,8 @@ class LongitudinalAligner:
                 current_df = self._apply_crosswalk_step(
                     current_df, src, tgt, geo, sfips, geoid_column,
                 )
-            except (ValueError, TypeError, KeyError, AttributeError, OSError) as exc:
+            except Exception as exc:
+                # Any crosswalk-step failure falls back to areal interpolation.
                 log.warning(
                     "Crosswalk %d→%d failed (%s), trying areal interpolation",
                     src, tgt, exc,
@@ -735,7 +736,7 @@ class LongitudinalAligner:
                     warnings.append(
                         f"Used areal interpolation for {src}→{tgt} (crosswalk unavailable)"
                     )
-                except (ValueError, TypeError, KeyError, AttributeError, OSError) as areal_exc:
+                except Exception as areal_exc:
                     msg = (
                         f"Both crosswalk and areal interpolation failed for "
                         f"{src}→{tgt}: {areal_exc}"

--- a/siege_utilities/git/git_operations.py
+++ b/siege_utilities/git/git_operations.py
@@ -5,7 +5,6 @@ Comprehensive git commands and workflow automation.
 
 from typing import Dict, Optional
 import re
-import subprocess
 
 from siege_utilities.core.logging import log_info, log_warning
 from siege_utilities.exceptions import GitError

--- a/siege_utilities/git/git_operations.py
+++ b/siege_utilities/git/git_operations.py
@@ -5,6 +5,10 @@ Comprehensive git commands and workflow automation.
 
 from typing import Dict, Optional
 import re
+# run_git_command lives in ._utils, but the git-command tests patch
+# `siege_utilities.git.git_operations.subprocess.run`, so this module must
+# expose `subprocess` as that patch surface. Kept deliberately; not dead code.
+import subprocess  # noqa: F401
 
 from siege_utilities.core.logging import log_info, log_warning
 from siege_utilities.exceptions import GitError

--- a/siege_utilities/reporting/client_branding.py
+++ b/siege_utilities/reporting/client_branding.py
@@ -273,7 +273,7 @@ class ClientBrandingManager:
             log.info(f"Created branding configuration for {client_name}: {config_file}")
             return config_file
 
-        except (OSError, ValueError, KeyError, TypeError) as e:
+        except (OSError, ValueError, KeyError, TypeError, yaml.YAMLError) as e:
             log.error(f"Error creating branding configuration for {client_name}: {e}")
             raise
 
@@ -309,7 +309,7 @@ class ClientBrandingManager:
 
         except (ClientBrandingNotFoundError, ClientBrandingError):
             raise
-        except (OSError, ValueError, KeyError, TypeError) as e:
+        except (OSError, ValueError, KeyError, TypeError, yaml.YAMLError) as e:
             raise ClientBrandingError(
                 f"Error loading branding configuration for {client_name}: {e}"
             ) from e
@@ -345,7 +345,7 @@ class ClientBrandingManager:
 
         except (ClientBrandingNotFoundError, ClientBrandingError):
             raise
-        except (OSError, ValueError, KeyError, TypeError) as e:
+        except (OSError, ValueError, KeyError, TypeError, yaml.YAMLError) as e:
             raise ClientBrandingError(
                 f"Error updating branding configuration for {client_name}: {e}"
             ) from e
@@ -433,7 +433,7 @@ class ClientBrandingManager:
             
             return self.create_client_branding(client_name, branding_config)
             
-        except (OSError, ValueError, KeyError, TypeError) as e:
+        except (OSError, ValueError, KeyError, TypeError, yaml.YAMLError) as e:
             log.error(f"Error creating branding from template: {e}")
             raise
 
@@ -547,7 +547,7 @@ class ClientBrandingManager:
 
         except (ClientBrandingError, ValueError):
             raise
-        except (OSError, KeyError, TypeError) as e:
+        except (OSError, KeyError, TypeError, yaml.YAMLError) as e:
             raise ClientBrandingError(
                 f"Error importing branding configuration: {e}"
             ) from e
@@ -578,7 +578,7 @@ class ClientBrandingManager:
 
         except (ClientBrandingNotFoundError, ClientBrandingError):
             raise
-        except (OSError, ValueError, KeyError, TypeError) as e:
+        except (OSError, ValueError, KeyError, TypeError, yaml.YAMLError) as e:
             raise ClientBrandingError(
                 f"Error getting branding summary for {client_name}: {e}"
             ) from e

--- a/siege_utilities/reporting/engines/bar_engine.py
+++ b/siege_utilities/reporting/engines/bar_engine.py
@@ -135,15 +135,14 @@ class BarChartMixin:
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
         except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-
-
-            raise RuntimeError(
-
-
-                f"Chart Error: {e}"
-
-
-            ) from e
+            # Reporting robustness: a single chart with bad/empty data renders a
+            # visible "Chart Error" placeholder (logged) rather than aborting the
+            # whole report. Consistent with the matplotlib-unavailable path above
+            # and the documented "Returns: ReportLab Image" contract.
+            log.warning(f"Chart generation failed ({e}); rendering placeholder")
+            return self._create_placeholder_chart(
+                width, height, text=f"Chart Error: {e}"
+            )
 
     def create_line_chart(self, data: Union[pd.DataFrame, Dict[str, Any]],
                          x_column: str = None, y_columns: List[str] = None,
@@ -227,15 +226,14 @@ class BarChartMixin:
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
         except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-
-
-            raise RuntimeError(
-
-
-                f"Chart Error: {e}"
-
-
-            ) from e
+            # Reporting robustness: a single chart with bad/empty data renders a
+            # visible "Chart Error" placeholder (logged) rather than aborting the
+            # whole report. Consistent with the matplotlib-unavailable path above
+            # and the documented "Returns: ReportLab Image" contract.
+            log.warning(f"Chart generation failed ({e}); rendering placeholder")
+            return self._create_placeholder_chart(
+                width, height, text=f"Chart Error: {e}"
+            )
 
     def create_pie_chart(self, data: Union[pd.DataFrame, Dict[str, Any]],
                         labels_column: str = None, values_column: str = None,
@@ -347,15 +345,14 @@ class BarChartMixin:
             return self._matplotlib_to_reportlab_image(fig, width, height)
 
         except (ValueError, TypeError, KeyError, IndexError, AttributeError) as e:
-
-
-            raise RuntimeError(
-
-
-                f"Chart Error: {e}"
-
-
-            ) from e
+            # Reporting robustness: a single chart with bad/empty data renders a
+            # visible "Chart Error" placeholder (logged) rather than aborting the
+            # whole report. Consistent with the matplotlib-unavailable path above
+            # and the documented "Returns: ReportLab Image" contract.
+            log.warning(f"Chart generation failed ({e}); rendering placeholder")
+            return self._create_placeholder_chart(
+                width, height, text=f"Chart Error: {e}"
+            )
 
     def create_proportional_text_bar_chart(self,
                                          data: 'pd.DataFrame',

--- a/siege_utilities/reporting/engines/base_engine.py
+++ b/siege_utilities/reporting/engines/base_engine.py
@@ -49,6 +49,21 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
+
+def _rl_image_from_data_uri(data_uri: str, width_pts: float, height_pts: float) -> "Image":
+    """Build a ReportLab Image from a base64 ``data:`` URI.
+
+    ReportLab 5 cannot construct an Image directly from a data: URI (its
+    open_for_read gates the data scheme behind trustedHosts and raises at
+    construction). Decode the URI to an in-memory buffer for rendering, then
+    keep the URI on ``.filename`` so image_utils can still extract the PNG.
+    """
+    b64 = data_uri.split(",", 1)[1]
+    buffer = io.BytesIO(base64.b64decode(b64))
+    image = Image(buffer, width=width_pts, height=height_pts)
+    image.filename = data_uri
+    return image
+
 __all__ = [
     "BaseChartEngine",
 ]
@@ -310,12 +325,17 @@ class BaseChartEngine:
                 width, height, max_width=max_width, max_height=max_height,
             )
 
-            # Always specify both width and height explicitly.
-            # ReportLab cannot reliably infer height from base64 data URLs
-            # and may treat raw pixel height as points, producing oversized
-            # images (e.g. 800px → 800pt = 11.1in instead of 4in at 200 DPI).
-            rl_image = Image(data_url, width=scaled_w * inch,
+            # ReportLab 5 cannot construct an Image from a data: URI -- its
+            # open_for_read gates the data scheme behind trustedHosts and fails
+            # at construction. Build the Image from the in-memory PNG buffer
+            # (which renders correctly), then keep the data URI on .filename so
+            # image_utils can still extract/save the embedded PNG. Width and
+            # height are set explicitly so ReportLab does not size from raw
+            # pixels (800px would otherwise become 800pt = 11.1in).
+            img_buffer.seek(0)
+            rl_image = Image(img_buffer, width=scaled_w * inch,
                              height=scaled_h * inch)
+            rl_image.filename = data_url
 
             return rl_image
 
@@ -352,14 +372,18 @@ class BaseChartEngine:
             else:
                 # Fallback to simple text — still honour auto-scaling
                 sw, sh = self._scale_dimensions(width, height)
-                return Image("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
-                           width=sw*inch, height=sh*inch)
+                return _rl_image_from_data_uri(
+                    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
+                    sw * inch, sh * inch,
+                )
         except (ValueError, TypeError, AttributeError, OSError) as e:
             log.error(f"Error creating placeholder chart: {e}")
             # Return a minimal image — still honour auto-scaling
             sw, sh = self._scale_dimensions(width, height)
-            return Image("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
-                       width=sw*inch, height=sh*inch)
+            return _rl_image_from_data_uri(
+                "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
+                sw * inch, sh * inch,
+            )
 
     def create_chart_with_caption(self, chart: Image, caption: str,
                                 caption_style: Optional[str] = None) -> List:

--- a/siege_utilities/reporting/examples/google_analytics_report_example.py
+++ b/siege_utilities/reporting/examples/google_analytics_report_example.py
@@ -20,28 +20,36 @@ import pandas as pd
 import numpy as np
 from pathlib import Path
 from datetime import datetime, timedelta
-from typing import Dict, List, Any, Optional, Tuple
+from typing import (
+    Dict,
+    List,
+    Any,
+    Optional,
+)
 import logging
-import io
 import subprocess
 import tempfile
 
 # ReportLab imports
 try:
     from reportlab.lib import colors
-    from reportlab.lib.pagesizes import letter, landscape
+    from reportlab.lib.pagesizes import letter
     from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
     from reportlab.lib.units import inch
-    from reportlab.lib.enums import TA_CENTER, TA_LEFT, TA_RIGHT
-    from reportlab.platypus import (
-        SimpleDocTemplate, Paragraph, Spacer, Table, TableStyle,
-        PageBreak, Image as RLImage, KeepTogether, Flowable
+    from reportlab.lib.enums import (
+        TA_CENTER,
+        TA_LEFT,
     )
-    from reportlab.graphics.shapes import Drawing, Rect, String, Line
-    from reportlab.graphics.charts.lineplots import LinePlot
-    from reportlab.graphics.charts.barcharts import VerticalBarChart
-    from reportlab.graphics.charts.piecharts import Pie
-    from reportlab.graphics.widgets.markers import makeMarker
+    from reportlab.platypus import (
+        SimpleDocTemplate,
+        Paragraph,
+        Spacer,
+        Table,
+        TableStyle,
+        PageBreak,
+        Image as RLImage,
+        Flowable,
+    )
     REPORTLAB_AVAILABLE = True
 except ImportError:
     REPORTLAB_AVAILABLE = False
@@ -55,8 +63,6 @@ except ImportError:
     MATPLOTLIB_AVAILABLE = False
 
 # siege_utilities imports
-from siege_utilities.reporting.chart_generator import ChartGenerator
-from siege_utilities.reporting.report_generator import ReportGenerator
 
 __all__ = [
     'KPICard',
@@ -1329,7 +1335,6 @@ def create_geo_city_scatter(ga_data: Dict[str, Any], width: float = 5.5*inch,
             lats = [loc['lat'] for loc in geo]
             lons = [loc['lon'] for loc in geo]
             sessions = [loc.get('sessions', 1) for loc in geo]
-            users = [loc.get('users', 1) for loc in geo]
             cities = [loc.get('city', '') for loc in geo]
 
             fig, ax = plt.subplots(figsize=(width / 72, height / 72))

--- a/siege_utilities/reporting/examples/google_analytics_report_example.py
+++ b/siege_utilities/reporting/examples/google_analytics_report_example.py
@@ -763,7 +763,7 @@ def fetch_real_ga4_data(property_id: str, start_date: str, end_date: str,
                         'pageviews': int(year_df['screenPageViews'].sum()),
                     }
             except (ValueError, TypeError, KeyError, AttributeError, OSError) as exc:
-                log.debug(f"Could not fetch longitudinal data for {year}")
+                log.debug(f"Could not fetch longitudinal data for {year}: {exc}")
 
         result = {
             'date_range': {'start': start_date, 'end': end_date},

--- a/siege_utilities/reporting/idml_export.py
+++ b/siege_utilities/reporting/idml_export.py
@@ -237,8 +237,9 @@ class IDMLExporter:
                 pkg.set_tag(placeholder, content)
             except (ValueError, KeyError, AttributeError, TypeError) as exc:
                 log.debug(
-                    "simpleidml.set_tag failed for %r; doing raw XML substitution.",
+                    "simpleidml.set_tag failed for %r (%s); doing raw XML substitution.",
                     placeholder,
+                    exc,
                 )
                 # Fall through to raw XML sub in _apply_replacements_raw
                 self._apply_replacements_raw_simpleidml(pkg, placeholder, content)

--- a/siege_utilities/runtime.py
+++ b/siege_utilities/runtime.py
@@ -132,11 +132,14 @@ def diagnose_environment() -> Dict:
     # siege_utilities
     try:
         diag["siege_utilities_version"] = importlib.metadata.version("siege-utilities")
-    except (ImportError, ValueError, ModuleNotFoundError):
+    except Exception:
+        # Any metadata-lookup failure falls back to the package __version__, and
+        # any failure there reports NOT INSTALLED -- version probing must never
+        # crash the diagnostic.
         try:
             from siege_utilities import __version__
             diag["siege_utilities_version"] = __version__
-        except (ImportError, AttributeError):
+        except Exception:
             diag["siege_utilities_version"] = "NOT INSTALLED"
 
     # Stale pydantic modules in sys.modules

--- a/siege_utilities/testing/environment.py
+++ b/siege_utilities/testing/environment.py
@@ -312,7 +312,9 @@ def setup_spark_environment() -> bool:
         else:
             log_warning("Apache Sedona not available (optional)")
 
-    except (ImportError, AttributeError) as e:
+    except Exception as e:
+        # Any failure probing dependencies means the environment is not ready;
+        # report it and return False rather than crashing the setup helper.
         log_error(f"Could not check dependencies: {e}")
         return False
 
@@ -355,7 +357,9 @@ def get_system_info() -> Dict[str, str]:
         package_info = siege_utilities.get_package_info()
         info['siege_utilities_functions'] = str(package_info['total_functions'])
         info['siege_utilities_modules'] = str(package_info['total_modules'])
-    except (ImportError, AttributeError) as e:
+    except Exception as e:
+        # Diagnostic info-gathering records any failure as a status string
+        # rather than crashing get_system_info.
         info['siege_utilities_status'] = f'Error: {e}'
 
     return info
@@ -385,7 +389,9 @@ def diagnose_environment() -> bool:
         log_info(f"Python: {info['python_version']}")
         log_info(f"Platform: {info['platform']}")
         log_info(f"Working directory: {info['working_directory']}")
-    except (OSError, ImportError, AttributeError) as e:
+    except Exception as e:
+        # Diagnostic: a sub-check failure is recorded as an issue and reported,
+        # never allowed to crash the survey, regardless of the error type.
         issues_found.append(f"Could not get system info: {e}")
 
     # Check environment variables
@@ -396,7 +402,7 @@ def diagnose_environment() -> bool:
         for var, value in resolved.items():
             if value is None:
                 issues_found.append(f"Missing environment variable: {var}")
-    except (OSError, KeyError, ValueError) as e:
+    except Exception as e:
         issues_found.append(f"Environment variable check failed: {e}")
 
     # Check Java
@@ -406,7 +412,7 @@ def diagnose_environment() -> bool:
             issues_found.append("Java not available")
         elif not java_compatible:
             issues_found.append(f"Java version {java_version} may be incompatible")
-    except (OSError, subprocess.TimeoutExpired, ValueError) as e:
+    except Exception as e:
         issues_found.append(f"Java check failed: {e}")
 
     # Check dependencies
@@ -419,7 +425,7 @@ def diagnose_environment() -> bool:
             if not deps.get(dep, False):
                 issues_found.append(f"Missing critical dependency: {dep}")
 
-    except (ImportError, AttributeError) as e:
+    except Exception as e:
         issues_found.append(f"Dependency check failed: {e}")
 
     # Report results
@@ -478,6 +484,6 @@ def quick_environment_setup() -> bool:
         log_info("Quick environment setup complete!")
         return True
 
-    except (OSError, ImportError, AttributeError, ValueError, AssertionError) as e:
+    except Exception as e:
         log_error(f"Quick setup failed: {e}")
         return False

--- a/siege_utilities/testing/runner.py
+++ b/siege_utilities/testing/runner.py
@@ -124,7 +124,9 @@ def quick_smoke_test() -> bool:
         log_info("\nBasic smoke test PASSED!")
         return True
 
-    except (ImportError, AttributeError, AssertionError, ValueError) as e:
+    except Exception as e:
+        # Runner status: any failure means the smoke test did not pass; report
+        # and return False rather than crashing.
         log_error(f"\nBasic smoke test FAILED: {e}")
         return False
 
@@ -265,7 +267,7 @@ def run_test_suite(
             import siege_utilities
             if not siege_utilities.setup_spark_environment():
                 log_warning("Environment setup had issues, continuing anyway...")
-        except (ImportError, AttributeError) as e:
+        except Exception as e:
             log_error(f"Environment setup failed: {e}")
             return False
 
@@ -386,7 +388,7 @@ def run_comprehensive_test() -> bool:
         if not env_healthy:
             log_warning("Environment issues detected, but continuing...")
             all_passed = False
-    except (ImportError, AttributeError) as e:
+    except Exception as e:
         log_error(f"Environment diagnostics failed: {e}")
         all_passed = False
 
@@ -408,7 +410,7 @@ def run_comprehensive_test() -> bool:
 
         if not deps.get('pyspark', False):
             log_warning("PySpark not available - some tests may be skipped")
-    except (ImportError, AttributeError) as e:
+    except Exception as e:
         log_error(f"Dependency check failed: {e}")
         all_passed = False
 

--- a/tests/integration/test_narrative_analytics_pipeline.py
+++ b/tests/integration/test_narrative_analytics_pipeline.py
@@ -9,7 +9,6 @@ SU-1 enforcement: expired/invalid auth raises, not returns empty DataFrame.
 """
 
 import importlib
-import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 

--- a/tests/perf/test_iterrows_regressions.py
+++ b/tests/perf/test_iterrows_regressions.py
@@ -35,7 +35,9 @@ def test_convert_to_postgis_output_matches_iterrows_baseline(tmp_path):
 
     out_path = tmp_path / "out.sql"
     transformer = SpatialDataTransformer()
-    assert transformer._convert_to_postgis(gdf, output_path=str(out_path)) is True
+    # _convert_to_postgis returns None and raises on failure (#967); success is
+    # verified by the output file comparison below.
+    transformer._convert_to_postgis(gdf, output_path=str(out_path))
 
     expected = "\n".join(
         f"INSERT INTO spatial_table (geom) VALUES (ST_GeomFromText('{escape(g.wkt)}'));"

--- a/tests/test_actor_types_exclude_sensitive.py
+++ b/tests/test_actor_types_exclude_sensitive.py
@@ -1,0 +1,55 @@
+"""Regression tests for the exclude_sensitive serialization path on the
+actor_types models (Organization, Collaboration).
+
+Guards against the F821 / NameError where actor_types.py called
+``_strip_sensitive_fields`` without importing it from ``.person``. Only
+``Organization.to_dict`` and ``Collaboration.to_dict`` reach that path;
+the pre-existing exclude_sensitive tests exercise ``User`` (a Person
+subclass that uses person.py's own import), so the bug shipped uncaught
+and was caught only by flake8, not by a behavior test. See ticket #1064.
+"""
+
+from siege_utilities.config.models.actor_types import Organization, Collaboration
+
+
+def _org() -> Organization:
+    return Organization(
+        org_id="test-org-1",
+        name="Test Org",
+        org_type="vendor",
+        primary_email="contact@example.com",
+    )
+
+
+def _collab() -> Collaboration:
+    return Collaboration(collab_id="test-collab-1", name="Test Collaboration")
+
+
+def test_organization_to_dict_exclude_sensitive_runs():
+    # Pre-fix this raised: NameError: name '_strip_sensitive_fields' is not defined
+    data = _org().to_dict(exclude_sensitive=True)
+    assert isinstance(data, dict)
+    assert data["org_id"] == "test-org-1"
+    assert data["name"] == "Test Org"
+
+
+def test_collaboration_to_dict_exclude_sensitive_runs():
+    data = _collab().to_dict(exclude_sensitive=True)
+    assert isinstance(data, dict)
+    assert data["collab_id"] == "test-collab-1"
+    assert data["name"] == "Test Collaboration"
+
+
+def test_organization_to_yaml_exclude_sensitive_runs():
+    # to_yaml() delegates to to_dict(exclude_sensitive=...), the same path.
+    text = _org().to_yaml(exclude_sensitive=True)
+    assert isinstance(text, str)
+    assert "test-org-1" in text
+
+
+def test_exclude_sensitive_preserves_non_sensitive_fields():
+    # Organization carries no credential-class keys, so the strip is a
+    # correct no-op on its fields; equality proves _strip_sensitive_fields
+    # executed (rather than erroring) and left non-sensitive data intact.
+    org = _org()
+    assert org.to_dict(exclude_sensitive=True) == org.to_dict(exclude_sensitive=False)

--- a/tests/test_batch_geocoder.py
+++ b/tests/test_batch_geocoder.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Union
 
 import pytest
 

--- a/tests/test_boundary_engine.py
+++ b/tests/test_boundary_engine.py
@@ -5,7 +5,6 @@ on boundary providers. Uses synthetic GeoDataFrames to avoid network calls.
 """
 
 import pytest
-import numpy as np
 import pandas as pd
 
 

--- a/tests/test_boundary_providers.py
+++ b/tests/test_boundary_providers.py
@@ -8,6 +8,7 @@ import pytest
 
 from siege_utilities.geo.providers.boundary_providers import (
     BoundaryProvider,
+    BoundaryFetchError,
     CensusTIGERProvider,
     GADMProvider,
     RDHProvider,
@@ -124,18 +125,19 @@ class TestCensusTIGERProvider:
         assert call_kwargs['geographic_level'] == 'county'
 
     @patch('siege_utilities.geo.spatial_data.CensusDataSource')
-    def test_get_boundary_failure_returns_none(self, MockDS):
-        """result.success=False returns None and logs a warning."""
+    def test_get_boundary_failure_raises(self, MockDS):
+        """A failed fetch (result.success=False) raises BoundaryFetchError.
+
+        SU-1 / consistent provider contract: get_boundary documents
+        "Raises BoundaryFetchError when retrieval fails"; it does not return
+        None. Previously asserted a None return plus a logged warning.
+        """
         mock_result = MagicMock(success=False, error_stage='download', message='404')
         MockDS.return_value.fetch_geographic_boundaries.return_value = mock_result
 
         provider = CensusTIGERProvider()
-        import logging
-        with patch.object(logging.getLogger('siege_utilities.geo.providers.boundary_providers'),
-                          'warning') as mock_warn:
-            result = provider.get_boundary('county')
-        assert result is None
-        mock_warn.assert_called_once()
+        with pytest.raises(BoundaryFetchError):
+            provider.get_boundary('county')
 
 
 # ---------------------------------------------------------------------------
@@ -173,11 +175,16 @@ class TestCensusTIGERVintageDiscovery:
         assert provider.latest_vintage() == 2025
 
     @patch('requests.get')
-    def test_list_vintages_empty_on_network_failure(self, mock_get):
+    def test_list_vintages_raises_on_network_failure(self, mock_get):
+        # SU-1: list_available_vintages re-raises the network error rather than
+        # returning [] (an empty list is indistinguishable from "no vintages
+        # published"). latest_vintage() is the documented None-on-failure
+        # variant. Previously asserted == [].
         import requests
         mock_get.side_effect = requests.ConnectionError('down')
         provider = CensusTIGERProvider()
-        assert provider.list_available_vintages() == []
+        with pytest.raises(requests.RequestException):
+            provider.list_available_vintages()
         assert provider.latest_vintage() is None
 
 
@@ -347,15 +354,19 @@ class TestRDHProvider:
         assert result is sentinel_gdf
 
     @patch('siege_utilities.geo.providers.boundary_providers.RDHProvider._get_client')
-    def test_get_boundary_no_datasets_returns_none(self, mock_get_client):
-        """When RDH returns no matching datasets, get_boundary returns None."""
+    def test_get_boundary_no_datasets_raises(self, mock_get_client):
+        """When RDH returns no matching datasets, get_boundary raises.
+
+        SU-1 / consistent provider contract: no datasets is a fetch failure
+        (BoundaryFetchError), not a None return. Previously asserted None.
+        """
         mock_client = MagicMock()
         mock_client.get_precinct_data.return_value = []
         mock_get_client.return_value = mock_client
 
         provider = RDHProvider(username=TEST_USERNAME, password=TEST_PASSWORD)
-        result = provider.get_boundary('precinct', identifier='TX')
-        assert result is None
+        with pytest.raises(BoundaryFetchError):
+            provider.get_boundary('precinct', identifier='TX')
 
     def test_credentials_from_env(self, monkeypatch):
         monkeypatch.setenv('RDH_USERNAME', 'env_user')

--- a/tests/test_census_api_client.py
+++ b/tests/test_census_api_client.py
@@ -464,29 +464,37 @@ class TestDataFetching:
         assert len(df['GEOID'].iloc[0]) == 11  # Tract GEOID is 11 digits
 
     @patch('siege_utilities.geo.census_api_client.requests.get')
-    def test_fetch_handles_empty_response(self, mock_get, census_client):
-        """Test handling of empty API response."""
+    def test_fetch_empty_response_raises(self, mock_get, census_client):
+        """An empty Census API response (< 2 rows) is a failure, not data.
+
+        SU-1: the client raises CensusAPIError rather than returning an empty
+        DataFrame the caller cannot distinguish from a real result. Previously
+        asserted a returned empty DataFrame.
+        """
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = []
         mock_response.raise_for_status = Mock()
         mock_get.return_value = mock_response
 
-        df = census_client.fetch_data(
-            variables=['B01001_001E'],
-            year=2020,
-            dataset='acs5',
-            geography='county',
-            state_fips='06',
-            include_moe=False
-        )
+        with pytest.raises(CensusAPIError):
+            census_client.fetch_data(
+                variables=['B01001_001E'],
+                year=2020,
+                dataset='acs5',
+                geography='county',
+                state_fips='06',
+                include_moe=False
+            )
 
-        assert isinstance(df, pd.DataFrame)
-        assert len(df) == 0
-
+    @patch('siege_utilities.geo.census.api.time.sleep')
     @patch('siege_utilities.geo.census_api_client.requests.get')
-    def test_fetch_handles_rate_limit(self, mock_get, census_client):
-        """Test handling of rate limit response."""
+    def test_fetch_handles_rate_limit(self, mock_get, mock_sleep, census_client):
+        """A 429 is retried then surfaced as CensusRateLimitError.
+
+        time.sleep is mocked so the production 60s-per-attempt retry delay does
+        not run in real time.
+        """
         mock_response = Mock()
         mock_response.status_code = 429
         mock_response.raise_for_status = Mock()

--- a/tests/test_census_batch.py
+++ b/tests/test_census_batch.py
@@ -2,14 +2,10 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-import pytest
 
-from siege_utilities.geo.providers.batch_geocoder import (
-    GeocodingResult,
-    MatchQuality,
-)
+from siege_utilities.geo.providers.batch_geocoder import MatchQuality
 from siege_utilities.geo.providers.census_batch import (
     CensusBatchGeocoder,
     _census_result_to_geocoding_result,

--- a/tests/test_census_catalog_cache.py
+++ b/tests/test_census_catalog_cache.py
@@ -2,10 +2,8 @@
 
 import json
 import time
-from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-import pytest
 
 from siege_utilities.geo.census.catalog import (
     CensusCatalog,

--- a/tests/test_census_catalog_docs.py
+++ b/tests/test_census_catalog_docs.py
@@ -1,6 +1,5 @@
 """Tests for siege_utilities.geo.census.catalog_docs."""
 
-import pytest
 
 from siege_utilities.geo.census.catalog import (
     CensusCatalog,
@@ -98,6 +97,7 @@ class TestGenerateDocs:
         written = generate_catalog_docs(cat, tmp_path)
         assert (tmp_path / "tables" / "B19001.md").exists()
         assert (tmp_path / "tables" / "B01001.md").exists()
+        assert (tmp_path / "tables" / "B19001.md") in written
 
     def test_table_page_has_variables(self, tmp_path):
         cat = _make_catalog()

--- a/tests/test_census_catalog_search.py
+++ b/tests/test_census_catalog_search.py
@@ -11,7 +11,6 @@ from siege_utilities.geo.census.catalog import (
     CensusVariable,
     FamilyType,
     SearchLevel,
-    SearchResult,
     _tokenize_query,
 )
 
@@ -170,7 +169,9 @@ class TestSearchCrossLevel:
         all_results = search_catalog.search("income", level=SearchLevel.TABLE)
         filtered = search_catalog.search("income", level=SearchLevel.TABLE, dataset="acs5_2022")
         # Dataset only has B19001 and B19013 for income, not B19001A/B
+        all_ids = {r.id for r in all_results}
         filtered_ids = {r.id for r in filtered}
+        assert filtered_ids < all_ids  # the dataset filter strictly narrows the result set
         assert "B19001A" not in filtered_ids
         assert "B19001" in filtered_ids
 

--- a/tests/test_client_branding_errors.py
+++ b/tests/test_client_branding_errors.py
@@ -26,9 +26,12 @@ class TestExceptionHierarchy:
 
 
 class TestGetClientBranding:
-    def test_returns_none_when_not_found(self, manager):
-        # No predefined template, no custom dir — legitimate "not found" path
-        assert manager.get_client_branding("nonexistent_xyz") is None
+    def test_not_found_raises(self, manager):
+        # SU-1 + ELE-2420 typed hierarchy: get_client_branding documents
+        # "Raises ClientBrandingNotFoundError if no branding configuration
+        # exists". Previously asserted `is None`, contradicting the contract.
+        with pytest.raises(ClientBrandingNotFoundError):
+            manager.get_client_branding("nonexistent_xyz")
 
     def test_io_error_raises(self, manager, tmp_path):
         client_dir = tmp_path / "corrupt_client"
@@ -57,13 +60,19 @@ class TestUpdateClientBranding:
 
 
 class TestDeleteClientBranding:
-    def test_predefined_template_returns_false(self, manager):
-        """Legitimate 'cannot delete template' path stays as False return."""
-        assert manager.delete_client_branding("siege_analytics") is False
+    def test_predefined_template_raises(self, manager):
+        # delete_client_branding documents "Raises ClientBrandingError if
+        # attempting to delete a predefined template". Previously asserted
+        # `is False`, contradicting the documented contract (SU-1).
+        with pytest.raises(ClientBrandingError):
+            manager.delete_client_branding("siege_analytics")
 
-    def test_missing_dir_returns_false(self, manager):
-        """Legitimate 'nothing to delete' path stays as False return."""
-        assert manager.delete_client_branding("never_existed") is False
+    def test_missing_dir_raises_not_found(self, manager):
+        # delete_client_branding documents "Raises ClientBrandingNotFoundError
+        # if no configuration exists for the client". Previously asserted
+        # `is False`.
+        with pytest.raises(ClientBrandingNotFoundError):
+            manager.delete_client_branding("never_existed")
 
     def test_io_error_raises(self, manager, tmp_path):
         manager.create_client_branding(
@@ -96,11 +105,14 @@ class TestImportBrandingConfig:
             manager.import_branding_config(bad)
         assert exc_info.value.__cause__ is not None
 
-    def test_unsupported_format_returns_false(self, manager, tmp_path):
-        """Legitimate 'unsupported format' path stays as False return (input validation)."""
+    def test_unsupported_format_raises(self, manager, tmp_path):
+        # import_branding_config documents "Raises ValueError if the file
+        # format is unsupported or validation fails". Previously asserted
+        # `is False` (SU-1: input validation failure is not a False return).
         bogus = tmp_path / "config.txt"
         bogus.write_text("whatever")
-        assert manager.import_branding_config(bogus) is False
+        with pytest.raises(ValueError, match="Unsupported file format"):
+            manager.import_branding_config(bogus)
 
 
 class TestGetBrandingSummary:

--- a/tests/test_client_branding_expanded.py
+++ b/tests/test_client_branding_expanded.py
@@ -3,7 +3,11 @@
 import pytest
 import json
 import yaml
-from siege_utilities.reporting.client_branding import ClientBrandingManager
+from siege_utilities.reporting.client_branding import (
+    ClientBrandingManager,
+    ClientBrandingError,
+    ClientBrandingNotFoundError,
+)
 
 
 class TestClientBrandingManagerInit:
@@ -43,10 +47,12 @@ class TestGetClientBranding:
         branding = mgr.get_client_branding("SIEGE_ANALYTICS")
         assert branding is not None
 
-    def test_get_nonexistent_returns_none(self, tmp_path):
+    def test_get_nonexistent_raises(self, tmp_path):
+        # SU-1 / ELE-2420: get_client_branding raises (documented contract),
+        # it does not return None. Previously asserted `is None`.
         mgr = ClientBrandingManager(config_dir=tmp_path / "branding")
-        branding = mgr.get_client_branding("nonexistent_client")
-        assert branding is None
+        with pytest.raises(ClientBrandingNotFoundError):
+            mgr.get_client_branding("nonexistent_client")
 
 
 class TestCreateClientBranding:
@@ -154,11 +160,16 @@ class TestDeleteClientBranding:
     """Tests for delete_client_branding."""
 
     def test_cannot_delete_predefined(self, tmp_path):
+        # delete raises ClientBrandingError on a predefined template (SU-1).
+        # Previously asserted `is False`.
         mgr = ClientBrandingManager(config_dir=tmp_path / "branding")
-        result = mgr.delete_client_branding("siege_analytics")
-        assert result is False
+        with pytest.raises(ClientBrandingError):
+            mgr.delete_client_branding("siege_analytics")
 
     def test_delete_custom_client(self, tmp_path):
+        # delete_client_branding returns None on success (#967 -> None signature);
+        # success is verified by the client no longer being retrievable.
+        # Previously asserted `is True`.
         mgr = ClientBrandingManager(config_dir=tmp_path / "branding")
         config = {
             "name": "Deletable",
@@ -166,13 +177,16 @@ class TestDeleteClientBranding:
             "fonts": {"default_font": "Arial"},
         }
         mgr.create_client_branding("deletable", config)
-        result = mgr.delete_client_branding("deletable")
-        assert result is True
+        mgr.delete_client_branding("deletable")
+        with pytest.raises(ClientBrandingNotFoundError):
+            mgr.get_client_branding("deletable")
 
-    def test_delete_nonexistent(self, tmp_path):
+    def test_delete_nonexistent_raises(self, tmp_path):
+        # delete raises ClientBrandingNotFoundError when nothing exists (SU-1).
+        # Previously asserted `is False`.
         mgr = ClientBrandingManager(config_dir=tmp_path / "branding")
-        result = mgr.delete_client_branding("nonexistent_xyz")
-        assert result is False
+        with pytest.raises(ClientBrandingNotFoundError):
+            mgr.delete_client_branding("nonexistent_xyz")
 
 
 class TestCreateBrandingFromTemplate:
@@ -203,8 +217,9 @@ class TestExportBrandingConfig:
     def test_export_yaml(self, tmp_path):
         mgr = ClientBrandingManager(config_dir=tmp_path / "branding")
         export_path = tmp_path / "export.yaml"
-        result = mgr.export_branding_config("siege_analytics", export_path)
-        assert result is True
+        # export_branding_config returns None and raises on failure (#967).
+        # Success is verified by the exported file's contents, not a True return.
+        mgr.export_branding_config("siege_analytics", export_path)
         assert export_path.exists()
         with open(export_path) as f:
             data = yaml.safe_load(f)
@@ -213,8 +228,8 @@ class TestExportBrandingConfig:
     def test_export_json(self, tmp_path):
         mgr = ClientBrandingManager(config_dir=tmp_path / "branding")
         export_path = tmp_path / "export.json"
-        result = mgr.export_branding_config("siege_analytics", export_path)
-        assert result is True
+        mgr.export_branding_config("siege_analytics", export_path)
+        assert export_path.exists()
         with open(export_path) as f:
             data = json.load(f)
         assert data["name"] == "Siege Analytics"
@@ -241,10 +256,13 @@ class TestGetBrandingSummary:
         assert "fonts" in summary
         assert "has_logo" in summary
 
-    def test_summary_of_nonexistent(self, tmp_path):
+    def test_summary_of_nonexistent_raises(self, tmp_path):
+        # get_branding_summary delegates to get_client_branding, which raises
+        # ClientBrandingNotFoundError for an unknown client (SU-1). Previously
+        # asserted `summary == {}`.
         mgr = ClientBrandingManager(config_dir=tmp_path / "branding")
-        summary = mgr.get_branding_summary("nonexistent")
-        assert summary == {}
+        with pytest.raises(ClientBrandingNotFoundError):
+            mgr.get_branding_summary("nonexistent")
 
 
 class TestImportBrandingConfig:
@@ -261,13 +279,18 @@ class TestImportBrandingConfig:
         import_file = tmp_path / "import.yaml"
         with open(import_file, "w") as f:
             yaml.dump(config, f)
-        result = mgr.import_branding_config(import_file)
-        assert result is True
+        # import_branding_config returns None and raises on failure (#967).
+        # Success is verified by the imported client becoming retrievable.
+        mgr.import_branding_config(import_file)
+        loaded = mgr.get_client_branding("Imported Client")
+        assert loaded["name"] == "Imported Client"
 
-    def test_import_invalid_config(self, tmp_path):
+    def test_import_invalid_config_raises(self, tmp_path):
+        # Validation failure raises ValueError (documented contract, SU-1).
+        # Previously asserted `is False`.
         mgr = ClientBrandingManager(config_dir=tmp_path / "branding")
         import_file = tmp_path / "bad.yaml"
         with open(import_file, "w") as f:
             yaml.dump({"invalid": True}, f)
-        result = mgr.import_branding_config(import_file)
-        assert result is False
+        with pytest.raises(ValueError, match="Invalid branding configuration"):
+            mgr.import_branding_config(import_file)

--- a/tests/test_codification.py
+++ b/tests/test_codification.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-import pytest
 
 from siege_utilities.geo.providers.batch_geocoder import (
     BatchGeocodingResult,

--- a/tests/test_codification_blocks.py
+++ b/tests/test_codification_blocks.py
@@ -7,8 +7,6 @@ import pytest
 from siege_utilities.geo.providers.batch_geocoder import GeocodingResult, MatchQuality
 from siege_utilities.geo.codification_blocks import (
     BlockAssignment,
-    BlockGroup,
-    SpreadMetrics,
     assign_blocks,
     compute_spread,
     group_by_block,

--- a/tests/test_codification_demographics.py
+++ b/tests/test_codification_demographics.py
@@ -6,7 +6,6 @@ import pytest
 
 from siege_utilities.geo.codification_demographics import (
     BlockDemographics,
-    DemographicSignature,
     DictBlockDemographicsProvider,
     compute_demographic_signature,
 )

--- a/tests/test_codification_recency.py
+++ b/tests/test_codification_recency.py
@@ -7,7 +7,6 @@ import pytest
 from siege_utilities.geo.codification_recency import (
     AddressVintage,
     DictAddressVintageProvider,
-    RecencyAnalysis,
     compute_recency,
 )
 

--- a/tests/test_codification_summary.py
+++ b/tests/test_codification_summary.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
 
 from siege_utilities.geo.codification import BlockProfile, CodificationResult
 from siege_utilities.geo.codification_blocks import BlockGroup, SpreadMetrics

--- a/tests/test_codification_urbanicity.py
+++ b/tests/test_codification_urbanicity.py
@@ -7,7 +7,6 @@ import pytest
 from siege_utilities.geo.codification_urbanicity import (
     BlockLocale,
     DictBlockLocaleProvider,
-    UrbanicityDistribution,
     compute_urbanicity_distribution,
 )
 

--- a/tests/test_config_connections.py
+++ b/tests/test_config_connections.py
@@ -101,6 +101,8 @@ class TestSaveAndLoadConnectionProfile:
         assert loaded["name"] == "Test"
         assert loaded["connection_type"] == "notebook"
 
-    def test_load_nonexistent(self, tmp_path):
-        loaded = load_connection_profile("nonexistent-id", str(tmp_path))
-        assert loaded is None
+    def test_load_nonexistent_raises(self, tmp_path):
+        # SU-1: load_connection_profile raises FileNotFoundError for a missing
+        # profile (documented contract), it does not return None.
+        with pytest.raises(FileNotFoundError):
+            load_connection_profile("nonexistent-id", str(tmp_path))

--- a/tests/test_config_errors.py
+++ b/tests/test_config_errors.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import logging
 from pathlib import Path
-from unittest.mock import patch, MagicMock
 
 import pytest
 import yaml
@@ -18,7 +16,6 @@ from siege_utilities.config.enhanced_config import (
     load_user_profile,
     save_user_profile,
     load_client_profile,
-    save_client_profile,
 )
 from siege_utilities.config.models.user_profile import UserProfile
 

--- a/tests/test_config_hydra_optional.py
+++ b/tests/test_config_hydra_optional.py
@@ -30,15 +30,18 @@ def _reload_siege_config_with_hydra_blocked(monkeypatch, caplog_or_handler):
     blocker = _BlockHydra()
     monkeypatch.setattr(sys, "meta_path", [blocker, *sys.meta_path])
 
-    # Purge any cached siege_utilities.config / hydra_manager modules so
-    # the re-import re-runs the try/except.
+    # Purge any cached siege_utilities.config / hydra_manager modules so the
+    # re-import re-runs the try/except. Use monkeypatch.delitem so the ORIGINAL
+    # modules are restored on teardown -- otherwise the reloaded (hydra-blocked)
+    # config leaks into later tests, whose model classes (ClientProfile,
+    # ContactInfo, ...) would then mismatch by module identity.
     for mod_name in list(sys.modules):
         if mod_name.startswith("siege_utilities.config") or mod_name in {
             "hydra",
             "omegaconf",
             "siege_utilities.config.hydra_manager",
         }:
-            sys.modules.pop(mod_name, None)
+            monkeypatch.delitem(sys.modules, mod_name, raising=False)
 
     # Capture warnings emitted during the (re-)import.
     return importlib.import_module("siege_utilities.config")
@@ -68,7 +71,12 @@ def test_hydra_missing_logs_at_debug_not_warning(monkeypatch, caplog):
     """Issue #498: optional-extra absence is DEBUG-level, not WARNING."""
     caplog.set_level(logging.DEBUG, logger="siege_utilities.config")
 
-    _reload_siege_config_with_hydra_blocked(monkeypatch, caplog)
+    cfg = _reload_siege_config_with_hydra_blocked(monkeypatch, caplog)
+
+    # The hydra-absent message is emitted lazily, when HydraConfigManager is
+    # first resolved (PEP 562 __getattr__), not at import time. Access it to
+    # trigger the resolution under the hydra-blocked meta_path finder.
+    _ = cfg.HydraConfigManager
 
     debug_records = [
         rec for rec in caplog.records

--- a/tests/test_config_model_validation.py
+++ b/tests/test_config_model_validation.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
 
 import pytest
 from pydantic import ValidationError
@@ -13,15 +12,12 @@ from siege_utilities.config.models.database_connection import DatabaseConnection
 from siege_utilities.config.models.data_sources import (
     DataSource,
     DataSourceType,
-    DataSourceStatus,
     Jurisdiction,
     JurisdictionLevel,
-    SourceCredential,
 )
 from siege_utilities.config.models.oauth_integration import (
     OAuthIntegration,
     OAuthProvider,
-    OAuthScope,
 )
 from siege_utilities.config.models.social_media_account import SocialMediaAccount
 from siege_utilities.config.models.report_preferences import ReportPreferences

--- a/tests/test_config_projects.py
+++ b/tests/test_config_projects.py
@@ -1,5 +1,6 @@
 """Tests for siege_utilities.config.projects module."""
 
+import pytest
 from pathlib import Path
 from siege_utilities.config.projects import (
     create_project_config,
@@ -79,10 +80,12 @@ class TestSaveAndLoadProjectConfig:
         assert loaded["project_name"] == "Test"
         assert loaded["project_code"] == "T001"
 
-    def test_load_nonexistent_returns_none(self, tmp_path):
+    def test_load_nonexistent_raises(self, tmp_path):
+        # SU-1: load_project_config raises FileNotFoundError for a missing
+        # project (documented contract), it does not return None.
         config_dir = str(tmp_path / "config")
-        result = load_project_config("NONEXIST", config_dir)
-        assert result is None
+        with pytest.raises(FileNotFoundError):
+            load_project_config("NONEXIST", config_dir)
 
 
 class TestGetProjectPath:
@@ -131,15 +134,18 @@ class TestUpdateProjectConfig:
         config_dir = str(tmp_path / "config")
         config = create_project_config("Test", "T001", base_directory=str(tmp_path))
         save_project_config(config, config_dir)
-        result = update_project_config("T001", {"description": "Updated"}, config_dir)
-        assert result is True
+        # update_project_config returns None and raises on failure (#967);
+        # success is verified by reloading the updated value.
+        update_project_config("T001", {"description": "Updated"}, config_dir)
         loaded = load_project_config("T001", config_dir)
         assert loaded["description"] == "Updated"
 
-    def test_update_nonexistent_returns_false(self, tmp_path):
+    def test_update_nonexistent_raises(self, tmp_path):
+        # SU-1: updating a missing project raises FileNotFoundError (documented
+        # contract), it does not return False.
         config_dir = str(tmp_path / "config")
-        result = update_project_config("NONEXIST", {"description": "test"}, config_dir)
-        assert result is False
+        with pytest.raises(FileNotFoundError):
+            update_project_config("NONEXIST", {"description": "test"}, config_dir)
 
 
 class TestSetupProjectDirectories:
@@ -147,8 +153,9 @@ class TestSetupProjectDirectories:
 
     def test_creates_directories(self, tmp_path):
         config = create_project_config("Test", "T001", base_directory=str(tmp_path))
-        result = setup_project_directories(config)
-        assert result is True
+        # setup_project_directories returns None and raises on failure (#967);
+        # success is verified by the directories existing.
+        setup_project_directories(config)
         for dir_path in config["directories"].values():
             assert Path(dir_path).exists()
 

--- a/tests/test_credential_manager.py
+++ b/tests/test_credential_manager.py
@@ -41,6 +41,7 @@ from siege_utilities.config.credential_manager import (
     get_ga_service_account_credentials,
     credential_status,
 )
+from siege_utilities.exceptions import SiegeConfigError
 
 
 # =============================================================================
@@ -311,14 +312,18 @@ class TestGetFromFiles:
                                           additional_paths=[tmp_cred_dir])
         assert result is None
 
-    def test_handles_invalid_json(self, manager_files_only, tmp_cred_dir):
+    def test_invalid_json_raises_config_error(self, manager_files_only, tmp_cred_dir):
+        # SU-1 (errors are not data): a malformed credential file is a failure,
+        # not an empty result. _extract_from_file raises SiegeConfigError on
+        # json.JSONDecodeError (hardened in #967). This test previously asserted
+        # `result is None`; it now asserts the raise so it fails on revert.
         manager, _ = manager_files_only
         cred_file = tmp_cred_dir / "myservice.json"
         cred_file.write_text("not valid json {{{")
 
-        result = manager._get_from_files('myservice', 'user', 'password',
-                                          additional_paths=[tmp_cred_dir])
-        assert result is None
+        with pytest.raises(SiegeConfigError):
+            manager._get_from_files('myservice', 'user', 'password',
+                                    additional_paths=[tmp_cred_dir])
 
     def test_handles_nonexistent_search_path(self, manager_files_only):
         manager, _ = manager_files_only
@@ -569,19 +574,27 @@ class TestGetFromPrompt:
             result = manager._get_from_prompt('service', 'user', 'username')
             assert result == 'my_username'
 
-    def test_handles_eof_error(self, mock_op_available):
+    def test_eof_raises_config_error(self, mock_op_available):
+        # SU-1 (errors are not data): EOF on the interactive prompt means stdin
+        # is not connected -- a failure, not an empty result. _get_from_prompt
+        # raises SiegeConfigError (hardened in #967). Previously asserted
+        # `result is None`; now asserts the raise so it fails on revert.
         manager = CredentialManager()
         with patch('os.isatty', return_value=True), \
              patch('getpass.getpass', side_effect=EOFError):
-            result = manager._get_from_prompt('service', 'user', 'secret')
-            assert result is None
+            with pytest.raises(SiegeConfigError):
+                manager._get_from_prompt('service', 'user', 'secret')
 
-    def test_handles_keyboard_interrupt(self, mock_op_available):
+    def test_keyboard_interrupt_propagates(self, mock_op_available):
+        # #967: a deliberate Ctrl-C during the prompt propagates so the caller
+        # does not silently fall through to a less-trusted backend. Previously
+        # asserted `result is None`, which let KeyboardInterrupt escape the test
+        # and abort the entire pytest session. Now asserts propagation.
         manager = CredentialManager()
         with patch('os.isatty', return_value=True), \
              patch('getpass.getpass', side_effect=KeyboardInterrupt):
-            result = manager._get_from_prompt('service', 'user', 'token')
-            assert result is None
+            with pytest.raises(KeyboardInterrupt):
+                manager._get_from_prompt('service', 'user', 'token')
 
 
 # =============================================================================
@@ -1614,7 +1627,12 @@ class TestFetchRealGA4DataOAuth2Fallback:
     def test_tries_oauth2_when_service_account_fails(self, mock_connector_cls, mock_sa, mock_oauth):
         from siege_utilities.reporting.examples.google_analytics_report_example import fetch_real_ga4_data
 
-        mock_sa.return_value = None
+        # writing-tests:4 mock fidelity: get_google_service_account_from_1password
+        # never returns None -- it raises subprocess.CalledProcessError when the
+        # 1Password item is absent (see its docstring). Mocking it to return None
+        # set up an impossible scenario. Use the real failure mode so Strategy 1
+        # is caught and the OAuth2 fallback (Strategy 2) is exercised.
+        mock_sa.side_effect = subprocess.CalledProcessError(1, ['op', 'item', 'get'])
         mock_oauth.return_value = {
             'client_id': 'test-id',
             'client_secret': 'test-secret',
@@ -1626,7 +1644,12 @@ class TestFetchRealGA4DataOAuth2Fallback:
         mock_connector.get_ga4_data.return_value = None
         mock_connector_cls.return_value = mock_connector
 
-        result = fetch_real_ga4_data('12345', '2026-01-01', '2026-01-31')
+        # The OAuth connector is built and authenticated (the behavior under
+        # test), then get_ga4_data returns None -> production raises ValueError
+        # ("No daily data returned"), wrapped as RuntimeError by the outer
+        # handler. SU-1: no-data is a failure, not a None return.
+        with pytest.raises(RuntimeError):
+            fetch_real_ga4_data('12345', '2026-01-01', '2026-01-31')
 
         mock_connector_cls.assert_called_once_with(
             client_id='test-id',
@@ -1634,38 +1657,42 @@ class TestFetchRealGA4DataOAuth2Fallback:
             redirect_uri='http://localhost',
         )
         mock_connector.authenticate.assert_called_once()
-        # get_ga4_data returns None, so the function should return None
-        assert result is None
 
     @patch('siege_utilities.config.get_google_oauth_from_1password')
     @patch('siege_utilities.config.get_google_service_account_from_1password')
-    def test_returns_none_when_both_fail(self, mock_sa, mock_oauth):
+    def test_raises_when_both_credentials_unavailable(self, mock_sa, mock_oauth):
         from siege_utilities.reporting.examples.google_analytics_report_example import fetch_real_ga4_data
 
-        mock_sa.return_value = None
-        mock_oauth.return_value = None
+        # writing-tests:4 + SU-1: both credential helpers raise (not return None)
+        # when 1Password has nothing. When every strategy fails, production
+        # raises RuntimeError ("No GA credentials found in 1Password ...") rather
+        # than returning None. Previously asserted `result is None`.
+        mock_sa.side_effect = subprocess.CalledProcessError(1, ['op', 'item', 'get'])
+        mock_oauth.side_effect = subprocess.CalledProcessError(1, ['op', 'item', 'get'])
 
-        result = fetch_real_ga4_data('12345', '2026-01-01', '2026-01-31')
-        assert result is None
+        with pytest.raises(RuntimeError):
+            fetch_real_ga4_data('12345', '2026-01-01', '2026-01-31')
 
     @patch('siege_utilities.config.get_google_oauth_from_1password')
     @patch('siege_utilities.config.get_google_service_account_from_1password')
     def test_passes_vault_account_to_both_strategies(self, mock_sa, mock_oauth):
         from siege_utilities.reporting.examples.google_analytics_report_example import fetch_real_ga4_data
 
-        mock_sa.return_value = None
-        mock_oauth.return_value = None
+        # writing-tests:4: the helpers raise (not return None) when creds are
+        # absent. The behavior under test is that vault/account are threaded to
+        # BOTH strategies before the final RuntimeError.
+        mock_sa.side_effect = subprocess.CalledProcessError(1, ['op', 'item', 'get'])
+        mock_oauth.side_effect = subprocess.CalledProcessError(1, ['op', 'item', 'get'])
 
-        result = fetch_real_ga4_data('12345', '2026-01-01', '2026-01-31',
-                           vault='Private', account='Dheeraj_Chand_Family')
+        with pytest.raises(RuntimeError):
+            fetch_real_ga4_data('12345', '2026-01-01', '2026-01-31',
+                                vault='Private', account='Dheeraj_Chand_Family')
 
         mock_sa.assert_called_once_with(
             item_title='Google Analytics Service Account - Multi-Client Reporter',
             vault='Private', account='Dheeraj_Chand_Family',
         )
         mock_oauth.assert_called_once_with(vault='Private', account='Dheeraj_Chand_Family')
-        # Both credential strategies failed, so result should be None
-        assert result is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_credential_manager.py
+++ b/tests/test_credential_manager.py
@@ -48,6 +48,28 @@ from siege_utilities.exceptions import SiegeConfigError
 # FIXTURES
 # =============================================================================
 
+@pytest.fixture(autouse=True)
+def _reset_default_manager_cache():
+    """Clear the module-level CredentialManager cache around every test.
+
+    ``_get_default_manager`` caches one manager per (vault, account) and each
+    manager detects backend availability (notably 1Password) exactly once at
+    construction. Without this reset the first convenience-function call in the
+    suite freezes that detection: a test that runs while ``op`` is unavailable
+    (real binary absent in CI, or a sibling mocking it unavailable) caches a
+    manager with ``1password=False`` that later tests reuse regardless of their
+    own subprocess mock. That is an order-dependent (random-seed-dependent)
+    failure -- e.g. test_get_credential_backward_compat raising
+    CredentialNotFoundError under one seed and passing under another. Clearing
+    the cache per test makes availability re-detect under each test's own mock.
+    """
+    from siege_utilities.config import credential_manager as _cm
+
+    _cm._default_managers.clear()
+    yield
+    _cm._default_managers.clear()
+
+
 @pytest.fixture
 def mock_op_available():
     """Mock subprocess so 1Password CLI appears available."""

--- a/tests/test_crs_axis_order.py
+++ b/tests/test_crs_axis_order.py
@@ -78,7 +78,7 @@ def test_reproject_geom_missing_src_crs():
 def test_reproject_geom_same_crs_noop():
     from shapely.geometry import Point
     p = Point(1.0, 2.0)
-    result = reproject_geom(p, "EPSG:4326", dst_epsg=4326)
+    result = reproject_geom(p, "EPSG:4326", dst_crs=4326)
     # Identity short-circuit returns the same object.
     assert result is p
 
@@ -88,8 +88,8 @@ def test_reproject_geom_4326_to_3857_round_trip():
 
     # Origin Point in Austin, TX
     src = Point(-97.7431, 30.2672)
-    web_merc = reproject_geom(src, "EPSG:4326", dst_epsg=3857)
-    back = reproject_geom(web_merc, "EPSG:3857", dst_epsg=4326)
+    web_merc = reproject_geom(src, "EPSG:4326", dst_crs=3857)
+    back = reproject_geom(web_merc, "EPSG:3857", dst_crs=4326)
 
     assert abs(back.x - src.x) < 1e-6
     assert abs(back.y - src.y) < 1e-6
@@ -103,7 +103,7 @@ def test_reproject_geom_trad_gis_lon_first():
     # is roughly -10878000 in EPSG:3857).
     src = Point(-97.7431, 30.2672)
     web_merc = reproject_geom(
-        src, "EPSG:4326", dst_epsg=3857, axis_order=AXIS_ORDER_TRAD_GIS
+        src, "EPSG:4326", dst_crs=3857, axis_order=AXIS_ORDER_TRAD_GIS
     )
     assert -1.1e7 < web_merc.x < -1.0e7
 
@@ -116,10 +116,10 @@ def test_reproject_geom_axis_order_toggle_differs():
 
     src = Point(-97.7431, 30.2672)
     trad = reproject_geom(
-        src, "EPSG:4326", dst_epsg=3857, axis_order=AXIS_ORDER_TRAD_GIS
+        src, "EPSG:4326", dst_crs=3857, axis_order=AXIS_ORDER_TRAD_GIS
     )
     auth = reproject_geom(
-        src, "EPSG:4326", dst_epsg=3857, axis_order=AXIS_ORDER_AUTH_COMPLIANT
+        src, "EPSG:4326", dst_crs=3857, axis_order=AXIS_ORDER_AUTH_COMPLIANT
     )
     # Under auth_compliant, the (x=-97.7431, y=30.2672) tuple is interpreted
     # as (lat=-97.7431, lon=30.2672) which is nonsense and produces a different

--- a/tests/test_database_config.py
+++ b/tests/test_database_config.py
@@ -1,7 +1,6 @@
 """Tests for database configuration security fixes."""
 
 import json
-import os
 
 import pytest
 

--- a/tests/test_databricks_auth_session_secrets.py
+++ b/tests/test_databricks_auth_session_secrets.py
@@ -156,9 +156,12 @@ def test_workspace_secret_scope_and_put():
             self.secrets = SecretsApi()
 
     client = WorkspaceClientStub()
-    assert ensure_secret_scope("existing-scope", workspace_client=client) is True
-    assert ensure_secret_scope("new-scope", workspace_client=client) is True
+    # ensure_secret_scope returns the scope name; put_secret returns the
+    # scope-qualified key (writing-code:11 inspectable return). Previously
+    # asserted `is True`.
+    assert ensure_secret_scope("existing-scope", workspace_client=client) == "existing-scope"
+    assert ensure_secret_scope("new-scope", workspace_client=client) == "new-scope"
     assert client.secrets.created == ["new-scope"]
 
-    assert put_secret("new-scope", "token", "abc", workspace_client=client) is True
+    assert put_secret("new-scope", "token", "abc", workspace_client=client) == "new-scope/token"
     assert client.secrets.puts == [("new-scope", "token", "abc")]

--- a/tests/test_databricks_download_dir.py
+++ b/tests/test_databricks_download_dir.py
@@ -94,13 +94,17 @@ class TestGetDownloadDirectory:
         auto-remediate to /tmp/siege_utilities/downloads instead of raising."""
         from siege_utilities.config import user_config as uc_mod
 
-        # Make user_config.get_download_directory() return an unwritable path
+        # #901 removed the eager user_config singleton; get_download_directory()
+        # now resolves the dir via get_user_config().get_download_directory().
+        # Stub that accessor to return an unwritable path.
         unwritable = tmp_path / "root_downloads"
         unwritable.mkdir()
-        monkeypatch.setattr(
-            uc_mod.user_config, "get_download_directory",
-            lambda specific_path=None: unwritable,
-        )
+
+        class _StubManager:
+            def get_download_directory(self, *a, **k):
+                return unwritable
+
+        monkeypatch.setattr(uc_mod, "get_user_config", lambda *a, **k: _StubManager())
         # Simulate unwritable directory
         original_access = os.access
         def fake_access(path, mode):
@@ -119,10 +123,12 @@ class TestGetDownloadDirectory:
 
         unwritable = tmp_path / "locked_dir"
         unwritable.mkdir()
-        monkeypatch.setattr(
-            uc_mod.user_config, "get_download_directory",
-            lambda specific_path=None: unwritable,
-        )
+
+        class _StubManager:
+            def get_download_directory(self, *a, **k):
+                return unwritable
+
+        monkeypatch.setattr(uc_mod, "get_user_config", lambda *a, **k: _StubManager())
         monkeypatch.setattr(os, "access", lambda path, mode: False)
 
         with patch.object(uc_mod, "_is_databricks_runtime", return_value=False):

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -792,9 +792,10 @@ class TestCreateSparkSession:
             ops = self._make_ops(tmpdir)
             # Since pyspark IS available in CI, we mock ImportError
             with patch('builtins.__import__', side_effect=ImportError("no pyspark")):
-                # The create_spark_session catches ImportError
-                result = ops.create_spark_session()
-                assert result is None
+                # writing-code:8 / SU-1: an unavailable PySpark raises a clear
+                # ImportError naming the install command, not a None return.
+                with pytest.raises(ImportError):
+                    ops.create_spark_session()
 
 
 class TestSetupDistributedEnvironment:
@@ -811,8 +812,8 @@ class TestSetupDistributedEnvironment:
         )
         return AbstractHDFSOperations(config)
 
-    def test_returns_none_triple_without_data_path(self):
-        """Returns (None, None, None) when no data path."""
+    def test_missing_data_path_raises(self):
+        """A missing data path raises ValueError (SU-1)."""
         from siege_utilities.distributed.hdfs_config import HDFSConfig
         from siege_utilities.distributed.hdfs_operations import AbstractHDFSOperations
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -823,11 +824,13 @@ class TestSetupDistributedEnvironment:
                 data_path=None,
             )
             ops = AbstractHDFSOperations(config)
-            result = ops.setup_distributed_environment()
-            assert result == (None, None, None)
+            # SU-1: a missing data path is invalid input -> ValueError, not a
+            # None triple the caller cannot distinguish from success.
+            with pytest.raises(ValueError):
+                ops.setup_distributed_environment()
 
-    def test_returns_none_triple_for_nonexistent_path(self):
-        """Returns (None, None, None) when data path doesn't exist."""
+    def test_nonexistent_path_raises(self):
+        """A nonexistent data path raises FileNotFoundError."""
         from siege_utilities.distributed.hdfs_config import HDFSConfig
         from siege_utilities.distributed.hdfs_operations import AbstractHDFSOperations
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -837,8 +840,10 @@ class TestSetupDistributedEnvironment:
                 log_error_func=Mock(),
             )
             ops = AbstractHDFSOperations(config)
-            result = ops.setup_distributed_environment(data_path='/nonexistent/path')
-            assert result == (None, None, None)
+            # SU-1: a nonexistent data path raises rather than returning a None
+            # triple.
+            with pytest.raises(FileNotFoundError):
+                ops.setup_distributed_environment(data_path='/nonexistent/path')
 
     @patch.object(
         __import__('siege_utilities.distributed.hdfs_operations',
@@ -925,8 +930,10 @@ class TestConvenienceFunction:
                 log_error_func=Mock(),
                 data_path=None,
             )
-            result = setup_distributed_environment(config)
-            assert result == (None, None, None)
+            # The convenience function delegates to the ops instance; a missing
+            # data path raises ValueError (SU-1), not a None triple.
+            with pytest.raises(ValueError):
+                setup_distributed_environment(config)
 
     def test_create_hdfs_operations_factory(self):
         """create_hdfs_operations returns an AbstractHDFSOperations instance."""
@@ -959,18 +966,20 @@ class TestFlattenJsonCorruptPathUsesUDF:
 
         The fix introduces `validate_json_udf = udf(validate_json, ...)`
         before the .otherwise() call. We assert the source contains that
-        wrapping at both call sites.
+        wrapping at the corrupt-record fallback branch.
         """
         import pathlib
         src = pathlib.Path(
             "siege_utilities/distributed/spark_utils.py"
         ).read_text()
-        # Two corrupt-path branches, both must wrap as UDF before use.
-        assert src.count("validate_json_udf = udf(validate_json, StringType())") == 2, (
+        # The corrupt-record fallback branch must wrap validate_json as a UDF
+        # before use (the schema-inference fallback was consolidated to one
+        # branch). A revert that drops the wrapping makes this count 0 -> red.
+        assert src.count("validate_json_udf = udf(validate_json, StringType())") == 1, (
             "spark_utils.py must wrap validate_json as a Spark UDF before "
             "calling it inside .otherwise(). Found "
             f"{src.count('validate_json_udf = udf(validate_json, StringType())')} "
-            "of the expected 2 wrappings."
+            "of the expected 1 wrapping."
         )
         # And the .otherwise() must call the udf-wrapped binding, not the
         # bare Python function.

--- a/tests/test_economic_bls_qcew.py
+++ b/tests/test_economic_bls_qcew.py
@@ -77,8 +77,18 @@ class TestDownloadCache:
         # tmp_path. Clean slate:
         (tmp_path / "2024.qcew.csv").unlink(missing_ok=True)
 
-        with patch.object(__import__("siege_utilities.economic.bls.qcew", fromlist=["requests"]).requests, "get") as mock_get:
-            mock_get.return_value = MagicMock(content=fake_zip_bytes, raise_for_status=lambda: None)
+        # writing-tests:4 mock fidelity: download() streams via
+        # `with requests.get(stream=True) as resp: resp.iter_content(...)`, so
+        # the mock must expose the streaming context-manager interface (not a
+        # plain `.content` attribute, which the streaming path never reads).
+        import siege_utilities.economic.bls.qcew as qcew_mod
+        with patch.object(qcew_mod.requests, "get") as mock_get:
+            stream_resp = MagicMock()
+            stream_resp.raise_for_status.return_value = None
+            stream_resp.iter_content.return_value = [fake_zip_bytes]
+            stream_resp.__enter__.return_value = stream_resp
+            stream_resp.__exit__.return_value = False
+            mock_get.return_value = stream_resp
             result = files.download(2024)
         assert result.exists()
         assert result.name == "2024.qcew.csv"

--- a/tests/test_gazetteer_errors.py
+++ b/tests/test_gazetteer_errors.py
@@ -286,9 +286,12 @@ class TestCensusSearchNonUSReturnsEmpty:
         not (cg.REQUESTS_AVAILABLE and cg.SHAPELY_AVAILABLE),
         reason="requests or shapely not installed",
     )
-    def test_non_us_search_returns_empty(self):
+    def test_non_us_search_raises(self):
+        # CensusGazetteer is US-only; a non-US country_hint is a usage error
+        # that raises GazetteerNotFoundError rather than returning [] (SU-1).
         gz = cg.CensusGazetteer()
-        assert gz.search("Berlin", country_hint="DE") == []
+        with pytest.raises(GazetteerNotFoundError):
+            gz.search("Berlin", country_hint="DE")
 
 
 class TestCensusSearchEmptyReturnsEmpty:

--- a/tests/test_gazetteer_errors.py
+++ b/tests/test_gazetteer_errors.py
@@ -7,7 +7,7 @@ exercised WITHOUT network, GDAL, or geopandas.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -175,7 +175,7 @@ class TestWklsFetchGeometryErrors:
                 gz._fetch_geometry("some-id")
 
     def test_resolve_failure_raises_backend_error(self, monkeypatch):
-        shapely_wkt = pytest.importorskip("shapely.wkt")
+        pytest.importorskip("shapely.wkt")
 
         fake_wkls = MagicMock()
         fake_wkls.resolve.side_effect = RuntimeError("network down")

--- a/tests/test_geoid_slugs.py
+++ b/tests/test_geoid_slugs.py
@@ -43,7 +43,8 @@ class TestGeoidToSlug:
         assert geoid_to_slug("06001", "sldl") == "ca-sldl-001"
 
     def test_vtd(self):
-        assert geoid_to_slug("06037001", "vtd") == "ca-037-vtd-001"
+        # Full Census VTD GEOID is 11 chars: state(2) + county(3) + VTD(6).
+        assert geoid_to_slug("06037000123", "vtd") == "ca-037-vtd-000123"
 
 
 class TestSlugToGeoid:
@@ -80,7 +81,7 @@ class TestSlugToGeoid:
         assert slug_to_geoid("ca-sldl-001") == "06001"
 
     def test_vtd(self):
-        assert slug_to_geoid("ca-037-vtd-001") == "06037001"
+        assert slug_to_geoid("ca-037-vtd-000123") == "06037000123"
 
     def test_unknown_state_raises(self):
         with pytest.raises(ValueError, match="Unknown state"):
@@ -105,7 +106,7 @@ class TestRoundTrip:
         ("0614", "cd"),
         ("06001", "sldu"),
         ("06001", "sldl"),
-        ("06037001", "vtd"),
+        ("06037000123", "vtd"),
     ]
 
     @pytest.mark.parametrize("geoid,level", CASES, ids=[c[1] for c in CASES])

--- a/tests/test_geoid_utils.py
+++ b/tests/test_geoid_utils.py
@@ -9,7 +9,6 @@ import pandas as pd
 
 from siege_utilities.geo.geoid_utils import (
     GEOID_LENGTHS,
-    GEOID_COMPONENT_LENGTHS,
     normalize_geoid,
     normalize_geoid_column,
     construct_geoid,

--- a/tests/test_geoid_utils.py
+++ b/tests/test_geoid_utils.py
@@ -413,7 +413,25 @@ class TestGEOIDLengthsCompleteness:
         assert GEOID_LENGTHS['puma'] == 7
 
     def test_vtd_geoid_length(self):
-        assert GEOID_LENGTHS['vtd'] == 6
+        # GEOID_LENGTHS stores the FULL concatenated GEOID length (county=5,
+        # tract=11, block=15, ...). A full Census VTD GEOID is 11 chars:
+        # state(2) + county(3) + VTD(6). The prior value of 6 stored the VTD
+        # component length, inconsistent with the table's full-length contract.
+        assert GEOID_LENGTHS['vtd'] == 11
+
+    def test_real_census_vtd_geoid_normalizes_at_full_length(self):
+        """A real 11-char Census VTD GEOID validates at its full length.
+
+        Structure: state(2) + county(3) + VTD(6). Example: California (06),
+        Los Angeles County (037), VTD 000123 -> "06037000123".
+        """
+        # Already-full 11-char GEOID is returned unchanged.
+        assert normalize_geoid("06037000123", "vtd") == "06037000123"
+        # A GEOID with a stripped leading zero is zero-padded to full length.
+        assert normalize_geoid("6037000123", "vtd") == "06037000123"
+        # Longer than the full VTD length is rejected (wrong level / malformed).
+        with pytest.raises(ValueError):
+            normalize_geoid("060370001234", "vtd")
 
     def test_cbsa_geoid_length(self):
         assert GEOID_LENGTHS['cbsa'] == 5

--- a/tests/test_gst_port.py
+++ b/tests/test_gst_port.py
@@ -1,9 +1,7 @@
 """Tests for GST-ported geocoding + spatial-data helpers (#515)."""
 
 import math
-import json
-from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_irs_soi.py
+++ b/tests/test_irs_soi.py
@@ -1,11 +1,9 @@
 """Tests for IRS SOI ZIP-code data helper (#539)."""
 
 import csv
-from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import pandas as pd
-import pytest
 
 from siege_utilities.economic.irs.soi import IRSSOIFiles, DEFAULT_CACHE_DIR
 
@@ -100,7 +98,6 @@ class TestIRSSOIFilesInit:
     """Constructor creates cache directory."""
 
     def test_default_cache_dir(self):
-        files = IRSSOIFiles.__new__(IRSSOIFiles)
         assert DEFAULT_CACHE_DIR.name == "irs_soi"
 
     def test_custom_cache_dir(self, tmp_path):

--- a/tests/test_naics_soc_integration.py
+++ b/tests/test_naics_soc_integration.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
 
 from siege_utilities.geo.providers.nlrb_clients import NLRBCaseRecord
 

--- a/tests/test_nlrb_cache.py
+++ b/tests/test_nlrb_cache.py
@@ -4,10 +4,8 @@ from __future__ import annotations
 
 import json
 from datetime import date, datetime, timedelta
-from pathlib import Path
 from unittest.mock import MagicMock
 
-import pytest
 
 from siege_utilities.geo.providers.nlrb_cache import (
     NLRBCache,

--- a/tests/test_nlrb_clients.py
+++ b/tests/test_nlrb_clients.py
@@ -7,9 +7,8 @@ import io
 import textwrap
 import xml.etree.ElementTree as ET
 from datetime import date
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
-import pytest
 
 from siege_utilities.geo.providers.nlrb_clients import (
     CaseStatus,

--- a/tests/test_nlrb_models.py
+++ b/tests/test_nlrb_models.py
@@ -14,7 +14,6 @@ except (ImportError, RuntimeError):
     _DJANGO_AVAILABLE = False
 
 try:
-    import pandas as pd
 
     _PANDAS_AVAILABLE = True
 except ImportError:

--- a/tests/test_nlrb_regions.py
+++ b/tests/test_nlrb_regions.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
-import pytest
 
 from siege_utilities.geo.providers.nlrb_clients import NLRBCaseRecord
 from siege_utilities.geo.providers.nlrb_regions import (
     NLRB_REGIONS,
-    STATE_TO_REGIONS,
     aggregate_by_region,
     assign_region,
     lookup_region_by_state,

--- a/tests/test_overlay_registry.py
+++ b/tests/test_overlay_registry.py
@@ -177,7 +177,7 @@ class TestOverlayRegistry:
     def test_get_unknown(self):
         assert self.registry.get("unknown") is None
 
-    def test_instantiation_failure_returns_none(self):
+    def test_instantiation_failure_raises(self):
         @self.registry.register("broken")
         class BrokenOverlay(PlaceHistoryOverlay):
             def __init__(self):
@@ -190,7 +190,12 @@ class TestOverlayRegistry:
             def fetch(self, geoid, from_year, to_year, state_fips=None):
                 return None
 
-        assert self.registry.get("broken") is None
+        # get() lazily instantiates and documents "Raises: Exception if the
+        # registered overlay class fails to instantiate" (SU-1: surface the
+        # broken provider, don't hide it as a None lookup miss). Previously
+        # asserted None.
+        with pytest.raises(RuntimeError):
+            self.registry.get("broken")
 
     def test_instance_overrides_class(self):
         @self.registry.register("dup")

--- a/tests/test_place_history.py
+++ b/tests/test_place_history.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-import pytest
 
 from siege_utilities.geo.place_history import (
-    CrosswalkRecord,
     DictCrosswalkProvider,
     Lineage,
     LineageStep,

--- a/tests/test_plan_lifecycle.py
+++ b/tests/test_plan_lifecycle.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from datetime import date
 
-import pytest
 
 from siege_utilities.geo.plan_lifecycle import (
     DictPlanLifecycleProvider,

--- a/tests/test_property_geocoding.py
+++ b/tests/test_property_geocoding.py
@@ -7,7 +7,7 @@ without crashing and that outputs satisfy domain invariants.
 import pytest
 
 hypothesis = pytest.importorskip("hypothesis")
-from hypothesis import given, assume, settings, HealthCheck
+from hypothesis import given, settings, HealthCheck
 import hypothesis.strategies as st
 
 

--- a/tests/test_property_geocoding.py
+++ b/tests/test_property_geocoding.py
@@ -20,7 +20,7 @@ class TestGetCoordinatesProperties:
     """Property tests for get_coordinates."""
 
     @given(st.text(max_size=200))
-    @settings(suppress_health_check=[HealthCheck.too_slow], max_examples=50)
+    @settings(suppress_health_check=[HealthCheck.too_slow], max_examples=50, deadline=None)
     def test_never_crashes_on_arbitrary_input(self, address):
         """get_coordinates must not raise unexpected exceptions on any string."""
         from siege_utilities.geo.geocoding import get_coordinates
@@ -31,7 +31,7 @@ class TestGetCoordinatesProperties:
             pass
 
     @given(latitudes, longitudes)
-    @settings(max_examples=30)
+    @settings(max_examples=30, deadline=None)
     def test_coordinate_string_does_not_crash(self, lat, lon):
         """Coordinate-like strings should not crash the function."""
         from siege_utilities.geo.geocoding import get_coordinates
@@ -46,7 +46,7 @@ class TestNominatimGeocoderProperties:
     """Property tests for use_nominatim_geocoder."""
 
     @given(st.text(min_size=1, max_size=100))
-    @settings(suppress_health_check=[HealthCheck.too_slow], max_examples=30)
+    @settings(suppress_health_check=[HealthCheck.too_slow], max_examples=30, deadline=None)
     def test_never_crashes_on_arbitrary_query(self, query):
         """use_nominatim_geocoder must not raise unexpected exceptions."""
         from siege_utilities.geo.geocoding import use_nominatim_geocoder

--- a/tests/test_property_geocoding.py
+++ b/tests/test_property_geocoding.py
@@ -23,22 +23,26 @@ class TestGetCoordinatesProperties:
     @settings(suppress_health_check=[HealthCheck.too_slow], max_examples=50, deadline=None)
     def test_never_crashes_on_arbitrary_input(self, address):
         """get_coordinates must not raise unexpected exceptions on any string."""
-        from siege_utilities.geo.geocoding import get_coordinates
+        from siege_utilities.geo.geocoding import get_coordinates, GeocodingError
 
         try:
             get_coordinates(address)
-        except (ValueError, TypeError, KeyError, AttributeError):
+        except (ValueError, TypeError, KeyError, AttributeError, GeocodingError):
+            # GeocodingError is the documented typed failure (network/service
+            # error, e.g. a 400 on a malformed query) -- graceful, not a crash.
             pass
 
     @given(latitudes, longitudes)
     @settings(max_examples=30, deadline=None)
     def test_coordinate_string_does_not_crash(self, lat, lon):
         """Coordinate-like strings should not crash the function."""
-        from siege_utilities.geo.geocoding import get_coordinates
+        from siege_utilities.geo.geocoding import get_coordinates, GeocodingError
 
         try:
             get_coordinates(f"{lat}, {lon}")
-        except (ValueError, TypeError, KeyError, AttributeError):
+        except (ValueError, TypeError, KeyError, AttributeError, GeocodingError):
+            # GeocodingError is the documented typed failure (network/service
+            # error, e.g. a 400 on a malformed query) -- graceful, not a crash.
             pass
 
 
@@ -49,9 +53,11 @@ class TestNominatimGeocoderProperties:
     @settings(suppress_health_check=[HealthCheck.too_slow], max_examples=30, deadline=None)
     def test_never_crashes_on_arbitrary_query(self, query):
         """use_nominatim_geocoder must not raise unexpected exceptions."""
-        from siege_utilities.geo.geocoding import use_nominatim_geocoder
+        from siege_utilities.geo.geocoding import use_nominatim_geocoder, GeocodingError
 
         try:
             use_nominatim_geocoder(query)
-        except (ValueError, TypeError, KeyError, AttributeError):
+        except (ValueError, TypeError, KeyError, AttributeError, GeocodingError):
+            # GeocodingError is the documented typed failure (network/service
+            # error, e.g. a 400 on a malformed query) -- graceful, not a crash.
             pass

--- a/tests/test_property_paths.py
+++ b/tests/test_property_paths.py
@@ -4,12 +4,11 @@ Tests that path functions handle arbitrary input without crashing
 and that sanitization is idempotent.
 """
 
-import os
 
 import pytest
 
 hypothesis = pytest.importorskip("hypothesis")
-from hypothesis import given, assume, settings
+from hypothesis import given, settings
 import hypothesis.strategies as st
 
 

--- a/tests/test_property_paths.py
+++ b/tests/test_property_paths.py
@@ -53,8 +53,11 @@ class TestEnsurePathExistsProperties:
     def test_never_crashes_on_arbitrary_input(self, raw_path):
         """ensure_path_exists should handle arbitrary strings gracefully."""
         from siege_utilities.files.paths import ensure_path_exists
+        from siege_utilities.files.validation import PathSecurityError
 
         try:
             ensure_path_exists(raw_path)
-        except (OSError, ValueError, TypeError):
+        except (OSError, ValueError, TypeError, PathSecurityError):
+            # PathSecurityError (e.g. embedded null byte) is a deliberate,
+            # graceful rejection of a malicious path, not an unexpected crash.
             pass

--- a/tests/test_pydantic_v1_compat.py
+++ b/tests/test_pydantic_v1_compat.py
@@ -10,7 +10,6 @@ system loads correctly (no regression).
 """
 
 import pytest
-import sys
 
 
 def _pydantic_major_version():
@@ -41,7 +40,7 @@ class TestCoreModulesAvailable:
     """Core modules that do NOT depend on pydantic must always work."""
 
     def test_core_logging(self):
-        from siege_utilities.core.logging import get_logger, log_info, log_warning
+        from siege_utilities.core.logging import get_logger, log_info
         assert callable(get_logger)
         assert callable(log_info)
 

--- a/tests/test_pydantic_v1_compat.py
+++ b/tests/test_pydantic_v1_compat.py
@@ -105,10 +105,17 @@ class TestPydanticV1Fallback:
         with pytest.raises(ImportError, match="pydantic"):
             get_default_profile_location()
 
-    @pytest.mark.skipif(_HAS_PYDANTIC_V2, reason="pydantic v2 is available")
-    def test_user_config_singleton_is_none(self):
-        from siege_utilities import user_config
-        assert user_config is None
+    def test_user_config_eager_singleton_removed(self):
+        # #901 removed the eager module-level `user_config = UserConfigManager()`
+        # singleton (it created directories on import) in favour of the lazy
+        # get_user_config() accessor. The top-level name is therefore no longer
+        # exported. This previously asserted `user_config is None`; that symbol
+        # no longer exists, so the lazy registry entry was also stale
+        # (writing-code:16 migration completeness). Assert the name is gone so a
+        # revert that re-adds the eager singleton fails here. Version-independent.
+        import siege_utilities
+        with pytest.raises(AttributeError):
+            siege_utilities.user_config
 
 
 class TestConfigDirectImportFallback:

--- a/tests/test_rdh_catalog.py
+++ b/tests/test_rdh_catalog.py
@@ -5,14 +5,11 @@ from __future__ import annotations
 import json
 import time
 
-import pytest
 
 from siege_utilities.geo.rdh_catalog import (
     CatalogEntry,
-    CoverageCell,
     DictRDHCatalogProvider,
     RDHCatalog,
-    SearchResult,
     _infer_chamber,
     _score_entry,
 )

--- a/tests/test_rdh_overlays.py
+++ b/tests/test_rdh_overlays.py
@@ -15,7 +15,6 @@ from siege_utilities.geo.overlays.redistricting import (
 )
 from siege_utilities.geo.overlays.election_results import (
     DictElectionDataProvider,
-    ElectionDataProvider,
     ElectionResultsOverlay,
     ElectionResultsOverlayResult,
     ElectionReturn,

--- a/tests/test_redistricting_data_hub.py
+++ b/tests/test_redistricting_data_hub.py
@@ -249,20 +249,22 @@ class TestListDatasets:
         # Should make 2 batches: 4 + 2
         assert mock_get.call_count == 2
 
-    def test_list_no_credentials(self, tmp_path):
+    def test_list_no_credentials_raises(self, tmp_path):
+        # Missing/invalid credentials is a configuration error, not an empty
+        # result set (SU-1). list_datasets raises ValueError. Previously [].
         c = RDHClient(username="", password="", cache_dir=tmp_path)
-        results = c.list_datasets(states=["VA"])
-        assert results == []
+        with pytest.raises(ValueError):
+            c.list_datasets(states=["VA"])
 
-    def test_list_api_error(self, client):
+    def test_list_api_error_raises(self, client):
+        # An API transport failure raises rather than returning [] (SU-1).
         import requests
         mock_resp = MagicMock()
         mock_resp.raise_for_status.side_effect = requests.RequestException("timeout")
 
         with patch.object(client._session, "get", return_value=mock_resp):
-            results = client.list_datasets(states=["VA"])
-
-        assert results == []
+            with pytest.raises(ConnectionError):
+                client.list_datasets(states=["VA"])
 
     def test_list_with_dataset_type_filter(self, client, sample_api_response):
         mock_resp = MagicMock()
@@ -888,8 +890,10 @@ class TestDemographicProfile:
         )
 
         from siege_utilities.geo.providers.redistricting_data_hub import demographic_profile
-        result = demographic_profile(plan, census)
-        assert len(result) == 0
+        # No population columns means the overlay cannot be computed; this is a
+        # data error that raises ValueError, not an empty result (SU-1).
+        with pytest.raises(ValueError):
+            demographic_profile(plan, census)
 
 
 class TestToCrosstabInput:

--- a/tests/test_redistricting_data_hub.py
+++ b/tests/test_redistricting_data_hub.py
@@ -424,7 +424,6 @@ class TestDownloadDataset:
 class TestLoadCSV:
 
     def test_load_csv_from_path(self, client, tmp_path):
-        import pandas as pd
         csv_file = tmp_path / "data.csv"
         csv_file.write_text("a,b\n1,2\n3,4\n")
 
@@ -617,7 +616,6 @@ class TestSchwartzberg:
 class TestComputeCompactness:
 
     def test_compute_from_geodataframe(self):
-        import pandas as pd
         import geopandas as gpd
         from shapely.geometry import Point, box
 
@@ -642,7 +640,6 @@ class TestComputeCompactness:
         assert result.iloc[0]["polsby_popper"] > result.iloc[2]["polsby_popper"]
 
     def test_compute_reprojects_geographic_crs(self):
-        import pandas as pd
         import geopandas as gpd
         from shapely.geometry import box
 
@@ -847,7 +844,6 @@ class TestDemographicProfile:
 
     def test_overlay_aggregates_by_district(self):
         import geopandas as gpd
-        import pandas as pd
         from shapely.geometry import box
 
         plan = gpd.GeoDataFrame(
@@ -899,7 +895,6 @@ class TestDemographicProfile:
 class TestToCrosstabInput:
 
     def test_melts_wide_to_long(self):
-        import pandas as pd
         df = pd.DataFrame({
             "GEOID": ["A", "B"],
             "TOTPOP": [100, 200],
@@ -911,7 +906,6 @@ class TestToCrosstabInput:
         assert set(result["variable"]) == {"TOTPOP", "VAP"}
 
     def test_explicit_variable_cols(self):
-        import pandas as pd
         df = pd.DataFrame({
             "GEOID": ["A"],
             "TOTPOP": [100],
@@ -923,7 +917,6 @@ class TestToCrosstabInput:
         assert result.iloc[0]["variable"] == "TOTPOP"
 
     def test_empty_dataframe(self):
-        import pandas as pd
         df = pd.DataFrame({"GEOID": [], "TOTPOP": []})
         result = RDHClient.to_crosstab_input(df)
         assert len(result) == 0

--- a/tests/test_redistricting_data_hub.py
+++ b/tests/test_redistricting_data_hub.py
@@ -8,6 +8,7 @@ import zipfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
 import pytest
 
 from siege_utilities.geo.providers.redistricting_data_hub import (

--- a/tests/test_reporting_config_exports.py
+++ b/tests/test_reporting_config_exports.py
@@ -37,13 +37,15 @@ class TestExportBrandingConfig:
             with pytest.raises(ReportingConfigError, match="acme"):
                 export_branding_config("acme", str(tmp_path / "out.yaml"))
 
-    def test_success_returns_true(self, tmp_path):
+    def test_success_returns_none(self, tmp_path):
+        # The wrapper returns None and raises ReportingConfigError on failure
+        # (#967); success is the absence of a raise. Previously asserted True.
         class _OK:
             def export_branding_config(self, *a, **kw):
-                return True
+                return None
 
         with patch("siege_utilities.reporting.client_branding.ClientBrandingManager", return_value=_OK()):
-            assert export_branding_config("acme", str(tmp_path / "out.yaml")) is True
+            assert export_branding_config("acme", str(tmp_path / "out.yaml")) is None
 
 
 class TestImportBrandingConfig:
@@ -72,10 +74,12 @@ class TestImportBrandingConfig:
             def import_branding_config(self, path, client_name):
                 captured["path"] = path
                 captured["client_name"] = client_name
-                return True
+                return None
 
         with patch("siege_utilities.reporting.client_branding.ClientBrandingManager", return_value=_OK()):
-            assert import_branding_config(str(tmp_path / "x.yaml"), client_name="acme") is True
+            # Returns None; the behavior under test is that client_name is
+            # threaded through to the manager. Previously asserted True.
+            import_branding_config(str(tmp_path / "x.yaml"), client_name="acme")
         assert captured["client_name"] == "acme"
 
 

--- a/tests/test_reporting_errors.py
+++ b/tests/test_reporting_errors.py
@@ -109,30 +109,32 @@ class TestReportGeneratorErrors:
         # Should have fallen back to empty config
         assert gen.branding_config is not None
 
-    def test_generate_pdf_report_invalid_output_dir_fails(self, tmp_path):
-        """Writing to a non-writable dir should return False."""
+    def test_generate_pdf_report_invalid_output_dir_raises(self, tmp_path):
+        """Writing to an unwritable dir raises OSError (documented, SU-1)."""
         from siege_utilities.reporting.report_generator import ReportGenerator
         gen = ReportGenerator(client_name="test", output_dir=tmp_path)
         report_content = gen.create_analytics_report(
             title="Test", charts=[], data_summary="test",
         )
-        # Use a path that can't be created (null byte or absurd depth)
-        result = gen.generate_pdf_report(
-            report_content,
-            output_path="/dev/null/impossible/path/report.pdf",
-        )
-        assert result is False
+        # A path that cannot be created/written. generate_pdf_report documents
+        # "Raises OSError if the output directory cannot be created or is not
+        # writable"; previously asserted a False return.
+        with pytest.raises(OSError):
+            gen.generate_pdf_report(
+                report_content,
+                output_path="/dev/null/impossible/path/report.pdf",
+            )
 
-    def test_generate_pdf_report_empty_content_fails_gracefully(self, tmp_path):
-        """Generating a PDF from empty content should not raise."""
+    def test_generate_pdf_report_empty_content_succeeds(self, tmp_path):
+        """Empty content produces a trivial PDF and returns None (success)."""
         from siege_utilities.reporting.report_generator import ReportGenerator
         gen = ReportGenerator(client_name="test", output_dir=tmp_path)
-        result = gen.generate_pdf_report(
-            report_content={},
-            output_path=str(tmp_path / "empty.pdf"),
-        )
-        # Should either succeed (trivial PDF) or return False gracefully
-        assert isinstance(result, bool)
+        out = tmp_path / "empty.pdf"
+        # Returns None on success and raises on failure (documented contract);
+        # previously asserted isinstance(result, bool).
+        result = gen.generate_pdf_report(report_content={}, output_path=str(out))
+        assert result is None
+        assert out.exists()
 
     def test_add_section_to_report_missing_sections_key(self, tmp_path):
         """add_section should create the sections list if missing."""
@@ -183,13 +185,15 @@ class TestChartGeneratorErrors:
         result = generator.create_line_chart(df, title="Empty Line")
         assert result is not None
 
-    def test_save_figure_as_vector_invalid_format_returns_none(self, generator):
-        """An unsupported vector format should return None."""
+    def test_save_figure_as_vector_invalid_format_raises(self, generator):
+        """An unsupported vector format is invalid input -> ValueError (SU-1)."""
         fig, ax = plt.subplots()
         ax.plot([1, 2, 3])
-        result = generator.save_figure_as_vector(fig, "/tmp/test", fmt="bmp")
-        assert result is None
-        plt.close(fig)
+        try:
+            with pytest.raises(ValueError):
+                generator.save_figure_as_vector(fig, "/tmp/test", fmt="bmp")
+        finally:
+            plt.close(fig)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_reporting_errors.py
+++ b/tests/test_reporting_errors.py
@@ -6,9 +6,6 @@ base_template, and client_branding error handling.
 
 from __future__ import annotations
 
-import logging
-from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest

--- a/tests/test_reporting_module.py
+++ b/tests/test_reporting_module.py
@@ -48,7 +48,11 @@ except ImportError:
     FOLIUM_AVAILABLE = False
 
 # Lazy-safe imports — modules themselves guard optional deps internally
-from siege_utilities.reporting.client_branding import ClientBrandingManager
+from siege_utilities.reporting.client_branding import (
+    ClientBrandingManager,
+    ClientBrandingError,
+    ClientBrandingNotFoundError,
+)
 from siege_utilities.reporting.legend_manager import (
     ColorScheme,
     LegendManager,
@@ -307,8 +311,10 @@ class TestChartGenerator:
         from siege_utilities.reporting.chart_generator import ChartGenerator
         cg = ChartGenerator(output_dir=tmp_output)
         fig = MagicMock()
-        result = cg.save_figure_as_vector(fig, tmp_output / "test_chart", fmt="bmp")
-        assert result is None
+        # SU-1: an unsupported vector format is invalid input; save_figure_as_vector
+        # raises ValueError rather than returning None.
+        with pytest.raises(ValueError):
+            cg.save_figure_as_vector(fig, tmp_output / "test_chart", fmt="bmp")
 
     @pytest.mark.skipif(not MATPLOTLIB_AVAILABLE, reason="matplotlib not installed")
     def test_matplotlib_to_reportlab_image(self, tmp_output):
@@ -458,9 +464,11 @@ class TestClientBrandingManager:
         config = branding_manager.get_client_branding("hillcrest")
         assert config is not None
 
-    def test_get_unknown_client_returns_none(self, branding_manager):
-        result = branding_manager.get_client_branding("totally_unknown_client")
-        assert result is None
+    def test_get_unknown_client_raises(self, branding_manager):
+        # SU-1: get_client_branding raises for an unknown client (documented
+        # ClientBrandingNotFoundError), it does not return None.
+        with pytest.raises(ClientBrandingNotFoundError):
+            branding_manager.get_client_branding("totally_unknown_client")
 
     def test_list_clients_includes_builtins(self, branding_manager):
         clients = branding_manager.list_clients()
@@ -498,9 +506,11 @@ class TestClientBrandingManager:
         errors = branding_manager.validate_branding_config(config)
         assert any("primary" in e for e in errors)
 
-    def test_delete_predefined_template_fails(self, branding_manager):
-        result = branding_manager.delete_client_branding("siege_analytics")
-        assert result is False
+    def test_delete_predefined_template_raises(self, branding_manager):
+        # SU-1: deleting a predefined template raises ClientBrandingError
+        # (documented), it does not return False.
+        with pytest.raises(ClientBrandingError):
+            branding_manager.delete_client_branding("siege_analytics")
 
     def test_branding_summary(self, branding_manager):
         summary = branding_manager.get_branding_summary("siege_analytics")
@@ -510,14 +520,14 @@ class TestClientBrandingManager:
 
     def test_export_branding_yaml(self, branding_manager, tmp_path):
         export_path = tmp_path / "export.yaml"
-        result = branding_manager.export_branding_config("siege_analytics", export_path)
-        assert result is True
+        # export_branding_config returns None and raises on failure (#967);
+        # success is verified by the exported file existing.
+        branding_manager.export_branding_config("siege_analytics", export_path)
         assert export_path.exists()
 
     def test_export_branding_json(self, branding_manager, tmp_path):
         export_path = tmp_path / "export.json"
-        result = branding_manager.export_branding_config("siege_analytics", export_path)
-        assert result is True
+        branding_manager.export_branding_config("siege_analytics", export_path)
         assert export_path.exists()
 
     def test_color_extraction_from_branding(self, branding_manager):

--- a/tests/test_seat_vtd_constraints.py
+++ b/tests/test_seat_vtd_constraints.py
@@ -11,12 +11,14 @@ try:
 
     from siege_utilities.geo.django.models.temporal_political import Seat
     from siege_utilities.geo.django.models.political import VTD
+    from siege_utilities.geo.django.models.boundaries import CongressionalDistrict
 
     HAS_DJANGO_GIS = True
 except (ImportError, RuntimeError, Exception):
     HAS_DJANGO_GIS = False
     Seat = None
     VTD = None
+    CongressionalDistrict = None
 
 pytestmark = pytest.mark.skipif(
     not HAS_DJANGO_GIS, reason="Django GIS (GDAL) not available"
@@ -51,16 +53,16 @@ class TestVTDCrossStateValidation:
             vintage_year=2020,
         )
         if cd_state_fips is not None:
-
-            class FakeCD:
-                def __init__(self, sf):
-                    self.state_fips = sf
-
-            vtd.congressional_district_id = 999
-            vtd._congressional_district_cache = FakeCD(cd_state_fips)
-            # Django caches FK objects on the descriptor; simulate by
-            # patching the attribute the clean() method reads.
-            vtd.congressional_district = FakeCD(cd_state_fips)
+            # writing-tests:4 mock fidelity: VTD.congressional_district is a
+            # real Django ForeignKey, whose descriptor rejects a stand-in stub
+            # ("must be a CongressionalDistrict instance"). Use a real
+            # CongressionalDistrict instance with an explicit pk so the FK id
+            # column is populated (clean() guards on congressional_district_id)
+            # without touching the database.
+            cd = CongressionalDistrict(
+                pk=999, state_fips=cd_state_fips, vintage_year=2020,
+            )
+            vtd.congressional_district = cd
         return vtd
 
     def test_same_state_passes(self):

--- a/tests/test_spatial_data_errors.py
+++ b/tests/test_spatial_data_errors.py
@@ -84,12 +84,19 @@ class TestGovernmentDataSource:
         with pytest.raises(AttributeError):
             src._find_best_format("not a dict", "geojson")
 
-    def test_format_finder_returns_none_on_empty_metadata(self):
-        """Missing 'resources' key returns None (no usable format), not
-        an error. This is the documented data-shaped failure mode."""
+    def test_format_finder_raises_on_empty_metadata(self):
+        """No downloadable resource is a failure, not data.
+
+        _find_best_format is typed `-> str` and documents "Raises
+        SpatialDataError if no downloadable resource URL is found" (SU-1,
+        writing-code:13). Previously asserted a None return -- the same
+        retroactive-fix as test_metadata_http_error_status_raises above.
+        """
         src = GovernmentDataSource(portal_url="https://example.com")
-        assert src._find_best_format({}, "geojson") is None
-        assert src._find_best_format({"resources": []}, "geojson") is None
+        with pytest.raises(SpatialDataError):
+            src._find_best_format({}, "geojson")
+        with pytest.raises(SpatialDataError):
+            src._find_best_format({"resources": []}, "geojson")
 
     def test_download_dataset_surface_raises(self):
         """download_dataset() wraps helper SpatialDataError cleanly
@@ -115,9 +122,13 @@ class TestOpenStreetMapDataSource:
                 src.download_osm_data("node[highway]")
         assert isinstance(exc_info.value.__cause__, ConnectionError)
 
-    def test_overpass_http_error_status_returns_none(self):
-        """Matches the metadata test — non-2xx responses legitimately
-        return None rather than raising."""
+    def test_overpass_http_error_status_raises(self):
+        """A non-2xx Overpass response is a failure, not data.
+
+        download_osm_data is typed `-> GeoDataFrame` and documents "Raises
+        SpatialDataError on HTTP or processing failure" (SU-1). Previously
+        asserted a None return.
+        """
         src = OpenStreetMapDataSource()
         fake_response = MagicMock()
         fake_response.ok = False
@@ -126,8 +137,8 @@ class TestOpenStreetMapDataSource:
             "siege_utilities.geo.spatial_data.requests.get",
             return_value=fake_response,
         ):
-            result = src.download_osm_data("node[highway]")
-        assert result is None
+            with pytest.raises(SpatialDataError):
+                src.download_osm_data("node[highway]")
 
 
 class TestKnownTigerDirectories:

--- a/tests/test_spatial_transformations.py
+++ b/tests/test_spatial_transformations.py
@@ -598,30 +598,37 @@ class TestConvenienceFunctions:
             return_value={},
         ):
             from siege_utilities.geo.spatial_transformations import convert_spatial_format
-            result = convert_spatial_format(sample_gdf, "geojson", output_path=out)
-        assert result is True
+            # convert_spatial_format returns None and raises on failure (#967);
+            # success is verified by the output file. Previously asserted True.
+            convert_spatial_format(sample_gdf, "geojson", output_path=out)
         assert Path(out).exists()
 
-    def test_upload_to_duckdb_unavailable(self, sample_gdf):
+    def test_upload_to_duckdb_unavailable_raises(self, sample_gdf):
+        # writing-code:8 / SU-1: with DuckDB unavailable, the optional-dependency
+        # path raises a clear ImportError naming the install command, rather than
+        # returning False. Previously asserted `is False`.
         with patch(
             "siege_utilities.geo.spatial_transformations.DUCKDB_AVAILABLE", False
         ):
             from siege_utilities.geo.spatial_transformations import upload_to_duckdb
-            assert upload_to_duckdb(sample_gdf, "tbl") is False
+            with pytest.raises(ImportError):
+                upload_to_duckdb(sample_gdf, "tbl")
 
-    def test_download_from_duckdb_unavailable(self):
+    def test_download_from_duckdb_unavailable_raises(self):
         with patch(
             "siege_utilities.geo.spatial_transformations.DUCKDB_AVAILABLE", False
         ):
             from siege_utilities.geo.spatial_transformations import download_from_duckdb
-            assert download_from_duckdb("tbl") is None
+            with pytest.raises(ImportError):
+                download_from_duckdb("tbl")
 
-    def test_execute_duckdb_query_unavailable(self):
+    def test_execute_duckdb_query_unavailable_raises(self):
         with patch(
             "siege_utilities.geo.spatial_transformations.DUCKDB_AVAILABLE", False
         ):
             from siege_utilities.geo.spatial_transformations import execute_duckdb_query
-            assert execute_duckdb_query("SELECT 1") is None
+            with pytest.raises(ImportError):
+                execute_duckdb_query("SELECT 1")
 
 
 # ---------------------------------------------------------------------------
@@ -634,6 +641,7 @@ class TestModuleExports:
         from siege_utilities.geo.spatial_transformations import __all__
 
         expected = {
+            "SpatialQueryError",
             "SpatialDataTransformer",
             "PostGISConnector",
             "DuckDBConnector",

--- a/tests/test_sprint_a_reliability.py
+++ b/tests/test_sprint_a_reliability.py
@@ -175,8 +175,10 @@ def test_generate_pdf_report_rejects_unwritable_dir(tmp_path):
     blocker.write_text("placeholder")
     bad_out = blocker / "report.pdf"
 
-    ok = gen.generate_pdf_report({"metadata": {"title": "x"}, "sections": []}, str(bad_out))
-    assert ok is False, "writability pre-check should fail before building PDF"
+    # generate_pdf_report raises OSError when the output directory cannot be
+    # created or written (documented contract, SU-1); previously asserted False.
+    with pytest.raises(OSError):
+        gen.generate_pdf_report({"metadata": {"title": "x"}, "sections": []}, str(bad_out))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tamu_batch.py
+++ b/tests/test_tamu_batch.py
@@ -11,7 +11,6 @@ from siege_utilities.geo.providers.batch_geocoder import MatchQuality
 from siege_utilities.geo.providers.tamu_batch import (
     DEFAULT_RATE_LIMIT,
     ENV_API_KEY,
-    TAMU_BASE_URL,
     TAMUBatchGeocoder,
 )
 

--- a/tests/test_testing_runner.py
+++ b/tests/test_testing_runner.py
@@ -66,7 +66,8 @@ class TestRunCommand:
         result = run_command(["echo", "hello"], "Echo test", log_file="/tmp/test.log")
 
         assert result is True
-        mock_file.assert_called_once_with("/tmp/test.log", "w")
+        # run_command opens the log file with an explicit utf-8 encoding.
+        mock_file.assert_called_once_with("/tmp/test.log", "w", encoding="utf-8")
         handle = mock_file()
         assert handle.write.call_count == 2
 

--- a/tests/test_timeseries_errors.py
+++ b/tests/test_timeseries_errors.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import pytest
 import pandas as pd
-import numpy as np
 
 from siege_utilities.geo.timeseries.change_metrics import (
     calculate_change_metrics,
@@ -16,12 +15,7 @@ from siege_utilities.geo.timeseries.change_metrics import (
     calculate_index,
     _find_year_columns,
 )
-from siege_utilities.geo.timeseries.trend_classifier import (
-    TrendThresholds,
-    classify_trends,
-    classify_by_quantiles,
-    identify_outliers,
-)
+from siege_utilities.geo.timeseries.trend_classifier import classify_trends, classify_by_quantiles, identify_outliers
 from siege_utilities.geo.timeseries.longitudinal_data import (
     validate_longitudinal_years,
     get_available_years,

--- a/tests/test_timeseries_errors.py
+++ b/tests/test_timeseries_errors.py
@@ -257,8 +257,11 @@ class TestValidateYearsEmptyInput:
 # =========================================================================
 
 class TestGetAvailableYearsUnknownDataset:
-    def test_unknown_dataset_returns_empty(self):
-        assert get_available_years(dataset="nonexistent") == []
+    def test_unknown_dataset_raises(self):
+        # SU-1: an unknown dataset is invalid input; get_available_years raises
+        # ValueError rather than returning an empty list.
+        with pytest.raises(ValueError):
+            get_available_years(dataset="nonexistent")
 
 
 class TestGetAvailableYearsKnownDatasets:

--- a/tests/test_timeseries_rollup_services.py
+++ b/tests/test_timeseries_rollup_services.py
@@ -5,7 +5,6 @@ Tests service class structure, statistics helpers, and configuration
 without requiring a full Django database.
 """
 
-import math
 
 import pytest
 

--- a/tests/test_timeseries_rollup_services.py
+++ b/tests/test_timeseries_rollup_services.py
@@ -58,10 +58,13 @@ class TestTimeseriesService:
         assert cagr is not None
         assert abs(cagr - 0.1487) < 0.001
 
-    def test_cagr_zero_start_returns_none(self):
+    def test_cagr_zero_start_raises(self):
         from siege_utilities.geo.django.services.timeseries_service import TimeseriesService
 
-        assert TimeseriesService._cagr(0, 100, 5) is None
+        # SU-1: CAGR is undefined for a zero start value; _cagr raises ValueError
+        # (its return type is float) rather than returning None.
+        with pytest.raises(ValueError):
+            TimeseriesService._cagr(0, 100, 5)
 
     def test_trend_direction_increasing(self):
         from siege_utilities.geo.django.services.timeseries_service import TimeseriesService
@@ -86,11 +89,14 @@ class TestTimeseriesService:
         model = svc._resolve_model("tract")
         assert model is Tract
 
-    def test_resolve_model_unknown_level(self):
+    def test_resolve_model_unknown_level_raises(self):
         from siege_utilities.geo.django.services.timeseries_service import TimeseriesService
 
+        # SU-1: an unknown geography level is invalid input; _resolve_model
+        # raises ValueError rather than returning None.
         svc = TimeseriesService()
-        assert svc._resolve_model("galaxy") is None
+        with pytest.raises(ValueError):
+            svc._resolve_model("galaxy")
 
 
 @pytest.mark.skipif(

--- a/tests/test_variable_groups_deprecation.py
+++ b/tests/test_variable_groups_deprecation.py
@@ -2,7 +2,6 @@
 
 import warnings
 
-import pytest
 
 
 def _reset_warned():


### PR DESCRIPTION
Fixes the two mechanical reasons the CI workflow is chronically red. Neither blocks the `release` job (which `needs: [build]` only — v3.23.0 published cleanly), but they keep the overall run red, masking real regressions.

## Fixes
1. **api-contract-regression self-trap** — `BASELINE_VERSION` was hardcoded to `3.18.0`, never published to PyPI, so `pip install siege-utilities==3.18.0` failed every run. Now resolves the baseline dynamically to the latest *published* version on PyPI.
2. **gdal build mismatch** — `uv sync` resolved `gdal>=3.6,<4` to 3.13.0 vs the runner's system GDAL 3.8.4 → `Failed to build gdal==3.13.0`. Now constrains gdal to `$(gdal-config --version)` for CI resolution only (via `UV_CONSTRAINT`); `pyproject.toml` range unchanged for consumers.

## Validation
This PR's own CI run is the validation: api-contract-regression and test/battle-test should go green.

## Out of scope (tracked in #1064)
`test-pydantic-v1`, `test-databricks`, `test-geo-no-gdal`/`test-smoke` (geo-extra structure question), `lint-ratchet-phase2-4`.

Refs: #1064

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI dependency handling by pinning the GDAL package to the runner’s installed GDAL version before syncing dependencies.
  * Made API contract regression baseline versioning automatic by resolving the latest released version from PyPI during the workflow.
* **Bug Fixes**
  * Fixed sensitive-field exclusion so organization and collaboration `to_dict(..., exclude_sensitive=...)` properly strips sensitive data.
* **Style**
  * Refined type-import usage and added type-checker-only imports where applicable.
  * Clarified exported attributes for lazily provided geo sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Real bugs filed (audit trail, per Dheeraj)

Each real production / canonical-data bug surfaced while making this suite run is tracked as its own issue with root-cause, impact, and fixing commit:

- #1081 — client_branding: YAML parse errors not wrapped (eec6b51c)
- #1082 — census_api_client: _process_response signature mismatch (089c6bf2)
- #1083 — reporting: data-URI Image rendering broken under ReportLab 5 (6d7e9f77)
- #1084 — geo: canonical VTD GEOID length 6 -> 11 (92e15e13)
- #1085 — test-infra: KeyboardInterrupt aborted the pytest run, masking ~130 failures (cc72c1af)
