### PR TITLE
feat(connectors): fully lazy init + epic document (#1013)

### DIFF
--- a/docs/epics/CRM_INTEGRATIONS_EPIC.md
+++ b/docs/epics/CRM_INTEGRATIONS_EPIC.md
@@ -1,0 +1,79 @@
+# Epic: CRM Integrations
+
+**Date:** 2026-06-03
+**Status:** IN PROGRESS
+**Package:** `siege_utilities.connectors`
+**GitHub Label:** `epic:crm-integrations`
+**Issues:** #1011–#1033
+
+## Issue Index
+
+| # | Ticket | Title | Size | Depends On |
+|---|--------|-------|------|------------|
+| #1011 | WS1-T1 | Connector Protocol definition | M | — |
+| #1012 | WS1-T2 | Shared CRM data models (Contact, Account, Opportunity, Activity) | M | #1011 |
+| #1013 | WS1-T3 | connectors/ package scaffold + lazy loading | S | #1011 |
+| #1014 | WS1-T4 | OAuthProvider enum extension (HubSpot, Zoho, Dynamics) | S | — |
+| #1015 | WS2-T1 | Salesforce OAuth + connection management | M | #1011, #1014 |
+| #1016 | WS2-T2 | Salesforce read: Contacts, Accounts, Opportunities, Leads | L | #1015 |
+| #1017 | WS2-T3 | Salesforce SOQL query builder | M | #1015 |
+| #1018 | WS2-T4 | Salesforce write-back (create/update/upsert) | L | #1016 |
+| #1019 | WS2-T5 | Salesforce Bulk API for large datasets | M | #1016 |
+| #1020 | WS3-T1 | HubSpot OAuth + connection management | M | #1011, #1014 |
+| #1021 | WS3-T2 | HubSpot read: Contacts, Companies, Deals, Activities | L | #1020 |
+| #1022 | WS3-T3 | HubSpot write-back + association handling | L | #1021 |
+| #1023 | WS4-T1 | Zoho CRM OAuth + connection management | M | #1011, #1014 |
+| #1024 | WS4-T2 | Zoho read: Leads, Contacts, Accounts, Deals | L | #1023 |
+| #1025 | WS4-T3 | Zoho write-back + custom module support | L | #1024 |
+| #1026 | WS5-T1 | Dynamics 365 MSAL/OAuth + Dataverse connection | M | #1011, #1014 |
+| #1027 | WS5-T2 | Dynamics 365 read: Contacts, Accounts, Opportunities | L | #1026 |
+| #1028 | WS5-T3 | Dynamics 365 write-back via Web API | L | #1027 |
+| #1029 | WS6-T1 | CRM DataFrame adapters for reporting primitives | M | #1012, any WS2-5 read |
+| #1030 | WS6-T2 | Sales pipeline chart type registration | S | #1029 |
+| #1031 | WS6-T3 | Cross-CRM dedup pipeline via identifiers/ | M | #1012, #1029 |
+| #1032 | WS6-T4 | Notebook: CRM → dedup → enrich → report | L | #1029, #1031 |
+| #1033 | WS6-T5 | Notebook: sales tables → charts → PDF | M | #1029, #1030 |
+
+## Goal
+
+Give siege_utilities read/write access to the four dominant commercial CRMs
+(Salesforce, HubSpot, Zoho, Microsoft Dynamics 365) through a unified
+connector protocol. CRM data flows into the existing analytics pipeline —
+normalize via `identifiers/`, enrich via `geo/`, visualize via `reporting/` —
+and enriched results write back.
+
+Anchor use cases:
+1. Pull contacts from multiple CRMs, deduplicate via `normalize_name_v1` + `uuid5_from_seed`, enrich with geo/demographics, push consolidated profiles back
+2. Pull sales/opportunity tables, generate charts and PDF reports using existing `reporting/` primitives
+3. Unify donor/customer records across systems without manual review
+
+## Dependency Graph
+
+```
+WS1 (Protocol + Foundation)  — independent, must go first
+WS2 (Salesforce)             — depends on WS1-T1, WS1-T4
+WS3 (HubSpot)               — depends on WS1-T1, WS1-T4
+WS4 (Zoho)                  — depends on WS1-T1, WS1-T4
+WS5 (Dynamics 365)           — depends on WS1-T1, WS1-T4
+
+WS6 (Reporting + Pipeline)  — depends on WS1-T2 + at least one
+                               WS2-5 read ticket completed
+```
+
+Recommended execution order: WS1 first, then WS2-5 (fully parallelizable), WS6 last.
+
+## Key Design Decisions
+
+1. **New `connectors/` package** — not extending `analytics/`; creates migration path for existing connectors
+2. **Protocol over ABC** — per CLAUDE.md tactical principle 1
+3. **Scope boundary:** connectors are primitives (pull/push records). No sync scheduling, no CDC, no conflict resolution beyond dedup.
+4. **Write-back:** create/update/upsert — not real-time sync
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| API versioning churn | Version-pin endpoints; test against sandbox instances |
+| Rate limiting | Explicit handling with backoff; never silently return partial results (SU-1) |
+| OAuth complexity | Leverage existing CredentialManager + OAuthIntegration model |
+| Scope creep into ETL | Connectors are primitives; transformation lives in identifiers/, geo/, reporting/ |

--- a/plans/self-review-1013.md
+++ b/plans/self-review-1013.md
@@ -1,0 +1,41 @@
+---
+ticket: "#1013"
+scope: "connectors/__init__.py, docs/epics/CRM_INTEGRATIONS_EPIC.md"
+---
+
+# Self-Review — #1013 connectors/ package scaffold + lazy loading
+
+## Junior Assessment
+
+Refactored `connectors/__init__.py` from eager protocol imports + hand-written
+models `__getattr__` to the `_register()` + `importlib.import_module` pattern
+matching `analytics/__init__.py`. All 12 public names now lazy-load. Added
+`__dir__()` for tab-completion. Commented placeholder slots for future connector
+modules.
+
+Committed `docs/epics/CRM_INTEGRATIONS_EPIC.md` from the #1010 issue body with
+status updated to IN PROGRESS.
+
+## Lead Assessment
+
+**Pattern consistency:** Now matches `analytics/__init__.py` exactly — same
+`_register`, `__getattr__`, `__dir__` structure. No deviation from established
+convention.
+
+**No behavioral change:** All previously importable names still import. The
+change is purely structural (eager → lazy). Verified all 12 names resolve.
+
+**SU-1 compliance:** `__getattr__` raises `AttributeError` for unknown names.
+No silent stubs.
+
+## Trivial-investigation declaration
+
+Mechanical refactor following an established pattern (`analytics/__init__.py`).
+No new contracts, no new dependencies, no behavioral changes. The only
+verification needed — import paths resolve — was tested.
+
+## Trivial pre-mortem declaration
+
+No contract changes. Existing imports continue to work. The only risk was
+breaking `from siege_utilities.connectors import ConnectorProtocol`, verified
+by running the import after the change.

--- a/siege_utilities/connectors/__init__.py
+++ b/siege_utilities/connectors/__init__.py
@@ -1,5 +1,5 @@
 """
-CRM connector primitives.
+CRM connector primitives — lazy-loaded.
 
 Pull/push records from commercial CRMs (Salesforce, HubSpot, Zoho,
 Microsoft Dynamics 365) through a unified :class:`ConnectorProtocol`.
@@ -9,17 +9,19 @@ CRM data flows into the analytics pipeline — normalize via
 See ``docs/epics/CRM_INTEGRATIONS_EPIC.md`` for the full epic.
 """
 
-from siege_utilities.connectors._protocol import (
-    ConnectorAuthError,
-    ConnectorError,
-    ConnectorNotFoundError,
-    ConnectorProtocol,
-    ConnectorRateLimitError,
-    UpsertError,
-    UpsertResult,
-)
+import importlib
+import sys
 
-__all__ = [
+_LAZY_IMPORTS = {}
+
+
+def _register(names, module):
+    for name in names:
+        _LAZY_IMPORTS[name] = module
+
+
+# Protocol, error hierarchy, bulk-operation types
+_register([
     "ConnectorProtocol",
     "UpsertResult",
     "UpsertError",
@@ -27,33 +29,34 @@ __all__ = [
     "ConnectorAuthError",
     "ConnectorRateLimitError",
     "ConnectorNotFoundError",
+], "._protocol")
+
+# Canonical CRM data models
+_register([
     "CRMAddress",
     "CRMContact",
     "CRMAccount",
     "CRMOpportunity",
     "CRMActivity",
-]
+], "._models")
 
-_MODEL_NAMES = {"CRMAddress", "CRMContact", "CRMAccount", "CRMOpportunity", "CRMActivity"}
+# --- Connector modules (added as workstreams land) ---
+# _register(["SalesforceConnector"], ".salesforce")
+# _register(["HubSpotConnector"], ".hubspot")
+# _register(["ZohoConnector"], ".zoho")
+# _register(["DynamicsConnector"], ".dynamics")
+
+__all__ = list(_LAZY_IMPORTS.keys())
 
 
-def __getattr__(name: str):
-    if name in _MODEL_NAMES:
-        from siege_utilities.connectors._models import (
-            CRMAccount,
-            CRMActivity,
-            CRMAddress,
-            CRMContact,
-            CRMOpportunity,
-        )
-
-        _lazy = {
-            "CRMAddress": CRMAddress,
-            "CRMContact": CRMContact,
-            "CRMAccount": CRMAccount,
-            "CRMOpportunity": CRMOpportunity,
-            "CRMActivity": CRMActivity,
-        }
-        globals().update(_lazy)
-        return _lazy[name]
+def __getattr__(name):
+    if name in _LAZY_IMPORTS:
+        mod = importlib.import_module(_LAZY_IMPORTS[name], __package__)
+        val = getattr(mod, name)
+        setattr(sys.modules[__name__], name, val)
+        return val
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(list(globals().keys()) + list(_LAZY_IMPORTS.keys())))


### PR DESCRIPTION
## Summary

- Refactors `connectors/__init__.py` to `_register()` + `importlib.import_module` pattern (matches `analytics/`)
- All 12 public names lazy-loaded; `__dir__()` for tab-completion
- Commented placeholder slots for Salesforce, HubSpot, Zoho, Dynamics connector modules
- Commits `docs/epics/CRM_INTEGRATIONS_EPIC.md`

Closes #1013