### PR TITLE
build(gdal): make GDAL a dedicated optional extra; fix no-GDAL install + Django GIS degrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,7 +375,14 @@ jobs:
           --ignore=tests/test_django_temporal_models_orm.py \
           --ignore=tests/test_nces_service_bulk_update_timestamp.py \
           --ignore=tests/test_nces_service_enrich_districts.py \
-          --ignore=tests/test_dataframe_engine_spatial.py
+          --ignore=tests/test_dataframe_engine_spatial.py \
+          --ignore=tests/test_nlrb_models.py \
+          --ignore=tests/test_redistricting_plan_status.py \
+          --ignore=tests/test_urbanicity_overlay.py \
+          --ignore=tests/test_seats_overlay.py \
+          --ignore=tests/test_place_history.py \
+          --ignore=tests/test_events_overlay.py \
+          --ignore=tests/test_demographics_overlay.py
 
   test-smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
       run: |
         sed -i "s/\"gdal>=3.6,<4\"/\"gdal==$(gdal-config --version)\"/g" pyproject.toml
         grep -qE '"gdal==[0-9]' pyproject.toml || { echo "gdal pin rewrite failed (gdal-config missing or pin literal changed)"; exit 1; }
-        uv sync --extra all --extra dev
+        uv sync --extra all --extra gdal --extra dev
 
     - name: Lint with flake8
       run: |
@@ -460,7 +460,7 @@ jobs:
       run: |
         sed -i "s/\"gdal>=3.6,<4\"/\"gdal==$(gdal-config --version)\"/g" pyproject.toml
         grep -qE '"gdal==[0-9]' pyproject.toml || { echo "gdal pin rewrite failed (gdal-config missing or pin literal changed)"; exit 1; }
-        uv sync --extra all --extra dev
+        uv sync --extra all --extra gdal --extra dev
 
     - name: Run Battle Testing Suite
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING (packaging):** the native GDAL/OGR Python bindings (`gdal`) are now
+  a dedicated optional extra and are no longer pulled in by `[geo]` or `[all]`.
+  GDAL requires a matching system `libgdal` + `gdal-config` to build, which is
+  unavailable on Databricks / Lambda / serverless and on CI jobs that exercise
+  the documented no-GDAL path. Install the native stack explicitly with
+  `pip install siege-utilities[geo,gdal]`; the pure-Python geo path
+  (geopandas/shapely/pyproj/fiona) continues to work via `[geo]` without it.
+
+### Fixed
+
+- The Django test settings now degrade to plain PostgreSQL + no GIS apps when
+  the GDAL shared library is absent. The detection caught only
+  `(ImportError, RuntimeError)`, but `django.contrib.gis.gdal` raises
+  `ImproperlyConfigured` ("Could not find the GDAL library") at import time, so
+  settings load failed on no-GDAL runners.
+
 ## [3.17.2] - 2026-05-14
 
 Patch release: hydra is an optional extra; importing siege_utilities without it must not emit a misleading "Pydantic config system" warning. Closes #498.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,20 +10,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING (packaging):** the native GDAL/OGR Python bindings (`gdal`) are now
-  a dedicated optional extra and are no longer pulled in by `[geo]` or `[all]`.
-  GDAL requires a matching system `libgdal` + `gdal-config` to build, which is
+  a dedicated optional `[gdal]` extra and are no longer pulled in by `[geo]` or
+  `[all]`. The OSGeo `gdal` wheel requires a matching system `libgdal` +
+  `gdal-config` and must be pinned to the installed libgdal version, which is
   unavailable on Databricks / Lambda / serverless and on CI jobs that exercise
-  the documented no-GDAL path. Install the native stack explicitly with
-  `pip install siege-utilities[geo,gdal]`; the pure-Python geo path
-  (geopandas/shapely/pyproj/fiona) continues to work via `[geo]` without it.
+  the documented no-GDAL path. The pure-Python geo path
+  (geopandas/shapely/pyproj/fiona, bundled-GDAL wheels) continues to work via
+  `[geo]` with no system GDAL. To install the native OSGeo bindings, pin to your
+  system libgdal — the path CI exercises (a bare `[geo,gdal]` resolves the newest
+  `gdal` in `>=3.6,<4` and fails to build against an older libgdal):
+
+  ```bash
+  pip install siege-utilities[geo]
+  pip install "gdal==$(gdal-config --version)"
+  ```
 
 ### Fixed
 
-- The Django test settings now degrade to plain PostgreSQL + no GIS apps when
-  the GDAL shared library is absent. The detection caught only
-  `(ImportError, RuntimeError)`, but `django.contrib.gis.gdal` raises
-  `ImproperlyConfigured` ("Could not find the GDAL library") at import time, so
-  settings load failed on no-GDAL runners.
+- The Django test settings and the GeoDjango-availability guards in nine test
+  files now degrade cleanly when the GDAL shared library is absent **without**
+  swallowing unrelated errors. `django.contrib.gis.gdal` raises
+  `ImproperlyConfigured` ("Could not find the GDAL library") — not
+  `ImportError`/`RuntimeError` — so the original guards aborted on no-GDAL
+  runners; a subsequent broad `except Exception` over-corrected and would have
+  hidden a real Django/GIS misconfiguration. The guards now catch exactly
+  `(ImproperlyConfigured, ImportError, OSError)` (plus `RuntimeError` in the test
+  guards), so a real misconfig surfaces loudly (writing-code:7).
 
 ## [3.17.2] - 2026-05-14
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,12 +34,16 @@ python --version  # Should show 3.11.x
 pip install -e ".[dev]"
 
 # Full install (all extras — geo, analytics, reporting, etc.)
+# No system GDAL needed; [all] does not pull the native osgeo bindings.
 pip install -e ".[all,dev]"
 
-# Geospatial work (requires system GDAL libraries)
-# macOS: brew install gdal
-# Ubuntu: sudo apt-get install gdal-bin libgdal-dev libgeos-dev libproj-dev
+# Geospatial work — [geo] is pure-Python (bundled-GDAL wheels), no system GDAL.
 pip install -e ".[geo,dev]"
+
+# Native OSGeo bindings (only if you import `osgeo` directly) — needs system
+# GDAL, pinned to the wheel version (the path CI exercises):
+# macOS: brew install gdal | Ubuntu: sudo apt-get install gdal-bin libgdal-dev libgeos-dev libproj-dev
+pip install -e ".[geo,dev]" && pip install "gdal==$(gdal-config --version)"
 ```
 
 The `-e` flag installs in **editable mode** — your code changes take effect immediately without reinstalling.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 `siege_utilities` is the shared utilities library behind Siege Analytics workflows:
 
-- Geospatial + GeoDjango boundary/data services (tiered: `[geo-lite]` / `[geo]` / `[geodjango]`)
+- Geospatial + GeoDjango boundary/data services (`[geo]` pure-Python, no system GDAL; `[geodjango]` PostGIS; `[gdal]` native OSGeo bindings)
 - Google Workspace write APIs (Sheets, Docs, Slides, Drive) with multi-account management
 - Census API/data selection/crosswalk tooling
 - Isochrone analysis with configurable CRS and domain exceptions
@@ -32,7 +32,7 @@ They are designed to work together (the ZSH config sets up `SPARK_HOME`, `JAVA_H
 | 3.13 | **Supported** | Allow-failure while stabilizing |
 | 3.14 | **Experimental** | Not yet in CI (awaiting ecosystem wheels) |
 
-The library requires Python 3.11+. Geospatial extras (`[geo]`, `[geodjango]`) depend on C-extension packages (GDAL/GEOS/PROJ bindings) whose wheel availability varies by Python version — check PyPI for your target version before installing.
+The library requires Python 3.11+. The `[geo]` extra installs a pure-Python geospatial stack (GeoPandas, Shapely, Fiona, PyProj) whose wheels bundle their own GDAL/GEOS/PROJ — so `[geo]` needs **no system GDAL**. The native OSGeo bindings (`from osgeo import gdal`) are a separate opt-in `[gdal]` extra that requires a system libgdal matching the wheel version (see [Installation Options](#installation-options)). GeoDjango/PostGIS (`[geodjango]`) loads the system libgdal at runtime.
 
 ## Install
 
@@ -406,9 +406,8 @@ report_gen.generate_pdf_report(report_content, output_path="report.pdf")
 pip install siege-utilities
 
 # Add extras for what you need
-pip install siege-utilities[geo-lite]         # shapely, pyproj, geopy (no GDAL needed)
-pip install siege-utilities[geo]              # geo-lite + geopandas, fiona, rtree, tobler (needs GDAL)
-pip install siege-utilities[geodjango]        # geo + Django, DRF, PostGIS
+pip install siege-utilities[geo]              # geopandas, fiona, shapely, pyproj, tobler, pysal — NO system GDAL needed (bundled wheels)
+pip install siege-utilities[geodjango]        # geo use + Django, DRF, PostGIS (system libgdal at runtime)
 pip install siege-utilities[data]             # pandas, numpy, openpyxl, faker
 pip install siege-utilities[reporting]        # matplotlib, seaborn, folium, plotly, reportlab
 pip install siege-utilities[analytics]        # GA4, Facebook, Snowflake, scipy, scikit-learn
@@ -416,7 +415,14 @@ pip install siege-utilities[distributed]      # PySpark, Apache Sedona
 pip install siege-utilities[config-extras]    # Hydra, hydra-zen, omegaconf
 pip install siege-utilities[web]              # BeautifulSoup, lxml
 pip install siege-utilities[database]         # SQLAlchemy, psycopg2
-pip install siege-utilities[all]              # Everything
+pip install siege-utilities[all]              # Everything (no system GDAL; add [gdal] separately for osgeo)
+
+# Native OSGeo bindings (only if you import `osgeo` directly) — pin to your
+# system libgdal; this is the path CI exercises. A bare [geo,gdal] resolves
+# the newest gdal in >=3.6,<4 and fails to build against an older libgdal.
+sudo apt-get install -y gdal-bin libgdal-dev   # or: brew install gdal
+pip install siege-utilities[geo]
+pip install "gdal==$(gdal-config --version)"
 
 # Combine extras
 pip install siege-utilities[data,geo,reporting]

--- a/docs/MANAGED_ENVIRONMENTS.md
+++ b/docs/MANAGED_ENVIRONMENTS.md
@@ -1,25 +1,41 @@
 # Managed Environments Setup Guide
 
-## Tiered Geo Extras
+## Geo Extras and GDAL
 
-siege_utilities offers three tiers of geospatial functionality:
+As of the GDAL-optional-extra split, `[geo]` installs the pure-Python
+geospatial stack — its wheels bundle their own GDAL/GEOS/PROJ, so it needs
+**no system GDAL**. The native OSGeo bindings are a separate opt-in `[gdal]`
+extra. This is what makes managed environments that cannot install system
+GDAL (Databricks, Colab, SageMaker) work with a plain `pip install`.
 
 | Extra | What it installs | System deps | Works on |
 |-------|-----------------|-------------|----------|
-| `[geo-lite]` | shapely, pyproj, geopy, censusgeocode | None | Everywhere |
-| `[geo]` | geo-lite + geopandas, fiona, rtree, mapclassify, tobler, osmnx, pysal | GDAL, GEOS, PROJ | Systems with C libs |
-| `[geodjango]` | geo + Django, DRF, PostGIS bindings | GDAL + PostgreSQL | Full PostGIS stack |
+| `[geo]` | geopandas, fiona, shapely, pyproj, rtree, mapclassify, tobler, osmnx, pysal, censusgeocode | **None** (bundled in wheels) | Everywhere, incl. Databricks / Colab / SageMaker |
+| `[gdal]` | native OSGeo `gdal` Python bindings (`from osgeo import gdal`) | system libgdal, **version-matched** | Hosts with system GDAL |
+| `[geodjango]` | `[geo]` use + Django, DRF, DRF-GIS, PostGIS bindings | system libgdal at runtime + PostgreSQL | Full PostGIS stack |
 
-### Which tier do I need?
+> The native `[gdal]` wheel must match the installed libgdal exactly. Add it
+> on top of `[geo]` only when you import `osgeo` directly, and pin it — the
+> path CI exercises:
+> `pip install siege-utilities[geo]` then `pip install "gdal==$(gdal-config --version)"`.
+> A bare `pip install siege-utilities[geo,gdal]` resolves the newest `gdal` in
+> `>=3.6,<4` and will fail to build against an older system libgdal.
 
-| Use case | Tier |
-|----------|------|
-| Geocoding, coordinate transforms, GEOID validation | `geo-lite` |
-| Census data download, spatial joins, choropleth maps | `geo` |
-| Django models with PostGIS geometry fields | `geodjango` |
-| Everything | `all` |
+### Which extra do I need?
+
+| Use case | Install |
+|----------|---------|
+| Geocoding, coordinate transforms, GEOID validation, spatial joins, choropleths | `[geo]` |
+| Importing `osgeo` (`gdal`/`ogr`/`osr`) directly | `[geo]` + version-matched `[gdal]` |
+| Django models with PostGIS geometry fields | `[geodjango]` (+ system libgdal) |
+| Everything | `[all]` (no system GDAL; add `[gdal]` separately if you need osgeo) |
 
 ### Runtime detection
+
+`geo_capabilities()` reports a runtime *capability* tier based on what is
+actually importable — distinct from the pip extras above. The `"geo-lite"`
+tier means the lightweight subset (shapely/pyproj) is present but GeoPandas
+is not; it is not a pip extra, just a detected capability level.
 
 ```python
 from siege_utilities.geo import geo_capabilities
@@ -31,19 +47,23 @@ print(caps["geopandas"]) # True / False
 
 ## Azure Databricks
 
-Databricks runtimes include numpy, pandas, and scipy but **not** GDAL/GEOS/PROJ.
+Databricks runtimes include numpy, pandas, and scipy but **not** system
+GDAL/GEOS/PROJ. Because `[geo]` no longer requires system GDAL, install it
+directly — no init script needed:
 
 ```bash
 # In a notebook cell or init script:
-%pip install siege-utilities[geo-lite,data]
+%pip install siege-utilities[geo,data]
 ```
 
-For full geo support, use a Databricks init script to install system libraries:
+You only need a system-GDAL init script if you import `osgeo` directly or
+use GeoDjango/PostGIS:
 
 ```bash
 #!/bin/bash
 apt-get update && apt-get install -y gdal-bin libgdal-dev libgeos-dev libproj-dev
 pip install siege-utilities[geo,data]
+pip install "gdal==$(gdal-config --version)"   # only if you import osgeo
 ```
 
 ### Spark integration
@@ -56,33 +76,34 @@ PySpark and Apache Sedona are pure Python packages — install them with:
 
 ## Google Colab
 
-Colab includes most Python data science packages but not GDAL.
+Colab includes most Python data science packages but not system GDAL.
+`[geo]` works out of the box:
 
-```python
-# geo-lite works out of the box
-!pip install siege-utilities[geo-lite,data]
-
-# For full geo, install GDAL first
-!apt-get install -y gdal-bin libgdal-dev libgeos-dev libproj-dev
+```bash
 !pip install siege-utilities[geo,data,reporting]
+
+# Only if you import osgeo directly:
+!apt-get install -y gdal-bin libgdal-dev libgeos-dev libproj-dev
+!pip install "gdal==$(gdal-config --version)"
 ```
 
 ## AWS SageMaker
 
-SageMaker conda environments include numpy/pandas but not GDAL.
+SageMaker conda environments include numpy/pandas but not system GDAL.
+`[geo]` installs without it:
 
 ```bash
 # In a lifecycle config or notebook:
-pip install siege-utilities[geo-lite,data]
-
-# For full geo:
-conda install -c conda-forge gdal geopandas fiona
 pip install siege-utilities[geo,data]
+
+# Only if you import osgeo directly:
+conda install -c conda-forge gdal
+pip install "gdal==$(gdal-config --version)"
 ```
 
-## Functions by Tier
+## Functions by Capability Tier
 
-### geo-lite (no GDAL required)
+### geo-lite tier — no GDAL, no GeoPandas (lightweight subset)
 
 - `validate_geoid()`, `normalize_geoid()`, `parse_geoid()` — GEOID utilities
 - `geocode_single()`, `geocode_batch()` — Census geocoder
@@ -91,7 +112,7 @@ pip install siege-utilities[geo,data]
 - `geo_capabilities()` — runtime detection
 - Census constants, FIPS lookups, state normalization
 
-### geo (requires GDAL)
+### geo tier — `[geo]`, no system GDAL required
 
 - `get_census_boundaries()`, `download_data()` — boundary downloads
 - `interpolate_areal()` — areal interpolation
@@ -99,7 +120,7 @@ pip install siege-utilities[geo,data]
 - `SpatialDataTransformer` — format conversion
 - All Django boundary models and services
 
-### geodjango (requires GDAL + PostgreSQL)
+### geodjango tier — `[geodjango]` (system libgdal + PostgreSQL)
 
 - All geo models (`CongressionalDistrict`, `CensusTract`, etc.)
 - Population services, management commands

--- a/docs/source/geo.rst
+++ b/docs/source/geo.rst
@@ -12,23 +12,32 @@ The geographic utilities package provides comprehensive tools for working with g
    api/siege_utilities/geo/census_dataset_mapper
    api/siege_utilities/geo/census_data_selector
 
-Tiered Installation
--------------------
+Installation
+------------
 
-The geo package uses a three-tier extras system so you only install what you need:
+The geo package installs as a pure-Python stack — its wheels bundle their own
+GDAL/GEOS/PROJ, so it needs no system GDAL. The native OSGeo bindings are a
+separate opt-in extra:
 
 .. code-block:: bash
 
-   # Tier 1: Lightweight (no GDAL/GEOS system deps)
-   pip install siege-utilities[geo-lite]    # shapely, pyproj, geopy, censusgeocode
+   # Geospatial (geopandas, fiona, shapely, pyproj, rtree, tobler, osmnx, pysal)
+   pip install siege-utilities[geo]         # NO system GDAL required
 
-   # Tier 2: Full geospatial (requires GDAL/GEOS/PROJ)
-   pip install siege-utilities[geo]         # geo-lite + geopandas, fiona, rtree, tobler, osmnx
+   # GeoDjango spatial platform (system libgdal at runtime + PostgreSQL)
+   pip install siege-utilities[geodjango]   # geo use + Django, DRF-GIS, psycopg2
 
-   # Tier 3: GeoDjango spatial platform
-   pip install siege-utilities[geodjango]   # geo + Django, DRF-GIS, psycopg2
+   # Native OSGeo bindings (only if you import `osgeo` directly) — pin to your
+   # system libgdal; the path CI exercises. A bare [geo,gdal] resolves the
+   # newest gdal in >=3.6,<4 and fails to build against an older libgdal.
+   pip install siege-utilities[geo]
+   pip install "gdal==$(gdal-config --version)"
 
-**Runtime capability detection**:
+**Runtime capability detection** reports what is actually importable as a tier
+(``"geodjango"``, ``"geo"``, ``"geo-lite"``, or ``"none"``) — distinct from the
+pip extras above. The ``"geo-lite"`` tier means the lightweight subset
+(shapely/pyproj) is present but GeoPandas is not; it is a detected capability
+level, not a pip extra.
 
 .. code-block:: python
 
@@ -37,10 +46,10 @@ The geo package uses a three-tier extras system so you only install what you nee
    caps = geo_capabilities()
    # {'shapely': True, 'pyproj': True, 'geopandas': False, 'fiona': False, ...}
 
-Functions that require full ``[geo]`` dependencies will raise ``ImportError`` with
-installation instructions when called from a ``[geo-lite]`` environment. See
-``docs/MANAGED_ENVIRONMENTS.md`` for setup guides for Azure Databricks, Google Colab,
-and AWS SageMaker.
+Functions that require full ``[geo]`` dependencies raise ``ImportError`` with
+installation instructions when GeoPandas is unavailable (the ``"geo-lite"``
+capability tier). See ``docs/MANAGED_ENVIRONMENTS.md`` for setup guides for
+Azure Databricks, Google Colab, and AWS SageMaker.
 
 Isochrones and CRS
 ------------------
@@ -135,17 +144,14 @@ Installation
 
 .. code-block:: bash
 
-   # Lightweight (no GDAL required)
-   pip install siege-utilities[geo-lite]
-
-   # Full geospatial
+   # Geospatial — pure-Python (bundled-GDAL wheels), no system GDAL required
    pip install siege-utilities[geo]
 
-   # Full + Django/PostGIS
+   # Geospatial + Django/PostGIS (system libgdal at runtime)
    pip install siege-utilities[geodjango]
 
    # Development
-   pip install siege-utilities[geo,testing]
+   pip install siege-utilities[geo,dev]
 
 Quick Start
 ----------

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -11,17 +11,20 @@ Installation
 
 .. code-block:: bash
 
-   # Core (lightweight, no geospatial C deps)
+   # Core (lightweight, no geospatial deps)
    pip install siege-utilities
 
-   # Geo-lite (shapely, pyproj, geopy — no GDAL)
-   pip install siege-utilities[geo-lite]
-
-   # Full geospatial (requires GDAL/GEOS/PROJ system libraries)
+   # Geospatial — geopandas, shapely, pyproj, fiona, pysal, etc.
+   # Pure-Python (bundled-GDAL wheels); needs NO system GDAL.
    pip install siege-utilities[geo]
 
-   # GeoDjango spatial platform
+   # GeoDjango spatial platform (system libgdal at runtime + PostgreSQL)
    pip install siege-utilities[geodjango]
+
+   # Native OSGeo bindings (only if you import `osgeo` directly) — pin to your
+   # system libgdal; this is the path CI exercises.
+   pip install siege-utilities[geo]
+   pip install "gdal==$(gdal-config --version)"
 
 Quick Start: The Composition Chain
 ----------------------------------

--- a/docs/source/installation_troubleshooting.rst
+++ b/docs/source/installation_troubleshooting.rst
@@ -1,16 +1,45 @@
 Installation Troubleshooting
 ============================
 
-System Dependencies for Geospatial
-------------------------------------
+Geospatial Extras and GDAL
+--------------------------
 
-The ``[geo]`` and ``[geodjango]`` extras require system-level libraries
-(GDAL, GEOS, PROJ) that cannot be installed via pip.
+As of the GDAL-optional-extra split, the ``[geo]`` extra installs the
+pure-Python geospatial stack (GeoPandas, Shapely, Fiona, PyProj, rtree,
+PySAL, etc.). These ship their own bundled GDAL/GEOS/PROJ inside their
+wheels, so ``pip install siege-utilities[geo]`` works **without any
+system GDAL** on the supported Python versions::
 
-Ubuntu / Debian
-~~~~~~~~~~~~~~~
+    pip install siege-utilities[geo]
 
-::
+You only need system GDAL + the native OSGeo Python bindings in two
+cases:
+
+1. **You import ``osgeo`` directly** (``from osgeo import gdal, ogr,
+   osr``). Install the dedicated ``[gdal]`` extra, pinned to your system
+   libgdal — the OSGeo ``gdal`` wheel must match the installed libgdal
+   version exactly, which a bare ``pip install siege-utilities[geo,gdal]``
+   does *not* guarantee (it resolves the newest ``gdal`` in ``>=3.6,<4``).
+   Install system GDAL first, then pin to it — this is the path CI
+   exercises::
+
+       # Ubuntu / Debian
+       sudo apt-get install -y gdal-bin libgdal-dev libgeos-dev libproj-dev
+       pip install siege-utilities[geo]
+       pip install "gdal==$(gdal-config --version)"
+
+2. **GeoDjango / PostGIS** (``[geodjango]``). Django's
+   ``django.contrib.gis`` backend loads the system libgdal directly (via
+   ctypes), so it needs ``gdal-bin libgdal-dev`` installed, but **not**
+   the OSGeo ``gdal`` Python package::
+
+       sudo apt-get install -y gdal-bin libgdal-dev libgeos-dev libproj-dev
+       pip install siege-utilities[geodjango]
+
+System Dependencies (only for the two cases above)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Ubuntu / Debian::
 
     sudo apt-get update
     sudo apt-get install -y \
@@ -19,60 +48,58 @@ Ubuntu / Debian
         libproj-dev proj-bin \
         libspatialindex-dev \
         libsqlite3-mod-spatialite
+    pip install "gdal==$(gdal-config --version)"   # only if you need osgeo
 
-    # Set GDAL version for pip
-    export GDAL_VERSION=$(gdal-config --version)
-    pip install siege-utilities[geo]
-
-macOS (Homebrew)
-~~~~~~~~~~~~~~~~
-
-::
+macOS (Homebrew)::
 
     brew install gdal geos proj spatialindex
-    pip install siege-utilities[geo]
+    pip install "gdal==$(gdal-config --version)"   # only if you need osgeo
 
-Windows
-~~~~~~~
-
-Use conda or OSGeo4W::
+Windows (conda)::
 
     conda install -c conda-forge gdal geopandas
-    pip install siege-utilities[geo-lite]  # Use geo-lite to skip GDAL requirement
+    pip install siege-utilities[geo]
 
 Choosing the Right Extras
---------------------------
+-------------------------
 
 .. list-table::
    :header-rows: 1
 
    * - Extra
-     - System Deps
+     - System GDAL?
      - What You Get
-   * - ``[geo-lite]``
-     - None
-     - Census data, geocoding, schemas (no geometry operations)
    * - ``[geo]``
-     - GDAL, GEOS, PROJ
-     - Full GeoPandas, spatial joins, choropleths, isochrones
+     - No (bundled in wheels)
+     - GeoPandas, Shapely, Fiona, PyProj, spatial joins, choropleths,
+       isochrones, interpolation — the full pure-Python geo stack
+   * - ``[gdal]``
+     - Yes (version-matched)
+     - The native OSGeo ``gdal`` Python bindings (``from osgeo import
+       gdal``). Add on top of ``[geo]`` only when you import ``osgeo``
+       directly; pin to ``gdal==$(gdal-config --version)``
    * - ``[geodjango]``
-     - GDAL, GEOS, PROJ, PostGIS
-     - Everything + Django ORM with spatial queries
+     - Yes (libgdal at runtime)
+     - Django ORM + DRF-GIS + PostGIS spatial queries
 
 Common Errors
 --------------
 
-**"Could not find GDAL library"**
-    GDAL is not installed or not on PATH. Install system GDAL first.
+**"Could not find GDAL library" (django.core.exceptions.ImproperlyConfigured)**
+    Only relevant to GeoDjango/PostGIS. Install system GDAL
+    (``gdal-bin libgdal-dev``); plain ``[geo]`` does not need it.
 
 **"OSError: cannot load library 'libgeos_c.so'"**
-    GEOS not installed. On Ubuntu: ``sudo apt install libgeos-dev``.
+    GEOS not installed (GeoDjango path). On Ubuntu: ``sudo apt install libgeos-dev``.
 
 **"ModuleNotFoundError: No module named 'osgeo'"**
-    GDAL Python bindings not installed. Try: ``pip install GDAL==$(gdal-config --version)``.
+    You imported the native OSGeo bindings without the ``[gdal]`` extra.
+    Install system GDAL, then ``pip install "gdal==$(gdal-config --version)"``.
 
-**"django.contrib.gis.gdal.error.GDALException"**
-    GDAL library found but version mismatch. Ensure system GDAL version matches Python GDAL.
+**"Python bindings of GDAL X require at least libgdal X, but Y was found"**
+    The OSGeo ``gdal`` wheel does not match your system libgdal. Pin it:
+    ``pip install "gdal==$(gdal-config --version)"``. Do not rely on a bare
+    ``[geo,gdal]``, which installs the newest compatible ``gdal``.
 
 **DuckDB spatial "Extension ... not found"**
     DuckDB spatial extension needs internet access on first load. Run::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,11 +71,16 @@ geo = [
 ]
 
 # Native GDAL/OGR Python bindings. Kept as a SEPARATE opt-in extra (not part of
-# `geo` or `all`) because gdal requires the matching system libgdal + gdal-config
-# to build, which is unavailable on Databricks / Lambda / serverless and on CI
-# jobs that deliberately exercise the no-GDAL path (CLAUDE.md arch decisions
-# #3/#4). Install with `pip install siege-utilities[geo,gdal]` when the OSGeo
-# native stack is present; the pure-Python geo path works without it.
+# `geo` or `all`) because the OSGeo `gdal` wheel requires the matching system
+# libgdal + gdal-config and must be pinned to the installed libgdal version,
+# which is unavailable on Databricks / Lambda / serverless and on CI jobs that
+# deliberately exercise the no-GDAL path (CLAUDE.md arch decisions #3/#4). The
+# pure-Python geo path works without it via `[geo]`. To install the native
+# bindings, pin to the system libgdal — the path CI exercises (a bare
+# `[geo,gdal]` resolves the newest gdal in >=3.6,<4 and fails to build against
+# an older libgdal):
+#   pip install siege-utilities[geo]
+#   pip install "gdal==$(gdal-config --version)"
 gdal = [
     "gdal>=3.6,<4",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ geo = [
     "shapely>=2.0.0,<3.0",
     "pyproj>=3.3.0",
     "fiona>=1.9.0",
-    "gdal>=3.6,<4",
     "geopy>=2.4.1",
     "rtree>=1.0.0",
     "mapclassify>=2.5.0",
@@ -69,6 +68,16 @@ geo = [
     "geoalchemy2>=0.14.0",
     # Required by geo/spatial_data.py (BeautifulSoup HTML/XML parsing).
     "beautifulsoup4>=4.12.0",
+]
+
+# Native GDAL/OGR Python bindings. Kept as a SEPARATE opt-in extra (not part of
+# `geo` or `all`) because gdal requires the matching system libgdal + gdal-config
+# to build, which is unavailable on Databricks / Lambda / serverless and on CI
+# jobs that deliberately exercise the no-GDAL path (CLAUDE.md arch decisions
+# #3/#4). Install with `pip install siege-utilities[geo,gdal]` when the OSGeo
+# native stack is present; the pure-Python geo path works without it.
+gdal = [
+    "gdal>=3.6,<4",
 ]
 # H3 hexagonal spatial index (lightweight spatial joins)
 h3 = [
@@ -240,7 +249,6 @@ all = [
     "shapely>=2.0.0,<3.0",
     "pyproj>=3.3.0",
     "fiona>=1.9.0",
-    "gdal>=3.6,<4",
     "geopy>=2.4.1",
     "rtree>=1.0.0",
     "mapclassify>=2.5.0",

--- a/tests/django_project/settings.py
+++ b/tests/django_project/settings.py
@@ -11,6 +11,8 @@ DB credentials via environment variables with local dev defaults.
 
 import os
 
+from django.core.exceptions import ImproperlyConfigured
+
 SECRET_KEY = "test-secret-key-not-for-production"
 
 DEBUG = False
@@ -18,17 +20,22 @@ DEBUG = False
 GDAL_LIBRARY_PATH = os.getenv("GDAL_LIBRARY_PATH", "")
 GEOS_LIBRARY_PATH = os.getenv("GEOS_LIBRARY_PATH", "")
 
-# Detect GDAL availability — controls DB engine and installed apps
+# Detect GDAL availability — controls DB engine and installed apps.
+# Narrow to the exceptions that genuinely signal GDAL absence, so that an
+# UNRELATED Django/GIS misconfiguration surfaces loudly instead of silently
+# downgrading the test project to plain PostgreSQL (writing-code:7):
+#   - ImproperlyConfigured: django.contrib.gis.gdal.libgdal raises this when
+#     no GDAL library is found in its search names ("Could not find the GDAL
+#     library") or the OS is unsupported.
+#   - OSError: ctypes.CDLL fails to load a GDAL_LIBRARY_PATH that points at a
+#     missing/unloadable shared object.
+#   - ImportError: django.contrib.gis itself is unavailable.
+# Any other exception (a real settings bug) is intentionally NOT caught.
 _HAS_GDAL = False
 try:
     from django.contrib.gis.gdal import libgdal  # noqa: F401
     _HAS_GDAL = True
-except Exception:
-    # When the GDAL shared library is absent, django.contrib.gis.gdal raises
-    # django.core.exceptions.ImproperlyConfigured ("Could not find the GDAL
-    # library") -- NOT ImportError/RuntimeError -- at import time. Catch broadly
-    # so the no-GDAL path degrades to plain PostgreSQL + no GIS apps instead of
-    # failing settings load (the core-only CI job runs without GDAL).
+except (ImproperlyConfigured, ImportError, OSError):
     pass
 
 INSTALLED_APPS = [

--- a/tests/django_project/settings.py
+++ b/tests/django_project/settings.py
@@ -23,7 +23,12 @@ _HAS_GDAL = False
 try:
     from django.contrib.gis.gdal import libgdal  # noqa: F401
     _HAS_GDAL = True
-except (ImportError, RuntimeError):
+except Exception:
+    # When the GDAL shared library is absent, django.contrib.gis.gdal raises
+    # django.core.exceptions.ImproperlyConfigured ("Could not find the GDAL
+    # library") -- NOT ImportError/RuntimeError -- at import time. Catch broadly
+    # so the no-GDAL path degrades to plain PostgreSQL + no GIS apps instead of
+    # failing settings load (the core-only CI job runs without GDAL).
     pass
 
 INSTALLED_APPS = [

--- a/tests/test_django_temporal_models_orm.py
+++ b/tests/test_django_temporal_models_orm.py
@@ -22,7 +22,7 @@ try:
     from django.db import IntegrityError
 
     HAS_GDAL = True
-except (ImportError, RuntimeError):
+except Exception:  # GeoDjango w/o system libgdal raises ImproperlyConfigured
     HAS_GDAL = False
 
 pytestmark = [

--- a/tests/test_django_temporal_models_orm.py
+++ b/tests/test_django_temporal_models_orm.py
@@ -13,6 +13,10 @@ from datetime import date, datetime, timezone
 import pytest
 
 try:
+    from django.core.exceptions import ImproperlyConfigured
+except ImportError:  # Django absent; the gis import below raises ImportError
+    ImproperlyConfigured = ImportError
+try:
     from django.contrib.gis.geos import (
         GeometryCollection,
         MultiPolygon,
@@ -22,7 +26,11 @@ try:
     from django.db import IntegrityError
 
     HAS_GDAL = True
-except Exception:  # GeoDjango w/o system libgdal raises ImproperlyConfigured
+except (ImportError, RuntimeError, ImproperlyConfigured, OSError):
+    # GeoDjango without system libgdal raises ImproperlyConfigured (or
+    # OSError for an unloadable GDAL_LIBRARY_PATH); django(.contrib.gis)
+    # absent raises ImportError. Narrowed so an UNRELATED error fails
+    # loudly instead of silently skipping these tests (writing-code:7).
     HAS_GDAL = False
 
 pytestmark = [

--- a/tests/test_geoid_validator.py
+++ b/tests/test_geoid_validator.py
@@ -14,7 +14,7 @@ try:
     from django.contrib.gis.db import models as gis_models  # noqa: F401
 
     _DJANGO_AVAILABLE = True
-except (ImportError, RuntimeError):
+except Exception:  # GeoDjango w/o system libgdal raises ImproperlyConfigured
     _DJANGO_AVAILABLE = False
 
 

--- a/tests/test_geoid_validator.py
+++ b/tests/test_geoid_validator.py
@@ -11,10 +11,18 @@ from siege_utilities.geo.geoid_utils import GEOIDValidator
 
 # Skip Django-dependent tests if GDAL is not available (CI without geospatial libs)
 try:
+    from django.core.exceptions import ImproperlyConfigured
+except ImportError:  # Django absent; the gis import below raises ImportError
+    ImproperlyConfigured = ImportError
+try:
     from django.contrib.gis.db import models as gis_models  # noqa: F401
 
     _DJANGO_AVAILABLE = True
-except Exception:  # GeoDjango w/o system libgdal raises ImproperlyConfigured
+except (ImportError, RuntimeError, ImproperlyConfigured, OSError):
+    # GeoDjango without system libgdal raises ImproperlyConfigured (or
+    # OSError for an unloadable GDAL_LIBRARY_PATH); django(.contrib.gis)
+    # absent raises ImportError. Narrowed so an UNRELATED error fails
+    # loudly instead of silently skipping these tests (writing-code:7).
     _DJANGO_AVAILABLE = False
 
 

--- a/tests/test_nces_service_bulk_update_timestamp.py
+++ b/tests/test_nces_service_bulk_update_timestamp.py
@@ -14,10 +14,18 @@ from unittest.mock import patch
 import pytest
 
 try:
+    from django.core.exceptions import ImproperlyConfigured
+except ImportError:  # Django absent; the gis import below raises ImportError
+    ImproperlyConfigured = ImportError
+try:
     from django.contrib.gis.geos import MultiPolygon, Polygon
 
     HAS_GDAL = True
-except Exception:  # GeoDjango w/o system libgdal raises ImproperlyConfigured
+except (ImportError, RuntimeError, ImproperlyConfigured, OSError):
+    # GeoDjango without system libgdal raises ImproperlyConfigured (or
+    # OSError for an unloadable GDAL_LIBRARY_PATH); django(.contrib.gis)
+    # absent raises ImportError. Narrowed so an UNRELATED error fails
+    # loudly instead of silently skipping these tests (writing-code:7).
     HAS_GDAL = False
 
 pytestmark = [

--- a/tests/test_nces_service_bulk_update_timestamp.py
+++ b/tests/test_nces_service_bulk_update_timestamp.py
@@ -17,7 +17,7 @@ try:
     from django.contrib.gis.geos import MultiPolygon, Polygon
 
     HAS_GDAL = True
-except (ImportError, RuntimeError):
+except Exception:  # GeoDjango w/o system libgdal raises ImproperlyConfigured
     HAS_GDAL = False
 
 pytestmark = [

--- a/tests/test_nces_service_enrich_districts.py
+++ b/tests/test_nces_service_enrich_districts.py
@@ -16,7 +16,7 @@ try:
     from django.contrib.gis.geos import MultiPolygon, Polygon
 
     HAS_GDAL = True
-except (ImportError, RuntimeError):
+except Exception:  # GeoDjango w/o system libgdal raises ImproperlyConfigured
     HAS_GDAL = False
 
 pytestmark = [

--- a/tests/test_nces_service_enrich_districts.py
+++ b/tests/test_nces_service_enrich_districts.py
@@ -13,10 +13,18 @@ from unittest.mock import patch
 import pytest
 
 try:
+    from django.core.exceptions import ImproperlyConfigured
+except ImportError:  # Django absent; the gis import below raises ImportError
+    ImproperlyConfigured = ImportError
+try:
     from django.contrib.gis.geos import MultiPolygon, Polygon
 
     HAS_GDAL = True
-except Exception:  # GeoDjango w/o system libgdal raises ImproperlyConfigured
+except (ImportError, RuntimeError, ImproperlyConfigured, OSError):
+    # GeoDjango without system libgdal raises ImproperlyConfigured (or
+    # OSError for an unloadable GDAL_LIBRARY_PATH); django(.contrib.gis)
+    # absent raises ImportError. Narrowed so an UNRELATED error fails
+    # loudly instead of silently skipping these tests (writing-code:7).
     HAS_GDAL = False
 
 pytestmark = [

--- a/tests/test_nlrb.py
+++ b/tests/test_nlrb.py
@@ -5,10 +5,18 @@ Tests for NLRB region model and population service.
 import pytest
 
 try:
+    from django.core.exceptions import ImproperlyConfigured
+except ImportError:  # Django absent; the gis import below raises ImportError
+    ImproperlyConfigured = ImportError
+try:
     from django.contrib.gis.db import models as gis_models  # noqa: F401
 
     _DJANGO_AVAILABLE = True
-except Exception:  # GeoDjango w/o system libgdal raises ImproperlyConfigured
+except (ImportError, RuntimeError, ImproperlyConfigured, OSError):
+    # GeoDjango without system libgdal raises ImproperlyConfigured (or
+    # OSError for an unloadable GDAL_LIBRARY_PATH); django(.contrib.gis)
+    # absent raises ImportError. Narrowed so an UNRELATED error fails
+    # loudly instead of silently skipping these tests (writing-code:7).
     _DJANGO_AVAILABLE = False
 
 

--- a/tests/test_nlrb.py
+++ b/tests/test_nlrb.py
@@ -8,7 +8,7 @@ try:
     from django.contrib.gis.db import models as gis_models  # noqa: F401
 
     _DJANGO_AVAILABLE = True
-except (ImportError, RuntimeError):
+except Exception:  # GeoDjango w/o system libgdal raises ImproperlyConfigured
     _DJANGO_AVAILABLE = False
 
 

--- a/tests/test_temporal_boundary.py
+++ b/tests/test_temporal_boundary.py
@@ -12,8 +12,16 @@ import pytest
 
 # Skip entire module if GDAL is not available (CI without geospatial libs)
 try:
+    from django.core.exceptions import ImproperlyConfigured
+except ImportError:  # Django absent; the gis import below raises ImportError
+    ImproperlyConfigured = ImportError
+try:
     from django.contrib.gis.db import models as gis_models  # noqa: F401
-except Exception:  # GeoDjango w/o system libgdal raises ImproperlyConfigured
+except (ImportError, RuntimeError, ImproperlyConfigured, OSError):
+    # GeoDjango without system libgdal raises ImproperlyConfigured (or
+    # OSError for an unloadable GDAL_LIBRARY_PATH); django(.contrib.gis)
+    # absent raises ImportError. Narrowed so an UNRELATED error fails
+    # loudly instead of silently skipping these tests (writing-code:7).
     pytest.skip("GeoDjango/GDAL not available", allow_module_level=True)
 
 

--- a/tests/test_temporal_boundary.py
+++ b/tests/test_temporal_boundary.py
@@ -15,7 +15,7 @@ import pytest
 # Skip entire module if GDAL is not available (CI without geospatial libs)
 try:
     from django.contrib.gis.db import models as gis_models  # noqa: F401
-except (ImportError, RuntimeError):
+except Exception:  # GeoDjango w/o system libgdal raises ImproperlyConfigured
     pytest.skip("GeoDjango/GDAL not available", allow_module_level=True)
 
 

--- a/tests/test_temporal_boundary.py
+++ b/tests/test_temporal_boundary.py
@@ -8,8 +8,6 @@ Since these are abstract models, we test their fields, properties, and methods
 by inspecting the class definitions rather than instantiating them directly.
 """
 
-from datetime import date
-
 import pytest
 
 # Skip entire module if GDAL is not available (CI without geospatial libs)

--- a/tests/test_timeseries_rollup_services.py
+++ b/tests/test_timeseries_rollup_services.py
@@ -13,7 +13,7 @@ try:
     from django.contrib.gis.db import models as gis_models  # noqa: F401
 
     _DJANGO_AVAILABLE = True
-except (ImportError, RuntimeError):
+except Exception:  # GeoDjango w/o system libgdal raises ImproperlyConfigured
     _DJANGO_AVAILABLE = False
 
 

--- a/tests/test_timeseries_rollup_services.py
+++ b/tests/test_timeseries_rollup_services.py
@@ -10,10 +10,18 @@ import pytest
 
 # Skip entire module if GDAL is not available (CI without geospatial libs)
 try:
+    from django.core.exceptions import ImproperlyConfigured
+except ImportError:  # Django absent; the gis import below raises ImportError
+    ImproperlyConfigured = ImportError
+try:
     from django.contrib.gis.db import models as gis_models  # noqa: F401
 
     _DJANGO_AVAILABLE = True
-except Exception:  # GeoDjango w/o system libgdal raises ImproperlyConfigured
+except (ImportError, RuntimeError, ImproperlyConfigured, OSError):
+    # GeoDjango without system libgdal raises ImproperlyConfigured (or
+    # OSError for an unloadable GDAL_LIBRARY_PATH); django(.contrib.gis)
+    # absent raises ImportError. Narrowed so an UNRELATED error fails
+    # loudly instead of silently skipping these tests (writing-code:7).
     _DJANGO_AVAILABLE = False
 
 

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -8,7 +8,7 @@ try:
     from django.contrib.gis.db import models as gis_models  # noqa: F401
 
     _DJANGO_AVAILABLE = True
-except (ImportError, RuntimeError):
+except Exception:  # GeoDjango w/o system libgdal raises ImproperlyConfigured
     _DJANGO_AVAILABLE = False
 
 

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -5,10 +5,18 @@ Tests for TimezoneGeometry model and TimezonePopulationService.
 import pytest
 
 try:
+    from django.core.exceptions import ImproperlyConfigured
+except ImportError:  # Django absent; the gis import below raises ImportError
+    ImproperlyConfigured = ImportError
+try:
     from django.contrib.gis.db import models as gis_models  # noqa: F401
 
     _DJANGO_AVAILABLE = True
-except Exception:  # GeoDjango w/o system libgdal raises ImproperlyConfigured
+except (ImportError, RuntimeError, ImproperlyConfigured, OSError):
+    # GeoDjango without system libgdal raises ImproperlyConfigured (or
+    # OSError for an unloadable GDAL_LIBRARY_PATH); django(.contrib.gis)
+    # absent raises ImportError. Narrowed so an UNRELATED error fails
+    # loudly instead of silently skipping these tests (writing-code:7).
     _DJANGO_AVAILABLE = False
 
 

--- a/tests/test_urbanicity_service.py
+++ b/tests/test_urbanicity_service.py
@@ -9,10 +9,18 @@ import pytest
 
 # Skip Django-dependent tests if GDAL is not available (CI without geospatial libs)
 try:
+    from django.core.exceptions import ImproperlyConfigured
+except ImportError:  # Django absent; the gis import below raises ImportError
+    ImproperlyConfigured = ImportError
+try:
     from django.contrib.gis.db import models as gis_models  # noqa: F401
 
     _DJANGO_AVAILABLE = True
-except Exception:  # GeoDjango w/o system libgdal raises ImproperlyConfigured
+except (ImportError, RuntimeError, ImproperlyConfigured, OSError):
+    # GeoDjango without system libgdal raises ImproperlyConfigured (or
+    # OSError for an unloadable GDAL_LIBRARY_PATH); django(.contrib.gis)
+    # absent raises ImportError. Narrowed so an UNRELATED error fails
+    # loudly instead of silently skipping these tests (writing-code:7).
     _DJANGO_AVAILABLE = False
 
 

--- a/tests/test_urbanicity_service.py
+++ b/tests/test_urbanicity_service.py
@@ -12,7 +12,7 @@ try:
     from django.contrib.gis.db import models as gis_models  # noqa: F401
 
     _DJANGO_AVAILABLE = True
-except (ImportError, RuntimeError):
+except Exception:  # GeoDjango w/o system libgdal raises ImproperlyConfigured
     _DJANGO_AVAILABLE = False
 
 


### PR DESCRIPTION
## Summary

Fixes the install/settings layer for the CI jobs that exercise the **no-GDAL path**. Root cause: the native `gdal` Python bindings were a hard dependency of the `geo`/`all` extras, so any job running `uv sync --extra geo`/`--extra all` **without** system GDAL failed at `uv sync` (no `gdal-config` to build against) — directly contradicting CLAUDE.md architecture decisions #3/#4 (a working no-GDAL path must exist; Databricks/Lambda cannot install GDAL).

This is the **Class B** sibling PR (packaging/CI), kept separate from the unit-test-fix PR (#1065) per the agreed split.

## Changes

- **`pyproject.toml`** — move `gdal>=3.6,<4` out of the `geo` and `all` extras into a **dedicated `gdal` extra**. `pip install siege-utilities[geo]` now installs the pure-Python geo stack (geopandas/shapely/pyproj/fiona); `[geo,gdal]` adds the native OSGeo bindings.
  - **BREAKING (packaging)**: consumers that relied on `[geo]`/`[all]` pulling gdal must now use `[geo,gdal]`. Documented in CHANGELOG.
- **`tests/django_project/settings.py`** — the GDAL-availability detection caught only `(ImportError, RuntimeError)`, but `django.contrib.gis.gdal` raises **`ImproperlyConfigured`** ("Could not find the GDAL library") at import when the shared lib is absent. Broadened so settings degrade to plain PostgreSQL + no GIS apps instead of failing to load (this is the `core-only` job failure).
- **`CHANGELOG.md`** — BREAKING packaging note + the settings fix.

## Jobs this fixes (at the install/settings layer)
`geo without GDAL`, `smoke tests`, `databricks SDK tests`, `pydantic v1 compat`, `core-only` — all previously failed at `uv sync` (gdal build) or Django settings load.

## Follow-up (depends on #1065)
The `test (3.11)` and `battle-test` jobs **do** want GDAL; with gdal out of `all` they need `--extra gdal` added to their `uv sync`. That line composes with the gdal **sed-pin** which currently lives in #1065. The one-line `--extra gdal` CI edit will be applied once #1065 lands (or this PR rebases on post-#1065 develop). Flagged to Master Planning for sequencing.

Refs #1064