### PR TITLE
feat(connectors): Salesforce SOQL query builder (#1017)

### DIFF
--- a/plans/self-review-1017.md
+++ b/plans/self-review-1017.md
@@ -1,0 +1,53 @@
+---
+ticket: "#1017"
+scope: "connectors/salesforce.py, connectors/__init__.py"
+---
+
+# Self-Review — #1017 Salesforce SOQL query builder
+
+## Junior Assessment
+
+Added `SOQLQuery` fluent builder class and `soql()` escape-hatch method:
+- `SOQLQuery`: `select()`, `from_()`, `where()`, `where_raw()`, `order_by()`,
+  `limit()`, `offset()`, `build()`
+- `where()` supports: eq, ne, gt, gte, lt, lte, in_, not_in, like, is_null
+- `_soql_literal()` module-level helper for value→SOQL conversion
+- `soql()` method on SalesforceConnector accepts raw strings or SOQLQuery objects
+- Registered `SOQLQuery` in `connectors/__init__.py` lazy loader
+
+## Lead Assessment
+
+**Sentinel pattern:** `_UNSET = object()` at module level. Comparison via
+`is not _UNSET` — correct identity check, not equality. This allows
+`where("field", eq=None)` to produce `field = null` (the value IS set, to
+None) while omitting the condition entirely when `eq` is not passed.
+
+**Type coercion in `_soql_literal()`:** bool before int/float (Python
+`isinstance(True, int)` is True). None→null, str→escaped single-quoted.
+Matches the existing `_soql_condition()` from #1016.
+
+**Relationship queries:** Supported naturally — `select("Account.Name")`
+just includes the dotted field in the SELECT clause. SOQL handles the
+rest.
+
+**Order and validation:** `build()` raises ValueError for missing
+`from_()` or empty `select()`. ORDER BY before LIMIT before OFFSET
+matches SOQL syntax.
+
+**`soql()` method:** Accepts `str | SOQLQuery`. Raw strings pass through
+unchanged. SOQLQuery objects call `.build()`. Results go through
+`_query_all()` for pagination. Empty results return empty DataFrame
+with warning (SU-1).
+
+**`where_raw()`:** Escape hatch for conditions the builder can't express
+(subqueries, INCLUDES/EXCLUDES, date literals like `LAST_N_DAYS:30`).
+
+## Trivial-investigation declaration
+
+SOQL syntax follows Salesforce SOQL reference. Fluent builder pattern
+is standard (no external dependencies).
+
+## Trivial pre-mortem declaration
+
+New class + one new method on existing connector + one-line init change.
+Existing `_build_soql()` and `_soql_condition()` from #1016 unchanged.

--- a/siege_utilities/connectors/__init__.py
+++ b/siege_utilities/connectors/__init__.py
@@ -41,7 +41,7 @@ _register([
 ], "._models")
 
 # --- Connector modules (added as workstreams land) ---
-_register(["SalesforceConnector"], ".salesforce")
+_register(["SalesforceConnector", "SOQLQuery"], ".salesforce")
 # _register(["HubSpotConnector"], ".hubspot")
 # _register(["ZohoConnector"], ".zoho")
 # _register(["DynamicsConnector"], ".dynamics")

--- a/siege_utilities/connectors/salesforce.py
+++ b/siege_utilities/connectors/salesforce.py
@@ -107,7 +107,155 @@ DEFAULT_FIELDS: dict[str, list[str]] = {
     ],
 }
 
-__all__ = ["SalesforceConnector"]
+__all__ = ["SalesforceConnector", "SOQLQuery"]
+
+_UNSET = object()
+
+
+class SOQLQuery:
+    """Fluent SOQL query builder.
+
+    Usage::
+
+        q = (SOQLQuery()
+             .select("FirstName", "LastName", "Email")
+             .from_("Contact")
+             .where("Status", eq="Active")
+             .where("Department", eq="Sales")
+             .order_by("LastName")
+             .limit(100))
+        print(q.build())
+        # SELECT FirstName, LastName, Email FROM Contact
+        # WHERE Status = 'Active' AND Department = 'Sales'
+        # ORDER BY LastName ASC LIMIT 100
+    """
+
+    def __init__(self) -> None:
+        self._fields: list[str] = []
+        self._object_type: str | None = None
+        self._conditions: list[str] = []
+        self._order_clauses: list[str] = []
+        self._limit_val: int | None = None
+        self._offset_val: int | None = None
+
+    def select(self, *fields: str) -> SOQLQuery:
+        """Add fields to the SELECT clause."""
+        self._fields.extend(fields)
+        return self
+
+    def from_(self, object_type: str) -> SOQLQuery:
+        """Set the FROM object type."""
+        self._object_type = object_type
+        return self
+
+    def where(
+        self,
+        field: str,
+        *,
+        eq: Any = _UNSET,
+        ne: Any = _UNSET,
+        gt: Any = _UNSET,
+        gte: Any = _UNSET,
+        lt: Any = _UNSET,
+        lte: Any = _UNSET,
+        in_: list | None = None,
+        not_in: list | None = None,
+        like: str | None = None,
+        is_null: bool | None = None,
+    ) -> SOQLQuery:
+        """Add a WHERE condition.
+
+        Supports equality, comparison, IN, NOT IN, LIKE, and null checks.
+        Multiple calls are joined with AND.
+        """
+        if eq is not _UNSET:
+            self._conditions.append(f"{field} = {_soql_literal(eq)}")
+        if ne is not _UNSET:
+            self._conditions.append(f"{field} != {_soql_literal(ne)}")
+        if gt is not _UNSET:
+            self._conditions.append(f"{field} > {_soql_literal(gt)}")
+        if gte is not _UNSET:
+            self._conditions.append(f"{field} >= {_soql_literal(gte)}")
+        if lt is not _UNSET:
+            self._conditions.append(f"{field} < {_soql_literal(lt)}")
+        if lte is not _UNSET:
+            self._conditions.append(f"{field} <= {_soql_literal(lte)}")
+        if in_ is not None:
+            vals = ", ".join(_soql_literal(v) for v in in_)
+            self._conditions.append(f"{field} IN ({vals})")
+        if not_in is not None:
+            vals = ", ".join(_soql_literal(v) for v in not_in)
+            self._conditions.append(f"{field} NOT IN ({vals})")
+        if like is not None:
+            self._conditions.append(f"{field} LIKE {_soql_literal(like)}")
+        if is_null is True:
+            self._conditions.append(f"{field} = null")
+        elif is_null is False:
+            self._conditions.append(f"{field} != null")
+        return self
+
+    def where_raw(self, condition: str) -> SOQLQuery:
+        """Add a raw SOQL WHERE condition string."""
+        self._conditions.append(condition)
+        return self
+
+    def order_by(self, field: str, *, desc: bool = False) -> SOQLQuery:
+        """Add an ORDER BY clause."""
+        direction = "DESC" if desc else "ASC"
+        self._order_clauses.append(f"{field} {direction}")
+        return self
+
+    def limit(self, n: int) -> SOQLQuery:
+        """Set the LIMIT value."""
+        self._limit_val = int(n)
+        return self
+
+    def offset(self, n: int) -> SOQLQuery:
+        """Set the OFFSET value."""
+        self._offset_val = int(n)
+        return self
+
+    def build(self) -> str:
+        """Build the SOQL query string.
+
+        Raises:
+            ValueError: If no object type or fields are set.
+        """
+        if not self._object_type:
+            raise ValueError("SOQLQuery requires from_() to set the object type.")
+        if not self._fields:
+            raise ValueError("SOQLQuery requires at least one field via select().")
+
+        parts = [f"SELECT {', '.join(self._fields)} FROM {self._object_type}"]
+
+        if self._conditions:
+            parts.append("WHERE " + " AND ".join(self._conditions))
+
+        if self._order_clauses:
+            parts.append("ORDER BY " + ", ".join(self._order_clauses))
+
+        if self._limit_val is not None:
+            parts.append(f"LIMIT {self._limit_val}")
+
+        if self._offset_val is not None:
+            parts.append(f"OFFSET {self._offset_val}")
+
+        return " ".join(parts)
+
+    def __str__(self) -> str:
+        return self.build()
+
+
+def _soql_literal(value: Any) -> str:
+    """Convert a Python value to a SOQL literal."""
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    escaped = str(value).replace("\\", "\\\\").replace("'", "\\'")
+    return f"'{escaped}'"
 
 
 class SalesforceConnector:
@@ -329,6 +477,21 @@ class SalesforceConnector:
         df = pd.DataFrame(cleaned)
         log.info("get_objects(%s): returned %d records, %d fields", object_type, len(df), len(df.columns))
         return df
+
+    def soql(self, query: str | SOQLQuery) -> pd.DataFrame:
+        """Execute a raw SOQL string or :class:`SOQLQuery` and return a DataFrame.
+
+        This is the escape hatch for queries that ``get_objects()`` can't
+        express (subqueries, aggregate functions, relationship traversals).
+        """
+        soql_str = query.build() if isinstance(query, SOQLQuery) else query
+        records = self._query_all(soql_str)
+        if not records:
+            log.warning("soql(): query returned 0 records")
+            return pd.DataFrame()
+        keys = [k for k in records[0].keys() if k != "attributes"]
+        cleaned = [{k: rec.get(k) for k in keys} for rec in records]
+        return pd.DataFrame(cleaned)
 
     # ------------------------------------------------------------------
     # CRM model mapping helpers


### PR DESCRIPTION
## Summary

- Add `SOQLQuery` fluent builder with full operator support (eq, ne, gt, gte, lt, lte, IN, NOT IN, LIKE, null checks, raw conditions)
- Add `soql()` method on `SalesforceConnector` — accepts raw SOQL strings or `SOQLQuery` objects, paginates, returns DataFrame
- Relationship queries work naturally (`select("Account.Name")`)

Closes #1017

## Self-Review

`plans/self-review-1017.md`