### PR TITLE
feat(connectors): Salesforce write-back (#1018)

### DIFF
--- a/plans/self-review-1018.md
+++ b/plans/self-review-1018.md
@@ -1,0 +1,55 @@
+---
+ticket: "#1018"
+scope: "connectors/salesforce.py"
+---
+
+# Self-Review — #1018 Salesforce write-back
+
+## Junior Assessment
+
+Replaced write stubs with real implementations:
+- `create_record()` — POST to `/sobjects/{type}`, returns record ID
+- `update_record()` — PATCH to `/sobjects/{type}/{id}`, returns True
+- `upsert_records()` — batches DataFrame into 25-record chunks, calls
+  Composite SObject Collections endpoint, returns `UpsertResult`
+- `_composite_upsert()` — single batch execution, parses per-record
+  success/failure, builds `UpsertError` entries
+
+## Lead Assessment
+
+**SU-1 compliance:** `create_record()` raises `ConnectorError` when
+`success` is false in the response. `update_record()` delegates to
+`request()` which raises on non-2xx — never returns False silently.
+`upsert_records()` returns `UpsertResult` with explicit `failure_count`
+and `errors` list — callers must check `result.ok`.
+
+**Composite API batching:** `COMPOSITE_BATCH_SIZE = 25` matches
+Salesforce's limit. Records are chunked before sending. Each batch
+response is parsed independently with `base_index` offset for error
+tracking across batches.
+
+**Partial success:** `allOrNone: false` in the request body means some
+records can succeed while others fail. The response is a list of per-
+record results. Failed records without error details still get an
+`UpsertError` entry ("Record failed without error details") — no
+silent failures.
+
+**Response parsing:** Handles both list responses (standard) and dict
+responses (some Salesforce versions wrap in `results` key). Defensive
+but not suppressive — unknown shapes propagate the original response.
+
+**Error detail extraction:** `fields` is a list in Salesforce errors;
+we take the first field. `statusCode` maps to `UpsertError.code`.
+
+**Logging:** Every batch logged with index and size. Final summary
+logged with success/failure totals.
+
+## Trivial-investigation declaration
+
+Composite SObject Collections endpoint follows Salesforce REST API
+documentation. Batch size of 25 is Salesforce's documented limit.
+
+## Trivial pre-mortem declaration
+
+Replaces three `NotImplementedError` stubs with real implementations.
+Existing read operations and auth contract unchanged.

--- a/siege_utilities/connectors/salesforce.py
+++ b/siege_utilities/connectors/salesforce.py
@@ -604,20 +604,40 @@ class SalesforceConnector:
         return results
 
     # ------------------------------------------------------------------
-    # ConnectorProtocol — write stubs (follow-up tickets)
+    # ConnectorProtocol — write operations
     # ------------------------------------------------------------------
+
+    COMPOSITE_BATCH_SIZE = 25
 
     def create_record(
         self, object_type: str, data: dict[str, Any]
     ) -> str:
-        """Create a single record. Implemented in #1018."""
-        raise NotImplementedError("create_record() — see #1018")
+        """Create a single record; return its ID.
+
+        Raises:
+            ConnectorError: Validation or API failure.
+        """
+        path = f"/services/data/{API_VERSION}/sobjects/{object_type}"
+        resp = self.request("POST", path, json_body=data)
+        if not resp.get("success"):
+            errors = resp.get("errors", [])
+            msg = errors[0].get("message", str(errors)) if errors else "Unknown error"
+            raise ConnectorError(f"Failed to create {object_type}: {msg}")
+        record_id = resp["id"]
+        log.info("Created %s record: %s", object_type, record_id)
+        return record_id
 
     def update_record(
         self, object_type: str, record_id: str, data: dict[str, Any]
     ) -> bool:
-        """Update a single record. Implemented in #1018."""
-        raise NotImplementedError("update_record() — see #1018")
+        """Update a single record; return True on success.
+
+        Raises on failure — never returns False silently (SU-1).
+        """
+        path = f"/services/data/{API_VERSION}/sobjects/{object_type}/{record_id}"
+        self.request("PATCH", path, json_body=data)
+        log.info("Updated %s record: %s", object_type, record_id)
+        return True
 
     def upsert_records(
         self,
@@ -625,8 +645,125 @@ class SalesforceConnector:
         records: pd.DataFrame,
         match_field: str,
     ) -> UpsertResult:
-        """Bulk upsert from DataFrame. Implemented in #1018/#1019."""
-        raise NotImplementedError("upsert_records() — see #1018/#1019")
+        """Bulk create-or-update from a DataFrame via Composite API.
+
+        Uses the Composite SObject Collections endpoint, batching up to
+        25 records per request. Each record is matched on *match_field*
+        (using the Salesforce external ID or standard field upsert endpoint).
+
+        Returns:
+            :class:`UpsertResult` with per-record outcome.
+        """
+        from siege_utilities.connectors._protocol import UpsertError
+
+        if records.empty:
+            log.warning("upsert_records(%s): empty DataFrame, nothing to upsert", object_type)
+            return UpsertResult(success_count=0, failure_count=0)
+
+        all_created: list[str] = []
+        all_updated: list[str] = []
+        all_errors: list[UpsertError] = []
+        total_success = 0
+        total_failure = 0
+
+        record_dicts = records.to_dict(orient="records")
+        batches = [
+            record_dicts[i:i + self.COMPOSITE_BATCH_SIZE]
+            for i in range(0, len(record_dicts), self.COMPOSITE_BATCH_SIZE)
+        ]
+
+        for batch_idx, batch in enumerate(batches):
+            log.info(
+                "upsert_records(%s): batch %d/%d (%d records)",
+                object_type, batch_idx + 1, len(batches), len(batch),
+            )
+            result = self._composite_upsert(
+                object_type, batch, match_field,
+                base_index=batch_idx * self.COMPOSITE_BATCH_SIZE,
+            )
+            total_success += result.success_count
+            total_failure += result.failure_count
+            all_created.extend(result.created_ids)
+            all_updated.extend(result.updated_ids)
+            all_errors.extend(result.errors)
+
+        log.info(
+            "upsert_records(%s): %d succeeded, %d failed (total %d)",
+            object_type, total_success, total_failure, total_success + total_failure,
+        )
+        return UpsertResult(
+            success_count=total_success,
+            failure_count=total_failure,
+            created_ids=all_created,
+            updated_ids=all_updated,
+            errors=all_errors,
+        )
+
+    def _composite_upsert(
+        self,
+        object_type: str,
+        records: list[dict[str, Any]],
+        match_field: str,
+        *,
+        base_index: int = 0,
+    ) -> UpsertResult:
+        """Execute a single Composite SObject Collections upsert batch."""
+        from siege_utilities.connectors._protocol import UpsertError
+
+        path = (
+            f"/services/data/{API_VERSION}/composite/sobjects"
+            f"/{object_type}/{match_field}"
+        )
+        for rec in records:
+            rec["attributes"] = {"type": object_type}
+
+        try:
+            resp = self.request("PATCH", path, json_body={"allOrNone": False, "records": records})
+        except ConnectorError:
+            raise
+
+        if not isinstance(resp, list):
+            resp_list = resp.get("results", [resp]) if isinstance(resp, dict) else [resp]
+        else:
+            resp_list = resp
+
+        created: list[str] = []
+        updated: list[str] = []
+        errors: list[UpsertError] = []
+        success_count = 0
+        failure_count = 0
+
+        for i, result in enumerate(resp_list):
+            if isinstance(result, dict) and result.get("success"):
+                record_id = result.get("id", "")
+                if result.get("created"):
+                    created.append(record_id)
+                else:
+                    updated.append(record_id)
+                success_count += 1
+            else:
+                failure_count += 1
+                err_list = result.get("errors", []) if isinstance(result, dict) else []
+                for err in err_list:
+                    errors.append(UpsertError(
+                        record_index=base_index + i,
+                        message=err.get("message", "Unknown error"),
+                        field=err.get("fields", [None])[0] if err.get("fields") else None,
+                        code=err.get("statusCode"),
+                    ))
+                if not err_list:
+                    errors.append(UpsertError(
+                        record_index=base_index + i,
+                        message="Record failed without error details",
+                    ))
+
+        return UpsertResult(
+            success_count=success_count,
+            failure_count=failure_count,
+            created_ids=created,
+            updated_ids=updated,
+            errors=errors,
+        )
 
     # ------------------------------------------------------------------
     # SOQL query building


### PR DESCRIPTION
## Summary

- Implement `create_record()` — POST to SObject endpoint, returns record ID
- Implement `update_record()` — PATCH to SObject endpoint, raises on failure (SU-1)
- Implement `upsert_records()` — Composite SObject Collections with 25-record batching, per-record error reporting via `UpsertResult`

Closes #1018

## Self-Review

`plans/self-review-1018.md`