### PR TITLE
fix(geo): correct VTD GEOID constraint from 8 to 11 digits

### DIFF
--- a/docs/data-relationships/CENSUS_DATASET_RELATIONSHIPS.md
+++ b/docs/data-relationships/CENSUS_DATASET_RELATIONSHIPS.md
@@ -145,7 +145,7 @@ datasets are available at all levels. The canonical level definitions live in
 | zcta | 5 | `90210` | ZZZZZ | zip_code, zcta5, zipcode |
 | cbsa | 5 | `31080` | MMMMM | — |
 | puma | 7 | `0600100` | SS+PPPPP | — |
-| vtd | 6 | `060370` | SS+CCCC (varies) | voting_district |
+| vtd | 11 | `06037001234` | SS+CCC+VVVVVV | voting_district |
 
 ### GEOID Hierarchy (Nesting)
 

--- a/docs/data-relationships/DATA_MODEL.md
+++ b/docs/data-relationships/DATA_MODEL.md
@@ -94,7 +94,7 @@ embeds its parent's identifier:
 | CongressionalDistrict | `0614` | 4 | SS+DD | State |
 | StateLegislativeUpper | `06001` | 5 | SS+DDD | State |
 | StateLegislativeLower | `06001` | 5 | SS+DDD | State |
-| VTD | `06037001` | 8 | SS+CCC+VVV | State, County, CD (soft) |
+| VTD | `06037001234` | 11 | SS+CCC+VVVVVV | State, County, CD (soft) |
 | Precinct | variable | — | SS+CCC+code | State, County |
 
 **Nesting hierarchy** (child GEOID always starts with parent GEOID):

--- a/docs/data-relationships/PL94_171_REDISTRICTING.md
+++ b/docs/data-relationships/PL94_171_REDISTRICTING.md
@@ -109,7 +109,7 @@ PL 94-171 is available at every Census summary level:
 | Block Group | 12 | `060371011001` |
 | **Block** | **15** | **`060371011001001`** |
 | Place | 7 | `0644000` |
-| VTD | 8 | `06037001` |
+| VTD | 11 | `06037001234` |
 | CD | 4 | `0614` |
 | SLDU / SLDL | 5 | `06001` |
 

--- a/siege_utilities/geo/django/migrations/0011_vtd_geoid_11_digits.py
+++ b/siege_utilities/geo/django/migrations/0011_vtd_geoid_11_digits.py
@@ -1,0 +1,48 @@
+"""Fix the VTD GEOID check constraint: 8 digits -> 11 digits.
+
+Census VTD GEOIDs are 11 characters = state FIPS (2) + county FIPS (3) +
+VTDST (6). The original `vtd_geoid_8_digits` constraint (regex ^\\d{8}$)
+was wrong: it assumed a 3-character VTD component and would reject every
+real Census VTD GEOID. This swaps it for `vtd_geoid_11_digits` (^\\d{11}$),
+matching the sibling boundary constraints (county=5, tract=11, etc.) and
+the model's own `vtd_code` field (max_length=6 = the VTDST component).
+
+Pre-author state measurement (authoring-against-state:6):
+- enterprise_geo.geo_censustiger_voter_tabulation_district (electinfo
+  loader table, measured by Spatial Hub 2026-06-24): 158,444 rows across
+  49 states, 100% 11-char geoid, vtdst component 6 chars, ZERO 8-char
+  rows. Confirms the 11-char direction conclusively.
+- Consuming-path note: that loader table is NOT this Django model's
+  physical table. This model binds to whatever DB the consuming app's
+  Django settings configure (in the library's own test context, the
+  ephemeral `test_siege_geo` DB, created empty per run). No persistent
+  siege-model VTD table exists in the electinfo PostGIS. The constraint
+  swap is therefore a clean swap against an empty/absent model table.
+- Downstream consumers applying this migration against a populated VTD
+  table: real Census VTD GEOIDs are 11-char, so any pre-existing 8-char
+  rows are malformed and must be re-derived as state(2)+county(3)+VTDST(6),
+  NOT zero-padded, before this AddConstraint will validate.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("siege_geo", "0010_seat_state_constraint"),
+    ]
+
+    operations = [
+        migrations.RemoveConstraint(
+            model_name="vtd",
+            name="vtd_geoid_8_digits",
+        ),
+        migrations.AddConstraint(
+            model_name="vtd",
+            constraint=models.CheckConstraint(
+                condition=models.Q(geoid__regex=r"^\d{11}$"),
+                name="vtd_geoid_11_digits",
+            ),
+        ),
+    ]

--- a/siege_utilities/geo/django/models/political.py
+++ b/siege_utilities/geo/django/models/political.py
@@ -123,8 +123,8 @@ class VTD(CensusTIGERBoundary):
     voting-age population data.  They approximate but don't exactly match
     election precincts.
 
-    GEOID: 8 digits = state (2) + county (3) + VTD (3)
-    Example: "06037001" for VTD 001 in LA County, CA
+    GEOID: 11 digits = state (2) + county (3) + VTD (6)
+    Example: "06037001234" for VTD 001234 in LA County, CA
 
     Enhanced fields support enterprise-compatible workflows:
     - precinct_name/precinct_code for election data linkage
@@ -202,14 +202,14 @@ class VTD(CensusTIGERBoundary):
         ]
         constraints = [
             models.CheckConstraint(
-                condition=models.Q(geoid__regex=r"^\d{8}$"),
-                name="vtd_geoid_8_digits",
+                condition=models.Q(geoid__regex=r"^\d{11}$"),
+                name="vtd_geoid_11_digits",
             ),
         ]
 
     @classmethod
     def get_geoid_length(cls) -> int:
-        return 8
+        return 11
 
     @classmethod
     def parse_geoid(cls, geoid: str) -> dict:

--- a/tests/test_geoid_validator.py
+++ b/tests/test_geoid_validator.py
@@ -18,6 +18,32 @@ except (ImportError, RuntimeError):
     _DJANGO_AVAILABLE = False
 
 
+def _constraint_geoid_regex(constraint):
+    """Extract the ``geoid__regex`` pattern from a CheckConstraint's condition.
+
+    The constraint's ``condition`` (``check`` on older Django) is a ``Q``
+    object such as ``Q(geoid__regex=r"^\\d{11}$")``. Walk its children
+    (including nested ``Q`` nodes) and return the regex bound to a
+    ``*regex`` lookup, or ``None`` if there isn't one.
+    """
+    condition = getattr(constraint, "condition", None)
+    if condition is None:
+        condition = getattr(constraint, "check", None)
+    if condition is None:
+        return None
+
+    stack = list(getattr(condition, "children", []))
+    while stack:
+        node = stack.pop()
+        if isinstance(node, tuple) and len(node) == 2:
+            lookup, value = node
+            if str(lookup).endswith("regex"):
+                return value
+        else:
+            stack.extend(getattr(node, "children", []))
+    return None
+
+
 class TestGEOIDValidator:
     """Tests for the GEOIDValidator callable."""
 
@@ -122,15 +148,33 @@ class TestBoundaryModelConstraints:
         ids=list(EXPECTED_CONSTRAINTS.keys()),
     )
     def test_model_has_geoid_constraint(self, model_name, expected):
-        """Each concrete boundary model should have a GEOID CheckConstraint."""
+        """Each concrete boundary model should have a GEOID CheckConstraint
+        whose regex matches the expected GEOID length.
+
+        This asserts the actual check expression, not just the constraint
+        name: a constraint correctly named ``vtd_geoid_11_digits`` that still
+        carried the old ``^\\d{8}$`` regex must fail here. Verified by mutation
+        (revert the regex to 8 digits -> this test goes red).
+        """
         from siege_utilities.geo.django import models as geo_models
 
         model_cls = getattr(geo_models, model_name)
+        expected_name, expected_regex = expected
+
+        constraint = next(
+            (c for c in model_cls._meta.constraints if c.name == expected_name),
+            None,
+        )
         constraint_names = [c.name for c in model_cls._meta.constraints]
-        expected_name, _ = expected
-        assert expected_name in constraint_names, (
+        assert constraint is not None, (
             f"{model_name} missing constraint '{expected_name}'. "
             f"Found: {constraint_names}"
+        )
+
+        actual_regex = _constraint_geoid_regex(constraint)
+        assert actual_regex == expected_regex, (
+            f"{model_name} constraint '{expected_name}' enforces regex "
+            f"{actual_regex!r}, expected {expected_regex!r}."
         )
 
 

--- a/tests/test_geoid_validator.py
+++ b/tests/test_geoid_validator.py
@@ -113,7 +113,7 @@ class TestBoundaryModelConstraints:
         "CongressionalDistrict": ("cd_geoid_4_digits", r"^\d{4}$"),
         "StateLegislativeUpper": ("sldu_geoid_5_digits", r"^\d{5}$"),
         "StateLegislativeLower": ("sldl_geoid_5_digits", r"^\d{5}$"),
-        "VTD": ("vtd_geoid_8_digits", r"^\d{8}$"),
+        "VTD": ("vtd_geoid_11_digits", r"^\d{11}$"),
     }
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## What

The `VTD` model's GEOID check constraint was `^\d{8}$` (`vtd_geoid_8_digits`), asserting an 8-char GEOID = state(2) + county(3) + VTD(3). Census VTD GEOIDs are **11 chars** = state FIPS(2) + county FIPS(3) + **VTDST(6)**. The 8-digit constraint would reject every real Census VTD GEOID.

This swaps it for `vtd_geoid_11_digits` (`^\d{11}$`), aligning with:
- the sibling boundary constraints (county=5, tract=11, block_group=12, block=15),
- the model's own `vtd_code` field (`max_length=6` = the VTDST component),
- the canonical Census VTD GEOID definition.

## Changes
- `geo/django/models/political.py`: constraint `^\d{8}$`→`^\d{11}$` + name `vtd_geoid_8_digits`→`vtd_geoid_11_digits`; `get_geoid_length()` 8→11; docstring corrected. `parse_geoid` already sliced `geoid[5:]` open-ended → yields the 6-char `vtd_code` for an 11-char GEOID with no change.
- `geo/django/migrations/0011_vtd_geoid_11_digits.py`: `RemoveConstraint(vtd_geoid_8_digits)` + `AddConstraint(vtd_geoid_11_digits)`.
- `tests/test_geoid_validator.py`: `TestBoundaryModelConstraints` VTD expectation updated to the 11-digit name/regex.

## Measure-before-author (authoring-against-state:6)
Spatial Hub measured the electinfo loader table `enterprise_geo.geo_censustiger_voter_tabulation_district`: **158,444 rows, 49 states, 100% 11-char geoid, VTDST 6 chars, zero 8-char rows** — conclusive confirmation of the 11-char direction.

**Consuming-path note (writing-claims:10):** that loader table is *not* this Django model's physical table. The model binds to the consuming app's configured DB. In the library's own context that is the ephemeral `test_siege_geo` DB (created empty per test run); no persistent siege-model VTD table exists in the electinfo PostGIS. The constraint swap is therefore a **clean swap** against an empty/absent model table. The migration docstring records that downstream consumers with a populated VTD table whose rows are 8-char must re-derive them as state(2)+county(3)+VTDST(6) (not zero-pad) before `AddConstraint` will validate.

## Verification (local, Django 5.2 + GeoDjango)
- `makemigrations siege_geo --check`: the VTD constraint swap produces **zero** detected changes (0011 fully captures it).
- `pytest tests/test_geoid_validator.py::TestBoundaryModelConstraints`: **11 passed**.
- flake8 (ratchet F-codes) clean on all touched files.

## Out-of-scope finding (flagged separately, not in this PR)
`makemigrations --check` also surfaced **9 pre-existing un-migrated `Meta.indexes`** on develop (`nlrbcase`, `electionresult`, `bargainingunit`, `ulpcharge`) — confirmed present on clean develop with my changes stashed. Separate latent migration-drift; will file an audit issue.

Refs #1064