### PR TITLE
fix(geo): drop duplicate RedistrictingPlan.state AddField in migration 0006 (fresh-migrate DuplicateColumn)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hidden a real Django/GIS misconfiguration. The guards now catch exactly
   `(ImproperlyConfigured, ImportError, OSError)` (plus `RuntimeError` in the test
   guards), so a real misconfig surfaces loudly (writing-code:7).
+- **`siege_geo` migration 0006 no longer re-adds `RedistrictingPlan.state`, which broke a fresh `migrate` with `DuplicateColumn`.**
+  Migration 0005 already adds `redistrictingplan.state` (identical `ForeignKey` definition); 0006 added it a second time. On an already-migrated database the second `AddField` was a no-op, but on a fresh database (CI, new deploys) it ran `ALTER TABLE siege_geo_redistrictingplan ADD COLUMN state_id` on a column 0005 had just created, aborting the whole migration graph. `state` is now owned solely by 0005; 0006 keeps its four genuinely-new fields (`effective_from`, `effective_to`, `superseded_by`, `court_case`). Model state is unchanged. A new static guard `tests/test_geo_migration_graph.py` fails if any `(model, field)` is `AddField`-ed twice without an intervening removal, so this bug class cannot recur.
 
 ## [3.17.2] - 2026-05-14
 

--- a/siege_utilities/geo/django/migrations/0006_redistrictingplan_missing_fields.py
+++ b/siege_utilities/geo/django/migrations/0006_redistrictingplan_missing_fields.py
@@ -1,15 +1,20 @@
 """Add the RedistrictingPlan fields declared on the model but absent from
-migration 0005: `state` FK, `effective_from`, `effective_to`,
-`superseded_by` self-FK, and `court_case`.
+migration 0005: `effective_from`, `effective_to`, `superseded_by`
+self-FK, and `court_case`.
 
 Fixes SU#527 — model declared the fields, schema didn't have the
 columns, so `for_date()` and any `select_related("redistricting_plan")`
 from downstream code crashed with UndefinedColumn.
 
+The `state` FK is NOT added here: migration 0005 already adds it (same
+definition). Re-adding it caused a DuplicateColumn error on a fresh
+`migrate` (the column exists once 0005 has run), so `state` is owned by
+0005 and this migration only fills the four remaining fields.
+
 All new columns are nullable / have safe defaults so existing rows
 backfill cleanly. No data migration needed: existing rows simply have
-NULL `state`, NULL `effective_from` / `effective_to`, NULL
-`superseded_by`, and empty `court_case`.
+NULL `effective_from` / `effective_to`, NULL `superseded_by`, and empty
+`court_case`.
 """
 
 from django.db import migrations, models
@@ -23,17 +28,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AddField(
-            model_name="redistrictingplan",
-            name="state",
-            field=models.ForeignKey(
-                null=True,
-                on_delete=django.db.models.deletion.CASCADE,
-                related_name="redistricting_plans",
-                to="siege_geo.state",
-                help_text="Parent state",
-            ),
-        ),
         migrations.AddField(
             model_name="redistrictingplan",
             name="effective_from",

--- a/tests/test_geo_migration_graph.py
+++ b/tests/test_geo_migration_graph.py
@@ -1,0 +1,78 @@
+"""Static consistency checks for the siege_geo Django migration graph.
+
+Guards against the duplicate-``AddField`` bug class: a field added by two
+different migrations applies cleanly to an already-migrated database but
+crashes a fresh ``migrate`` with ``DuplicateColumn``, because the second
+``AddField`` re-runs ``ALTER TABLE ... ADD COLUMN`` on a column the first
+migration already created. Regression for the ``redistrictingplan.state``
+field that was added by both 0005 and 0006.
+
+Pure static analysis: imports the migration modules and inspects their
+operation lists. No database and no ``migrate`` run is required, so this
+executes in the standard test job without a PostGIS service.
+"""
+import importlib.util
+import pathlib
+
+import pytest
+
+try:
+    import django  # noqa: F401
+    from django.db import migrations
+
+    _HAS_DJANGO = True
+except (ImportError, RuntimeError):
+    _HAS_DJANGO = False
+
+MIG_DIR = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "siege_utilities" / "geo" / "django" / "migrations"
+)
+
+pytestmark = pytest.mark.skipif(not _HAS_DJANGO, reason="Django not installed")
+
+
+def _load_migration(path):
+    spec = importlib.util.spec_from_file_location(f"siege_geo_{path.stem}", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.Migration
+
+
+def _iter_field_ops(operations):
+    """Yield ``(kind, model, field)`` for Add/RemoveField operations.
+
+    Recurses into ``SeparateDatabaseAndState.state_operations`` so a field
+    declared via a state-only operation still counts.
+    """
+    for op in operations:
+        if isinstance(op, migrations.AddField):
+            yield "add", op.model_name.lower(), op.name.lower()
+        elif isinstance(op, migrations.RemoveField):
+            yield "remove", op.model_name.lower(), op.name.lower()
+        elif isinstance(op, migrations.SeparateDatabaseAndState):
+            yield from _iter_field_ops(op.state_operations)
+
+
+def test_no_duplicate_addfield_in_geo_migrations():
+    """Every ``(model, field)`` is added at most once between removals."""
+    paths = sorted(MIG_DIR.glob("0*.py"))
+    assert paths, f"no migrations found under {MIG_DIR}"
+
+    added_by = {}
+    duplicates = []
+    for path in paths:
+        for kind, model, field in _iter_field_ops(_load_migration(path).operations):
+            key = (model, field)
+            if kind == "add":
+                if key in added_by:
+                    duplicates.append((key, added_by[key], path.name))
+                else:
+                    added_by[key] = path.name
+            else:  # remove
+                added_by.pop(key, None)
+
+    assert not duplicates, "duplicate AddField across migrations: " + "; ".join(
+        f"{model}.{field} in both {first} and {second}"
+        for (model, field), first, second in duplicates
+    )


### PR DESCRIPTION
## The bug

`siege_geo` migration `0006_redistrictingplan_missing_fields` re-adds `RedistrictingPlan.state`, which migration `0005_add_temporal_models_and_plan_assignment` **already** adds with an identical `ForeignKey` definition (`null=True`, `on_delete=CASCADE`, `related_name="redistricting_plans"`, `to="siege_geo.state"`).

On an **already-migrated** database the second `AddField` is a no-op (column exists, migration recorded applied), so this stayed latent. On a **fresh** database — CI, new deploys — `migrate` runs 0005 (creates `state_id`) then 0006, which executes `ALTER TABLE siege_geo_redistrictingplan ADD COLUMN state_id ...` on a column that already exists:

```
psycopg2.errors.DuplicateColumn: column "state_id" of relation "siege_geo_redistrictingplan" already exists
django.db.utils.ProgrammingError: ... Applying siege_geo.0006_redistrictingplan_missing_fields... → exit 1
```

This aborts the entire migration graph, so **any consumer doing a fresh `migrate` against siege_utilities ≥ 3.18.0 cannot bring up the schema.** Surfaced downstream in `siege-analytics/socialwarehouse` CI (every PR red).

## The fix

`state` is now owned solely by 0005. Migration 0006 keeps only its four genuinely-new fields (`effective_from`, `effective_to`, `superseded_by`, `court_case`). The resulting **model state is unchanged** (the field is still defined exactly once in the migration graph, by 0005), and **already-migrated DBs are unaffected** (0006 stays recorded-applied; Django does not re-run it).

## Regression guard

`tests/test_geo_migration_graph.py` — a **DB-free, PostGIS-free** static check that imports the `siege_geo` migration modules and asserts no `(model, field)` is `AddField`-ed twice without an intervening removal (recursing `SeparateDatabaseAndState.state_operations`). It runs in the standard `test` job (no DB service needed), closing the gap that let this ship: the CI `test` job has no Postgres service and ignores `test_django_temporal_models_orm.py`, so a fresh migrate of the geo app was never exercised.

## Verification

- Detector run against current migrations flags `redistrictingplan.state` in **both** 0005 and 0006 (pre-fix); clean after the fix.
- New test **passes** with the fix and **fails on revert** (re-adding the duplicate), confirming it is a real fail-on-revert guard, not theater.
- `flake8 --select=E9,F63,F7,F82` clean on both touched files; no lines > 127; `py_compile` clean.
- 0006 still adds exactly `['effective_from', 'effective_to', 'superseded_by', 'court_case']`.
- End-to-end fresh-migrate proof rides socialwarehouse CI (which has a PostGIS service + runs `migrate`) once it consumes this fix.

Scope-clean: only `0006`, the new test, and a CHANGELOG `[Unreleased]` entry. Refs SU#527.