### PR TITLE
fix(config): tolerate unwritable HOME at import (UserConfigManager mkdir) — closes #1117

### DIFF
--- a/siege_utilities/config/user_config.py
+++ b/siege_utilities/config/user_config.py
@@ -11,6 +11,7 @@ import yaml
 from pathlib import Path
 from typing import Optional
 import os
+import tempfile
 from dataclasses import dataclass, asdict
 
 # Import enhanced config for validation
@@ -52,6 +53,54 @@ def _default_download_directory() -> Path:
     if _is_databricks_runtime():
         return Path("/tmp/siege_utilities/downloads")
     return Path.home() / "Downloads" / "siege_utilities"
+
+
+def _resolve_config_dir(config_dir: Optional[Path] = None) -> Path:
+    """Resolve and create the user-config directory without hard-failing.
+
+    Resolution order: an explicit ``config_dir`` argument, then the
+    ``SIEGE_USER_CONFIG`` environment override, then
+    ``~/.siege_utilities/config``.
+
+    Directory creation is best-effort. An unwritable or non-existent HOME
+    (e.g. ``HOME=/nonexistent`` on a non-root Spark/Kubernetes pod) must not
+    crash ``import siege_utilities`` — the module-level singleton below runs
+    this at import time. On failure we warn and fall back to the system temp
+    dir; if that also fails we warn and return the resolved path anyway
+    (profile load/save already degrade gracefully without raising).
+    """
+    resolved = config_dir
+    if resolved is None:
+        env_override = os.environ.get("SIEGE_USER_CONFIG")
+        if env_override:
+            resolved = Path(env_override)
+    if resolved is None:
+        try:
+            resolved = Path.home() / ".siege_utilities" / "config"
+        except RuntimeError:
+            # Path.home() raises when HOME is unset and no passwd entry exists.
+            resolved = Path(tempfile.gettempdir()) / "siege_utilities" / "config"
+
+    try:
+        resolved.mkdir(parents=True, exist_ok=True)
+        return resolved
+    except (PermissionError, FileNotFoundError, OSError) as exc:
+        fallback = Path(tempfile.gettempdir()) / "siege_utilities" / "config"
+        log.warning(
+            "Could not create user-config dir %s (%s); falling back to %s. "
+            "Set SIEGE_USER_CONFIG to a writable path to silence this.",
+            resolved, exc, fallback,
+        )
+        try:
+            fallback.mkdir(parents=True, exist_ok=True)
+            return fallback
+        except (PermissionError, FileNotFoundError, OSError) as exc2:
+            log.warning(
+                "Could not create fallback user-config dir %s (%s); "
+                "config persistence is disabled for this session.",
+                fallback, exc2,
+            )
+            return resolved
 
 @dataclass
 class UserProfile:
@@ -110,9 +159,8 @@ class UserConfigManager:
         Args:
             config_dir: Directory containing user configuration files
         """
-        self.config_dir = config_dir or Path.home() / ".siege_utilities" / "config"
-        self.config_dir.mkdir(parents=True, exist_ok=True)
-        
+        self.config_dir = _resolve_config_dir(config_dir)
+
         self.user_config_file = self.config_dir / "user_config.yaml"
         self.user_profile = self._load_user_profile()
         

--- a/tests/test_user_config_unwritable_home.py
+++ b/tests/test_user_config_unwritable_home.py
@@ -1,0 +1,87 @@
+"""Regression tests for #1117: import-time UserConfigManager mkdir must not
+hard-fail on an unwritable/nonexistent HOME (the non-root Spark/Kubernetes
+pod case, HOME=/nonexistent).
+"""
+
+import os
+import sys
+import subprocess
+import tempfile
+
+import pytest
+
+from siege_utilities.config.user_config import _resolve_config_dir
+
+
+def test_import_and_construct_with_unwritable_home_does_not_crash():
+    """The exact #1117 repro: HOME=/nonexistent must not crash import/construct.
+
+    Runs in a subprocess so the unwritable HOME is process-global (matches the
+    Spark-pod environment) without mutating this test process. Root-safe: if the
+    test runs as root (which can write under /), construction simply succeeds
+    without the fallback — either way the process must exit 0, never raise
+    PermissionError at import.
+    """
+    env = {k: v for k, v in os.environ.items()}
+    env["HOME"] = "/nonexistent"
+    env.pop("SIEGE_USER_CONFIG", None)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import siege_utilities.config.user_config as m; "
+            "mgr = m.UserConfigManager(); "
+            "print('OK', mgr.config_dir)",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"import/construct crashed on unwritable HOME:\n{result.stderr}"
+    )
+    assert "OK" in result.stdout
+
+
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="root can write anywhere, so an unwritable parent cannot be simulated",
+)
+def test_resolve_config_dir_falls_back_to_tempdir_when_unwritable(tmp_path, monkeypatch):
+    """When the resolved dir's parent is unwritable, fall back to the temp dir
+    (and never raise). Exercises the except path directly (writing-tests:5)."""
+    monkeypatch.delenv("SIEGE_USER_CONFIG", raising=False)
+    read_only = tmp_path / "ro"
+    read_only.mkdir()
+    os.chmod(read_only, 0o500)  # r-x: cannot create children
+    target = read_only / ".siege_utilities" / "config"
+
+    result = _resolve_config_dir(target)
+
+    assert result.exists(), "fallback dir should have been created"
+    assert tempfile.gettempdir() in str(result), (
+        f"expected a temp-dir fallback, got {result}"
+    )
+
+
+def test_resolve_config_dir_honors_siege_user_config_override(tmp_path, monkeypatch):
+    """SIEGE_USER_CONFIG overrides the default location."""
+    override = tmp_path / "custom_cfg"
+    monkeypatch.setenv("SIEGE_USER_CONFIG", str(override))
+
+    result = _resolve_config_dir()
+
+    assert result == override
+    assert result.exists()
+
+
+def test_resolve_config_dir_uses_explicit_arg_over_env(tmp_path, monkeypatch):
+    """An explicit config_dir argument wins over the env override."""
+    explicit = tmp_path / "explicit"
+    monkeypatch.setenv("SIEGE_USER_CONFIG", str(tmp_path / "from_env"))
+
+    result = _resolve_config_dir(explicit)
+
+    assert result == explicit
+    assert result.exists()

--- a/tests/test_user_config_unwritable_home.py
+++ b/tests/test_user_config_unwritable_home.py
@@ -1,6 +1,11 @@
 """Regression tests for #1117: import-time UserConfigManager mkdir must not
 hard-fail on an unwritable/nonexistent HOME (the non-root Spark/Kubernetes
 pod case, HOME=/nonexistent).
+
+The error-path tests below each force one of the ``except`` handlers added to
+``_resolve_config_dir`` — the outer mkdir failure, the inner temp-dir-fallback
+failure, and the ``RuntimeError`` from ``Path.home()`` when HOME is
+unresolvable — per writing-tests:5.
 """
 
 import os
@@ -10,17 +15,18 @@ import tempfile
 
 import pytest
 
+import siege_utilities.config.user_config as user_config
 from siege_utilities.config.user_config import _resolve_config_dir
+
+_IS_ROOT = hasattr(os, "geteuid") and os.geteuid() == 0
 
 
 def test_import_and_construct_with_unwritable_home_does_not_crash():
     """The exact #1117 repro: HOME=/nonexistent must not crash import/construct.
 
-    Runs in a subprocess so the unwritable HOME is process-global (matches the
-    Spark-pod environment) without mutating this test process. Root-safe: if the
-    test runs as root (which can write under /), construction simply succeeds
-    without the fallback — either way the process must exit 0, never raise
-    PermissionError at import.
+    Runs in a subprocess so the unwritable HOME is process-global (matching the
+    Spark-pod environment). Root-safe: if the test runs as root, construction
+    simply succeeds without the fallback — either way the process must exit 0.
     """
     env = {k: v for k, v in os.environ.items()}
     env["HOME"] = "/nonexistent"
@@ -44,13 +50,9 @@ def test_import_and_construct_with_unwritable_home_does_not_crash():
     assert "OK" in result.stdout
 
 
-@pytest.mark.skipif(
-    hasattr(os, "geteuid") and os.geteuid() == 0,
-    reason="root can write anywhere, so an unwritable parent cannot be simulated",
-)
-def test_resolve_config_dir_falls_back_to_tempdir_when_unwritable(tmp_path, monkeypatch):
-    """When the resolved dir's parent is unwritable, fall back to the temp dir
-    (and never raise). Exercises the except path directly (writing-tests:5)."""
+@pytest.mark.skipif(_IS_ROOT, reason="root can write anywhere; cannot simulate an unwritable parent")
+def test_resolve_config_dir_falls_back_to_tempdir_on_mkdir_failure(tmp_path, monkeypatch):
+    """An unwritable resolved dir forces the OUTER except → temp-dir fallback."""
     monkeypatch.delenv("SIEGE_USER_CONFIG", raising=False)
     read_only = tmp_path / "ro"
     read_only.mkdir()
@@ -60,9 +62,42 @@ def test_resolve_config_dir_falls_back_to_tempdir_when_unwritable(tmp_path, monk
     result = _resolve_config_dir(target)
 
     assert result.exists(), "fallback dir should have been created"
-    assert tempfile.gettempdir() in str(result), (
-        f"expected a temp-dir fallback, got {result}"
-    )
+    assert tempfile.gettempdir() in str(result)
+
+
+@pytest.mark.skipif(_IS_ROOT, reason="root can write anywhere; cannot simulate an unwritable parent")
+def test_resolve_config_dir_returns_resolved_when_both_paths_fail(tmp_path, monkeypatch):
+    """BOTH the resolved dir and the temp-dir fallback unwritable forces the
+    INNER except: warn and return the resolved path without raising."""
+    monkeypatch.delenv("SIEGE_USER_CONFIG", raising=False)
+    read_only = tmp_path / "ro"
+    read_only.mkdir()
+    os.chmod(read_only, 0o500)
+    target = read_only / ".siege_utilities" / "config"
+
+    ro_tmp = tmp_path / "ro_tmp"
+    ro_tmp.mkdir()
+    os.chmod(ro_tmp, 0o500)
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(ro_tmp))
+
+    result = _resolve_config_dir(target)
+
+    assert result == target, "best-effort: returns the resolved path, never raises"
+
+
+def test_resolve_config_dir_handles_missing_home(monkeypatch):
+    """``Path.home()`` raising ``RuntimeError`` (HOME unresolvable) is caught and
+    falls back to the temp dir, exercising the RuntimeError except."""
+    monkeypatch.delenv("SIEGE_USER_CONFIG", raising=False)
+
+    def _no_home():
+        raise RuntimeError("HOME unresolvable")
+
+    monkeypatch.setattr(user_config.Path, "home", staticmethod(_no_home))
+
+    result = _resolve_config_dir()  # config_dir=None, no env → Path.home() raises
+
+    assert tempfile.gettempdir() in str(result)
 
 
 def test_resolve_config_dir_honors_siege_user_config_override(tmp_path, monkeypatch):


### PR DESCRIPTION
## What

Fixes #1117 — importing `siege_utilities` (or any geo/census submodule) crashed with `PermissionError` at **import time** when `HOME` is unset, non-existent, or unwritable. This is the default for non-root Spark/Kubernetes pods (`HOME=/nonexistent`), so it blocked the Enterprise RDH/census ingest (electinfo/enterprise#2302).

## Root cause

`UserConfigManager.__init__` did an unconditional `self.config_dir.mkdir(parents=True, exist_ok=True)` on `~/.siege_utilities/config`. Via the module-level singleton, this runs at import. Every *other* siege dir (`~/.siege_cache`, `~/.siege_temp`, …) already warns-and-defers on failure — only this one raised fatally.

## Fix

New `_resolve_config_dir(config_dir)`:
- **Resolution order:** explicit `config_dir` arg → `SIEGE_USER_CONFIG` env override → `~/.siege_utilities/config`.
- **Best-effort creation:** on `PermissionError`/`FileNotFoundError`/`OSError`, **warn** and fall back to the system temp dir (`tempfile.gettempdir()/siege_utilities/config`); if that also fails, warn and return the resolved path anyway. Also catches `RuntimeError` from `Path.home()` when `HOME` is unset.
- Mirrors the warn-and-defer convention in `paths.py::initialize_siege_directories`. `_load_user_profile` already guards on `.exists()` and `_save_user_profile` already catches `OSError` — so a degraded config dir never crashes import.

The fix is **behavior-identical on the happy path** (writable HOME → same dir, same mkdir); only the failure path changed (crash → loud warning + working tempdir fallback). This is the no-debt / silent-vs-loud discipline: it fails loudly with an actionable message (`Set SIEGE_USER_CONFIG to a writable path…`), not silently.

## Verification (local)

- **Literal #1117 repro** — `env -i HOME=/nonexistent python -c "import siege_utilities.config.user_config; m.UserConfigManager()"` → warns and falls back to `/tmp/siege_utilities/config`, **no crash** (previously `PermissionError`).
- New regression tests (`tests/test_user_config_unwritable_home.py`, **4 passed**): the subprocess `HOME=/nonexistent` repro (asserts exit 0), a forced-except unit test (unwritable parent → tempdir fallback, exercises the except path per writing-tests:5, skipif-root), and `SIEGE_USER_CONFIG` / explicit-arg precedence.
- flake8 phase4-rules clean; both files parse.

Closes #1117 · Refs #1064