### PR TITLE
fix(reporting): clear ImportError when reportlab absent (#1125)

### DIFF
--- a/plans/self-review-1125.md
+++ b/plans/self-review-1125.md
@@ -1,0 +1,82 @@
+---
+ticket_refs:
+  - siege-analytics/siege_utilities#1125
+---
+## Self-Review: #1125 — Clear reportlab-missing error
+
+## Assumptions
+Working as: software engineer
+Domain(s): software engineering
+Geospatial cross-cut: no
+Goal source: ticket #1125
+Goal source verification: ticket body describes cryptic TypeError from `float * NoneType` when reportlab absent
+Plan reference: https://github.com/siege-analytics/siege_utilities/issues/1125#issuecomment-4836035231
+Pre-author-inventory: investigate-gate.json (workspace)
+Trivial-against-state: no authoring-against-state contact — changes are guard additions to reporting code, not domain content
+Investigate-artifact: investigate-gate.json (ticket siege-analytics/siege_utilities#1125)
+Pre-mortem-artifact: plans/pre-mortem-1125.md (workspace)
+
+## Peer review
+
+writing-code: all changes are guard insertions at method entry points in reporting engine/template files. No new features, no API changes, no domain logic.
+
+### Syntax check
+- `python3 -c "import ast; ast.parse(open('siege_utilities/reporting/engines/base_engine.py').read())"` → exit 0
+- `python3 -c "import ast; ast.parse(open('siege_utilities/reporting/templates/base_template.py').read())"` → exit 0
+- `python3 -c "import ast; ast.parse(open('siege_utilities/reporting/templates/content_page_template.py').read())"` → exit 0
+- `python3 -c "import ast; ast.parse(open('siege_utilities/reporting/templates/table_of_contents_template.py').read())"` → exit 0
+
+### Guard coverage verification
+- `grep -rn '* inch' siege_utilities/reporting/` → 29 sites across 2 files (base_engine.py, base_template.py)
+- All base_engine.py sites are in methods guarded by `_require_reportlab()` at entry
+- All base_template.py sites are in `__init__` or methods reachable only from a constructed instance; `__init__` has the guard
+- content_page_template.py and table_of_contents_template.py: guard in `__init__`
+- Type annotations using `canvas.Canvas` changed to string form `"canvas.Canvas"` to avoid AttributeError when canvas=None
+
+### Behavioral verification
+- Simulated reportlab absence via `sys.modules` blocking
+- `BaseChartEngine()._create_placeholder_chart(6, 4)` → `ImportError: reportlab is required for PDF chart generation but is not installed. Install it with: pip install reportlab`
+- `BaseReportTemplate('test.pdf')` → `ImportError: reportlab is required for PDF report generation but is not installed. Install it with: pip install reportlab`
+- Previously: `TypeError: unsupported operand type(s) for *: 'float' and 'NoneType'`
+
+### Test results
+- `pytest tests/test_reporting_config_exports.py tests/test_bar_engine_errors.py tests/test_chart_types.py` → 9 passed, 3 skipped, 0 failures
+
+### Existing guards in sibling files
+- `legend_manager.py:186`: returns `None` when `not REPORTLAB_AVAILABLE` (SU-1 violation — errors are not data — but out of scope for this ticket)
+- `report_generator.py:544,639`: raises `ImportError` with clear message — same pattern we're adding
+
+## Lead review
+
+Four files modified, one class of bug fixed. The pattern is uniform: check `REPORTLAB_AVAILABLE` at method/constructor entry, raise `ImportError` with install instructions.
+
+**Approach fit:** Method-entry guards (not import-time) preserve lazy loading. Per-file guards (not shared) because each file has its own `REPORTLAB_AVAILABLE` flag from its own conditional import block.
+
+**Blast radius:** Minimal. Only code paths that previously crashed with TypeError now crash with ImportError. No behavioral change when reportlab IS installed.
+
+**Sequencing assumption:** None — this is a standalone fix.
+
+**legend_manager.py SU-1 violation:** `create_legend_table()` returns `None` on missing reportlab instead of raising. This is a separate bug (errors are not data), noted but not fixed here to keep scope tight.
+
+Verdict: correct and minimal. The fix converts a class of cryptic runtime errors into actionable installation guidance.
+
+## Findings
+
+| ID | Priority | Description | Resolution |
+|----|----------|-------------|------------|
+| 1 | P3 | legend_manager.py:186 returns None instead of raising — SU-1 violation | noted — separate ticket |
+
+## Quantified claims
+- "4 files changed, 31 insertions" — `git diff --stat` → `4 files changed, 31 insertions(+), 4 deletions(-)`
+- "29 `* inch` sites" — `grep -c '* inch' siege_utilities/reporting/engines/base_engine.py siege_utilities/reporting/templates/base_template.py` → 9 + 20
+- "9 passed, 3 skipped" — pytest output
+
+## Rework ledger
+
+No rework cycles occurred.
+
+## Evidence-predates-work
+Artifact: plans/self-review-1125.md
+First-added commit: (same commit — artifact written after initial commit, will be in amend)
+Work commit: (pending amend)
+Verification: N/A — artifact and work in same commit

--- a/siege_utilities/reporting/engines/base_engine.py
+++ b/siege_utilities/reporting/engines/base_engine.py
@@ -50,6 +50,14 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 
+def _require_reportlab() -> None:
+    if not REPORTLAB_AVAILABLE:
+        raise ImportError(
+            "reportlab is required for PDF chart generation but is not installed. "
+            "Install it with: pip install reportlab"
+        )
+
+
 def _rl_image_from_data_uri(data_uri: str, width_pts: float, height_pts: float) -> "Image":
     """Build a ReportLab Image from a base64 ``data:`` URI.
 
@@ -288,6 +296,7 @@ class BaseChartEngine:
         Returns:
             ReportLab Image object
         """
+        _require_reportlab()
         try:
             # Save vector copy if requested (before closing the figure)
             if vector_export_path is not None:
@@ -357,6 +366,7 @@ class BaseChartEngine:
         Returns:
             ReportLab Image object
         """
+        _require_reportlab()
         try:
             # Create a simple placeholder using matplotlib
             if MATPLOTLIB_AVAILABLE:
@@ -398,6 +408,7 @@ class BaseChartEngine:
         Returns:
             List containing chart and caption
         """
+        _require_reportlab()
         if caption_style is None:
             caption_style = 'Caption' if 'Caption' in self.styles else 'Normal'
 
@@ -418,6 +429,7 @@ class BaseChartEngine:
         Returns:
             List of flowables for the section
         """
+        _require_reportlab()
         section = []
 
         # Add title

--- a/siege_utilities/reporting/templates/base_template.py
+++ b/siege_utilities/reporting/templates/base_template.py
@@ -63,6 +63,11 @@ class BaseReportTemplate:
             page_size: Page size ('letter' or 'A4')
             margins: Custom margins in inches (top, bottom, left, right)
         """
+        if not REPORTLAB_AVAILABLE:
+            raise ImportError(
+                "reportlab is required for PDF report generation but is not installed. "
+                "Install it with: pip install reportlab"
+            )
         self.output_filename = output_filename
         self.branding_config_path = branding_config_path
         self.page_size = self._get_page_size(page_size)

--- a/siege_utilities/reporting/templates/content_page_template.py
+++ b/siege_utilities/reporting/templates/content_page_template.py
@@ -37,7 +37,12 @@ __all__ = [
 class ContentPageTemplate:
     """Professional content page generator for siege utilities reports"""
     
-    def __init__(self, canvas_obj: canvas.Canvas, page_size: tuple = letter):
+    def __init__(self, canvas_obj: "canvas.Canvas", page_size: tuple = letter):
+        if not REPORTLAB_AVAILABLE:
+            raise ImportError(
+                "reportlab is required for PDF content pages but is not installed. "
+                "Install it with: pip install reportlab"
+            )
         self.canvas = canvas_obj
         self.page_size = page_size
         self.width, self.height = page_size
@@ -375,7 +380,7 @@ class ContentPageTemplate:
         self.canvas.drawString(page_x, 15, page_text)
 
 
-def create_content_page(canvas_obj: canvas.Canvas,
+def create_content_page(canvas_obj: "canvas.Canvas",
                        page_title: str,
                        page_number: int,
                        content_sections: List[Dict[str, Any]],

--- a/siege_utilities/reporting/templates/table_of_contents_template.py
+++ b/siege_utilities/reporting/templates/table_of_contents_template.py
@@ -37,7 +37,12 @@ __all__ = [
 class TableOfContentsTemplate:
     """Professional table of contents generator for siege utilities reports"""
     
-    def __init__(self, canvas_obj: canvas.Canvas, page_size: tuple = letter):
+    def __init__(self, canvas_obj: "canvas.Canvas", page_size: tuple = letter):
+        if not REPORTLAB_AVAILABLE:
+            raise ImportError(
+                "reportlab is required for PDF table of contents but is not installed. "
+                "Install it with: pip install reportlab"
+            )
         self.canvas = canvas_obj
         self.page_size = page_size
         self.width, self.height = page_size
@@ -277,7 +282,7 @@ class TableOfContentsTemplate:
         self.canvas.drawString(page_x, footer_y, page_text)
 
 
-def create_table_of_contents(canvas_obj: canvas.Canvas,
+def create_table_of_contents(canvas_obj: "canvas.Canvas",
                            sections: List[Dict[str, Any]],
                            title: str = "Table of Contents",
                            page_number: int = 2,


### PR DESCRIPTION
## Summary

- Without reportlab installed, `inch = None` fallback caused cryptic `TypeError: unsupported operand type(s) for *: 'float' and 'NoneType'` deep in chart/template code
- Adds `_require_reportlab()` guard at method entry points in `base_engine.py` and `__init__` guards in `base_template.py`, `content_page_template.py`, `table_of_contents_template.py`
- All 29 `* inch` sites across the reporting package are now behind guards that raise `ImportError` with install instructions

## Test plan

- [x] Syntax check: all 4 modified files parse via `ast.parse`
- [x] Guard fires correctly: simulated absent reportlab → `ImportError: reportlab is required for PDF chart generation but is not installed. Install it with: pip install reportlab`
- [x] No regressions: `pytest tests/test_reporting_config_exports.py tests/test_bar_engine_errors.py tests/test_chart_types.py` → 9 passed, 3 skipped
- [x] Lazy loading preserved: module imports succeed without reportlab; guard fires at method call time, not import time

Closes #1125