### PR TITLE
fix(reporting): legend_manager raises ImportError instead of returning None (#1128)

### DIFF
--- a/plans/self-review-1128.md
+++ b/plans/self-review-1128.md
@@ -1,0 +1,56 @@
+---
+ticket_refs:
+  - siege-analytics/siege_utilities#1128
+---
+## Self-Review: #1128 — legend_manager SU-1 fix
+
+## Assumptions
+Working as: software engineer
+Domain(s): software engineering
+Geospatial cross-cut: no
+Goal source: ticket #1128
+Goal source verification: ticket body describes SU-1 violation (return None instead of raising)
+Plan reference: #1128 ticket body
+Pre-author-inventory: #1125 self-review Finding #1
+Investigate-artifact: investigate-gate.json (ticket siege-analytics/siege_utilities#1128)
+Pre-mortem-artifact: plans/pre-mortem-1128.md (workspace)
+
+## Peer review
+
+writing-code: one-line change — replace `return None` with `raise ImportError(...)` in legend_manager.py.
+
+### Syntax check
+- `python3 -c "import ast; ast.parse(open('siege_utilities/reporting/legend_manager.py').read())"` → exit 0
+
+### Caller verification
+- `grep -rn 'create_legend_table' siege_utilities/` → 0 callers (function is defined but uncalled in library)
+- No code depends on the None return value
+
+### Docstring update
+- Changed "ReportLab Table object or None if ReportLab not available" → "ReportLab Table object"
+
+### Test results
+- 9 passed, 2 skipped, 0 failures
+
+## Lead review
+
+Single-line fix, identical pattern to report_generator.py:544,639. No callers to break. Docstring updated to match new contract.
+
+Verdict: correct and trivial.
+
+## Findings
+
+No findings.
+
+## Quantified claims
+- "1 file changed" — `git diff --stat` confirms
+- "0 callers" — grep for create_legend_table found 0 call sites in library code
+
+## Rework ledger
+
+No rework cycles.
+
+## Evidence-predates-work
+Artifact: plans/self-review-1128.md
+First-added commit: (same commit)
+Work commit: (pending)

--- a/siege_utilities/reporting/legend_manager.py
+++ b/siege_utilities/reporting/legend_manager.py
@@ -181,11 +181,13 @@ class LegendManager:
             levels: Number of intensity levels (default 5)
             
         Returns:
-            ReportLab Table object or None if ReportLab not available
+            ReportLab Table object
         """
         if not REPORTLAB_AVAILABLE:
-            log.warning("ReportLab not available for legend table generation")
-            return None
+            raise ImportError(
+                "reportlab is required for legend table generation but is not installed. "
+                "Install it with: pip install reportlab"
+            )
 
         # Create legend data
         legend_data = [["Intensity", "Color", f"{value_name} Range"]]


### PR DESCRIPTION
## Summary

- `create_legend_table()` returned `None` when reportlab was absent — SU-1 violation (errors are not data)
- Now raises `ImportError` with install instructions, consistent with #1125 pattern
- 0 callers depend on the `None` return; docstring updated to match new contract

## Test plan

- [x] Syntax check passes
- [x] grep confirms 0 callers of `create_legend_table` in library code
- [x] Reporting tests: 9 passed, 2 skipped

Closes #1128