### PR TITLE
feat(analytics): add multi-signal risk stacking (#402)

### DIFF
--- a/plans/self-review-402.md
+++ b/plans/self-review-402.md
@@ -1,0 +1,60 @@
+---
+propagation-deferred: will post to ticket with PR
+---
+
+# Self-review: Multi-signal risk stacking (#402)
+
+Self-Review: risk stacking engine with signal types, tier classification, and intervention mapping
+Self-Review-Source: plans/self-review-402.md
+Design-Note-Source: https://github.com/siege-analytics/claude-configs-public/issues/402
+Investigate-artifact: TRIVIAL (see ## Trivial-investigation declaration below)
+Pre-mortem-artifact: TRIVIAL (see ## Trivial-investigation declaration below)
+Hostile-review-artifact: WAIVED — new module, no existing callers affected
+
+## Hostile-review-waiver
+Reason: New module addition — no existing code modified
+Scope: siege_utilities/analytics/risk.py (new), tests/test_analytics_risk.py (new), __init__.py (lazy import)
+Compensating-control: 23 tests pass; module is isolated
+
+## Trivial-investigation declaration
+Category: new module addition
+Cannot produce error: no existing behavior modified
+Reason: Adding new risk module to analytics package
+Evidence: git diff --stat shows 2 new files + 5 lines added to __init__.py
+Falsification: If existing analytics imports broke, investigation would be required
+
+## Assumptions
+Goal source: https://github.com/siege-analytics/claude-configs-public/issues/402
+Investigate-artifact: TRIVIAL (see ## Trivial-investigation declaration above)
+Pre-mortem-artifact: TRIVIAL (see ## Trivial-investigation declaration above)
+Pre-author-inventory: NONE
+Trivial-against-state: new module addition, no existing state contact
+Working as: software engineer
+Roles: Junior (implemented risk engine and tests), Senior (verified SU-1 compliance, enum enforcement, tier boundaries)
+
+## Peer review
+
+Shelves checked: writing-code:1, writing-tests:1
+
+### Gate evidence
+- 23 tests pass: `python -m pytest tests/test_analytics_risk.py -v -o 'addopts=' — 23 passed`
+- SU-1: ValueError for invalid weights, missing signals, out-of-range scores, bad enum types
+- SignalType enforced as enum per acceptance criteria
+
+## Lead review
+
+**[Senior]** Clean implementation. Signal types as enum prevents free-text drift.
+RiskTier ordering is validated in RiskTierConfig. Intervention mapping is optional.
+Shares the weighted-composition pattern with scoring.py but is independent — no
+coupling between modules.
+
+## Quantified claims
+
+- 1 new module: siege_utilities/analytics/risk.py
+- 1 new test file: tests/test_analytics_risk.py
+- 23 tests: 1 enum, 4 signal, 6 config, 12 analyzer
+- Every raise path has a negative test
+
+## Findings
+
+No findings.

--- a/siege_utilities/analytics/__init__.py
+++ b/siege_utilities/analytics/__init__.py
@@ -97,6 +97,11 @@ _register([
     'Dimension', 'ThresholdConfig', 'EntityScore', 'HealthScorer',
 ], '.scoring')
 
+_register([
+    'SignalType', 'RiskTier', 'RiskSignal', 'RiskTierConfig',
+    'RiskAssessment', 'RiskAnalyzer',
+], '.risk')
+
 __all__ = list(_LAZY_IMPORTS.keys())
 
 

--- a/siege_utilities/analytics/risk.py
+++ b/siege_utilities/analytics/risk.py
@@ -1,0 +1,249 @@
+"""
+Multi-signal risk stacking.
+
+Composable risk assessment that stacks N weighted signals into a
+composite risk score with tier classification and optional
+intervention mapping.
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+import math
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class SignalType(enum.Enum):
+    """Types of risk signals."""
+
+    DECLINE = "decline"
+    THRESHOLD = "threshold"
+    ABSENCE = "absence"
+    ANOMALY = "anomaly"
+
+
+class RiskTier(enum.Enum):
+    """Risk classification tiers, ordered by severity."""
+
+    CRITICAL = "Critical"
+    HIGH = "High"
+    MEDIUM = "Medium"
+    LOW = "Low"
+
+
+@dataclass(frozen=True)
+class RiskSignal:
+    """A named risk signal with type and weight.
+
+    Parameters
+    ----------
+    name : str
+        Signal identifier.
+    signal_type : SignalType
+        Category of risk this signal measures.
+    weight : float
+        Relative weight (0, 100]. All signals' weights must sum to 100.
+    """
+
+    name: str
+    signal_type: SignalType
+    weight: float
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("Signal name must not be empty")
+        if not isinstance(self.signal_type, SignalType):
+            raise ValueError(
+                f"signal_type must be a SignalType enum, got {type(self.signal_type)}"
+            )
+        if not (0 < self.weight <= 100):
+            raise ValueError(
+                f"Signal weight must be in (0, 100], got {self.weight}"
+            )
+
+
+@dataclass(frozen=True)
+class RiskTierConfig:
+    """Thresholds for risk tier classification.
+
+    Scores >= critical_min are Critical, >= high_min are High, etc.
+    """
+
+    critical_min: float = 80.0
+    high_min: float = 60.0
+    medium_min: float = 40.0
+
+    def __post_init__(self) -> None:
+        if not (self.medium_min < self.high_min < self.critical_min):
+            raise ValueError(
+                f"Thresholds must be ordered: medium_min ({self.medium_min}) "
+                f"< high_min ({self.high_min}) < critical_min ({self.critical_min})"
+            )
+
+    def classify(self, score: float) -> RiskTier:
+        if score >= self.critical_min:
+            return RiskTier.CRITICAL
+        if score >= self.high_min:
+            return RiskTier.HIGH
+        if score >= self.medium_min:
+            return RiskTier.MEDIUM
+        return RiskTier.LOW
+
+
+@dataclass(frozen=True)
+class RiskAssessment:
+    """Result of a risk assessment."""
+
+    entity_id: str
+    composite_score: float
+    tier: RiskTier
+    signal_scores: dict[str, float]
+    signal_types: dict[str, SignalType]
+    intervention: str | None = None
+
+
+class RiskAnalyzer:
+    """Multi-signal risk stacking engine.
+
+    Parameters
+    ----------
+    signals : list[RiskSignal]
+        Risk signals to evaluate. Weights must sum to 100.
+    tier_config : RiskTierConfig, optional
+        Tier classification thresholds.
+    interventions : dict[RiskTier, str], optional
+        Mapping from risk tier to recommended intervention.
+
+    Raises
+    ------
+    ValueError
+        If signals is empty or weights don't sum to 100.
+    """
+
+    def __init__(
+        self,
+        signals: list[RiskSignal],
+        tier_config: RiskTierConfig | None = None,
+        interventions: dict[RiskTier, str] | None = None,
+    ) -> None:
+        if not signals:
+            raise ValueError("At least one risk signal is required")
+
+        total_weight = sum(s.weight for s in signals)
+        if not math.isclose(total_weight, 100.0, abs_tol=0.01):
+            raise ValueError(
+                f"Signal weights must sum to 100, got {total_weight}"
+            )
+
+        self._signals = list(signals)
+        self._tier_config = tier_config or RiskTierConfig()
+        self._interventions = dict(interventions or {})
+
+        logger.info(
+            "RiskAnalyzer initialized with %d signals: %s",
+            len(self._signals),
+            ", ".join(
+                f"{s.name}({s.signal_type.value},{s.weight}%)"
+                for s in self._signals
+            ),
+        )
+
+    @property
+    def signal_names(self) -> list[str]:
+        return [s.name for s in self._signals]
+
+    def assess(
+        self,
+        entity_id: str,
+        scores: dict[str, float],
+    ) -> RiskAssessment:
+        """Assess risk for an entity.
+
+        Parameters
+        ----------
+        entity_id : str
+            Identifier for the entity.
+        scores : dict[str, float]
+            Per-signal risk scores (0-100). Higher = more risk.
+
+        Returns
+        -------
+        RiskAssessment
+
+        Raises
+        ------
+        ValueError
+            If scores dict is missing signals or values are out of range.
+        """
+        missing = set(self.signal_names) - set(scores.keys())
+        if missing:
+            raise ValueError(f"Missing scores for signals: {missing}")
+
+        for name, value in scores.items():
+            if name not in self.signal_names:
+                raise ValueError(f"Unknown signal: {name!r}")
+            if not (0 <= value <= 100):
+                raise ValueError(
+                    f"Score for {name!r} must be in [0, 100], got {value}"
+                )
+
+        composite = sum(
+            scores[s.name] * s.weight / 100.0 for s in self._signals
+        )
+
+        tier = self._tier_config.classify(composite)
+        intervention = self._interventions.get(tier)
+
+        signal_scores = {s.name: scores[s.name] for s in self._signals}
+        signal_types = {s.name: s.signal_type for s in self._signals}
+
+        result = RiskAssessment(
+            entity_id=entity_id,
+            composite_score=round(composite, 2),
+            tier=tier,
+            signal_scores=signal_scores,
+            signal_types=signal_types,
+            intervention=intervention,
+        )
+
+        logger.info(
+            "Risk assessed %s: %.1f (%s)%s",
+            entity_id,
+            result.composite_score,
+            tier.value,
+            f" → {intervention}" if intervention else "",
+        )
+
+        return result
+
+    def assess_batch(
+        self,
+        entities: list[dict[str, Any]],
+    ) -> list[RiskAssessment]:
+        """Assess risk for multiple entities.
+
+        Each dict must have 'entity_id' and 'scores' keys.
+
+        Returns
+        -------
+        list[RiskAssessment]
+        """
+        results = []
+        for entity in entities:
+            if "entity_id" not in entity or "scores" not in entity:
+                raise ValueError(
+                    "Each entity dict must have 'entity_id' and 'scores' keys"
+                )
+            results.append(
+                self.assess(
+                    entity_id=entity["entity_id"],
+                    scores=entity["scores"],
+                )
+            )
+
+        logger.info("Assessed risk for %d entities in batch", len(results))
+        return results

--- a/tests/test_analytics_risk.py
+++ b/tests/test_analytics_risk.py
@@ -1,0 +1,199 @@
+"""Tests for siege_utilities.analytics.risk."""
+
+import pytest
+
+from siege_utilities.analytics.risk import (
+    RiskAnalyzer,
+    RiskAssessment,
+    RiskSignal,
+    RiskTier,
+    RiskTierConfig,
+    SignalType,
+)
+
+
+class TestSignalType:
+    def test_all_types(self):
+        assert SignalType.DECLINE.value == "decline"
+        assert SignalType.THRESHOLD.value == "threshold"
+        assert SignalType.ABSENCE.value == "absence"
+        assert SignalType.ANOMALY.value == "anomaly"
+
+
+class TestRiskSignal:
+    def test_valid_signal(self):
+        s = RiskSignal(name="polling", signal_type=SignalType.DECLINE, weight=50.0)
+        assert s.name == "polling"
+        assert s.signal_type == SignalType.DECLINE
+        assert s.weight == 50.0
+
+    def test_empty_name_raises(self):
+        with pytest.raises(ValueError, match="name must not be empty"):
+            RiskSignal(name="", signal_type=SignalType.DECLINE, weight=50.0)
+
+    def test_invalid_type_raises(self):
+        with pytest.raises(ValueError, match="must be a SignalType"):
+            RiskSignal(name="x", signal_type="decline", weight=50.0)
+
+    def test_zero_weight_raises(self):
+        with pytest.raises(ValueError, match="weight must be in"):
+            RiskSignal(name="x", signal_type=SignalType.DECLINE, weight=0)
+
+
+class TestRiskTierConfig:
+    def test_default_thresholds(self):
+        c = RiskTierConfig()
+        assert c.critical_min == 80.0
+        assert c.high_min == 60.0
+        assert c.medium_min == 40.0
+
+    def test_classify_critical(self):
+        c = RiskTierConfig()
+        assert c.classify(90.0) == RiskTier.CRITICAL
+        assert c.classify(80.0) == RiskTier.CRITICAL
+
+    def test_classify_high(self):
+        c = RiskTierConfig()
+        assert c.classify(70.0) == RiskTier.HIGH
+        assert c.classify(60.0) == RiskTier.HIGH
+
+    def test_classify_medium(self):
+        c = RiskTierConfig()
+        assert c.classify(50.0) == RiskTier.MEDIUM
+        assert c.classify(40.0) == RiskTier.MEDIUM
+
+    def test_classify_low(self):
+        c = RiskTierConfig()
+        assert c.classify(30.0) == RiskTier.LOW
+        assert c.classify(0.0) == RiskTier.LOW
+
+    def test_invalid_order_raises(self):
+        with pytest.raises(ValueError, match="must be ordered"):
+            RiskTierConfig(critical_min=50.0, high_min=70.0, medium_min=40.0)
+
+
+class TestRiskAnalyzer:
+    @pytest.fixture
+    def election_analyzer(self):
+        return RiskAnalyzer(
+            signals=[
+                RiskSignal(name="polling_decline", signal_type=SignalType.DECLINE, weight=40.0),
+                RiskSignal(name="fundraising_drop", signal_type=SignalType.DECLINE, weight=30.0),
+                RiskSignal(name="endorsement_loss", signal_type=SignalType.ABSENCE, weight=30.0),
+            ]
+        )
+
+    def test_empty_signals_raises(self):
+        with pytest.raises(ValueError, match="At least one"):
+            RiskAnalyzer(signals=[])
+
+    def test_weights_not_100_raises(self):
+        with pytest.raises(ValueError, match="weights must sum to 100"):
+            RiskAnalyzer(
+                signals=[
+                    RiskSignal(name="a", signal_type=SignalType.DECLINE, weight=30.0),
+                    RiskSignal(name="b", signal_type=SignalType.THRESHOLD, weight=30.0),
+                ]
+            )
+
+    def test_happy_path(self, election_analyzer):
+        result = election_analyzer.assess(
+            entity_id="candidate-1",
+            scores={
+                "polling_decline": 80.0,
+                "fundraising_drop": 60.0,
+                "endorsement_loss": 40.0,
+            },
+        )
+        assert isinstance(result, RiskAssessment)
+        assert result.entity_id == "candidate-1"
+        expected = 80.0 * 0.4 + 60.0 * 0.3 + 40.0 * 0.3
+        assert result.composite_score == pytest.approx(expected)
+        assert result.tier == RiskTier.HIGH
+        assert result.signal_types["polling_decline"] == SignalType.DECLINE
+        assert result.intervention is None
+
+    def test_missing_signal_raises(self, election_analyzer):
+        with pytest.raises(ValueError, match="Missing scores"):
+            election_analyzer.assess(
+                entity_id="e1",
+                scores={"polling_decline": 80.0},
+            )
+
+    def test_unknown_signal_raises(self, election_analyzer):
+        with pytest.raises(ValueError, match="Unknown signal"):
+            election_analyzer.assess(
+                entity_id="e1",
+                scores={
+                    "polling_decline": 80.0,
+                    "fundraising_drop": 60.0,
+                    "endorsement_loss": 40.0,
+                    "bogus": 50.0,
+                },
+            )
+
+    def test_score_out_of_range_raises(self, election_analyzer):
+        with pytest.raises(ValueError, match="must be in"):
+            election_analyzer.assess(
+                entity_id="e1",
+                scores={
+                    "polling_decline": 110.0,
+                    "fundraising_drop": 60.0,
+                    "endorsement_loss": 40.0,
+                },
+            )
+
+    def test_tier_boundary_critical(self):
+        analyzer = RiskAnalyzer(
+            signals=[RiskSignal(name="risk", signal_type=SignalType.ANOMALY, weight=100.0)]
+        )
+        result = analyzer.assess(entity_id="e1", scores={"risk": 80.0})
+        assert result.tier == RiskTier.CRITICAL
+
+    def test_tier_boundary_low(self):
+        analyzer = RiskAnalyzer(
+            signals=[RiskSignal(name="risk", signal_type=SignalType.ANOMALY, weight=100.0)]
+        )
+        result = analyzer.assess(entity_id="e1", scores={"risk": 10.0})
+        assert result.tier == RiskTier.LOW
+
+    def test_intervention_mapping(self):
+        analyzer = RiskAnalyzer(
+            signals=[RiskSignal(name="risk", signal_type=SignalType.DECLINE, weight=100.0)],
+            interventions={
+                RiskTier.CRITICAL: "immediate escalation",
+                RiskTier.HIGH: "review within 24h",
+                RiskTier.MEDIUM: "monitor weekly",
+                RiskTier.LOW: "no action",
+            },
+        )
+        result = analyzer.assess(entity_id="e1", scores={"risk": 85.0})
+        assert result.intervention == "immediate escalation"
+
+        result_low = analyzer.assess(entity_id="e2", scores={"risk": 10.0})
+        assert result_low.intervention == "no action"
+
+    def test_batch_assessment(self, election_analyzer):
+        entities = [
+            {
+                "entity_id": "c1",
+                "scores": {"polling_decline": 90.0, "fundraising_drop": 80.0, "endorsement_loss": 70.0},
+            },
+            {
+                "entity_id": "c2",
+                "scores": {"polling_decline": 10.0, "fundraising_drop": 20.0, "endorsement_loss": 15.0},
+            },
+        ]
+        results = election_analyzer.assess_batch(entities)
+        assert len(results) == 2
+        assert results[0].tier == RiskTier.CRITICAL
+        assert results[1].tier == RiskTier.LOW
+
+    def test_batch_missing_keys_raises(self, election_analyzer):
+        with pytest.raises(ValueError, match="must have"):
+            election_analyzer.assess_batch([{"scores": {"polling_decline": 80.0}}])
+
+    def test_signal_names_property(self, election_analyzer):
+        assert election_analyzer.signal_names == [
+            "polling_decline", "fundraising_drop", "endorsement_loss"
+        ]


### PR DESCRIPTION
Adds RiskAnalyzer for composable N-signal risk stacking with enum-enforced signal types (decline, threshold, absence, anomaly), configurable tier classification (Critical/High/Medium/Low), and optional intervention mapping. 23 tests.

Closes siege-analytics/claude-configs-public#402