### PR TITLE
feat(analytics): add comparative analysis framework (#403)

### DIFF
--- a/plans/self-review-403.md
+++ b/plans/self-review-403.md
@@ -1,0 +1,60 @@
+---
+propagation-deferred: will post to ticket with PR
+---
+
+# Self-review: Comparative analysis framework (#403)
+
+Self-Review: N-entity x M-dimension comparison engine with evidence citation and feature matrix
+Self-Review-Source: plans/self-review-403.md
+Design-Note-Source: https://github.com/siege-analytics/claude-configs-public/issues/403
+Investigate-artifact: TRIVIAL (see ## Trivial-investigation declaration below)
+Pre-mortem-artifact: TRIVIAL (see ## Trivial-investigation declaration below)
+Hostile-review-artifact: WAIVED — new module, no existing callers
+
+## Hostile-review-waiver
+Reason: New module addition — no existing code modified
+Scope: siege_utilities/analytics/comparison.py (new), tests/test_analytics_comparison.py (new)
+Compensating-control: 20 tests pass; module is isolated
+
+## Trivial-investigation declaration
+Category: new module addition
+Cannot produce error: no existing behavior modified
+Reason: Adding new comparison module to analytics package
+Evidence: git diff --stat shows 2 new files + lazy import registration
+Falsification: If existing analytics imports broke, investigation would be required
+
+## Assumptions
+Goal source: https://github.com/siege-analytics/claude-configs-public/issues/403
+Investigate-artifact: TRIVIAL (see ## Trivial-investigation declaration above)
+Pre-mortem-artifact: TRIVIAL (see ## Trivial-investigation declaration above)
+Pre-author-inventory: NONE
+Trivial-against-state: new module addition, no existing state contact
+Working as: software engineer
+Roles: Junior (implemented comparison engine), Senior (verified evidence enforcement, gap analysis correctness)
+
+## Peer review
+
+Shelves checked: writing-code:1, writing-tests:1
+
+### Gate evidence
+- 20 tests pass
+- SU-1: ValueError for empty evidence, out-of-range scores, missing dimensions
+- Evidence citation is mandatory on DimensionScore (enforced in __post_init__)
+
+## Lead review
+
+**[Senior]** Evidence citation enforcement at the data class level is correct —
+impossible to construct a DimensionScore without evidence. Gap analysis uses
+statistics.variance which is appropriate for small N. Feature matrix handles
+missing features by defaulting to False. Clean design.
+
+## Quantified claims
+
+- 1 new module: siege_utilities/analytics/comparison.py
+- 1 new test file: tests/test_analytics_comparison.py
+- 20 tests: 6 DimensionScore, 10 ComparativeAnalyzer, 4 FeatureMatrix
+- Every raise path has a negative test
+
+## Findings
+
+No findings.

--- a/siege_utilities/analytics/__init__.py
+++ b/siege_utilities/analytics/__init__.py
@@ -102,6 +102,11 @@ _register([
     'RiskAssessment', 'RiskAnalyzer',
 ], '.risk')
 
+_register([
+    'DimensionScore', 'ComparisonResult', 'FeatureMatrix',
+    'ComparativeAnalyzer',
+], '.comparison')
+
 __all__ = list(_LAZY_IMPORTS.keys())
 
 

--- a/siege_utilities/analytics/comparison.py
+++ b/siege_utilities/analytics/comparison.py
@@ -1,0 +1,246 @@
+"""
+Evidence-based comparative analysis.
+
+Structured comparison framework for scoring and comparing N entities
+across M dimensions with mandatory evidence citation, feature matrix
+construction, and gap analysis.
+"""
+
+from __future__ import annotations
+
+import logging
+import statistics
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DimensionScore:
+    """A score for one entity on one dimension.
+
+    Parameters
+    ----------
+    score : int
+        Score on a 1-5 scale.
+    evidence : str
+        Citation supporting the score (URL, doc reference, test result).
+    """
+
+    score: int
+    evidence: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.score, int) or not (1 <= self.score <= 5):
+            raise ValueError(
+                f"Score must be an integer in [1, 5], got {self.score!r}"
+            )
+        if not self.evidence or not self.evidence.strip():
+            raise ValueError("Evidence citation must not be empty")
+
+
+@dataclass(frozen=True)
+class ComparisonResult:
+    """Result of comparing entities across dimensions."""
+
+    dimensions: list[str]
+    entities: list[str]
+    scores: dict[str, dict[str, DimensionScore]]
+    weighted_totals: dict[str, float]
+    gap_analysis: list[tuple[str, float]]
+
+
+@dataclass(frozen=True)
+class FeatureMatrix:
+    """Boolean feature support matrix with coverage scoring."""
+
+    entities: list[str]
+    features: list[str]
+    matrix: dict[str, dict[str, bool]]
+    coverage: dict[str, float]
+
+
+class ComparativeAnalyzer:
+    """N-entity x M-dimension comparison engine.
+
+    Parameters
+    ----------
+    dimensions : list[str]
+        Dimension names for comparison.
+    weights : dict[str, float] | None
+        Optional dimension weights. If provided, must cover all
+        dimensions. If omitted, equal weights are used.
+
+    Raises
+    ------
+    ValueError
+        If dimensions is empty or weights don't match dimensions.
+    """
+
+    def __init__(
+        self,
+        dimensions: list[str],
+        weights: dict[str, float] | None = None,
+    ) -> None:
+        if not dimensions:
+            raise ValueError("At least one dimension is required")
+
+        if len(dimensions) != len(set(dimensions)):
+            raise ValueError("Dimension names must be unique")
+
+        self._dimensions = list(dimensions)
+
+        if weights is not None:
+            missing = set(dimensions) - set(weights.keys())
+            if missing:
+                raise ValueError(f"Missing weights for dimensions: {missing}")
+            extra = set(weights.keys()) - set(dimensions)
+            if extra:
+                raise ValueError(f"Weights for unknown dimensions: {extra}")
+            self._weights = dict(weights)
+        else:
+            equal_weight = 1.0 / len(dimensions)
+            self._weights = {d: equal_weight for d in dimensions}
+
+        logger.info(
+            "ComparativeAnalyzer initialized with %d dimensions: %s",
+            len(self._dimensions),
+            ", ".join(self._dimensions),
+        )
+
+    def compare(
+        self,
+        entity_scores: dict[str, dict[str, DimensionScore]],
+    ) -> ComparisonResult:
+        """Compare entities across all dimensions.
+
+        Parameters
+        ----------
+        entity_scores : dict[str, dict[str, DimensionScore]]
+            Outer key = entity name, inner key = dimension name.
+
+        Returns
+        -------
+        ComparisonResult
+
+        Raises
+        ------
+        ValueError
+            If any entity is missing a dimension score.
+        """
+        if not entity_scores:
+            raise ValueError("At least one entity is required")
+
+        for entity, scores in entity_scores.items():
+            missing = set(self._dimensions) - set(scores.keys())
+            if missing:
+                raise ValueError(
+                    f"Entity {entity!r} missing scores for: {missing}"
+                )
+
+        weighted_totals: dict[str, float] = {}
+        for entity, scores in entity_scores.items():
+            total = sum(
+                scores[d].score * self._weights[d]
+                for d in self._dimensions
+            )
+            weighted_totals[entity] = round(total, 4)
+
+        gap_analysis = self._compute_gap_analysis(entity_scores)
+
+        entities = sorted(entity_scores.keys())
+
+        result = ComparisonResult(
+            dimensions=list(self._dimensions),
+            entities=entities,
+            scores=entity_scores,
+            weighted_totals=weighted_totals,
+            gap_analysis=gap_analysis,
+        )
+
+        logger.info(
+            "Compared %d entities across %d dimensions. "
+            "Highest variance: %s (%.2f)",
+            len(entities),
+            len(self._dimensions),
+            gap_analysis[0][0] if gap_analysis else "N/A",
+            gap_analysis[0][1] if gap_analysis else 0.0,
+        )
+
+        return result
+
+    def _compute_gap_analysis(
+        self,
+        entity_scores: dict[str, dict[str, DimensionScore]],
+    ) -> list[tuple[str, float]]:
+        """Identify dimensions with largest score variance across entities."""
+        if len(entity_scores) < 2:
+            return [(d, 0.0) for d in self._dimensions]
+
+        variances: list[tuple[str, float]] = []
+        for dim in self._dimensions:
+            dim_scores = [
+                scores[dim].score for scores in entity_scores.values()
+            ]
+            variance = statistics.variance(dim_scores)
+            variances.append((dim, round(variance, 4)))
+
+        variances.sort(key=lambda x: x[1], reverse=True)
+        return variances
+
+    @staticmethod
+    def build_feature_matrix(
+        entity_features: dict[str, dict[str, bool]],
+    ) -> FeatureMatrix:
+        """Build a boolean feature support matrix with coverage scores.
+
+        Parameters
+        ----------
+        entity_features : dict[str, dict[str, bool]]
+            Outer key = entity name, inner key = feature name.
+
+        Returns
+        -------
+        FeatureMatrix
+
+        Raises
+        ------
+        ValueError
+            If no entities or no features are provided.
+        """
+        if not entity_features:
+            raise ValueError("At least one entity is required")
+
+        all_features: set[str] = set()
+        for features in entity_features.values():
+            all_features.update(features.keys())
+
+        if not all_features:
+            raise ValueError("At least one feature is required")
+
+        sorted_features = sorted(all_features)
+        entities = sorted(entity_features.keys())
+
+        normalized: dict[str, dict[str, bool]] = {}
+        coverage: dict[str, float] = {}
+
+        for entity in entities:
+            features = entity_features[entity]
+            row = {f: features.get(f, False) for f in sorted_features}
+            normalized[entity] = row
+            supported = sum(1 for v in row.values() if v)
+            coverage[entity] = round(supported / len(sorted_features) * 100, 2)
+
+        logger.info(
+            "Feature matrix: %d entities × %d features",
+            len(entities),
+            len(sorted_features),
+        )
+
+        return FeatureMatrix(
+            entities=entities,
+            features=sorted_features,
+            matrix=normalized,
+            coverage=coverage,
+        )

--- a/tests/test_analytics_comparison.py
+++ b/tests/test_analytics_comparison.py
@@ -1,0 +1,166 @@
+"""Tests for siege_utilities.analytics.comparison."""
+
+import pytest
+
+from siege_utilities.analytics.comparison import (
+    ComparativeAnalyzer,
+    ComparisonResult,
+    DimensionScore,
+    FeatureMatrix,
+)
+
+
+class TestDimensionScore:
+    def test_valid_score(self):
+        ds = DimensionScore(score=4, evidence="benchmark report 2024")
+        assert ds.score == 4
+        assert ds.evidence == "benchmark report 2024"
+
+    def test_score_below_range_raises(self):
+        with pytest.raises(ValueError, match="must be an integer in"):
+            DimensionScore(score=0, evidence="test")
+
+    def test_score_above_range_raises(self):
+        with pytest.raises(ValueError, match="must be an integer in"):
+            DimensionScore(score=6, evidence="test")
+
+    def test_float_score_raises(self):
+        with pytest.raises(ValueError, match="must be an integer in"):
+            DimensionScore(score=3.5, evidence="test")
+
+    def test_empty_evidence_raises(self):
+        with pytest.raises(ValueError, match="Evidence citation must not be empty"):
+            DimensionScore(score=3, evidence="")
+
+    def test_whitespace_evidence_raises(self):
+        with pytest.raises(ValueError, match="Evidence citation must not be empty"):
+            DimensionScore(score=3, evidence="   ")
+
+
+class TestComparativeAnalyzer:
+    @pytest.fixture
+    def geocoder_analyzer(self):
+        return ComparativeAnalyzer(
+            dimensions=["accuracy", "coverage", "speed"],
+            weights={"accuracy": 0.5, "coverage": 0.3, "speed": 0.2},
+        )
+
+    def test_empty_dimensions_raises(self):
+        with pytest.raises(ValueError, match="At least one dimension"):
+            ComparativeAnalyzer(dimensions=[])
+
+    def test_duplicate_dimensions_raises(self):
+        with pytest.raises(ValueError, match="must be unique"):
+            ComparativeAnalyzer(dimensions=["a", "b", "a"])
+
+    def test_missing_weights_raises(self):
+        with pytest.raises(ValueError, match="Missing weights"):
+            ComparativeAnalyzer(
+                dimensions=["a", "b"],
+                weights={"a": 0.5},
+            )
+
+    def test_extra_weights_raises(self):
+        with pytest.raises(ValueError, match="unknown dimensions"):
+            ComparativeAnalyzer(
+                dimensions=["a"],
+                weights={"a": 0.5, "b": 0.5},
+            )
+
+    def test_happy_path(self, geocoder_analyzer):
+        result = geocoder_analyzer.compare({
+            "Census": {
+                "accuracy": DimensionScore(score=3, evidence="TIGER accuracy report"),
+                "coverage": DimensionScore(score=5, evidence="full US coverage"),
+                "speed": DimensionScore(score=2, evidence="batch processing benchmarks"),
+            },
+            "Google": {
+                "accuracy": DimensionScore(score=5, evidence="Places API precision test"),
+                "coverage": DimensionScore(score=4, evidence="global but gaps in rural"),
+                "speed": DimensionScore(score=5, evidence="sub-100ms p95"),
+            },
+        })
+        assert isinstance(result, ComparisonResult)
+        assert len(result.entities) == 2
+        assert "Census" in result.entities
+        assert "Google" in result.entities
+        assert result.weighted_totals["Google"] > result.weighted_totals["Census"]
+        assert len(result.gap_analysis) == 3
+
+    def test_single_entity(self, geocoder_analyzer):
+        result = geocoder_analyzer.compare({
+            "Census": {
+                "accuracy": DimensionScore(score=3, evidence="report"),
+                "coverage": DimensionScore(score=5, evidence="report"),
+                "speed": DimensionScore(score=2, evidence="report"),
+            },
+        })
+        assert len(result.entities) == 1
+        assert all(v == 0.0 for _, v in result.gap_analysis)
+
+    def test_missing_dimension_raises(self, geocoder_analyzer):
+        with pytest.raises(ValueError, match="missing scores for"):
+            geocoder_analyzer.compare({
+                "Census": {
+                    "accuracy": DimensionScore(score=3, evidence="report"),
+                },
+            })
+
+    def test_no_entities_raises(self, geocoder_analyzer):
+        with pytest.raises(ValueError, match="At least one entity"):
+            geocoder_analyzer.compare({})
+
+    def test_equal_weights_default(self):
+        analyzer = ComparativeAnalyzer(dimensions=["a", "b"])
+        result = analyzer.compare({
+            "X": {
+                "a": DimensionScore(score=4, evidence="e1"),
+                "b": DimensionScore(score=2, evidence="e2"),
+            },
+        })
+        assert result.weighted_totals["X"] == pytest.approx(3.0)
+
+    def test_gap_analysis_ordering(self):
+        analyzer = ComparativeAnalyzer(dimensions=["d1", "d2", "d3"])
+        result = analyzer.compare({
+            "A": {
+                "d1": DimensionScore(score=1, evidence="e"),
+                "d2": DimensionScore(score=3, evidence="e"),
+                "d3": DimensionScore(score=5, evidence="e"),
+            },
+            "B": {
+                "d1": DimensionScore(score=5, evidence="e"),
+                "d2": DimensionScore(score=3, evidence="e"),
+                "d3": DimensionScore(score=5, evidence="e"),
+            },
+        })
+        assert result.gap_analysis[0][0] == "d1"
+        assert result.gap_analysis[-1][0] in ("d2", "d3")
+
+
+class TestFeatureMatrix:
+    def test_happy_path(self):
+        matrix = ComparativeAnalyzer.build_feature_matrix({
+            "Census": {"geocoding": True, "reverse": True, "batch": False},
+            "Google": {"geocoding": True, "reverse": True, "batch": True},
+        })
+        assert isinstance(matrix, FeatureMatrix)
+        assert len(matrix.entities) == 2
+        assert len(matrix.features) == 3
+        assert matrix.coverage["Google"] == pytest.approx(100.0)
+        assert matrix.coverage["Census"] == pytest.approx(66.67)
+
+    def test_missing_feature_defaults_to_false(self):
+        matrix = ComparativeAnalyzer.build_feature_matrix({
+            "A": {"f1": True},
+            "B": {"f1": True, "f2": True},
+        })
+        assert matrix.matrix["A"]["f2"] is False
+
+    def test_no_entities_raises(self):
+        with pytest.raises(ValueError, match="At least one entity"):
+            ComparativeAnalyzer.build_feature_matrix({})
+
+    def test_no_features_raises(self):
+        with pytest.raises(ValueError, match="At least one feature"):
+            ComparativeAnalyzer.build_feature_matrix({"A": {}})


### PR DESCRIPTION
Adds ComparativeAnalyzer for N-entity x M-dimension scoring with mandatory evidence citation, gap analysis (highest-variance dimensions), and feature matrix builder with coverage scoring. 20 tests.

Closes siege-analytics/claude-configs-public#403