### PR TITLE
feat(analytics): add deterministic intervention mapping (#406)

### DIFF
--- a/siege_utilities/analytics/__init__.py
+++ b/siege_utilities/analytics/__init__.py
@@ -118,6 +118,11 @@ _register([
     'PipelineReport', 'PipelineAnalyzer',
 ], '.pipeline')
 
+_register([
+    'MappingRule', 'Outcome', 'EffectivenessReport',
+    'InterventionMapper',
+], '.intervention')
+
 __all__ = list(_LAZY_IMPORTS.keys())
 
 

--- a/siege_utilities/analytics/intervention.py
+++ b/siege_utilities/analytics/intervention.py
@@ -1,0 +1,271 @@
+"""
+Deterministic intervention mapping.
+
+Rule-based signal-to-action mapping with priority ordering,
+effectiveness tracking, and override support.
+"""
+
+from __future__ import annotations
+
+import logging
+import warnings
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class MappingRule:
+    """A signal-to-action mapping rule.
+
+    Parameters
+    ----------
+    signal : str
+        The categorical input signal.
+    action : str
+        The recommended action.
+    priority : int
+        Lower number = higher priority. Used when multiple rules match.
+    """
+
+    signal: str
+    action: str
+    priority: int = 0
+
+    def __post_init__(self) -> None:
+        if not self.signal or not self.signal.strip():
+            raise ValueError("Signal must not be empty")
+        if not self.action or not self.action.strip():
+            raise ValueError("Action must not be empty")
+
+
+@dataclass
+class Outcome:
+    """Recorded outcome for an intervention."""
+
+    signal: str
+    action: str
+    success: bool
+    overridden: bool = False
+    override_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class EffectivenessReport:
+    """Effectiveness statistics for one action."""
+
+    action: str
+    total: int
+    successes: int
+    success_rate: float
+
+
+class InterventionMapper:
+    """Rule-based intervention mapping engine.
+
+    Parameters
+    ----------
+    rules : list[MappingRule]
+        Signal-to-action mapping rules.
+    default_action : str | None
+        Action for unmapped signals. If None, unmapped signals raise.
+    strict : bool
+        If True, unmapped signals raise ValueError. If False, warn
+        and return default_action.
+
+    Raises
+    ------
+    ValueError
+        If rules is empty or strict=False without default_action.
+    """
+
+    def __init__(
+        self,
+        rules: list[MappingRule],
+        default_action: str | None = None,
+        strict: bool = True,
+    ) -> None:
+        if not rules:
+            raise ValueError("At least one mapping rule is required")
+
+        if not strict and default_action is None:
+            raise ValueError(
+                "default_action is required when strict=False"
+            )
+
+        if default_action is not None and not default_action.strip():
+            raise ValueError("default_action must not be empty")
+
+        sorted_rules = sorted(rules, key=lambda r: r.priority)
+        self._rule_map: dict[str, str] = {}
+        for rule in sorted_rules:
+            if rule.signal not in self._rule_map:
+                self._rule_map[rule.signal] = rule.action
+
+        self._default_action = default_action
+        self._strict = strict
+        self._outcomes: list[Outcome] = []
+
+        logger.info(
+            "InterventionMapper initialized with %d rules (%d unique signals)",
+            len(rules),
+            len(self._rule_map),
+        )
+
+    @property
+    def signals(self) -> list[str]:
+        return sorted(self._rule_map.keys())
+
+    def map(
+        self,
+        signal: str,
+        *,
+        override_action: str | None = None,
+        override_reason: str | None = None,
+    ) -> str:
+        """Map a signal to an action.
+
+        Parameters
+        ----------
+        signal : str
+            The categorical input signal.
+        override_action : str, optional
+            Override the mapped action. Must include override_reason.
+        override_reason : str, optional
+            Reason for the override (mandatory when overriding).
+
+        Returns
+        -------
+        str
+            The recommended action.
+
+        Raises
+        ------
+        ValueError
+            If signal is unmapped and strict=True, or if override
+            is given without a reason.
+        """
+        if override_action is not None and (
+            not override_reason or not override_reason.strip()
+        ):
+            raise ValueError(
+                "override_reason is required when providing override_action"
+            )
+
+        if override_action is not None:
+            mapped_action = self._rule_map.get(signal)
+            logger.info(
+                "Override for signal %r: %r → %r (reason: %s)",
+                signal,
+                mapped_action,
+                override_action,
+                override_reason,
+            )
+            return override_action
+
+        mapped_action = self._rule_map.get(signal)
+
+        if mapped_action is None:
+            if self._strict:
+                raise ValueError(
+                    f"Unmapped signal: {signal!r}. "
+                    f"Known signals: {self.signals}"
+                )
+            warnings.warn(
+                f"Unmapped signal {signal!r}; using default action "
+                f"{self._default_action!r}",
+                UserWarning,
+                stacklevel=2,
+            )
+            mapped_action = self._default_action
+
+        return mapped_action
+
+    def record_outcome(
+        self,
+        signal: str,
+        action: str,
+        success: bool,
+        *,
+        overridden: bool = False,
+        override_reason: str | None = None,
+    ) -> None:
+        """Record the outcome of an intervention.
+
+        Parameters
+        ----------
+        signal : str
+            The signal that triggered the intervention.
+        action : str
+            The action taken.
+        success : bool
+            Whether the intervention succeeded.
+        overridden : bool
+            Whether the action was an override.
+        override_reason : str, optional
+            Reason for override (required if overridden=True).
+
+        Raises
+        ------
+        ValueError
+            If overridden=True without override_reason.
+        """
+        if overridden and (not override_reason or not override_reason.strip()):
+            raise ValueError(
+                "override_reason is required when overridden=True"
+            )
+
+        outcome = Outcome(
+            signal=signal,
+            action=action,
+            success=success,
+            overridden=overridden,
+            override_reason=override_reason,
+        )
+        self._outcomes.append(outcome)
+
+        logger.info(
+            "Outcome recorded: signal=%r action=%r success=%s%s",
+            signal,
+            action,
+            success,
+            f" (override: {override_reason})" if overridden else "",
+        )
+
+    def effectiveness(self) -> list[EffectivenessReport]:
+        """Compute effectiveness per action.
+
+        Returns
+        -------
+        list[EffectivenessReport]
+            One entry per distinct action, sorted by success rate ascending.
+
+        Raises
+        ------
+        ValueError
+            If no outcomes have been recorded.
+        """
+        if not self._outcomes:
+            raise ValueError("No outcomes recorded yet")
+
+        action_stats: dict[str, tuple[int, int]] = {}
+        for outcome in self._outcomes:
+            total, successes = action_stats.get(outcome.action, (0, 0))
+            total += 1
+            if outcome.success:
+                successes += 1
+            action_stats[outcome.action] = (total, successes)
+
+        reports = []
+        for action, (total, successes) in action_stats.items():
+            rate = successes / total if total > 0 else 0.0
+            reports.append(EffectivenessReport(
+                action=action,
+                total=total,
+                successes=successes,
+                success_rate=round(rate, 4),
+            ))
+
+        reports.sort(key=lambda r: r.success_rate)
+        return reports

--- a/tests/test_analytics_intervention.py
+++ b/tests/test_analytics_intervention.py
@@ -1,0 +1,160 @@
+"""Tests for siege_utilities.analytics.intervention."""
+
+import warnings
+
+import pytest
+
+from siege_utilities.analytics.intervention import (
+    EffectivenessReport,
+    InterventionMapper,
+    MappingRule,
+)
+
+
+class TestMappingRule:
+    def test_valid_rule(self):
+        r = MappingRule(signal="timeout", action="retry")
+        assert r.signal == "timeout"
+        assert r.action == "retry"
+        assert r.priority == 0
+
+    def test_empty_signal_raises(self):
+        with pytest.raises(ValueError, match="Signal must not be empty"):
+            MappingRule(signal="", action="retry")
+
+    def test_empty_action_raises(self):
+        with pytest.raises(ValueError, match="Action must not be empty"):
+            MappingRule(signal="timeout", action="")
+
+    def test_whitespace_signal_raises(self):
+        with pytest.raises(ValueError, match="Signal must not be empty"):
+            MappingRule(signal="   ", action="retry")
+
+    def test_whitespace_action_raises(self):
+        with pytest.raises(ValueError, match="Action must not be empty"):
+            MappingRule(signal="timeout", action="   ")
+
+
+class TestInterventionMapper:
+    @pytest.fixture
+    def geocoder_mapper(self):
+        return InterventionMapper(
+            rules=[
+                MappingRule(signal="timeout", action="retry_with_backoff"),
+                MappingRule(signal="not_found", action="fallback_provider"),
+                MappingRule(signal="rate_limit", action="queue_and_wait"),
+            ]
+        )
+
+    def test_empty_rules_raises(self):
+        with pytest.raises(ValueError, match="At least one"):
+            InterventionMapper(rules=[])
+
+    def test_non_strict_without_default_raises(self):
+        with pytest.raises(ValueError, match="default_action is required"):
+            InterventionMapper(
+                rules=[MappingRule(signal="a", action="b")],
+                strict=False,
+            )
+
+    def test_happy_path(self, geocoder_mapper):
+        assert geocoder_mapper.map("timeout") == "retry_with_backoff"
+        assert geocoder_mapper.map("not_found") == "fallback_provider"
+        assert geocoder_mapper.map("rate_limit") == "queue_and_wait"
+
+    def test_unmapped_strict_raises(self, geocoder_mapper):
+        with pytest.raises(ValueError, match="Unmapped signal"):
+            geocoder_mapper.map("unknown_error")
+
+    def test_unmapped_non_strict_warns(self):
+        mapper = InterventionMapper(
+            rules=[MappingRule(signal="a", action="b")],
+            default_action="log_and_skip",
+            strict=False,
+        )
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = mapper.map("unmapped")
+            assert len(w) == 1
+            assert "Unmapped signal" in str(w[0].message)
+        assert result == "log_and_skip"
+
+    def test_priority_ordering(self):
+        mapper = InterventionMapper(
+            rules=[
+                MappingRule(signal="error", action="low_priority", priority=10),
+                MappingRule(signal="error", action="high_priority", priority=1),
+            ]
+        )
+        assert mapper.map("error") == "high_priority"
+
+    def test_override_with_reason(self, geocoder_mapper):
+        result = geocoder_mapper.map(
+            "timeout",
+            override_action="manual_fix",
+            override_reason="known flaky endpoint",
+        )
+        assert result == "manual_fix"
+
+    def test_override_without_reason_raises(self, geocoder_mapper):
+        with pytest.raises(ValueError, match="override_reason is required"):
+            geocoder_mapper.map("timeout", override_action="manual_fix")
+
+    def test_override_whitespace_reason_raises(self, geocoder_mapper):
+        with pytest.raises(ValueError, match="override_reason is required"):
+            geocoder_mapper.map(
+                "timeout", override_action="manual_fix", override_reason="   "
+            )
+
+    def test_empty_default_action_raises(self):
+        with pytest.raises(ValueError, match="default_action must not be empty"):
+            InterventionMapper(
+                rules=[MappingRule(signal="a", action="b")],
+                default_action="",
+                strict=False,
+            )
+
+    def test_record_override_whitespace_reason_raises(self, geocoder_mapper):
+        with pytest.raises(ValueError, match="override_reason is required"):
+            geocoder_mapper.record_outcome(
+                "timeout", "manual_fix", success=True,
+                overridden=True, override_reason="   ",
+            )
+
+    def test_signals_property(self, geocoder_mapper):
+        assert geocoder_mapper.signals == ["not_found", "rate_limit", "timeout"]
+
+    def test_record_outcome(self, geocoder_mapper):
+        geocoder_mapper.record_outcome("timeout", "retry_with_backoff", success=True)
+        geocoder_mapper.record_outcome("timeout", "retry_with_backoff", success=False)
+        reports = geocoder_mapper.effectiveness()
+        assert len(reports) == 1
+        assert reports[0].total == 2
+        assert reports[0].successes == 1
+        assert reports[0].success_rate == 0.5
+
+    def test_record_override_without_reason_raises(self, geocoder_mapper):
+        with pytest.raises(ValueError, match="override_reason is required"):
+            geocoder_mapper.record_outcome(
+                "timeout", "manual_fix", success=True, overridden=True
+            )
+
+    def test_effectiveness_no_outcomes_raises(self, geocoder_mapper):
+        with pytest.raises(ValueError, match="No outcomes recorded"):
+            geocoder_mapper.effectiveness()
+
+    def test_effectiveness_multiple_actions(self, geocoder_mapper):
+        geocoder_mapper.record_outcome("timeout", "retry_with_backoff", success=True)
+        geocoder_mapper.record_outcome("timeout", "retry_with_backoff", success=True)
+        geocoder_mapper.record_outcome("not_found", "fallback_provider", success=False)
+        reports = geocoder_mapper.effectiveness()
+        assert len(reports) == 2
+        assert reports[0].success_rate < reports[1].success_rate
+
+    def test_record_override_outcome(self, geocoder_mapper):
+        geocoder_mapper.record_outcome(
+            "timeout", "manual_fix", success=True,
+            overridden=True, override_reason="testing",
+        )
+        reports = geocoder_mapper.effectiveness()
+        assert reports[0].action == "manual_fix"


### PR DESCRIPTION
Rule-based signal-to-action mapping with priority ordering, override
support with mandatory reason, and effectiveness tracking via outcome
recording.

- MappingRule: frozen dataclass with signal/action/priority, whitespace validation
- InterventionMapper: map(), record_outcome(), effectiveness()
- Strict mode raises on unmapped signals; non-strict warns and returns default
- Override mechanism with mandatory reason (whitespace rejected)
- Effectiveness reports sorted ascending (worst-first for attention)
- 22 tests covering all branches including hostile review edge cases

Hostile review: plans/hostile-review-406.md (4 S1 fixed, 7 S2/S3 dispositioned)