### PR TITLE
fix(config): tolerate unwritable HOME in UserConfigManager (#1117)

### DIFF
--- a/plans/self-review-1117.md
+++ b/plans/self-review-1117.md
@@ -1,0 +1,65 @@
+---
+ticket_refs:
+  - siege-analytics/siege_utilities#1117: open
+type: self-review
+---
+
+## Self-review for #1117: unwritable HOME import crash
+
+Working as: software engineer
+
+## Assumptions
+
+Domain(s): software engineering, configuration management
+Geospatial cross-cut: no
+Goal source: ticket #1117 (import-time PermissionError)
+Plan reference: none (1 modified file + 1 new test file)
+Pre-author-inventory: NONE
+Trivial-against-state: modifies UserConfigManager.__init__ to tolerate unwritable HOME
+Investigate-artifact: ticket #1117 and electinfo/enterprise#2302
+Pre-mortem-artifact: WAIVED (defensive hardening; fail-open behavior change only)
+Hostile-review-artifact: WAIVED (single-function fix; no enforcement-path touch)
+Project-contribution: Unblocks siege_utilities import in containers with unwritable HOME (Spark/Kubernetes pods with HOME=/nonexistent)
+
+## Pre-implementation comprehension
+
+**Current behavior:** UserConfigManager.__init__ does unconditional mkdir on Path.home()/.siege_utilities/config. Crashes with PermissionError when HOME is unwritable.
+
+**Intended behavior:** Three-tier config dir resolution: SIEGE_USER_CONFIG_DIR env var > Path.home() > TMPDIR fallback. If both fail, run read-only without crashing. _save_user_profile respects _read_only flag.
+
+**Steps:** 1 modified file (config/user_config.py), 1 new test file.
+
+**Success criteria:** HOME=/nonexistent import works without crash. All 4 new tests pass. Existing behavior unchanged for writable HOME.
+
+**What could go wrong:** Temp dir fallback could be unexpected. Mitigated by: warning log message at WARNING level.
+
+## Peer review (the Junior's checklist)
+
+Syntax check: python3 -c "import siege_utilities.config.user_config" succeeds
+Test suite: 4 tests pass (unwritable fallback, explicit dir, env override, read-only mode)
+writing-code: follows existing warn-and-continue pattern from paths.py
+writing-claims: 1 modified file + 1 new test file
+
+## Lead review (the Lead's adversarial pass)
+
+In software engineering: this is a defensive fix that brings UserConfigManager in line with every other siege directory manager. The existing cache/temp/log dirs already warn-and-continue; the config manager was the only outlier.
+
+**Approach fit:** Correct. Three-tier resolution (env > home > tmpdir) with read-only fallback covers all container scenarios.
+
+**Remaining risk:** None. The fix is additive — existing HOME-writable behavior is unchanged.
+
+**Blast radius:** 1 file modified (defensive guard in __init__), 1 new test file.
+
+## Findings
+
+No findings.
+
+## Quantified claims
+
+- "1 modified file" — siege_utilities/config/user_config.py
+- "1 new test file" — tests/test_user_config_unwritable_home.py (4 tests)
+- "HOME=/nonexistent works" — verified via manual test
+
+## Rework ledger
+
+No rework occurred.

--- a/siege_utilities/config/user_config.py
+++ b/siege_utilities/config/user_config.py
@@ -106,20 +106,43 @@ class UserConfigManager:
     def __init__(self, config_dir: Optional[Path] = None):
         """
         Initialize the user configuration manager.
-        
+
         Args:
             config_dir: Directory containing user configuration files
         """
-        self.config_dir = config_dir or Path.home() / ".siege_utilities" / "config"
-        self.config_dir.mkdir(parents=True, exist_ok=True)
-        
+        self._read_only = False
+        self.config_dir = config_dir or self._resolve_config_dir()
+        try:
+            self.config_dir.mkdir(parents=True, exist_ok=True)
+        except (PermissionError, OSError) as exc:
+            fallback = Path(os.environ.get("TMPDIR", "/tmp")) / "siege_utilities" / "config"
+            log.warning(
+                "Cannot create config dir %s (%s); falling back to %s",
+                self.config_dir, exc, fallback,
+            )
+            self.config_dir = fallback
+            try:
+                self.config_dir.mkdir(parents=True, exist_ok=True)
+            except (PermissionError, OSError):
+                log.warning("Fallback config dir %s also unwritable; running read-only", fallback)
+                self._read_only = True
+
         self.user_config_file = self.config_dir / "user_config.yaml"
         self.user_profile = self._load_user_profile()
-        
-        # Set default download directory if not specified
+
         if not self.user_profile.preferred_download_directory:
             self.user_profile.preferred_download_directory = str(_default_download_directory())
             self._save_user_profile()
+
+    @staticmethod
+    def _resolve_config_dir() -> Path:
+        env_override = os.environ.get("SIEGE_USER_CONFIG_DIR")
+        if env_override:
+            return Path(env_override)
+        try:
+            return Path.home() / ".siege_utilities" / "config"
+        except (RuntimeError, KeyError):
+            return Path(os.environ.get("TMPDIR", "/tmp")) / "siege_utilities" / "config"
     
     def _load_user_profile(self) -> UserProfile:
         """Load user profile from configuration file."""
@@ -140,6 +163,8 @@ class UserConfigManager:
     
     def _save_user_profile(self):
         """Save user profile to configuration file."""
+        if self._read_only:
+            return
         try:
             config_dict = asdict(self.user_profile)
             # Convert tuples to lists for YAML compatibility

--- a/tests/test_user_config_unwritable_home.py
+++ b/tests/test_user_config_unwritable_home.py
@@ -1,0 +1,45 @@
+"""Tests for UserConfigManager resilience to unwritable HOME. Ref: #1117."""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from siege_utilities.config.user_config import UserConfigManager
+
+
+class TestUnwritableHome:
+    def test_unwritable_home_falls_back_to_tmpdir(self, tmp_path):
+        unwritable = tmp_path / "nope"
+        unwritable.mkdir()
+        unwritable.chmod(0o000)
+        try:
+            config_dir = unwritable / ".siege_utilities" / "config"
+            mgr = UserConfigManager(config_dir=config_dir)
+            assert mgr.config_dir != config_dir
+            assert mgr.user_profile is not None
+        finally:
+            unwritable.chmod(0o755)
+
+    def test_explicit_config_dir_works(self, tmp_path):
+        config_dir = tmp_path / "custom_config"
+        mgr = UserConfigManager(config_dir=config_dir)
+        assert mgr.config_dir == config_dir
+        assert config_dir.exists()
+
+    def test_siege_user_config_dir_env_override(self, tmp_path):
+        custom = tmp_path / "env_override"
+        with mock.patch.dict(os.environ, {"SIEGE_USER_CONFIG_DIR": str(custom)}):
+            mgr = UserConfigManager()
+            assert mgr.config_dir == custom
+            assert custom.exists()
+
+    def test_read_only_mode_does_not_crash(self):
+        mgr = UserConfigManager.__new__(UserConfigManager)
+        mgr._read_only = True
+        mgr.config_dir = Path("/nonexistent/path")
+        mgr.user_config_file = mgr.config_dir / "user_config.yaml"
+        mgr.user_profile = type(mgr)._load_user_profile(mgr)
+        mgr._save_user_profile()


### PR DESCRIPTION
## Summary

- UserConfigManager.__init__ crashed with PermissionError when HOME was unwritable (containers with HOME=/nonexistent, Spark/K8s pods)
- Adds three-tier config dir resolution: SIEGE_USER_CONFIG_DIR env var > Path.home() > TMPDIR fallback
- If all dirs are unwritable, runs in read-only mode without crashing

## Changes

- `siege_utilities/config/user_config.py` — wrap mkdir in try/except, add `_resolve_config_dir()` static method, add `_read_only` flag
- `tests/test_user_config_unwritable_home.py` — 4 tests covering fallback, env override, explicit dir, read-only mode

## Testing

- `HOME=/nonexistent python3 -c "from siege_utilities.config.user_config import UserConfigManager; m = UserConfigManager(); print('OK:', m.config_dir)"` succeeds with fallback warning
- All 4 new tests pass

Closes #1117