### PR TITLE
fix(lint): clear 13 phase4 F401 violations red on develop (unblocks all open PRs)

### DIFF
--- a/siege_utilities/analytics/comparison.py
+++ b/siege_utilities/analytics/comparison.py
@@ -10,8 +10,7 @@ from __future__ import annotations
 
 import logging
 import statistics
-from dataclasses import dataclass, field
-from typing import Any
+from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
 

--- a/siege_utilities/analytics/forecast.py
+++ b/siege_utilities/analytics/forecast.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any
 
 logger = logging.getLogger(__name__)
 

--- a/siege_utilities/analytics/intervention.py
+++ b/siege_utilities/analytics/intervention.py
@@ -9,8 +9,7 @@ from __future__ import annotations
 
 import logging
 import warnings
-from dataclasses import dataclass, field
-from typing import Any
+from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
 

--- a/siege_utilities/analytics/pipeline.py
+++ b/siege_utilities/analytics/pipeline.py
@@ -9,9 +9,8 @@ from __future__ import annotations
 
 import logging
 import warnings
-from dataclasses import dataclass, field
-from datetime import datetime, timedelta
-from typing import Any
+from dataclasses import dataclass
+from datetime import datetime
 
 logger = logging.getLogger(__name__)
 

--- a/siege_utilities/analytics/scoring.py
+++ b/siege_utilities/analytics/scoring.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 import math
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 logger = logging.getLogger(__name__)

--- a/tests/test_analytics_intervention.py
+++ b/tests/test_analytics_intervention.py
@@ -5,7 +5,6 @@ import warnings
 import pytest
 
 from siege_utilities.analytics.intervention import (
-    EffectivenessReport,
     InterventionMapper,
     MappingRule,
 )

--- a/tests/test_analytics_pipeline.py
+++ b/tests/test_analytics_pipeline.py
@@ -6,7 +6,6 @@ from datetime import datetime, timedelta
 import pytest
 
 from siege_utilities.analytics.pipeline import (
-    ConcentrationAlert,
     PipelineAnalyzer,
     PipelineItem,
     PipelineReport,

--- a/tests/test_user_config_unwritable_home.py
+++ b/tests/test_user_config_unwritable_home.py
@@ -1,11 +1,9 @@
 """Tests for UserConfigManager resilience to unwritable HOME. Ref: #1117."""
 
 import os
-import tempfile
 from pathlib import Path
 from unittest import mock
 
-import pytest
 
 from siege_utilities.config.user_config import UserConfigManager
 


### PR DESCRIPTION
## What

The **`lint ratchet phases2-4`** required check is red on `develop` (`check_lint_ratchet.py --phase phase4`: baseline 0, **current 13**, FAIL). Because phase4 evaluates the whole merged tree against a 0 baseline, **every open PR inherits this red required check via merge-checkout** and shows `mergeable_state: blocked` regardless of its own diff. This resets the count back to 0 by removing the violations (the #1111 no-debt approach, not a baseline bump).

## Root cause

13 `F401` unused imports landed on develop through the then-non-blocking lint window — from the analytics feature merges (#1131–#1143) and the #1117 config fix:

- `analytics/comparison.py` — `dataclasses.field`, `typing.Any`
- `analytics/forecast.py` — `typing.Any`
- `analytics/intervention.py` — `dataclasses.field`, `typing.Any`
- `analytics/pipeline.py` — `dataclasses.field`, `datetime.timedelta`, `typing.Any`
- `analytics/scoring.py` — `dataclasses.field` (`typing.Any` **kept** — it's used at line 206)
- `tests/test_analytics_intervention.py` — unused `EffectivenessReport`
- `tests/test_analytics_pipeline.py` — unused `ConcentrationAlert`
- `tests/test_user_config_unwritable_home.py` — unused `pytest`, `tempfile`

## Fix

Unused-import removals only. Each removal screened against the #1111 regression traps: none of the removed names is a `patch()` target string, a pytest fixture, or a load-bearing side-effect import (`import pytest`/`tempfile` in the config test have no other reference in the file; confirmed by the tests still passing).

## Verification (local, reproduced the CI job)

- `python scripts/check_lint_ratchet.py --phase phase4` → **PASS (current 0 / baseline 0)** (was FAIL, 13).
- `py_compile` clean on all 8 files (SU-5 batch-parse).
- Analytics modules import cleanly; affected tests: **114 passed** (`test_analytics_{comparison,forecast,intervention,pipeline,scoring}.py`, `test_user_config_unwritable_home.py`).

No behavioral change; no public API change. Once this lands, the open PRs (#1122, #1116, #1119) can re-run phase4 green.

Refs #1064